### PR TITLE
Fix Changesets release PR generation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
-  "changelog": false,
+  "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
## Summary

- enable Changesets' standard changelog generator
- allow the release action to compose the version PR body for changed packages

## Why

The first release run with a pending changeset failed after versioning because the action expects a generated `CHANGELOG.md`, while the repository configuration explicitly disabled changelog generation.

## Validation

- `pnpm check`
- dry-run `pnpm changeset version` in an isolated copy; generated the expected `0.2.0` changelog
