### PR TITLE
Fix release publishing workflow runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm
@@ -27,11 +27,11 @@ jobs:
       run:
         working-directory: examples/pokemon
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
           package_json_file: examples/pokemon/package.json
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
## Summary

- upgrade `actions/checkout` from v4 to v7
- upgrade `actions/setup-node` from v4 to v7
- upgrade `pnpm/action-setup` from v4 to v6
- retain the existing tokenless npm OIDC configuration

## Root cause

The `0.2.0` publish reached npm through OIDC and generated provenance, but npm returned `E404` because the package's trusted publisher does not authorize the exact GitHub workflow identity. That npm account setting cannot be committed to this repository.

The Node deprecation warning came from the older action majors, which declared the Node 20 action runtime. The new majors declare Node 24.

## Validation

- `pnpm check`
- YAML parsing for both workflow files
- official action manifests verified to use `node24`

## Before merging

Configure npm trusted publishing for `@typeonce/effect-machine` with organization `typeonce-dev`, repository `effect-machine`, workflow `release.yml`, environment `npm`, and allow `npm publish`.
