### PR TITLE
Allow Changesets release pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,19 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - run: >-
+      - name: Require a changeset
+        if: >-
+          github.head_ref != 'changeset-release/main' ||
+          github.event.pull_request.user.login != 'github-actions[bot]'
+        run: >-
           node scripts/check-changeset.mjs
           --base ${{ github.event.pull_request.base.sha }}
           --head ${{ github.event.pull_request.head.sha }}
+      - name: Accept the Changesets release pull request
+        if: >-
+          github.head_ref == 'changeset-release/main' &&
+          github.event.pull_request.user.login == 'github-actions[bot]'
+        run: echo "Changesets release pull requests consume their changeset files."
 
   discover-examples:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- allow the automated Changesets release pull request to bypass the ordinary changeset-presence policy
- keep the `changeset-policy` job running and successful for branch-protection compatibility
- continue enforcing the policy for normal and human-created pull requests

## Root cause

The release PR updates `package.json` while consuming and deleting its source changeset files. The policy requires an added or modified changeset for every package metadata change, so the generated `changeset-release/main` PR could never satisfy it.

The exemption requires both the expected release branch and `github-actions[bot]` as the pull request creator.

## Changeset

- [ ] Added or updated for a library or package-metadata change
- [x] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed — not applicable
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed — not applicable
