### PR TITLE
Add machine inspection APIs and planner visualizer

### DIFF
--- a/.changeset/quiet-spiders-inspect.md
+++ b/.changeset/quiet-spiders-inspect.md
@@ -2,4 +2,4 @@
 "@typeonce/effect-machine": minor
 ---
 
-Add public getters for inspecting compiled state nodes, registered transition handlers, declared transition targets, and the active state configuration of a snapshot. Event handlers may declare an upper bound of target paths that is checked against inferred and runtime results.
+Add public getters for inspecting compiled state nodes, registered transition handlers, declared transition targets, and the active state configuration of a snapshot. Event, eventless, and completion handlers may declare an upper bound of target paths that is checked against inferred and runtime results.

--- a/.changeset/quiet-spiders-inspect.md
+++ b/.changeset/quiet-spiders-inspect.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Add public getters for inspecting compiled state nodes, registered transition handlers, and the active state configuration of a snapshot.

--- a/.changeset/quiet-spiders-inspect.md
+++ b/.changeset/quiet-spiders-inspect.md
@@ -2,4 +2,4 @@
 "@typeonce/effect-machine": minor
 ---
 
-Add public getters for inspecting compiled state nodes, registered transition handlers, and the active state configuration of a snapshot.
+Add public getters for inspecting compiled state nodes, registered transition handlers, declared transition targets, and the active state configuration of a snapshot. Event handlers may declare an upper bound of target paths that is checked against inferred and runtime results.

--- a/examples/platformer/src/machine.test.ts
+++ b/examples/platformer/src/machine.test.ts
@@ -1,7 +1,10 @@
 import { Machine } from "@typeonce/effect-machine"
 import { Effect } from "effect"
 import { describe, expect, it } from "vitest"
+import { makeTextRenderer } from "../../../test/visualization/text.ts"
 import { CharacterMachine, type CharacterSnapshot, Event } from "./machine.ts"
+
+const renderMachine = makeTextRenderer<typeof CharacterMachine, CharacterSnapshot>(Machine)
 
 const playingSnapshot = (snapshot: CharacterSnapshot) => {
   const locomotion = snapshot.states.locomotion.state
@@ -15,6 +18,31 @@ const runPlan = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   Effect.runPromise(effect as unknown as Effect.Effect<A, E, never>)
 
 describe("platformer history integration", () => {
+  it("renders registered and candidate events separately from states", async () => {
+    await runPlan(Effect.gen(function*() {
+      const initial = yield* Machine.planInitial(CharacterMachine)
+      const definitions = Machine.transitionDefinitions(CharacterMachine)
+      const rendered = renderMachine(CharacterMachine, initial.state)
+
+      expect(definitions).toHaveLength(27)
+      expect(definitions).toContainEqual({
+        source: "Character.locomotion.Playing.Airborne.airJump",
+        trigger: { type: "event", event: "WallJump" },
+        reenter: true,
+        targets: {
+          type: "declared",
+          paths: ["Character.locomotion.Playing.Airborne.airJump.AirJumpWallLock"]
+        }
+      })
+      expect(definitions.every(({ targets }) => targets.type === "declared")).toBe(true)
+      expect(rendered).toContain("◇ on: WallJump [reenter] → AirJumpWallLock")
+      expect(rendered).toContain(
+        "Candidate events: Move, DownPressed, JumpPressed, Pause, WallJump, WallContact, Reset"
+      )
+      expect(rendered).not.toContain("Observed event samples")
+    }))
+  })
+
   it("resumes the exact grounded leaf and its state-local value", async () => {
     await runPlan(Effect.gen(function*() {
       const initial = yield* Machine.planInitial(CharacterMachine)

--- a/examples/platformer/src/machine.ts
+++ b/examples/platformer/src/machine.ts
@@ -174,7 +174,10 @@ export const CharacterMachine = Machine.make({
 }).handle({
   Character: {
     on: {
-      Reset: initialCharacter
+      Reset: {
+        targets: ["Character"],
+        transition: initialCharacter
+      }
     },
     states: {
       locomotion: {
@@ -186,59 +189,83 @@ export const CharacterMachine = Machine.make({
               }
             },
             on: {
-              Pause: ({ event, target }) =>
-                target.branch.Character.locomotion.Paused(State.cases.Paused.make({ pausedAt: event.at }))
+              Pause: {
+                targets: ["Character.locomotion.Paused"],
+                transition: ({ event, target }) =>
+                  target.branch.Character.locomotion.Paused(State.cases.Paused.make({ pausedAt: event.at }))
+              }
             },
             states: {
               Grounded: {
                 on: {
-                  JumpPressed: ({ event, target }) =>
-                    target.full.Character(State.cases.Character.make({}), (character) =>
-                      character
-                        .locomotion(State.cases.Locomotion.make({}), (locomotion) =>
-                          locomotion.Playing(State.cases.Playing.make({}), (playing) =>
-                            playing.Airborne(State.cases.Airborne.make({ originY: event.y }), (airborne) =>
-                              airborne
-                                .motion(State.cases.Motion.make({}), (motion) =>
-                                  motion.Jumping(
-                                    State.cases.Jumping.make({ startedAt: event.at, push: 0, kind: "Ground" })
-                                  ))
-                                .airJump(State.cases.AirJump.make({}), (airJump) =>
-                                  airJump.AirJumpGroundLock(State.cases.AirJumpGroundLock.make({}))))))
-                        .facing(State.cases.Facing.make({}), (facing) =>
-                          facing.Right(State.cases.Right.make({})))
-                        .contact(State.cases.WallContact.make({}), (contact) =>
-                          event.wall === -1
-                            ? contact.LeftWall(State.cases.LeftWall.make({}))
-                            : event.wall === 1
-                            ? contact.RightWall(State.cases.RightWall.make({}))
-                            : contact.NoWall(State.cases.NoWall.make({}))))
+                  JumpPressed: {
+                    targets: ["Character"],
+                    transition: ({ event, target }) =>
+                      target.full.Character(State.cases.Character.make({}), (character) =>
+                        character
+                          .locomotion(State.cases.Locomotion.make({}), (locomotion) =>
+                            locomotion.Playing(State.cases.Playing.make({}), (playing) =>
+                              playing.Airborne(State.cases.Airborne.make({ originY: event.y }), (airborne) =>
+                                airborne
+                                  .motion(State.cases.Motion.make({}), (motion) =>
+                                    motion.Jumping(
+                                      State.cases.Jumping.make({ startedAt: event.at, push: 0, kind: "Ground" })
+                                    ))
+                                  .airJump(State.cases.AirJump.make({}), (airJump) =>
+                                    airJump.AirJumpGroundLock(State.cases.AirJumpGroundLock.make({}))))))
+                          .facing(State.cases.Facing.make({}), (facing) =>
+                            facing.Right(State.cases.Right.make({})))
+                          .contact(State.cases.WallContact.make({}), (contact) =>
+                            event.wall === -1
+                              ? contact.LeftWall(State.cases.LeftWall.make({}))
+                              : event.wall === 1
+                              ? contact.RightWall(State.cases.RightWall.make({}))
+                              : contact.NoWall(State.cases.NoWall.make({}))))
+                  }
                 },
                 states: {
                   Standing: {
                     on: {
-                      Move: ({ event, target }) =>
-                        event.axis === 0
-                          ? undefined
-                          : target.local.Running(State.cases.Running.make({ startedAt: event.at })),
-                      DownPressed: ({ event, target }) =>
-                        target.local.Ducking(State.cases.Ducking.make({ startedAt: event.at }))
+                      Move: {
+                        targets: ["Character.locomotion.Playing.Grounded.Running"],
+                        transition: ({ event, target }) =>
+                          event.axis === 0
+                            ? undefined
+                            : target.local.Running(State.cases.Running.make({ startedAt: event.at }))
+                      },
+                      DownPressed: {
+                        targets: ["Character.locomotion.Playing.Grounded.Ducking"],
+                        transition: ({ event, target }) =>
+                          target.local.Ducking(State.cases.Ducking.make({ startedAt: event.at }))
+                      }
                     }
                   },
                   Running: {
                     on: {
-                      Move: ({ event, target }) =>
-                        event.axis === 0 ? target.local.Standing(State.cases.Standing.make({})) : undefined,
-                      DownPressed: ({ event, target }) =>
-                        target.local.Ducking(State.cases.Ducking.make({ startedAt: event.at }))
+                      Move: {
+                        targets: ["Character.locomotion.Playing.Grounded.Standing"],
+                        transition: ({ event, target }) =>
+                          event.axis === 0 ? target.local.Standing(State.cases.Standing.make({})) : undefined
+                      },
+                      DownPressed: {
+                        targets: ["Character.locomotion.Playing.Grounded.Ducking"],
+                        transition: ({ event, target }) =>
+                          target.local.Ducking(State.cases.Ducking.make({ startedAt: event.at }))
+                      }
                     }
                   },
                   Ducking: {
                     on: {
-                      DownReleased: ({ event, target }) =>
-                        event.axis === 0
-                          ? target.local.Standing(State.cases.Standing.make({}))
-                          : target.local.Running(State.cases.Running.make({ startedAt: event.at }))
+                      DownReleased: {
+                        targets: [
+                          "Character.locomotion.Playing.Grounded.Standing",
+                          "Character.locomotion.Playing.Grounded.Running"
+                        ],
+                        transition: ({ event, target }) =>
+                          event.axis === 0
+                            ? target.local.Standing(State.cases.Standing.make({}))
+                            : target.local.Running(State.cases.Running.make({ startedAt: event.at }))
+                      }
                     }
                   },
                   Landing: {
@@ -246,65 +273,95 @@ export const CharacterMachine = Machine.make({
                       id: "landing-settle"
                     }),
                     on: {
-                      Move: ({ event, state, target }) =>
-                        target.local.Landing(Machine.retag(State.cases.Landing, state, { resumeAxis: event.axis })),
-                      LandingSettled: ({ state, target }) =>
-                        state.resumeAxis === 0
-                          ? target.local.Standing(State.cases.Standing.make({}))
-                          : target.local.Running(State.cases.Running.make({ startedAt: state.landedAt + 140 }))
+                      Move: {
+                        targets: ["Character.locomotion.Playing.Grounded.Landing"],
+                        transition: ({ event, state, target }) =>
+                          target.local.Landing(Machine.retag(State.cases.Landing, state, { resumeAxis: event.axis }))
+                      },
+                      LandingSettled: {
+                        targets: [
+                          "Character.locomotion.Playing.Grounded.Standing",
+                          "Character.locomotion.Playing.Grounded.Running"
+                        ],
+                        transition: ({ state, target }) =>
+                          state.resumeAxis === 0
+                            ? target.local.Standing(State.cases.Standing.make({}))
+                            : target.local.Running(State.cases.Running.make({ startedAt: state.landedAt + 140 }))
+                      }
                     }
                   }
                 }
               },
               Airborne: {
                 on: {
-                  JumpPressed: Effect.fn(function*({ event, runtime }) {
-                    const machine = yield* runtime
-                    const push = awayFrom(event.wall)
-                    yield* machine.raise(
-                      push === 0
-                        ? InternalEvent.cases.TryAirJump.make({ at: event.at })
-                        : InternalEvent.cases.WallJump.make({ at: event.at, push })
-                    )
-                  }),
-                  Landed: ({ event, target }) =>
-                    target.branch.Character.locomotion.Playing.Grounded(
-                      State.cases.Grounded.make({}),
-                      (grounded) =>
-                        grounded.Landing(
-                          State.cases.Landing.make({
-                            impact: event.impact,
-                            resumeAxis: event.axis,
-                            landedAt: event.at
-                          })
-                        )
-                    )
+                  JumpPressed: {
+                    targets: [],
+                    transition: Effect.fn(function*({ event, runtime }) {
+                      const machine = yield* runtime
+                      const push = awayFrom(event.wall)
+                      yield* machine.raise(
+                        push === 0
+                          ? InternalEvent.cases.TryAirJump.make({ at: event.at })
+                          : InternalEvent.cases.WallJump.make({ at: event.at, push })
+                      )
+                    })
+                  },
+                  Landed: {
+                    targets: ["Character.locomotion.Playing.Grounded.Landing"],
+                    transition: ({ event, target }) =>
+                      target.branch.Character.locomotion.Playing.Grounded(
+                        State.cases.Grounded.make({}),
+                        (grounded) =>
+                          grounded.Landing(
+                            State.cases.Landing.make({
+                              impact: event.impact,
+                              resumeAxis: event.axis,
+                              landedAt: event.at
+                            })
+                          )
+                      )
+                  }
                 },
                 states: {
                   motion: {
                     on: {
-                      DoubleJump: ({ event, target }) =>
-                        target.local.Jumping(
-                          State.cases.Jumping.make({ startedAt: event.at, push: 0, kind: "Double" })
-                        ),
-                      WallJump: ({ event, target }) =>
-                        target.local.Jumping(
-                          State.cases.Jumping.make({ startedAt: event.at, push: event.push, kind: "Wall" })
-                        )
+                      DoubleJump: {
+                        targets: ["Character.locomotion.Playing.Airborne.motion.Jumping"],
+                        transition: ({ event, target }) =>
+                          target.local.Jumping(
+                            State.cases.Jumping.make({ startedAt: event.at, push: 0, kind: "Double" })
+                          )
+                      },
+                      WallJump: {
+                        targets: ["Character.locomotion.Playing.Airborne.motion.Jumping"],
+                        transition: ({ event, target }) =>
+                          target.local.Jumping(
+                            State.cases.Jumping.make({ startedAt: event.at, push: event.push, kind: "Wall" })
+                          )
+                      }
                     },
                     states: {
                       Jumping: {
                         on: {
-                          ApexReached: ({ event, target }) =>
-                            target.local.Falling(State.cases.Falling.make({ apexY: event.y })),
-                          DownPressed: ({ event, target }) =>
-                            target.local.Diving(State.cases.Diving.make({ startedAt: event.at }))
+                          ApexReached: {
+                            targets: ["Character.locomotion.Playing.Airborne.motion.Falling"],
+                            transition: ({ event, target }) =>
+                              target.local.Falling(State.cases.Falling.make({ apexY: event.y }))
+                          },
+                          DownPressed: {
+                            targets: ["Character.locomotion.Playing.Airborne.motion.Diving"],
+                            transition: ({ event, target }) =>
+                              target.local.Diving(State.cases.Diving.make({ startedAt: event.at }))
+                          }
                         }
                       },
                       Falling: {
                         on: {
-                          DownPressed: ({ event, target }) =>
-                            target.local.Diving(State.cases.Diving.make({ startedAt: event.at }))
+                          DownPressed: {
+                            targets: ["Character.locomotion.Playing.Airborne.motion.Diving"],
+                            transition: ({ event, target }) =>
+                              target.local.Diving(State.cases.Diving.make({ startedAt: event.at }))
+                          }
                         }
                       },
                       Diving: {}
@@ -314,6 +371,7 @@ export const CharacterMachine = Machine.make({
                     on: {
                       WallJump: {
                         reenter: true,
+                        targets: ["Character.locomotion.Playing.Airborne.airJump.AirJumpWallLock"],
                         transition: ({ target }) => target.local.AirJumpWallLock(State.cases.AirJumpWallLock.make({}))
                       }
                     },
@@ -323,7 +381,10 @@ export const CharacterMachine = Machine.make({
                           id: "ground-air-jump-unlock"
                         }),
                         on: {
-                          AirJumpUnlocked: ({ target }) => target.local.AirJumpReady(State.cases.AirJumpReady.make({}))
+                          AirJumpUnlocked: {
+                            targets: ["Character.locomotion.Playing.Airborne.airJump.AirJumpReady"],
+                            transition: ({ target }) => target.local.AirJumpReady(State.cases.AirJumpReady.make({}))
+                          }
                         }
                       },
                       AirJumpWallLock: {
@@ -331,16 +392,22 @@ export const CharacterMachine = Machine.make({
                           id: "wall-air-jump-unlock"
                         }),
                         on: {
-                          AirJumpUnlocked: ({ target }) => target.local.AirJumpReady(State.cases.AirJumpReady.make({}))
+                          AirJumpUnlocked: {
+                            targets: ["Character.locomotion.Playing.Airborne.airJump.AirJumpReady"],
+                            transition: ({ target }) => target.local.AirJumpReady(State.cases.AirJumpReady.make({}))
+                          }
                         }
                       },
                       AirJumpReady: {
                         on: {
-                          TryAirJump: Effect.fn(function*({ event, runtime, target }) {
-                            const machine = yield* runtime
-                            yield* machine.raise(InternalEvent.cases.DoubleJump.make({ at: event.at }))
-                            return target.local.AirJumpSpent(State.cases.AirJumpSpent.make({}))
-                          })
+                          TryAirJump: {
+                            targets: ["Character.locomotion.Playing.Airborne.airJump.AirJumpSpent"],
+                            transition: Effect.fn(function*({ event, runtime, target }) {
+                              const machine = yield* runtime
+                              yield* machine.raise(InternalEvent.cases.DoubleJump.make({ at: event.at }))
+                              return target.local.AirJumpSpent(State.cases.AirJumpSpent.make({}))
+                            })
+                          }
                         }
                       },
                       AirJumpSpent: {}
@@ -352,7 +419,10 @@ export const CharacterMachine = Machine.make({
           },
           Paused: {
             on: {
-              Resume: ({ target }) => target.history.Character.locomotion.Playing.resume()
+              Resume: {
+                targets: ["Character.locomotion.Playing.resume"],
+                transition: ({ target }) => target.history.Character.locomotion.Playing.resume()
+              }
             }
           }
         }
@@ -361,29 +431,45 @@ export const CharacterMachine = Machine.make({
         states: {
           Left: {
             on: {
-              Move: ({ event, target }) =>
-                event.axis === 1 ? target.local.Right(State.cases.Right.make({})) : undefined,
-              WallJump: ({ event, target }) =>
-                event.push === 1 ? target.local.Right(State.cases.Right.make({})) : undefined
+              Move: {
+                targets: ["Character.facing.Right"],
+                transition: ({ event, target }) =>
+                  event.axis === 1 ? target.local.Right(State.cases.Right.make({})) : undefined
+              },
+              WallJump: {
+                targets: ["Character.facing.Right"],
+                transition: ({ event, target }) =>
+                  event.push === 1 ? target.local.Right(State.cases.Right.make({})) : undefined
+              }
             }
           },
           Right: {
             on: {
-              Move: ({ event, target }) => event.axis === -1 ? target.local.Left(State.cases.Left.make({})) : undefined,
-              WallJump: ({ event, target }) =>
-                event.push === -1 ? target.local.Left(State.cases.Left.make({})) : undefined
+              Move: {
+                targets: ["Character.facing.Left"],
+                transition: ({ event, target }) =>
+                  event.axis === -1 ? target.local.Left(State.cases.Left.make({})) : undefined
+              },
+              WallJump: {
+                targets: ["Character.facing.Left"],
+                transition: ({ event, target }) =>
+                  event.push === -1 ? target.local.Left(State.cases.Left.make({})) : undefined
+              }
             }
           }
         }
       },
       contact: {
         on: {
-          WallContact: ({ event, target }) =>
-            event.wall === -1
-              ? target.local.LeftWall(State.cases.LeftWall.make({}))
-              : event.wall === 1
-              ? target.local.RightWall(State.cases.RightWall.make({}))
-              : target.local.NoWall(State.cases.NoWall.make({}))
+          WallContact: {
+            targets: ["Character.contact.NoWall", "Character.contact.LeftWall", "Character.contact.RightWall"],
+            transition: ({ event, target }) =>
+              event.wall === -1
+                ? target.local.LeftWall(State.cases.LeftWall.make({}))
+                : event.wall === 1
+                ? target.local.RightWall(State.cases.RightWall.make({}))
+                : target.local.NoWall(State.cases.NoWall.make({}))
+          }
         },
         states: {
           NoWall: {},

--- a/examples/visualizer/.gitignore
+++ b/examples/visualizer/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/examples/visualizer/README.md
+++ b/examples/visualizer/README.md
@@ -1,0 +1,15 @@
+# Effect Machine visualizer experiment
+
+This example is an external planner sandbox built only from public machine APIs. It renders static state and transition
+definitions, highlights the active configuration, and plans concrete public events without running deferred actions or
+invoked services.
+
+Named event fixtures are preferred when payload semantics matter. Missing public event cases receive deterministic
+schema-generated samples through `Schema.toArbitrary` and `fast-check`.
+
+```sh
+pnpm install
+pnpm dev
+```
+
+Use `pnpm check` to run the controller tests, typecheck the example, and build the page.

--- a/examples/visualizer/index.html
+++ b/examples/visualizer/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#f5f3ee" />
+    <title>Effect Machine Planner Sandbox</title>
+  </head>
+  <body>
+    <main id="app"></main>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/visualizer/package.json
+++ b/examples/visualizer/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@typeonce/effect-machine-example-visualizer",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Planner sandbox and generated event explorer for @typeonce/effect-machine",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "build": "pnpm typecheck && vite build",
+    "preview": "vite preview",
+    "check": "pnpm test && pnpm build"
+  },
+  "dependencies": {
+    "@typeonce/effect-machine": "file:../..",
+    "effect": "4.0.0-beta.102",
+    "fast-check": "4.9.0"
+  },
+  "devDependencies": {
+    "typescript": "6.0.3",
+    "vite": "8.1.5",
+    "vitest": "4.1.10"
+  },
+  "packageManager": "pnpm@10.17.1",
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  }
+}

--- a/examples/visualizer/pnpm-lock.yaml
+++ b/examples/visualizer/pnpm-lock.yaml
@@ -1,0 +1,941 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+overrides:
+  effect: 4.0.0-beta.102
+
+importers:
+
+  .:
+    dependencies:
+      '@typeonce/effect-machine':
+        specifier: file:../..
+        version: file:../..(effect@4.0.0-beta.102)
+      effect:
+        specifier: 4.0.0-beta.102
+        version: 4.0.0-beta.102
+      fast-check:
+        specifier: 4.9.0
+        version: 4.9.0
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vite:
+        specifier: 8.1.5
+        version: 8.1.5(yaml@2.9.0)
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(vite@8.1.5(yaml@2.9.0))
+
+packages:
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    resolution: {integrity: sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    resolution: {integrity: sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    resolution: {integrity: sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    resolution: {integrity: sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/wasm-runtime@1.2.2':
+    resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
+
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@typeonce/effect-machine@file:../..':
+    resolution: {directory: ../.., type: directory}
+    engines: {node: '>=20'}
+    peerDependencies:
+      effect: 4.0.0-beta.102
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  effect@4.0.0-beta.102:
+    resolution: {integrity: sha512-z8Y+Q76Hh/kjLFZrXu8tGn6e+tDsg45R+UHhxd190pXxD53OGwf/G/zDxXTkse4HJ5mobNZfitLfUCp4fMvu6w==}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
+    engines: {node: '>=12.17.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  find-my-way-ts@0.1.6:
+    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  ini@7.0.0:
+    resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  kubernetes-types@1.30.0:
+    resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
+
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  msgpackr-extract@3.0.4:
+    resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
+    hasBin: true
+
+  msgpackr@2.0.5:
+    resolution: {integrity: sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==}
+
+  multipasta@0.2.8:
+    resolution: {integrity: sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==}
+
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  pure-rand@8.4.2:
+    resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
+
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
+  toml@4.3.0:
+    resolution: {integrity: sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==}
+    engines: {node: '>=20'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
+
+  vite@8.1.5:
+    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+snapshots:
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@oxc-project/types@0.139.0': {}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@typeonce/effect-machine@file:../..(effect@4.0.0-beta.102)':
+    dependencies:
+      effect: 4.0.0-beta.102
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.1.5(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
+  assertion-error@2.0.1: {}
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  effect@4.0.0-beta.102:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 4.9.0
+      find-my-way-ts: 0.1.6
+      ini: 7.0.0
+      kubernetes-types: 1.30.0
+      msgpackr: 2.0.5
+      multipasta: 0.2.8
+      toml: 4.3.0
+      uuid: 14.0.1
+      yaml: 2.9.0
+
+  es-module-lexer@2.3.1: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fast-check@4.9.0:
+    dependencies:
+      pure-rand: 8.4.2
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  find-my-way-ts@0.1.6: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  ini@7.0.0: {}
+
+  kubernetes-types@1.30.0: {}
+
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  msgpackr-extract@3.0.4:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
+    optional: true
+
+  msgpackr@2.0.5:
+    optionalDependencies:
+      msgpackr-extract: 3.0.4
+
+  multipasta@0.2.8: {}
+
+  nanoid@3.3.17: {}
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
+
+  obug@2.1.4: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.25:
+    dependencies:
+      nanoid: 3.3.17
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  pure-rand@8.4.2: {}
+
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
+
+  toml@4.3.0: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@6.0.3: {}
+
+  uuid@14.0.1: {}
+
+  vite@8.1.5(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.25
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      fsevents: 2.3.3
+      yaml: 2.9.0
+
+  vitest@4.1.10(vite@8.1.5(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.1.5(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  yaml@2.9.0: {}

--- a/examples/visualizer/pnpm-workspace.yaml
+++ b/examples/visualizer/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+packages:
+  - "."
+
+overrides:
+  effect: 4.0.0-beta.102
+
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - effect@4.0.0-beta.102
+  - vite@8.1.5

--- a/examples/visualizer/src/eventSamples.test.ts
+++ b/examples/visualizer/src/eventSamples.test.ts
@@ -1,0 +1,46 @@
+import { Schema } from "effect"
+import { describe, expect, it } from "vitest"
+import { defineEventFixtures, generateEventSamples, mergeEventSamples } from "./eventSamples.ts"
+import { Event, VisualizerMachine } from "./machine.ts"
+
+describe("generated event samples", () => {
+  it("generates one deterministic, valid value for every tagged-union case", () => {
+    const first = generateEventSamples(VisualizerMachine, { seed: 123 })
+    const second = generateEventSamples(VisualizerMachine, { seed: 123 })
+
+    expect(first.issues).toEqual([])
+    expect(first.samples).toEqual(second.samples)
+    expect(first.samples.map(({ event }) => event._tag).sort()).toEqual([
+      "Approve",
+      "Disconnect",
+      "Edit",
+      "Reconnect",
+      "Reset",
+      "Start",
+      "Submit"
+    ])
+    expect(first.samples.every(({ event }) => Schema.is(Event)(event))).toBe(true)
+  })
+
+  it("prefers named fixtures over generated values for the same tag", () => {
+    const generated = generateEventSamples(VisualizerMachine, { seed: 123 })
+    const fixtures = defineEventFixtures(VisualizerMachine, [
+      {
+        id: "start-known-task",
+        label: "Start known task",
+        event: Event.cases.Start.make({ task: "Known task" })
+      }
+    ])
+    const merged = mergeEventSamples(generated.samples, fixtures)
+    const starts = merged.filter(({ event }) => event._tag === "Start")
+
+    expect(starts).toEqual([
+      {
+        id: "start-known-task",
+        label: "Start known task",
+        event: Event.cases.Start.make({ task: "Known task" }),
+        origin: "fixture"
+      }
+    ])
+  })
+})

--- a/examples/visualizer/src/eventSamples.ts
+++ b/examples/visualizer/src/eventSamples.ts
@@ -1,0 +1,110 @@
+import { Machine } from "@typeonce/effect-machine"
+import { Schema } from "effect"
+import * as FastCheck from "fast-check"
+
+export interface EventSample<Event extends { readonly _tag: PropertyKey }> {
+  readonly id: string
+  readonly label: string
+  readonly event: Event
+  readonly origin: "fixture" | "generated"
+}
+
+export interface EventFixture<Event extends { readonly _tag: PropertyKey }> {
+  readonly id: string
+  readonly label: string
+  readonly event: Event
+}
+
+export interface EventSampleIssue {
+  readonly schema: string
+  readonly message: string
+}
+
+export interface GeneratedEventSamples<Event extends { readonly _tag: PropertyKey }> {
+  readonly samples: ReadonlyArray<EventSample<Event>>
+  readonly issues: ReadonlyArray<EventSampleIssue>
+}
+
+export const defineEventFixtures = <
+  M extends Machine.Machine.Any,
+  const Fixtures extends ReadonlyArray<EventFixture<Machine.Machine.InputEvent<M>>>
+>(
+  _machine: M,
+  fixtures: Fixtures
+): Fixtures => fixtures
+
+const hasCases = (schema: unknown): schema is { readonly cases: Readonly<Record<PropertyKey, Schema.Constraint>> } =>
+  (typeof schema === "object" || typeof schema === "function") && schema !== null && "cases" in schema &&
+  typeof schema.cases === "object" && schema.cases !== null
+
+const printableError = (error: unknown): string => error instanceof Error ? error.message : String(error)
+
+const caseSchemas = (
+  schemas: ReadonlyArray<Machine.Machine.TaggedSchema>
+): ReadonlyArray<readonly [string, Schema.Constraint]> => {
+  const cases: Array<readonly [string, Schema.Constraint]> = []
+
+  schemas.forEach((schema, schemaIndex) => {
+    if (hasCases(schema)) {
+      for (const key of Reflect.ownKeys(schema.cases)) {
+        const member = schema.cases[key]
+        if (member !== undefined) cases.push([String(key), member])
+      }
+      return
+    }
+    cases.push([`schema-${schemaIndex + 1}`, schema as Schema.Constraint])
+  })
+
+  return cases
+}
+
+export const generateEventSamples = <M extends Machine.Machine.Any>(
+  machine: M,
+  options?: {
+    readonly seed?: number
+  }
+): GeneratedEventSamples<Machine.Machine.InputEvent<M>> => {
+  const samples: Array<EventSample<Machine.Machine.InputEvent<M>>> = []
+  const issues: Array<EventSampleIssue> = []
+  const seed = options?.seed ?? 42
+
+  caseSchemas(machine.events).forEach(([schemaName, schema], index) => {
+    try {
+      const { report, value } = Schema.toArbitrary(schema, { report: true })
+      const event = FastCheck.sample(value, { numRuns: 1, seed: seed + index })[0] as
+        | Machine.Machine.InputEvent<M>
+        | undefined
+      if (event === undefined || typeof event !== "object" || !("_tag" in event)) {
+        issues.push({ schema: schemaName, message: "The schema did not generate a tagged event" })
+        return
+      }
+      samples.push({
+        id: `generated-${String(event._tag)}`,
+        label: String(event._tag),
+        event,
+        origin: "generated"
+      })
+      for (const warning of report.warnings) {
+        issues.push({
+          schema: schemaName,
+          message: `${warning._tag} at ${warning.path.map(String).join(".") || "<root>"}`
+        })
+      }
+    } catch (error) {
+      issues.push({ schema: schemaName, message: printableError(error) })
+    }
+  })
+
+  return { samples, issues }
+}
+
+export const mergeEventSamples = <Event extends { readonly _tag: PropertyKey }>(
+  generated: ReadonlyArray<EventSample<Event>>,
+  fixtures: ReadonlyArray<EventFixture<Event>>
+): ReadonlyArray<EventSample<Event>> => {
+  const fixtureTags = new Set(fixtures.map(({ event }) => event._tag))
+  return [
+    ...fixtures.map((fixture): EventSample<Event> => ({ ...fixture, origin: "fixture" })),
+    ...generated.filter(({ event }) => !fixtureTags.has(event._tag))
+  ]
+}

--- a/examples/visualizer/src/graph.test.ts
+++ b/examples/visualizer/src/graph.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+import { buildDiagramGraph } from "./graph.ts"
+import { VisualizerMachine } from "./machine.ts"
+
+describe("diagram graph", () => {
+  it("lays out nested and parallel state nodes using public inspection data", () => {
+    const graph = buildDiagramGraph(VisualizerMachine)
+    const application = graph.nodes.find(({ path }) => path === "application")
+    const editing = graph.nodes.find(({ path }) => path === "application.workflow.running.editing")
+    const online = graph.nodes.find(({ path }) => path === "application.connection.online")
+
+    expect(application?.type).toBe("parallel")
+    expect(editing?.depth).toBe(3)
+    expect(online?.depth).toBe(2)
+    expect(graph.nodes.every((node) => node.x >= 0 && node.y >= 0)).toBe(true)
+    expect(graph.nodes.every((node) => node.x + node.width <= graph.width)).toBe(true)
+    expect(graph.nodes.every((node) => node.y + node.height <= graph.height)).toBe(true)
+  })
+
+  it("keeps declared transition targets available to the renderer", () => {
+    const graph = buildDiagramGraph(VisualizerMachine)
+    const start = graph.transitions.find((transition) =>
+      transition.trigger.type === "event" && transition.trigger.event === "Start"
+    )
+
+    expect(start).toMatchObject({
+      source: "application.workflow.idle",
+      targets: {
+        type: "declared",
+        paths: ["application.workflow.running"]
+      }
+    })
+    expect(graph.transitions.every(({ targets }) => targets.type === "declared")).toBe(true)
+  })
+})

--- a/examples/visualizer/src/graph.ts
+++ b/examples/visualizer/src/graph.ts
@@ -1,0 +1,146 @@
+import { Machine } from "@typeonce/effect-machine"
+
+const leafWidth = 112
+const leafHeight = 58
+const historyWidth = 100
+const historyHeight = 46
+const groupMinWidth = 164
+const groupHeader = 36
+const groupPadding = 14
+const childGap = 24
+const rootGap = 40
+const canvasPadding = 24
+
+export interface DiagramNode {
+  readonly path: string
+  readonly key: string
+  readonly type: Machine.Machine.StateNode["type"]
+  readonly parent: string | undefined
+  readonly initial: string | undefined
+  readonly depth: number
+  readonly x: number
+  readonly y: number
+  readonly width: number
+  readonly height: number
+}
+
+export interface DiagramTransition {
+  readonly id: string
+  readonly source: string
+  readonly trigger:
+    | { readonly type: "event"; readonly event: PropertyKey }
+    | { readonly type: "always" }
+    | { readonly type: "done" }
+  readonly reenter: boolean
+  readonly targets:
+    | { readonly type: "dynamic" }
+    | { readonly type: "declared"; readonly paths: ReadonlyArray<string> }
+}
+
+export interface DiagramGraph {
+  readonly id: string
+  readonly width: number
+  readonly height: number
+  readonly nodes: ReadonlyArray<DiagramNode>
+  readonly transitions: ReadonlyArray<DiagramTransition>
+}
+
+interface Dimensions {
+  readonly width: number
+  readonly height: number
+}
+
+export const buildDiagramGraph = <M extends Machine.Machine.Any>(machine: M): DiagramGraph => {
+  const definitions = Machine.stateNodes(machine)
+  const byPath = new Map(definitions.map((node) => [node.path as string, node]))
+  const children = new Map<string | undefined, Array<string>>()
+
+  for (const node of definitions) {
+    const siblings = children.get(node.parent) ?? []
+    siblings.push(node.path)
+    children.set(node.parent, siblings)
+  }
+
+  const dimensions = new Map<string, Dimensions>()
+  const measure = (path: string): Dimensions => {
+    const cached = dimensions.get(path)
+    if (cached !== undefined) return cached
+    const node = byPath.get(path)
+    if (node === undefined) throw new Error(`Missing diagram node: ${path}`)
+    const childPaths = children.get(path) ?? []
+    const result = childPaths.length === 0
+      ? node.type === "history"
+        ? { width: historyWidth, height: historyHeight }
+        : { width: leafWidth, height: leafHeight }
+      : (() => {
+        const childDimensions = childPaths.map(measure)
+        return {
+          width: Math.max(
+            groupMinWidth,
+            groupPadding * 2 + childDimensions.reduce((total, child) => total + child.width, 0) +
+              childGap * Math.max(0, childDimensions.length - 1)
+          ),
+          height: groupHeader + groupPadding * 2 + Math.max(...childDimensions.map(({ height }) => height))
+        }
+      })()
+    dimensions.set(path, result)
+    return result
+  }
+
+  const roots = children.get(undefined) ?? []
+  roots.forEach(measure)
+  const positioned: Array<DiagramNode> = []
+
+  const place = (path: string, x: number, y: number, depth: number): void => {
+    const node = byPath.get(path)
+    const size = dimensions.get(path)
+    if (node === undefined || size === undefined) throw new Error(`Missing measured diagram node: ${path}`)
+    positioned.push({
+      path,
+      key: node.key,
+      type: node.type,
+      parent: node.parent,
+      initial: node.initial,
+      depth,
+      x,
+      y,
+      ...size
+    })
+
+    let childX = x + groupPadding
+    const childY = y + groupHeader + groupPadding
+    for (const childPath of children.get(path) ?? []) {
+      place(childPath, childX, childY, depth + 1)
+      childX += measure(childPath).width + childGap
+    }
+  }
+
+  let rootX = canvasPadding
+  for (const root of roots) {
+    place(root, rootX, canvasPadding, 0)
+    rootX += measure(root).width + rootGap
+  }
+
+  const width = Math.max(
+    360,
+    positioned.reduce((maximum, node) => Math.max(maximum, node.x + node.width + canvasPadding), 0)
+  )
+  const height = Math.max(
+    220,
+    positioned.reduce((maximum, node) => Math.max(maximum, node.y + node.height + canvasPadding), 0)
+  )
+
+  return {
+    id: machine.id ?? "Machine",
+    width,
+    height,
+    nodes: positioned,
+    transitions: Machine.transitionDefinitions(machine).map((definition, index) => ({
+      id: `${definition.source}:${definition.trigger.type}:${index}`,
+      source: definition.source,
+      trigger: definition.trigger,
+      reenter: definition.reenter,
+      targets: definition.targets
+    }))
+  }
+}

--- a/examples/visualizer/src/machine.ts
+++ b/examples/visualizer/src/machine.ts
@@ -1,0 +1,170 @@
+import { Machine } from "@typeonce/effect-machine"
+import { Schema } from "effect"
+
+const State = Schema.TaggedUnion({
+  Application: {},
+  Workflow: {},
+  Idle: {},
+  Running: { task: Schema.String },
+  Editing: { note: Schema.String },
+  Reviewing: { reviewer: Schema.String },
+  Complete: { result: Schema.String },
+  Connection: {},
+  Online: { connectedAt: Schema.Number },
+  Offline: { reason: Schema.String }
+})
+
+export const Event = Schema.TaggedUnion({
+  Start: {
+    task: Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(24))
+  },
+  Edit: {
+    note: Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(20))
+  },
+  Submit: {
+    reviewer: Schema.Literals(["Ada", "Grace", "Linus"])
+  },
+  Approve: {
+    result: Schema.Literals(["approved", "changes-requested"])
+  },
+  Reset: {},
+  Disconnect: {
+    reason: Schema.Literals(["manual", "server", "wifi"])
+  },
+  Reconnect: {
+    at: Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 1_000 }))
+  }
+})
+
+export const VisualizerStates = Machine.defineStates({
+  application: {
+    schema: State.cases.Application,
+    type: "parallel",
+    states: {
+      workflow: {
+        schema: State.cases.Workflow,
+        initial: "idle",
+        states: {
+          idle: State.cases.Idle,
+          running: {
+            schema: State.cases.Running,
+            initial: "editing",
+            states: {
+              editing: State.cases.Editing,
+              reviewing: State.cases.Reviewing
+            }
+          },
+          complete: State.cases.Complete
+        }
+      },
+      connection: {
+        schema: State.cases.Connection,
+        initial: "online",
+        states: {
+          online: State.cases.Online,
+          offline: State.cases.Offline
+        }
+      }
+    }
+  }
+})
+
+const initial = () =>
+  VisualizerStates.initial.application(State.cases.Application.make({}), (application) =>
+    application
+      .workflow(State.cases.Workflow.make({}), (workflow) => workflow.idle(State.cases.Idle.make({})))
+      .connection(State.cases.Connection.make({}), (connection) =>
+        connection.online(State.cases.Online.make({ connectedAt: 0 }))))
+
+export const VisualizerMachine = Machine.make({
+  id: "planner-sandbox",
+  states: VisualizerStates.states,
+  events: [Event],
+  initial
+}).handle({
+  application: {
+    states: {
+      workflow: {
+        states: {
+          idle: {
+            on: {
+              Start: {
+                targets: ["application.workflow.running"],
+                transition: ({ event, target }) =>
+                  target.local.running(
+                    State.cases.Running.make({ task: event.task }),
+                    (running) => running.editing(State.cases.Editing.make({ note: "draft" }))
+                  )
+              }
+            }
+          },
+          running: {
+            states: {
+              editing: {
+                on: {
+                  Edit: {
+                    targets: ["application.workflow.running.editing"],
+                    transition: ({ event, target }) =>
+                      target.local.editing(State.cases.Editing.make({ note: event.note }))
+                  },
+                  Submit: {
+                    targets: ["application.workflow.running.reviewing"],
+                    transition: ({ event, target }) =>
+                      target.local.reviewing(State.cases.Reviewing.make({ reviewer: event.reviewer }))
+                  }
+                }
+              },
+              reviewing: {
+                on: {
+                  Approve: {
+                    targets: ["application.workflow.complete"],
+                    transition: ({ event, target }) =>
+                      target.branch.application.workflow.complete(State.cases.Complete.make({ result: event.result }))
+                  },
+                  Edit: {
+                    targets: ["application.workflow.running.editing"],
+                    transition: ({ event, target }) =>
+                      target.local.editing(State.cases.Editing.make({ note: event.note }))
+                  }
+                }
+              }
+            }
+          },
+          complete: {
+            on: {
+              Reset: {
+                targets: ["application.workflow.idle"],
+                transition: ({ target }) => target.local.idle(State.cases.Idle.make({}))
+              }
+            }
+          }
+        }
+      },
+      connection: {
+        states: {
+          online: {
+            on: {
+              Disconnect: {
+                targets: ["application.connection.offline"],
+                transition: ({ event, target }) =>
+                  target.local.offline(State.cases.Offline.make({ reason: event.reason }))
+              }
+            }
+          },
+          offline: {
+            on: {
+              Reconnect: {
+                targets: ["application.connection.online"],
+                transition: ({ event, target }) =>
+                  target.local.online(State.cases.Online.make({ connectedAt: event.at }))
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+})
+
+export type VisualizerEvent = Machine.Machine.InputEvent<typeof VisualizerMachine>
+export type VisualizerSnapshot = Machine.Machine.Snapshot<Machine.Machine.States<typeof VisualizerMachine>>

--- a/examples/visualizer/src/main.ts
+++ b/examples/visualizer/src/main.ts
@@ -1,0 +1,338 @@
+import "./styles.css"
+import { Machine } from "@typeonce/effect-machine"
+import { Effect } from "effect"
+import { defineEventFixtures, type EventSample, generateEventSamples, mergeEventSamples } from "./eventSamples.ts"
+import { buildDiagramGraph, type DiagramNode, type DiagramTransition } from "./graph.ts"
+import { Event, type VisualizerEvent, VisualizerMachine } from "./machine.ts"
+import { createPlannerSession, type PlannerView } from "./plannerSession.ts"
+
+const requiredElement = <ElementType extends Element>(selector: string): ElementType => {
+  const element = document.querySelector<ElementType>(selector)
+  if (element === null) throw new Error(`Missing element: ${selector}`)
+  return element
+}
+
+const explicitFixtures = defineEventFixtures(VisualizerMachine, [
+  {
+    id: "start-visualizer",
+    label: "Start visualizer task",
+    event: Event.cases.Start.make({ task: "Visualize machine" })
+  }
+])
+const generated = generateEventSamples(VisualizerMachine, { seed: 20_260_805 })
+const samples = mergeEventSamples(generated.samples, explicitFixtures)
+const samplesByTag = new Map<PropertyKey, EventSample<VisualizerEvent>>()
+for (const sample of samples) {
+  if (!samplesByTag.has(sample.event._tag)) samplesByTag.set(sample.event._tag, sample)
+}
+
+const session = await createPlannerSession(
+  {
+    machine: VisualizerMachine,
+    initial: () => Effect.runPromise(Machine.planInitial(VisualizerMachine)).then(({ state }) => state),
+    enabled: (snapshot) => Machine.enabled(VisualizerMachine, snapshot),
+    plan: (snapshot, event) => Effect.runPromise(Machine.plan(VisualizerMachine, snapshot, event))
+  },
+  samples
+)
+const graph = buildDiagramGraph(VisualizerMachine)
+const nodesByPath = new Map(graph.nodes.map((node) => [node.path, node]))
+
+document.title = `${graph.id} · Effect Machine`
+requiredElement<HTMLElement>("#app").innerHTML = `
+  <header class="page-header">
+    <div>
+      <p class="eyebrow">@typeonce/effect-machine · planner experiment</p>
+      <h1>${graph.id}</h1>
+      <p class="lede">Click a currently enabled event to plan the next settled snapshot.</p>
+    </div>
+    <button class="reset-button" id="reset-session" type="button">Restart session</button>
+  </header>
+  <section class="workspace">
+    <div class="diagram-panel">
+      <div class="diagram-heading">
+        <div>
+          <strong>Statechart</strong>
+          <span id="active-summary"></span>
+        </div>
+        <div class="legend" aria-label="Diagram legend">
+          <span><i class="legend-dot active"></i>active</span>
+          <span><i class="legend-dot"></i>inactive</span>
+          <span><i class="legend-line"></i>declared transition</span>
+        </div>
+      </div>
+      <div class="diagram-viewport">
+        <div class="diagram-canvas" id="diagram-canvas"></div>
+      </div>
+      <p class="step-summary" id="step-summary">Machine initialized. No event has been planned yet.</p>
+      <p class="error-summary" id="error-summary" role="alert"></p>
+    </div>
+    <aside class="events-panel">
+      <div class="events-heading">
+        <strong>Enabled event values</strong>
+        <span>seed 20,260,805</span>
+      </div>
+      <div id="event-list" class="event-list"></div>
+      <div id="generation-issues" class="generation-issues"></div>
+    </aside>
+  </section>
+  <p class="planner-note">
+    This sandbox calls <code>Machine.plan</code>. It settles raised, eventless, and completion transitions, but it does
+    not execute deferred actions, timers, or invoked services.
+  </p>
+`
+
+const svgElement = <Name extends keyof SVGElementTagNameMap>(
+  name: Name,
+  attributes: Readonly<Record<string, string | number>> = {}
+): SVGElementTagNameMap[Name] => {
+  const element = document.createElementNS("http://www.w3.org/2000/svg", name)
+  for (const [key, value] of Object.entries(attributes)) element.setAttribute(key, String(value))
+  return element
+}
+
+const center = (node: DiagramNode) => ({
+  x: node.x + node.width / 2,
+  y: node.y + node.height / 2
+})
+
+const edgePath = (source: DiagramNode, target: DiagramNode): string => {
+  const from = center(source)
+  const to = center(target)
+  if (source.path === target.path) {
+    const right = source.x + source.width
+    const top = source.y
+    return `M ${right - 16} ${top + 16} C ${right + 54} ${top - 46}, ${source.x + 32} ${top - 46}, ${source.x + 16} ${
+      top + 12
+    }`
+  }
+
+  const horizontal = Math.abs(to.x - from.x) >= Math.abs(to.y - from.y)
+  if (horizontal) {
+    const forwards = to.x >= from.x
+    const startX = forwards ? source.x + source.width : source.x
+    const endX = forwards ? target.x : target.x + target.width
+    const middleX = (startX + endX) / 2
+    const laneOffset = forwards ? -12 : 12
+    return `M ${startX} ${from.y} C ${middleX} ${from.y + laneOffset}, ${middleX} ${to.y + laneOffset}, ${endX} ${to.y}`
+  }
+  const downwards = to.y >= from.y
+  const startY = downwards ? source.y + source.height : source.y
+  const endY = downwards ? target.y : target.y + target.height
+  const middleY = (startY + endY) / 2
+  return `M ${from.x} ${startY} C ${from.x} ${middleY}, ${to.x} ${middleY}, ${to.x} ${endY}`
+}
+
+const eventPoint = (transition: DiagramTransition): { readonly x: number; readonly y: number } => {
+  const source = nodesByPath.get(transition.source)
+  if (source === undefined) return { x: 0, y: 0 }
+  if (transition.targets.type === "declared" && transition.targets.paths.length > 0) {
+    const target = nodesByPath.get(transition.targets.paths[0]!)
+    if (target !== undefined) {
+      const from = center(source)
+      const to = center(target)
+      if (source.path === target.path) return { x: from.x, y: source.y - 20 }
+      const horizontal = Math.abs(to.x - from.x) >= Math.abs(to.y - from.y)
+      return {
+        x: (from.x + to.x) / 2 + (horizontal ? 0 : to.y >= from.y ? 16 : -16),
+        y: (from.y + to.y) / 2 + (horizontal ? to.x >= from.x ? -14 : 14 : 0)
+      }
+    }
+  }
+  return { x: source.x + source.width / 2, y: source.y - 18 }
+}
+
+const canvas = requiredElement<HTMLElement>("#diagram-canvas")
+canvas.style.width = `${graph.width}px`
+canvas.style.height = `${graph.height}px`
+const svg = svgElement("svg", {
+  viewBox: `0 0 ${graph.width} ${graph.height}`,
+  width: graph.width,
+  height: graph.height,
+  role: "img",
+  "aria-label": `${graph.id} statechart`
+})
+canvas.append(svg)
+
+const definitions = svgElement("defs")
+const marker = svgElement("marker", {
+  id: "arrow",
+  viewBox: "0 0 10 10",
+  refX: 9,
+  refY: 5,
+  markerWidth: 7,
+  markerHeight: 7,
+  orient: "auto-start-reverse"
+})
+marker.append(svgElement("path", { d: "M 0 0 L 10 5 L 0 10 z", class: "arrow-head" }))
+definitions.append(marker)
+svg.append(definitions)
+
+const nodeElements = new Map<string, SVGGElement>()
+const drawNode = (node: DiagramNode, group: boolean): void => {
+  const element = svgElement("g", { class: `state-node ${group ? "state-group" : "state-leaf"}` })
+  element.dataset.nodePath = node.path
+  const box = svgElement("rect", {
+    x: node.x,
+    y: node.y,
+    width: node.width,
+    height: node.height,
+    rx: group ? 16 : node.type === "history" ? 24 : 10,
+    class: "state-box"
+  })
+  const label = svgElement("text", {
+    x: node.x + (group ? 15 : node.width / 2),
+    y: node.y + (group ? 24 : node.height / 2 + 5),
+    class: "state-label",
+    "text-anchor": group ? "start" : "middle"
+  })
+  label.textContent = node.key
+  element.append(box, label)
+  if (group) {
+    const kind = svgElement("text", {
+      x: node.x + node.width - 14,
+      y: node.y + 23,
+      class: "state-kind",
+      "text-anchor": "end"
+    })
+    kind.textContent = node.type
+    element.append(kind)
+  }
+  if (node.type === "history") element.classList.add("is-history")
+  svg.append(element)
+  nodeElements.set(node.path, element)
+}
+
+const grouped = graph.nodes.filter(({ type }) => type === "compound" || type === "parallel")
+for (const node of grouped.sort((left, right) => left.depth - right.depth)) drawNode(node, true)
+
+for (const transition of graph.transitions) {
+  const source = nodesByPath.get(transition.source)
+  if (source === undefined || transition.targets.type !== "declared") continue
+  for (const targetPath of transition.targets.paths) {
+    const target = nodesByPath.get(targetPath)
+    if (target === undefined) continue
+    const path = svgElement("path", {
+      d: edgePath(source, target),
+      class: `transition-edge${transition.reenter ? " is-reenter" : ""}`,
+      "marker-end": "url(#arrow)"
+    })
+    svg.append(path)
+  }
+}
+
+for (const node of graph.nodes.filter(({ type }) => type !== "compound" && type !== "parallel")) drawNode(node, false)
+
+const eventButtons = new Map<string, HTMLButtonElement>()
+for (const transition of graph.transitions) {
+  if (transition.trigger.type !== "event") continue
+  const point = eventPoint(transition)
+  const sample = samplesByTag.get(transition.trigger.event)
+  const button = document.createElement("button")
+  button.type = "button"
+  button.className = "edge-event"
+  button.style.left = `${point.x}px`
+  button.style.top = `${point.y}px`
+  button.textContent = `${String(transition.trigger.event)}${transition.reenter ? " ↻" : ""}`
+  button.dataset.transitionId = transition.id
+  button.dataset.sourcePath = transition.source
+  if (sample !== undefined) button.dataset.sampleId = sample.id
+  button.addEventListener("click", () => {
+    if (sample !== undefined) void planSample(sample.id)
+  })
+  canvas.append(button)
+  eventButtons.set(transition.id, button)
+}
+
+const payload = (event: VisualizerEvent): string => {
+  const { _tag: _, ...fields } = event
+  return Object.keys(fields).length === 0 ? "{}" : JSON.stringify(fields)
+}
+
+const render = (view: PlannerView<typeof VisualizerMachine>): void => {
+  const activePaths = new Set(view.activePaths)
+  const entered = new Set(view.lastStep?.microsteps.flatMap(({ entryPaths }) => entryPaths) ?? [])
+  const exited = new Set(view.lastStep?.microsteps.flatMap(({ exitPaths }) => exitPaths) ?? [])
+  for (const [path, element] of nodeElements) {
+    element.classList.toggle("is-active", activePaths.has(path))
+    element.classList.toggle("was-entered", entered.has(path))
+    element.classList.toggle("was-exited", exited.has(path))
+  }
+
+  for (const transition of graph.transitions) {
+    if (transition.trigger.type !== "event") continue
+    const button = eventButtons.get(transition.id)
+    const sample = samplesByTag.get(transition.trigger.event)
+    if (button === undefined) continue
+    const enabled = sample !== undefined && activePaths.has(transition.source) &&
+      view.enabledTags.has(transition.trigger.event)
+    button.disabled = !enabled
+    button.classList.toggle("is-enabled", enabled)
+  }
+
+  requiredElement<HTMLElement>("#active-summary").textContent = view.activePaths
+    .filter((path) => !view.activePaths.some((candidate) => candidate !== path && candidate.startsWith(`${path}.`)))
+    .map((path) => path.slice(path.lastIndexOf(".") + 1))
+    .join(" · ")
+
+  const eventList = requiredElement<HTMLElement>("#event-list")
+  eventList.replaceChildren()
+  for (const sample of view.availableSamples) {
+    const row = document.createElement("div")
+    row.className = "event-row"
+    const button = document.createElement("button")
+    button.type = "button"
+    button.className = "event-send"
+    button.textContent = sample.label
+    button.addEventListener("click", () => void planSample(sample.id))
+    const detail = document.createElement("div")
+    const origin = document.createElement("span")
+    origin.className = `event-origin is-${sample.origin}`
+    origin.textContent = sample.origin
+    const code = document.createElement("code")
+    code.textContent = payload(sample.event)
+    detail.append(origin, code)
+    row.append(button, detail)
+    eventList.append(row)
+  }
+
+  const stepSummary = requiredElement<HTMLElement>("#step-summary")
+  if (view.lastStep === undefined) {
+    stepSummary.textContent = "Machine initialized. No event has been planned yet."
+  } else {
+    const entries = [...new Set(view.lastStep.microsteps.flatMap(({ entryPaths }) => entryPaths))]
+    const detail = entries.length === 0 ? "no active path changed" : `entered ${entries.join(", ")}`
+    stepSummary.textContent = `${String(view.lastStep.event._tag)} · ${view.lastStep.classification} · ${detail}`
+  }
+}
+
+const planSample = async (sampleId: string): Promise<void> => {
+  const error = requiredElement<HTMLElement>("#error-summary")
+  error.textContent = ""
+  try {
+    render(await session.send(sampleId))
+  } catch (cause) {
+    error.textContent = cause instanceof Error ? cause.message : String(cause)
+  }
+}
+
+requiredElement<HTMLButtonElement>("#reset-session").addEventListener("click", () => {
+  void session.reset().then(render)
+})
+
+const issues = requiredElement<HTMLElement>("#generation-issues")
+if (generated.issues.length > 0) {
+  const summary = document.createElement("details")
+  const label = document.createElement("summary")
+  label.textContent = `${generated.issues.length} generation diagnostic${generated.issues.length === 1 ? "" : "s"}`
+  const list = document.createElement("ul")
+  for (const issue of generated.issues) {
+    const item = document.createElement("li")
+    item.textContent = `${issue.schema}: ${issue.message}`
+    list.append(item)
+  }
+  summary.append(label, list)
+  issues.append(summary)
+}
+
+render(session.inspect())

--- a/examples/visualizer/src/plannerSession.test.ts
+++ b/examples/visualizer/src/plannerSession.test.ts
@@ -1,0 +1,74 @@
+import { Machine } from "@typeonce/effect-machine"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import { generateEventSamples } from "./eventSamples.ts"
+import { VisualizerMachine } from "./machine.ts"
+import { createPlannerSession } from "./plannerSession.ts"
+
+const makeSession = () =>
+  createPlannerSession(
+    {
+      machine: VisualizerMachine,
+      initial: () => Effect.runPromise(Machine.planInitial(VisualizerMachine)).then(({ state }) => state),
+      enabled: (snapshot) => Machine.enabled(VisualizerMachine, snapshot),
+      plan: (snapshot, event) => Effect.runPromise(Machine.plan(VisualizerMachine, snapshot, event))
+    },
+    generateEventSamples(VisualizerMachine, { seed: 123 }).samples
+  )
+
+describe("planner session", () => {
+  it("steps concrete public events and recomputes active states and enabled inputs", async () => {
+    const session = await makeSession()
+    const initial = session.inspect()
+
+    expect(initial.activePaths).toEqual([
+      "application",
+      "application.workflow",
+      "application.workflow.idle",
+      "application.connection",
+      "application.connection.online"
+    ])
+    expect(initial.availableSamples.map(({ event }) => event._tag).sort()).toEqual(["Disconnect", "Start"])
+
+    const started = await session.send("generated-Start")
+    expect(started.activePaths).toContain("application.workflow.running.editing")
+    expect(started.activePaths).toContain("application.connection.online")
+    expect(started.lastStep?.classification).toBe("transitioned")
+    expect(started.availableSamples.map(({ event }) => event._tag).sort()).toEqual([
+      "Disconnect",
+      "Edit",
+      "Submit"
+    ])
+  })
+
+  it("retains value-only same-path plans even when topology is unchanged", async () => {
+    const session = await makeSession()
+    await session.send("generated-Start")
+    const edited = await session.send("generated-Edit")
+
+    expect(edited.activePaths).toContain("application.workflow.running.editing")
+    expect(edited.lastStep?.classification).toBe("handled")
+    expect(edited.lastStep?.microsteps).toHaveLength(1)
+    expect(edited.lastStep?.microsteps[0]?.changed).toBe(false)
+  })
+
+  it("updates one parallel region without disturbing the other", async () => {
+    const session = await makeSession()
+    const disconnected = await session.send("generated-Disconnect")
+
+    expect(disconnected.activePaths).toContain("application.workflow.idle")
+    expect(disconnected.activePaths).toContain("application.connection.offline")
+    expect(disconnected.lastStep?.classification).toBe("transitioned")
+  })
+
+  it("rejects disabled fixtures and can restart from the initial snapshot", async () => {
+    const session = await makeSession()
+
+    await expect(session.send("generated-Approve")).rejects.toThrow("Event sample is not enabled")
+    await session.send("generated-Start")
+    const reset = await session.reset()
+
+    expect(reset.activePaths).toContain("application.workflow.idle")
+    expect(reset.lastStep).toBeUndefined()
+  })
+})

--- a/examples/visualizer/src/plannerSession.ts
+++ b/examples/visualizer/src/plannerSession.ts
@@ -1,0 +1,110 @@
+import { Machine } from "@typeonce/effect-machine"
+import type { EventSample } from "./eventSamples.ts"
+
+type SnapshotOf<M extends Machine.Machine.Any> = Machine.Machine.Snapshot<Machine.Machine.States<M>>
+type InputEventOf<M extends Machine.Machine.Any> = Machine.Machine.InputEvent<M>
+
+export interface PlannedMicrostep {
+  readonly event: unknown
+  readonly exitPaths: ReadonlyArray<string>
+  readonly entryPaths: ReadonlyArray<string>
+  readonly raisedEvents: ReadonlyArray<unknown>
+  readonly emittedEvents: ReadonlyArray<unknown>
+  readonly changed: boolean
+}
+
+export interface PlannerResult<M extends Machine.Machine.Any> {
+  readonly next: SnapshotOf<M>
+  readonly microsteps: ReadonlyArray<PlannedMicrostep>
+  readonly actions: ReadonlyArray<unknown>
+  readonly emittedEvents: ReadonlyArray<unknown>
+  readonly done: boolean
+}
+
+export interface PlannerDriver<M extends Machine.Machine.Any> {
+  readonly machine: M
+  readonly initial: () => Promise<SnapshotOf<M>>
+  readonly enabled: (snapshot: SnapshotOf<M>) => ReadonlyArray<PropertyKey>
+  readonly plan: (snapshot: SnapshotOf<M>, event: InputEventOf<M>) => Promise<PlannerResult<M>>
+}
+
+export type StepClassification = "done" | "ignored" | "handled" | "transitioned"
+
+export interface StepSummary<Event extends { readonly _tag: PropertyKey }> {
+  readonly sampleId: string
+  readonly event: Event
+  readonly classification: StepClassification
+  readonly actionCount: number
+  readonly emittedEvents: ReadonlyArray<unknown>
+  readonly microsteps: ReadonlyArray<PlannedMicrostep>
+}
+
+export interface PlannerView<M extends Machine.Machine.Any> {
+  readonly snapshot: SnapshotOf<M>
+  readonly activePaths: ReadonlyArray<string>
+  readonly enabledTags: ReadonlySet<PropertyKey>
+  readonly availableSamples: ReadonlyArray<EventSample<InputEventOf<M>>>
+  readonly lastStep: StepSummary<InputEventOf<M>> | undefined
+}
+
+export interface PlannerSession<M extends Machine.Machine.Any> {
+  readonly inspect: () => PlannerView<M>
+  readonly send: (sampleId: string) => Promise<PlannerView<M>>
+  readonly reset: () => Promise<PlannerView<M>>
+}
+
+const classify = <M extends Machine.Machine.Any>(result: PlannerResult<M>): StepClassification =>
+  result.done ?
+    "done"
+    : result.microsteps.length === 0 ?
+    "ignored"
+    : result.microsteps.some(({ changed }) => changed) ?
+    "transitioned"
+    : "handled"
+
+export const createPlannerSession = async <M extends Machine.Machine.Any>(
+  driver: PlannerDriver<M>,
+  samples: ReadonlyArray<EventSample<InputEventOf<M>>>
+): Promise<PlannerSession<M>> => {
+  let snapshot = await driver.initial()
+  let lastStep: StepSummary<InputEventOf<M>> | undefined
+
+  const inspect = (): PlannerView<M> => {
+    const enabledTags = new Set<PropertyKey>(driver.enabled(snapshot))
+    return {
+      snapshot,
+      activePaths: Machine.configuration(driver.machine, snapshot).map(({ path }) => path),
+      enabledTags,
+      availableSamples: samples.filter(({ event }) => enabledTags.has(event._tag)),
+      lastStep
+    }
+  }
+
+  const send = async (sampleId: string): Promise<PlannerView<M>> => {
+    const sample = samples.find(({ id }) => id === sampleId)
+    if (sample === undefined) throw new Error(`Unknown event sample: ${sampleId}`)
+    if (!inspect().enabledTags.has(sample.event._tag)) {
+      throw new Error(`Event sample is not enabled: ${sampleId}`)
+    }
+
+    const result = await driver.plan(snapshot, sample.event)
+    snapshot = result.next
+    lastStep = {
+      sampleId,
+      event: sample.event,
+      classification: classify(result),
+      actionCount: result.actions.length,
+      emittedEvents: result.emittedEvents,
+      microsteps: result.microsteps
+    }
+    return inspect()
+  }
+
+  const reset = async (): Promise<PlannerView<M>> => {
+    snapshot = await driver.initial()
+    lastStep = undefined
+    return inspect()
+  }
+
+  return { inspect, send, reset }
+}

--- a/examples/visualizer/src/styles.css
+++ b/examples/visualizer/src/styles.css
@@ -1,0 +1,427 @@
+:root {
+  color: #272622;
+  background: #f5f3ee;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  font-synthesis: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 8% 0%, rgb(92 91 220 / 10%), transparent 34rem),
+    #f5f3ee;
+}
+
+button,
+code {
+  font: inherit;
+}
+
+#app {
+  width: min(1480px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 34px 0 48px;
+}
+
+.page-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 22px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #5b5bd6;
+  font: 700 11px/1.2 ui-monospace, monospace;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(38px, 6vw, 68px);
+  line-height: 0.94;
+  letter-spacing: -0.055em;
+}
+
+.lede {
+  margin: 12px 0 0;
+  color: #706e67;
+}
+
+.reset-button,
+.event-send,
+.edge-event {
+  border: 1px solid #bbb8ae;
+  border-radius: 8px;
+  color: #34322e;
+  background: #fff;
+  cursor: pointer;
+}
+
+.reset-button {
+  padding: 9px 13px;
+}
+
+.reset-button:hover,
+.event-send:hover,
+.edge-event.is-enabled:hover {
+  border-color: #5b5bd6;
+  color: #3e3da9;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  gap: 16px;
+  align-items: start;
+}
+
+.diagram-panel,
+.events-panel {
+  border: 1px solid #d5d1c7;
+  border-radius: 16px;
+  background: rgb(255 255 255 / 82%);
+  box-shadow: 0 18px 60px rgb(63 59 49 / 8%);
+}
+
+.diagram-panel {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.diagram-heading,
+.events-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 13px 15px;
+  border-bottom: 1px solid #dedbd2;
+}
+
+.diagram-heading > div:first-child {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+#active-summary,
+.events-heading span {
+  color: #77746c;
+  font: 11px ui-monospace, monospace;
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  color: #77746c;
+  font-size: 11px;
+}
+
+.legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.legend-dot {
+  width: 9px;
+  height: 9px;
+  border: 1px solid #aaa79f;
+  border-radius: 50%;
+  background: #fff;
+}
+
+.legend-dot.active {
+  border-color: #5b5bd6;
+  background: #5b5bd6;
+}
+
+.legend-line {
+  width: 18px;
+  border-top: 1px solid #85827a;
+}
+
+.diagram-viewport {
+  overflow: auto;
+  min-height: 430px;
+  background-color: #fbfaf7;
+  background-image: radial-gradient(#d8d5cd 0.7px, transparent 0.7px);
+  background-size: 15px 15px;
+}
+
+.diagram-canvas {
+  position: relative;
+}
+
+.diagram-canvas > svg {
+  position: absolute;
+  inset: 0;
+  display: block;
+}
+
+.state-box {
+  fill: #fff;
+  stroke: #aaa79f;
+  stroke-width: 1.25;
+  transition: fill 160ms ease, stroke 160ms ease, stroke-width 160ms ease;
+}
+
+.state-group > .state-box {
+  fill: rgb(250 249 246 / 88%);
+  stroke: #cac7bf;
+}
+
+.state-label {
+  fill: #33312d;
+  font-size: 12px;
+  font-weight: 600;
+  pointer-events: none;
+}
+
+.state-group > .state-label {
+  font-size: 13px;
+}
+
+.state-kind {
+  fill: #8b887f;
+  font: 10px ui-monospace, monospace;
+  pointer-events: none;
+}
+
+.state-node.is-active > .state-box {
+  fill: #efefff;
+  stroke: #5b5bd6;
+  stroke-width: 2;
+}
+
+.state-group.is-active > .state-box {
+  fill: rgb(239 239 255 / 46%);
+}
+
+.state-node.was-entered > .state-box {
+  animation: entered 700ms ease-out;
+}
+
+.state-node.was-exited > .state-box {
+  animation: exited 700ms ease-out;
+}
+
+.state-node.is-history > .state-box {
+  fill: #faf8f1;
+  stroke-dasharray: 4 4;
+}
+
+.transition-edge {
+  fill: none;
+  stroke: #87847d;
+  stroke-width: 1.3;
+}
+
+.transition-edge.is-reenter {
+  stroke-dasharray: 5 4;
+}
+
+.arrow-head {
+  fill: #87847d;
+}
+
+.edge-event {
+  position: absolute;
+  z-index: 2;
+  padding: 5px 8px;
+  border-color: #d0cdc5;
+  color: #8b887f;
+  font: 10px ui-monospace, monospace;
+  transform: translate(-50%, -50%);
+  cursor: default;
+}
+
+.edge-event.is-enabled {
+  border-color: #5b5bd6;
+  color: #3e3da9;
+  background: #f4f3ff;
+  box-shadow: 0 3px 12px rgb(91 91 214 / 14%);
+  cursor: pointer;
+}
+
+.step-summary,
+.error-summary {
+  margin: 0;
+  padding: 11px 15px;
+  border-top: 1px solid #dedbd2;
+  font: 11px ui-monospace, monospace;
+}
+
+.step-summary {
+  color: #66635c;
+}
+
+.error-summary {
+  display: none;
+  color: #a03232;
+}
+
+.error-summary:not(:empty) {
+  display: block;
+}
+
+.events-panel {
+  overflow: hidden;
+}
+
+.events-heading {
+  align-items: baseline;
+}
+
+.event-list {
+  display: grid;
+  gap: 1px;
+  background: #dedbd2;
+}
+
+.event-row {
+  padding: 12px;
+  background: #fff;
+}
+
+.event-send {
+  width: 100%;
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.event-row > div {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 8px;
+  min-width: 0;
+}
+
+.event-row code {
+  overflow: hidden;
+  color: #6d6a63;
+  font: 10px ui-monospace, monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.event-origin {
+  flex: none;
+  padding: 2px 5px;
+  border-radius: 999px;
+  color: #5b5bd6;
+  background: #efefff;
+  font: 9px ui-monospace, monospace;
+  text-transform: uppercase;
+}
+
+.event-origin.is-fixture {
+  color: #27634d;
+  background: #e4f4ec;
+}
+
+.generation-issues {
+  color: #756f64;
+  font-size: 11px;
+}
+
+.generation-issues details {
+  padding: 12px;
+  border-top: 1px solid #dedbd2;
+}
+
+.generation-issues ul {
+  margin: 8px 0 0;
+  padding-left: 18px;
+}
+
+.planner-note {
+  max-width: 900px;
+  margin: 18px 0 0;
+  color: #706e67;
+  font-size: 12px;
+}
+
+.planner-note code {
+  color: #4a489d;
+  font: 11px ui-monospace, monospace;
+}
+
+@keyframes entered {
+  0% {
+    fill: #dff5e7;
+    stroke: #2e8c55;
+    stroke-width: 3;
+  }
+}
+
+@keyframes exited {
+  0% {
+    fill: #fff0df;
+    stroke: #c4762d;
+    stroke-width: 3;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .state-node.was-entered > .state-box,
+  .state-node.was-exited > .state-box {
+    animation: none;
+  }
+}
+
+@media (max-width: 1300px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .events-panel {
+    order: -1;
+  }
+
+  .event-list {
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  }
+}
+
+@media (max-width: 620px) {
+  #app {
+    width: min(100% - 20px, 1480px);
+    padding-top: 22px;
+  }
+
+  .page-header,
+  .diagram-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .reset-button {
+    align-self: start;
+  }
+
+  .diagram-heading > div:first-child {
+    align-items: start;
+    flex-direction: column;
+    gap: 4px;
+  }
+}

--- a/examples/visualizer/src/vite-env.d.ts
+++ b/examples/visualizer/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/visualizer/tsconfig.json
+++ b/examples/visualizer/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src"]
+}

--- a/examples/visualizer/vite.config.ts
+++ b/examples/visualizer/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite"
+
+export default defineConfig({
+  server: {
+    port: 5176
+  }
+})

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -2035,27 +2035,43 @@ export declare namespace Machine {
     }
 
   /**
+   * Statically inspectable destination paths for a transition handler.
+   * A declared parent path covers every descendant below that state.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export type TransitionTargets<Path extends string = string> =
+    | {
+      readonly type: "dynamic"
+    }
+    | {
+      readonly type: "declared"
+      readonly paths: ReadonlyArray<Path>
+    }
+
+  /**
    * Inspectable registration for a transition handler.
    *
    * **Details**
    *
-   * Current transition handlers resolve their target at runtime and may return
-   * no target, so `target` is explicitly reported as dynamic. The source,
-   * trigger, and reentry behavior are available without executing the handler.
+   * Event handlers may declare an upper bound of possible target paths. A
+   * handler without that declaration is explicitly reported as dynamic. The
+   * source, trigger, and reentry behavior are available without executing the
+   * handler.
    *
    * @category models
    * @since 4.0.0
    */
   export interface TransitionDefinition<
-    Path extends string = string,
-    EventTag extends PropertyKey = PropertyKey
+    SourcePath extends string = string,
+    EventTag extends PropertyKey = PropertyKey,
+    TargetPath extends string = SourcePath
   > {
-    readonly source: Path
+    readonly source: SourcePath
     readonly trigger: TransitionTrigger<EventTag>
     readonly reenter: boolean
-    readonly target: {
-      readonly type: "dynamic"
-    }
+    readonly targets: TransitionTargets<TargetPath>
   }
 
   /**
@@ -3589,6 +3605,12 @@ export declare namespace Machine {
         ) => HandlerResult<States, any, any>)
         | {
           readonly reenter?: boolean
+          /**
+           * Upper bound of state or history paths this handler may target.
+           * Returning `void` is always permitted. Declaring a parent state also
+           * permits concrete descendant targets below it.
+           */
+          readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
           readonly transition: (
             context: HandlerContext<States, Events, Emits, StateId, EventTag, E, R>
           ) => HandlerResult<States, any, any>
@@ -3871,6 +3893,48 @@ export declare namespace Machine {
     }
     : unknown
 
+  type TransitionResultTargetPath<Result> = IsAny<Result> extends true ? never
+    : Result extends Effect.Effect<infer Success, any, any> ? TransitionResultTargetPath<Success>
+    : Result extends StateConstruction<infer Constructed> ? TransitionResultTargetPath<Constructed>
+    : Result extends { readonly path: infer Path extends string } ? Path
+    : never
+
+  type DeclaredTransitionTarget<Transition> = Transition extends {
+    readonly targets: infer Targets extends ReadonlyArray<string>
+  } ? Targets[number]
+    : never
+
+  type ExcludeDeclaredTransitionTarget<Returned, Declared extends string> = Returned extends string ?
+    Returned extends Declared | `${Declared}.${string}` ? never : Returned
+    : never
+
+  type UndeclaredTransitionTarget<Transition> = "targets" extends keyof Transition ? ExcludeDeclaredTransitionTarget<
+      TransitionResultTargetPath<EventTransitionReturn<Transition>>,
+      DeclaredTransitionTarget<Transition>
+    >
+    : never
+
+  type HandlerOnTargetValidationErrors<StateId extends string, On> = {
+    readonly [
+      EventTag in keyof On as [UndeclaredTransitionTarget<On[EventTag]>] extends [never] ? never
+        : EventTag
+    ]: HandlerValidationError<
+      "Transition returns a target not listed in targets",
+      StateId,
+      readonly [event: EventTag, target: UndeclaredTransitionTarget<On[EventTag]>]
+    >
+  }
+
+  type HandlerOnTargetValidation<StateId extends string, Config> = "on" extends keyof Config ?
+    Config extends { readonly on?: infer On } ? HandlerOnTargetValidationErrors<
+        StateId,
+        NonNullable<On>
+      > extends infer Errors ? keyof Errors extends never ? unknown
+        : { readonly on: Errors }
+      : never
+    : unknown
+    : unknown
+
   type HandlerDepth = readonly [unknown, unknown, unknown, unknown, unknown, unknown, unknown, unknown]
 
   type HandlerNextDepth<Depth extends ReadonlyArray<unknown>> = Depth extends
@@ -3959,6 +4023,7 @@ export declare namespace Machine {
   > =
     & HandlerUnknownConfigKeyValidation<StateId, Config>
     & HandlerOnKeyValidation<Events, StateId, Config>
+    & HandlerOnTargetValidation<StateId, Config>
     & HandlerInvokeOutputValidation<Events, StateId, Config>
     & HandlerInvokeEmitsValidation<Events, StateId, Config>
     & HandlerInvokeSnapshotValidation<Events, StateId, Config>
@@ -4402,6 +4467,8 @@ export declare namespace Machine {
       | ((context: HandlerContext<States, Events, Emits, StateId, EventTag, E, R>) => HandlerResult<States, E, R>)
       | {
         readonly reenter?: boolean
+        /** Statically declared upper bound of possible target paths. */
+        readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
         readonly transition: (
           context: HandlerContext<States, Events, Emits, StateId, EventTag, E, R>
         ) => HandlerResult<States, E, R>
@@ -4485,6 +4552,7 @@ const cloneWithHandlers = (
 
 const flattenHandlers = (
   handlers: Record<PropertyKey, Machine.AnyStateConfig>,
+  stateNodes: Machine.StateNodes,
   states: Machine.StateTree,
   prefix: string,
   config: Record<string, unknown>
@@ -4499,6 +4567,27 @@ const flattenHandlers = (
       throw new Error(`Machine expected state "${path}" handler to be an object`)
     }
     const { states: childConfig, ...stateConfig } = nodeConfig as Record<string, unknown>
+    const on = stateConfig.on
+    if (typeof on === "object" && on !== null) {
+      for (const event of Reflect.ownKeys(on)) {
+        const transition = (on as Record<PropertyKey, unknown>)[event]
+        if (typeof transition !== "object" || transition === null || !hasProperty(transition, "targets")) {
+          continue
+        }
+        if (!Array.isArray(transition.targets)) {
+          throw new Error(
+            `Machine expected transition targets for state "${path}" on "${String(event)}" to be an array`
+          )
+        }
+        for (const target of transition.targets) {
+          if (typeof target !== "string" || !stateNodes.byPath.has(target)) {
+            throw new Error(
+              `Machine transition for state "${path}" on "${String(event)}" declares unknown target "${String(target)}"`
+            )
+          }
+        }
+      }
+    }
     handlers[path] = stateConfig as Machine.AnyStateConfig
     if (childConfig !== undefined) {
       const node = Model.getStateNodeDefinition(path, states[key])
@@ -4508,7 +4597,7 @@ const flattenHandlers = (
       if (typeof childConfig !== "object" || childConfig === null) {
         throw new Error(`Machine expected state "${path}" child handlers to be an object`)
       }
-      flattenHandlers(handlers, node.states, path, childConfig as Record<string, unknown>)
+      flattenHandlers(handlers, stateNodes, node.states, path, childConfig as Record<string, unknown>)
     }
   }
 }
@@ -4519,7 +4608,7 @@ const makeHandle = (self: Machine.Any): Machine.Any["handle"] =>
       Object.create(null),
       self.handlers
     )
-    flattenHandlers(handlers, self.states, "", config)
+    flattenHandlers(handlers, self.stateNodes, self.states, "", config)
     return cloneWithHandlers(self, handlers)
   }) as Machine.Any["handle"]
 
@@ -5889,9 +5978,8 @@ export const stateNodes = <M extends Machine.Any>(
  *
  * Event handlers retain their handler-key order within each source state and
  * are followed by eventless and completion handlers. This function does not
- * execute handlers. Targets are reported as dynamic because the current
- * function-based transition model resolves them from a concrete snapshot and
- * event at runtime.
+ * execute handlers. Event handlers with a `targets` declaration expose those
+ * possible paths; handlers without one remain dynamic.
  *
  * @category getters
  * @since 4.0.0
@@ -5901,13 +5989,15 @@ export const transitionDefinitions = <M extends Machine.Any>(
 ): ReadonlyArray<
   Machine.TransitionDefinition<
     Machine.StateIdentifier<Machine.States<M>>,
-    Machine.TagOf<Machine.Events<M>[number]>
+    Machine.TagOf<Machine.Events<M>[number]>,
+    Machine.StateNodeIdentifier<Machine.States<M>>
   >
 > =>
   Model.transitionDefinitions(machine) as ReadonlyArray<
     Machine.TransitionDefinition<
       Machine.StateIdentifier<Machine.States<M>>,
-      Machine.TagOf<Machine.Events<M>[number]>
+      Machine.TagOf<Machine.Events<M>[number]>,
+      Machine.StateNodeIdentifier<Machine.States<M>>
     >
   >
 

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -2055,10 +2055,10 @@ export declare namespace Machine {
    *
    * **Details**
    *
-   * Event handlers may declare an upper bound of possible target paths. A
-   * handler without that declaration is explicitly reported as dynamic. The
-   * source, trigger, and reentry behavior are available without executing the
-   * handler.
+   * Event, eventless, and completion handlers may declare an upper bound of
+   * possible target paths. A handler without that declaration is explicitly
+   * reported as dynamic. The source, trigger, and reentry behavior are
+   * available without executing the handler.
    *
    * @category models
    * @since 4.0.0
@@ -3417,7 +3417,7 @@ export declare namespace Machine {
    * @since 4.0.0
    */
   export type AlwaysReturn<Config> = Config extends { readonly always?: infer Always }
-    ? NonNullable<Always> extends (...args: any) => infer Ret ? Ret : never
+    ? EventTransitionReturn<NonNullable<Always>>
     : never
   /**
    * Extracts the return value from a state completion transition.
@@ -3426,7 +3426,7 @@ export declare namespace Machine {
    * @since 4.0.0
    */
   export type DoneReturn<Config> = Config extends { readonly onDone?: infer OnDone }
-    ? NonNullable<OnDone> extends (...args: any) => infer Ret ? Ret : never
+    ? EventTransitionReturn<NonNullable<OnDone>>
     : never
   /**
    * Extracts the return value from a final state output function.
@@ -3596,8 +3596,24 @@ export declare namespace Machine {
     readonly entry?: (context: StateActionContext<States, Events, Emits, StateId>) => StateActionResult<any, any>
     readonly exit?: (context: StateActionContext<States, Events, Emits, StateId>) => StateActionResult<any, any>
     readonly invoke?: InvokeDefinition<States, Events, Emits, StateId>
-    readonly always?: (context: AlwaysContext<States, Events, Emits, StateId>) => HandlerResult<States, any, any>
-    readonly onDone?: (context: DoneContext<States, Events, Emits, StateId>) => HandlerResult<States, any, any>
+    readonly always?:
+      | ((context: AlwaysContext<States, Events, Emits, StateId>) => HandlerResult<States, any, any>)
+      | {
+        /** Statically declared upper bound of possible target paths. */
+        readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
+        readonly transition: (
+          context: AlwaysContext<States, Events, Emits, StateId>
+        ) => HandlerResult<States, any, any>
+      }
+    readonly onDone?:
+      | ((context: DoneContext<States, Events, Emits, StateId>) => HandlerResult<States, any, any>)
+      | {
+        /** Statically declared upper bound of possible target paths. */
+        readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
+        readonly transition: (
+          context: DoneContext<States, Events, Emits, StateId>
+        ) => HandlerResult<States, any, any>
+      }
     readonly on?: {
       readonly [EventTag in TagOf<Events[number]>]?:
         | ((
@@ -3935,6 +3951,22 @@ export declare namespace Machine {
     : unknown
     : unknown
 
+  type HandlerDirectTargetValidation<
+    StateId extends string,
+    Config,
+    Trigger extends "always" | "onDone",
+    Transition = Config extends { readonly [Key in Trigger]?: infer Value } ? NonNullable<Value> : never,
+    Undeclared extends string = UndeclaredTransitionTarget<Transition>
+  > = Trigger extends keyof Config ? [Undeclared] extends [never] ? unknown
+    : {
+      readonly [Key in Trigger]: HandlerValidationError<
+        "Transition returns a target not listed in targets",
+        StateId,
+        readonly [trigger: Trigger, target: Undeclared]
+      >
+    }
+    : unknown
+
   type HandlerDepth = readonly [unknown, unknown, unknown, unknown, unknown, unknown, unknown, unknown]
 
   type HandlerNextDepth<Depth extends ReadonlyArray<unknown>> = Depth extends
@@ -4024,6 +4056,8 @@ export declare namespace Machine {
     & HandlerUnknownConfigKeyValidation<StateId, Config>
     & HandlerOnKeyValidation<Events, StateId, Config>
     & HandlerOnTargetValidation<StateId, Config>
+    & HandlerDirectTargetValidation<StateId, Config, "always">
+    & HandlerDirectTargetValidation<StateId, Config, "onDone">
     & HandlerInvokeOutputValidation<Events, StateId, Config>
     & HandlerInvokeEmitsValidation<Events, StateId, Config>
     & HandlerInvokeSnapshotValidation<Events, StateId, Config>
@@ -4494,8 +4528,22 @@ export declare namespace Machine {
     readonly entry?: (context: StateActionContext<States, Events, Emits, StateId>) => StateActionResult<E, R>
     readonly exit?: (context: StateActionContext<States, Events, Emits, StateId>) => StateActionResult<E, R>
     readonly invoke?: InvokeDefinition<States, Events, Emits, StateId>
-    readonly always?: (context: AlwaysContext<States, Events, Emits, StateId>) => HandlerResult<States, E, R>
-    readonly onDone?: (context: DoneContext<States, Events, Emits, StateId>) => HandlerResult<States, E, R>
+    readonly always?:
+      | ((context: AlwaysContext<States, Events, Emits, StateId>) => HandlerResult<States, E, R>)
+      | {
+        readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
+        readonly transition: (
+          context: AlwaysContext<States, Events, Emits, StateId>
+        ) => HandlerResult<States, E, R>
+      }
+    readonly onDone?:
+      | ((context: DoneContext<States, Events, Emits, StateId>) => HandlerResult<States, E, R>)
+      | {
+        readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
+        readonly transition: (
+          context: DoneContext<States, Events, Emits, StateId>
+        ) => HandlerResult<States, E, R>
+      }
     readonly output?:
       | ((context: FinalOutputContext<States, Events, StateId>) => unknown)
       | ((context: ParallelOutputContext<States, Events, StateId>) => unknown)
@@ -4550,6 +4598,29 @@ const cloneWithHandlers = (
   return machine
 }
 
+const validateTransitionTargets = (
+  stateNodes: Machine.StateNodes,
+  path: string,
+  trigger: PropertyKey,
+  transition: unknown
+): void => {
+  if (typeof transition !== "object" || transition === null || !hasProperty(transition, "targets")) {
+    return
+  }
+  if (!Array.isArray(transition.targets)) {
+    throw new Error(
+      `Machine expected transition targets for state "${path}" on "${String(trigger)}" to be an array`
+    )
+  }
+  for (const target of transition.targets) {
+    if (typeof target !== "string" || !stateNodes.byPath.has(target)) {
+      throw new Error(
+        `Machine transition for state "${path}" on "${String(trigger)}" declares unknown target "${String(target)}"`
+      )
+    }
+  }
+}
+
 const flattenHandlers = (
   handlers: Record<PropertyKey, Machine.AnyStateConfig>,
   stateNodes: Machine.StateNodes,
@@ -4570,24 +4641,11 @@ const flattenHandlers = (
     const on = stateConfig.on
     if (typeof on === "object" && on !== null) {
       for (const event of Reflect.ownKeys(on)) {
-        const transition = (on as Record<PropertyKey, unknown>)[event]
-        if (typeof transition !== "object" || transition === null || !hasProperty(transition, "targets")) {
-          continue
-        }
-        if (!Array.isArray(transition.targets)) {
-          throw new Error(
-            `Machine expected transition targets for state "${path}" on "${String(event)}" to be an array`
-          )
-        }
-        for (const target of transition.targets) {
-          if (typeof target !== "string" || !stateNodes.byPath.has(target)) {
-            throw new Error(
-              `Machine transition for state "${path}" on "${String(event)}" declares unknown target "${String(target)}"`
-            )
-          }
-        }
+        validateTransitionTargets(stateNodes, path, event, (on as Record<PropertyKey, unknown>)[event])
       }
     }
+    validateTransitionTargets(stateNodes, path, "always", stateConfig.always)
+    validateTransitionTargets(stateNodes, path, "done", stateConfig.onDone)
     handlers[path] = stateConfig as Machine.AnyStateConfig
     if (childConfig !== undefined) {
       const node = Model.getStateNodeDefinition(path, states[key])
@@ -5978,8 +6036,9 @@ export const stateNodes = <M extends Machine.Any>(
  *
  * Event handlers retain their handler-key order within each source state and
  * are followed by eventless and completion handlers. This function does not
- * execute handlers. Event handlers with a `targets` declaration expose those
- * possible paths; handlers without one remain dynamic.
+ * execute handlers. Object-form event, eventless, and completion handlers with
+ * a `targets` declaration expose those possible paths; handlers without one
+ * remain dynamic.
  *
  * @category getters
  * @since 4.0.0

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -1655,6 +1655,7 @@ export declare namespace Machine {
     readonly emits: ReadonlyArray<TaggedSchema>
     readonly input: Schema.Top | undefined
     readonly id: string | undefined
+    /** @internal */
     readonly stateNodes: StateNodes
     /** @internal */
     readonly makeTargetBuilder: any
@@ -1990,16 +1991,17 @@ export declare namespace Machine {
    * @category models
    * @since 4.0.0
    */
-  export interface StateNode {
-    readonly path: string
+  export interface StateNode<Path extends string = string> {
+    readonly path: Path
     readonly key: string
     readonly schema: TaggedSchema | undefined
     readonly output: Schema.Top | undefined
     readonly type: "atomic" | "compound" | "parallel" | "final" | "history"
     readonly history: "shallow" | "deep" | undefined
-    readonly parent: string | undefined
-    readonly children: ReadonlyArray<string>
-    readonly initial: string | undefined
+    readonly parent: Path | undefined
+    /** Active child paths. History pseudo-states are available through their `parent` relationship. */
+    readonly children: ReadonlyArray<Path>
+    readonly initial: Path | undefined
     readonly order: number
   }
 
@@ -2009,9 +2011,51 @@ export declare namespace Machine {
    * @category models
    * @since 4.0.0
    */
-  export interface StateNodes {
-    readonly byPath: ReadonlyMap<string, StateNode>
-    readonly roots: ReadonlyArray<string>
+  export interface StateNodes<Path extends string = string> {
+    readonly byPath: ReadonlyMap<Path, StateNode<Path>>
+    readonly roots: ReadonlyArray<Path>
+  }
+
+  /**
+   * Trigger that selects a registered transition handler.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export type TransitionTrigger<EventTag extends PropertyKey = PropertyKey> =
+    | {
+      readonly type: "event"
+      readonly event: EventTag
+    }
+    | {
+      readonly type: "always"
+    }
+    | {
+      readonly type: "done"
+    }
+
+  /**
+   * Inspectable registration for a transition handler.
+   *
+   * **Details**
+   *
+   * Current transition handlers resolve their target at runtime and may return
+   * no target, so `target` is explicitly reported as dynamic. The source,
+   * trigger, and reentry behavior are available without executing the handler.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface TransitionDefinition<
+    Path extends string = string,
+    EventTag extends PropertyKey = PropertyKey
+  > {
+    readonly source: Path
+    readonly trigger: TransitionTrigger<EventTag>
+    readonly reenter: boolean
+    readonly target: {
+      readonly type: "dynamic"
+    }
   }
 
   /**
@@ -2083,6 +2127,14 @@ export declare namespace Machine {
    * @since 4.0.0
    */
   export type HistoryIdentifier<States extends StateSchemas> = HistoryIdentifierWithPrefix<States>
+
+  /**
+   * Extracts every compiled state-node path, including history pseudo-states.
+   *
+   * @category utility types
+   * @since 4.0.0
+   */
+  export type StateNodeIdentifier<States extends StateSchemas> = StateIdentifier<States> | HistoryIdentifier<States>
 
   /** @internal */
   export type HistoryIdentifierWithPrefix<
@@ -5809,6 +5861,77 @@ export const planInitial: <
   InitialE | E | InfiniteTransitionError | MachineSchemaDecodeError | StartupError,
   ExcludeCompatibleRuntime<PlanningServices<InitialR | R>, Machine.EventOf<Events>, Machine.EmitOf<Emits>>
 > = internalPlanner.planInitial as any
+
+/**
+ * Returns every compiled state node in definition order.
+ *
+ * **Details**
+ *
+ * The result includes atomic, compound, parallel, final, and history nodes.
+ * Use each node's `parent` property to reconstruct the complete hierarchy.
+ * History pseudo-states are intentionally omitted from `children` because they
+ * can never appear in an active configuration.
+ *
+ * @category getters
+ * @since 4.0.0
+ */
+export const stateNodes = <M extends Machine.Any>(
+  machine: M
+): ReadonlyArray<Machine.StateNode<Machine.StateNodeIdentifier<Machine.States<M>>>> =>
+  Array.from(machine.stateNodes.byPath.values()) as unknown as ReadonlyArray<
+    Machine.StateNode<Machine.StateNodeIdentifier<Machine.States<M>>>
+  >
+
+/**
+ * Returns every registered transition handler in state definition order.
+ *
+ * **Details**
+ *
+ * Event handlers retain their handler-key order within each source state and
+ * are followed by eventless and completion handlers. This function does not
+ * execute handlers. Targets are reported as dynamic because the current
+ * function-based transition model resolves them from a concrete snapshot and
+ * event at runtime.
+ *
+ * @category getters
+ * @since 4.0.0
+ */
+export const transitionDefinitions = <M extends Machine.Any>(
+  machine: M
+): ReadonlyArray<
+  Machine.TransitionDefinition<
+    Machine.StateIdentifier<Machine.States<M>>,
+    Machine.TagOf<Machine.Events<M>[number]>
+  >
+> =>
+  Model.transitionDefinitions(machine) as ReadonlyArray<
+    Machine.TransitionDefinition<
+      Machine.StateIdentifier<Machine.States<M>>,
+      Machine.TagOf<Machine.Events<M>[number]>
+    >
+  >
+
+/**
+ * Returns every state node active in a decoded snapshot, in definition order.
+ *
+ * **Details**
+ *
+ * Active compound ancestors and parallel regions are included together with
+ * their active descendants. History pseudo-states are never active and are not
+ * returned.
+ *
+ * @category getters
+ * @since 4.0.0
+ */
+export const configuration = <M extends Machine.Any>(
+  machine: M,
+  state: Machine.Snapshot<Machine.States<M>>
+): ReadonlyArray<Machine.StateNode<Machine.StateIdentifier<Machine.States<M>>>> => {
+  const active = Model.normalizeConfiguration(machine, state).active
+  return stateNodes(machine).filter((node) => active.has(node.path)) as ReadonlyArray<
+    Machine.StateNode<Machine.StateIdentifier<Machine.States<M>>>
+  >
+}
 
 /**
  * Returns the event tags handled by the current state snapshot.

--- a/src/internal/machineModel.ts
+++ b/src/internal/machineModel.ts
@@ -356,7 +356,7 @@ export const compileStateNodes = (states: Machine.StateSchemas): Machine.StateNo
   } as Machine.StateNodes
 }
 
-const dynamicTransitionTarget = { type: "dynamic" } as const
+const dynamicTransitionTargets = { type: "dynamic" } as const
 
 export const transitionDefinitions = (
   machine: Machine.Any
@@ -373,7 +373,9 @@ export const transitionDefinitions = (
         source: node.path,
         trigger: { type: "event", event },
         reenter: typeof handler === "object" && handler !== null && handler.reenter === true,
-        target: dynamicTransitionTarget
+        targets: typeof handler === "object" && handler !== null && handler.targets !== undefined
+          ? { type: "declared", paths: Array.from(handler.targets) }
+          : dynamicTransitionTargets
       })
     }
     if (config.always !== undefined) {
@@ -381,7 +383,7 @@ export const transitionDefinitions = (
         source: node.path,
         trigger: { type: "always" },
         reenter: false,
-        target: dynamicTransitionTarget
+        targets: dynamicTransitionTargets
       })
     }
     if (config.onDone !== undefined) {
@@ -389,7 +391,7 @@ export const transitionDefinitions = (
         source: node.path,
         trigger: { type: "done" },
         reenter: false,
-        target: dynamicTransitionTarget
+        targets: dynamicTransitionTargets
       })
     }
   }

--- a/src/internal/machineModel.ts
+++ b/src/internal/machineModel.ts
@@ -356,6 +356,46 @@ export const compileStateNodes = (states: Machine.StateSchemas): Machine.StateNo
   } as Machine.StateNodes
 }
 
+const dynamicTransitionTarget = { type: "dynamic" } as const
+
+export const transitionDefinitions = (
+  machine: Machine.Any
+): ReadonlyArray<Machine.TransitionDefinition> => {
+  const definitions: Array<Machine.TransitionDefinition> = []
+  for (const node of machine.stateNodes.byPath.values()) {
+    const config = machine.handlers[node.path] as Machine.AnyStateConfig | undefined
+    if (config === undefined) {
+      continue
+    }
+    for (const event of Reflect.ownKeys(config.on ?? {})) {
+      const handler = config.on?.[event]
+      definitions.push({
+        source: node.path,
+        trigger: { type: "event", event },
+        reenter: typeof handler === "object" && handler !== null && handler.reenter === true,
+        target: dynamicTransitionTarget
+      })
+    }
+    if (config.always !== undefined) {
+      definitions.push({
+        source: node.path,
+        trigger: { type: "always" },
+        reenter: false,
+        target: dynamicTransitionTarget
+      })
+    }
+    if (config.onDone !== undefined) {
+      definitions.push({
+        source: node.path,
+        trigger: { type: "done" },
+        reenter: false,
+        target: dynamicTransitionTarget
+      })
+    }
+  }
+  return definitions
+}
+
 export const makeTarget = <
   const States extends Machine.StateSchemas,
   const StateId extends Machine.StateIdentifier<States>

--- a/src/internal/machineModel.ts
+++ b/src/internal/machineModel.ts
@@ -358,6 +358,11 @@ export const compileStateNodes = (states: Machine.StateSchemas): Machine.StateNo
 
 const dynamicTransitionTargets = { type: "dynamic" } as const
 
+const transitionTargets = (handler: unknown): Machine.TransitionTargets =>
+  typeof handler === "object" && handler !== null && "targets" in handler && handler.targets !== undefined
+    ? { type: "declared", paths: Array.from(handler.targets as ReadonlyArray<string>) }
+    : dynamicTransitionTargets
+
 export const transitionDefinitions = (
   machine: Machine.Any
 ): ReadonlyArray<Machine.TransitionDefinition> => {
@@ -373,9 +378,7 @@ export const transitionDefinitions = (
         source: node.path,
         trigger: { type: "event", event },
         reenter: typeof handler === "object" && handler !== null && handler.reenter === true,
-        targets: typeof handler === "object" && handler !== null && handler.targets !== undefined
-          ? { type: "declared", paths: Array.from(handler.targets) }
-          : dynamicTransitionTargets
+        targets: transitionTargets(handler)
       })
     }
     if (config.always !== undefined) {
@@ -383,7 +386,7 @@ export const transitionDefinitions = (
         source: node.path,
         trigger: { type: "always" },
         reenter: false,
-        targets: dynamicTransitionTargets
+        targets: transitionTargets(config.always)
       })
     }
     if (config.onDone !== undefined) {
@@ -391,7 +394,7 @@ export const transitionDefinitions = (
         source: node.path,
         trigger: { type: "done" },
         reenter: false,
-        targets: dynamicTransitionTargets
+        targets: transitionTargets(config.onDone)
       })
     }
   }

--- a/src/internal/machinePlanner.ts
+++ b/src/internal/machinePlanner.ts
@@ -239,7 +239,7 @@ type MicrostepTransition<States extends Machine.StateSchemas, E, R, Context> = {
   readonly transition: TransitionHandler<States, E, R, Context>
 }
 
-const normalizeEventTransition = <States extends Machine.StateSchemas, E, R, Context>(
+const normalizeTransition = <States extends Machine.StateSchemas, E, R, Context>(
   transition: EventTransition<States, E, R, Context> | undefined
 ): MicrostepTransition<States, E, R, Context> | undefined => {
   if (transition === undefined) {
@@ -481,6 +481,7 @@ const resolveHistoryTarget = Effect.fnUntraced(function*(
 type SelectedTransition<States extends Machine.StateSchemas, E, R, Context> = {
   readonly sourcePath: string
   readonly leafPath: string
+  readonly trigger: Machine.TransitionTrigger
   readonly transition: MicrostepTransition<States, E, R, Context>
   readonly context: Context
 }
@@ -703,14 +704,15 @@ const selectAlwaysTransitions = <
   const selectedSources = new Set<string>()
   for (const leaf of getActiveLeafPaths(machine, configuration)) {
     for (const path of getLeafCandidatePaths(machine, leaf)) {
-      const always = machine.handlers[path]?.always
+      const always = normalizeTransition(machine.handlers[path]?.always)
       if (always !== undefined) {
         if (!selectedSources.has(path)) {
           selectedSources.add(path)
           selected.push({
             sourcePath: path,
             leafPath: leaf,
-            transition: { reenter: false, targets: undefined, transition: always } as MicrostepTransition<
+            trigger: { type: "always" },
+            transition: always as unknown as MicrostepTransition<
               States,
               E,
               R,
@@ -771,13 +773,14 @@ const selectDoneTransitions = <
   > = []
   const selectedSources = new Set<string>()
   for (const completion of completions) {
-    const onDone = machine.handlers[completion.path]?.onDone
+    const onDone = normalizeTransition(machine.handlers[completion.path]?.onDone)
     if (onDone !== undefined && !selectedSources.has(completion.path)) {
       selectedSources.add(completion.path)
       selected.push({
         sourcePath: completion.path,
         leafPath: getActiveLeafPathFrom(machine, configuration, completion.path),
-        transition: { reenter: false, targets: undefined, transition: onDone } as MicrostepTransition<
+        trigger: { type: "done" },
+        transition: onDone as unknown as MicrostepTransition<
           States,
           E,
           R,
@@ -833,13 +836,14 @@ const selectEventTransitions = <
   const selectedSources = new Set<string>()
   for (const leaf of getActiveLeafPaths(machine, configuration)) {
     for (const path of getLeafCandidatePaths(machine, leaf)) {
-      const transition = normalizeEventTransition(machine.handlers[path]?.on?.[event._tag])
+      const transition = normalizeTransition(machine.handlers[path]?.on?.[event._tag])
       if (transition !== undefined) {
         if (!selectedSources.has(path)) {
           selectedSources.add(path)
           selected.push({
             sourcePath: path,
             leafPath: leaf,
+            trigger: { type: "event", event: event._tag },
             transition: transition as unknown as MicrostepTransition<
               States,
               E,
@@ -884,7 +888,7 @@ const getTargetNodePath = <const States extends Machine.StateSchemas>(
 
 const validateDeclaredTransitionTarget = (
   sourcePath: string,
-  event: unknown,
+  trigger: Machine.TransitionTrigger,
   declaredTargets: ReadonlyArray<string> | undefined,
   target: unknown
 ): void => {
@@ -895,10 +899,9 @@ const validateDeclaredTransitionTarget = (
     ? String(target.path)
     : "<unknown>"
   if (!declaredTargets.some((path) => actual === path || actual.startsWith(`${path}.`))) {
+    const triggerLabel = trigger.type === "event" ? String(trigger.event) : trigger.type
     throw new Error(
-      `Machine transition from "${sourcePath}" on "${
-        String(event)
-      }" returned target "${actual}" outside declared targets: ${
+      `Machine transition from "${sourcePath}" on "${triggerLabel}" returned target "${actual}" outside declared targets: ${
         declaredTargets.length === 0 ? "none" : declaredTargets.map((path) => `"${path}"`).join(", ")
       }`
     )
@@ -1002,7 +1005,7 @@ const collectEvaluatedTransition = Effect.fnUntraced(function*<
       | Machine.Target<States, Machine.StateIdentifier<States>>
   validateDeclaredTransitionTarget(
     selection.sourcePath,
-    (selection.context as { readonly event: { readonly _tag: unknown } }).event._tag,
+    selection.trigger,
     selection.transition.targets,
     unresolvedTarget
   )

--- a/src/internal/machinePlanner.ts
+++ b/src/internal/machinePlanner.ts
@@ -229,11 +229,13 @@ type EventTransition<States extends Machine.StateSchemas, E, R, Context> =
   | TransitionHandler<States, E, R, Context>
   | {
     readonly reenter?: boolean
+    readonly targets?: ReadonlyArray<string>
     readonly transition: TransitionHandler<States, E, R, Context>
   }
 
 type MicrostepTransition<States extends Machine.StateSchemas, E, R, Context> = {
   readonly reenter: boolean
+  readonly targets: ReadonlyArray<string> | undefined
   readonly transition: TransitionHandler<States, E, R, Context>
 }
 
@@ -244,8 +246,12 @@ const normalizeEventTransition = <States extends Machine.StateSchemas, E, R, Con
     return undefined
   }
   return typeof transition === "function"
-    ? { reenter: false, transition }
-    : { reenter: transition.reenter === true, transition: transition.transition }
+    ? { reenter: false, targets: undefined, transition }
+    : {
+      reenter: transition.reenter === true,
+      targets: transition.targets,
+      transition: transition.transition
+    }
 }
 
 const collectStateAction = Effect.fnUntraced(function*<Context, Event, E, R>(
@@ -704,7 +710,7 @@ const selectAlwaysTransitions = <
           selected.push({
             sourcePath: path,
             leafPath: leaf,
-            transition: { reenter: false, transition: always } as MicrostepTransition<
+            transition: { reenter: false, targets: undefined, transition: always } as MicrostepTransition<
               States,
               E,
               R,
@@ -771,7 +777,7 @@ const selectDoneTransitions = <
       selected.push({
         sourcePath: completion.path,
         leafPath: getActiveLeafPathFrom(machine, configuration, completion.path),
-        transition: { reenter: false, transition: onDone } as MicrostepTransition<
+        transition: { reenter: false, targets: undefined, transition: onDone } as MicrostepTransition<
           States,
           E,
           R,
@@ -876,6 +882,29 @@ const getTargetNodePath = <const States extends Machine.StateSchemas>(
   throw new Error("Machine expected transition target to be a snapshot or target builder result")
 }
 
+const validateDeclaredTransitionTarget = (
+  sourcePath: string,
+  event: unknown,
+  declaredTargets: ReadonlyArray<string> | undefined,
+  target: unknown
+): void => {
+  if (declaredTargets === undefined || target === undefined) {
+    return
+  }
+  const actual = typeof target === "object" && target !== null && "path" in target
+    ? String(target.path)
+    : "<unknown>"
+  if (!declaredTargets.some((path) => actual === path || actual.startsWith(`${path}.`))) {
+    throw new Error(
+      `Machine transition from "${sourcePath}" on "${
+        String(event)
+      }" returned target "${actual}" outside declared targets: ${
+        declaredTargets.length === 0 ? "none" : declaredTargets.map((path) => `"${path}"`).join(", ")
+      }`
+    )
+  }
+}
+
 const hasPathIntersection = (left: ReadonlyArray<string>, right: ReadonlyArray<string>): boolean => {
   for (const path of left) {
     if (right.includes(path)) {
@@ -971,6 +1000,12 @@ const collectEvaluatedTransition = Effect.fnUntraced(function*<
     : transitionResult.state as
       | Machine.Snapshot<States>
       | Machine.Target<States, Machine.StateIdentifier<States>>
+  validateDeclaredTransitionTarget(
+    selection.sourcePath,
+    (selection.context as { readonly event: { readonly _tag: unknown } }).event._tag,
+    selection.transition.targets,
+    unresolvedTarget
+  )
   let historyResolution: {
     readonly target: unknown
     readonly actions: ReadonlyArray<DeferredAction>

--- a/test/MachineVisualization.test.ts
+++ b/test/MachineVisualization.test.ts
@@ -121,6 +121,47 @@ const machine = Machine.make({
 
 const renderMachine = makeTextRenderer<typeof machine, typeof initial>(Machine)
 
+const LifecycleStates = Machine.defineStates({
+  idle: Idle,
+  workflow: {
+    schema: Workflow,
+    initial: "complete",
+    states: {
+      complete: {
+        schema: Complete,
+        type: "final"
+      }
+    }
+  },
+  disabled: Disabled
+})
+
+const lifecycleMachine = Machine.make({
+  id: "lifecycle-inspection",
+  states: LifecycleStates.states,
+  events: [],
+  initial: () => LifecycleStates.initial.idle(new Idle({}))
+}).handle({
+  idle: {
+    always: {
+      targets: ["workflow"],
+      transition: ({ target }) =>
+        target.full.workflow(new Workflow({}), (workflow) => workflow.complete(new Complete({})))
+    }
+  },
+  workflow: {
+    onDone: {
+      targets: ["disabled"],
+      transition: ({ target }) => target.full.disabled(new Disabled({}))
+    }
+  }
+})
+
+const renderLifecycleMachine = makeTextRenderer<
+  typeof lifecycleMachine,
+  Machine.Machine.Snapshot<typeof LifecycleStates.states>
+>(Machine)
+
 describe("Machine structural visualization", () => {
   it("exposes every state node in definition order", () => {
     assert.deepStrictEqual(Machine.stateNodes(machine).map(({ path, type }) => ({ path, type })), [
@@ -184,8 +225,14 @@ describe("Machine structural visualization", () => {
             transition: () => undefined
           }
         },
-        always: () => undefined,
-        onDone: () => undefined
+        always: {
+          targets: ["idle"],
+          transition: () => undefined
+        },
+        onDone: {
+          targets: ["idle"],
+          transition: () => undefined
+        }
       }
     })
 
@@ -200,16 +247,55 @@ describe("Machine structural visualization", () => {
         source: "idle",
         trigger: { type: "always" },
         reenter: false,
-        targets: { type: "dynamic" }
+        targets: { type: "declared", paths: ["idle"] }
       },
       {
         source: "idle",
         trigger: { type: "done" },
         reenter: false,
-        targets: { type: "dynamic" }
+        targets: { type: "declared", paths: ["idle"] }
       }
     ])
   })
+
+  it.effect("plans declared eventless and completion transitions", () =>
+    Effect.gen(function*() {
+      const planned = yield* Machine.planInitial(lifecycleMachine)
+
+      assert.deepStrictEqual(Machine.configuration(lifecycleMachine, planned.state).map(({ path }) => path), [
+        "disabled"
+      ])
+      assert.deepStrictEqual(Machine.transitionDefinitions(lifecycleMachine), [
+        {
+          source: "idle",
+          trigger: { type: "always" },
+          reenter: false,
+          targets: { type: "declared", paths: ["workflow"] }
+        },
+        {
+          source: "workflow",
+          trigger: { type: "done" },
+          reenter: false,
+          targets: { type: "declared", paths: ["disabled"] }
+        }
+      ])
+      assert.strictEqual(
+        renderLifecycleMachine(lifecycleMachine, planned.state),
+        [
+          "lifecycle-inspection",
+          "● active  ○ inactive  ◇ transition (→ declared, ∅ none, omitted dynamic)",
+          "",
+          "├─ ○ idle",
+          "│  └─ ◇ always → workflow",
+          "├─ ○ workflow [compound, initial: complete]",
+          "│  ├─ ◇ done → disabled",
+          "│  └─ ○ complete [final]",
+          "└─ ● disabled",
+          "",
+          "Candidate events: none"
+        ].join("\n")
+      )
+    }))
 
   it("renders the structure and active configuration as text", () => {
     assert.strictEqual(
@@ -284,6 +370,47 @@ describe("Machine structural visualization", () => {
       }
     }))
 
+  it.effect("rejects runtime targets outside always and onDone declarations", () =>
+    Effect.gen(function*() {
+      const unsafeAlways = lifecycleMachine.handle({
+        idle: {
+          always: {
+            targets: ["idle"],
+            transition: ({ target }) =>
+              target.full.workflow(
+                new Workflow({}),
+                (workflow) => workflow.complete(new Complete({}))
+              ) as unknown as Machine.Machine.Target<typeof LifecycleStates.states, "idle">
+          }
+        }
+      })
+      const alwaysExit = yield* Effect.exit(Machine.planInitial(unsafeAlways))
+
+      assert.strictEqual(alwaysExit._tag, "Failure")
+      if (alwaysExit._tag === "Failure") {
+        assert.include(Cause.pretty(alwaysExit.cause), "on \"always\" returned target \"workflow\"")
+      }
+
+      const unsafeDone = lifecycleMachine.handle({
+        workflow: {
+          onDone: {
+            targets: ["workflow"],
+            transition: ({ target }) =>
+              target.full.disabled(new Disabled({})) as unknown as Machine.Machine.Target<
+                typeof LifecycleStates.states,
+                "workflow"
+              >
+          }
+        }
+      })
+      const doneExit = yield* Effect.exit(Machine.planInitial(unsafeDone))
+
+      assert.strictEqual(doneExit._tag, "Failure")
+      if (doneExit._tag === "Failure") {
+        assert.include(Cause.pretty(doneExit.cause), "on \"done\" returned target \"disabled\"")
+      }
+    }))
+
   it("rejects a declared path that is not a machine state", () => {
     assert.throws(
       () =>
@@ -306,6 +433,30 @@ describe("Machine structural visualization", () => {
           }
         }),
       /declares unknown target "missing"/
+    )
+    assert.throws(
+      () =>
+        lifecycleMachine.handle({
+          idle: {
+            always: {
+              targets: ["missing"],
+              transition: () => undefined
+            }
+          }
+        } as any),
+      /on "always" declares unknown target "missing"/
+    )
+    assert.throws(
+      () =>
+        lifecycleMachine.handle({
+          workflow: {
+            onDone: {
+              targets: ["missing"],
+              transition: () => undefined
+            }
+          }
+        } as any),
+      /on "done" declares unknown target "missing"/
     )
   })
 })

--- a/test/MachineVisualization.test.ts
+++ b/test/MachineVisualization.test.ts
@@ -1,0 +1,233 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Schema } from "effect"
+import { Machine } from "../src/index.js"
+import { makeTextRenderer } from "./visualization/text.js"
+
+class Application extends Schema.TaggedClass<Application>("Application")("Application", {}) {}
+class Workflow extends Schema.TaggedClass<Workflow>("Workflow")("Workflow", {}) {}
+class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", {}) {}
+class Running extends Schema.TaggedClass<Running>("Running")("Running", {}) {}
+class Editing extends Schema.TaggedClass<Editing>("Editing")("Editing", {}) {}
+class Complete extends Schema.TaggedClass<Complete>("Complete")("Complete", {}) {}
+class Connection extends Schema.TaggedClass<Connection>("Connection")("Connection", {}) {}
+class Online extends Schema.TaggedClass<Online>("Online")("Online", {}) {}
+class Offline extends Schema.TaggedClass<Offline>("Offline")("Offline", {}) {}
+class Disabled extends Schema.TaggedClass<Disabled>("Disabled")("Disabled", {}) {}
+class Start extends Schema.TaggedClass<Start>("Start")("Start", {}) {}
+class Disconnect extends Schema.TaggedClass<Disconnect>("Disconnect")("Disconnect", {}) {}
+class Refresh extends Schema.TaggedClass<Refresh>("Refresh")("Refresh", {}) {}
+
+const States = Machine.defineStates({
+  application: {
+    schema: Application,
+    type: "parallel",
+    states: {
+      workflow: {
+        schema: Workflow,
+        initial: "idle",
+        states: {
+          idle: Idle,
+          running: {
+            schema: Running,
+            initial: "editing",
+            states: {
+              editing: Editing,
+              complete: {
+                schema: Complete,
+                type: "final"
+              }
+            }
+          },
+          recent: {
+            type: "history"
+          }
+        }
+      },
+      connection: {
+        schema: Connection,
+        initial: "online",
+        states: {
+          online: Online,
+          offline: Offline
+        }
+      }
+    }
+  },
+  disabled: Disabled
+})
+
+const initial = States.initial.application(
+  new Application({}),
+  (application) =>
+    application
+      .workflow(new Workflow({}), (workflow) => workflow.idle(new Idle({})))
+      .connection(new Connection({}), (connection) => connection.online(new Online({})))
+)
+
+const initialWorkflow = (): Machine.Machine.SnapshotByIdentifier<typeof States.states, "application.workflow"> => ({
+  path: "application.workflow",
+  value: new Workflow({}),
+  state: {
+    path: "application.workflow.idle",
+    value: new Idle({})
+  }
+})
+
+const machine = Machine.make({
+  id: "inspection-example",
+  states: States.states,
+  events: [Start, Disconnect, Refresh],
+  initial: () => initial
+}).handle({
+  application: {
+    states: {
+      workflow: {
+        history: {
+          recent: {
+            default: initialWorkflow
+          }
+        },
+        states: {
+          idle: {
+            on: {
+              Start: ({ target }) =>
+                target.local.running(new Running({}), (running) => running.editing(new Editing({}))),
+              Refresh: () => undefined
+            }
+          },
+          running: {
+            initial: () => new Editing({})
+          }
+        }
+      },
+      connection: {
+        states: {
+          online: {
+            on: {
+              Disconnect: ({ target }) => target.local.offline(new Offline({}))
+            }
+          }
+        }
+      }
+    }
+  }
+})
+
+const renderMachine = makeTextRenderer<typeof machine, typeof initial>(Machine)
+
+describe("Machine structural visualization", () => {
+  it("exposes every state node in definition order", () => {
+    assert.deepStrictEqual(Machine.stateNodes(machine).map(({ path, type }) => ({ path, type })), [
+      { path: "application", type: "parallel" },
+      { path: "application.workflow", type: "compound" },
+      { path: "application.workflow.idle", type: "atomic" },
+      { path: "application.workflow.running", type: "compound" },
+      { path: "application.workflow.running.editing", type: "atomic" },
+      { path: "application.workflow.running.complete", type: "final" },
+      { path: "application.workflow.recent", type: "history" },
+      { path: "application.connection", type: "compound" },
+      { path: "application.connection.online", type: "atomic" },
+      { path: "application.connection.offline", type: "atomic" },
+      { path: "disabled", type: "atomic" }
+    ])
+  })
+
+  it("exposes active ancestors and parallel regions in definition order", () => {
+    assert.deepStrictEqual(Machine.configuration(machine, initial).map((node) => node.path), [
+      "application",
+      "application.workflow",
+      "application.workflow.idle",
+      "application.connection",
+      "application.connection.online"
+    ])
+  })
+
+  it("exposes registered transition handlers without executing them", () => {
+    assert.deepStrictEqual(Machine.transitionDefinitions(machine), [
+      {
+        source: "application.workflow.idle",
+        trigger: { type: "event", event: "Start" },
+        reenter: false,
+        target: { type: "dynamic" }
+      },
+      {
+        source: "application.workflow.idle",
+        trigger: { type: "event", event: "Refresh" },
+        reenter: false,
+        target: { type: "dynamic" }
+      },
+      {
+        source: "application.connection.online",
+        trigger: { type: "event", event: "Disconnect" },
+        reenter: false,
+        target: { type: "dynamic" }
+      }
+    ])
+  })
+
+  it("describes reentry, eventless, and completion handlers", () => {
+    const metadataMachine = Machine.make({
+      states: { idle: Idle },
+      events: [Refresh],
+      initial: () => ({ path: "idle", value: new Idle({}) })
+    }).handle({
+      idle: {
+        on: {
+          Refresh: {
+            reenter: true,
+            transition: () => undefined
+          }
+        },
+        always: () => undefined,
+        onDone: () => undefined
+      }
+    })
+
+    assert.deepStrictEqual(Machine.transitionDefinitions(metadataMachine), [
+      {
+        source: "idle",
+        trigger: { type: "event", event: "Refresh" },
+        reenter: true,
+        target: { type: "dynamic" }
+      },
+      {
+        source: "idle",
+        trigger: { type: "always" },
+        reenter: false,
+        target: { type: "dynamic" }
+      },
+      {
+        source: "idle",
+        trigger: { type: "done" },
+        reenter: false,
+        target: { type: "dynamic" }
+      }
+    ])
+  })
+
+  it("renders the structure and active configuration as text", () => {
+    assert.strictEqual(
+      renderMachine(machine, initial),
+      [
+        "inspection-example",
+        "● active  ○ inactive  ◇ registered triggers (targets resolve at runtime)",
+        "",
+        "├─ ● application [parallel]",
+        "│  ├─ ● workflow [compound, initial: idle]",
+        "│  │  ├─ ● idle",
+        "│  │  │  └─ ◇ on: Start, Refresh",
+        "│  │  ├─ ○ running [compound, initial: editing]",
+        "│  │  │  ├─ ○ editing",
+        "│  │  │  └─ ○ complete [final]",
+        "│  │  └─ ○ recent [history, shallow]",
+        "│  └─ ● connection [compound, initial: online]",
+        "│     ├─ ● online",
+        "│     │  └─ ◇ on: Disconnect",
+        "│     └─ ○ offline",
+        "└─ ○ disabled",
+        "",
+        "Candidate events: Start, Refresh, Disconnect"
+      ].join("\n")
+    )
+  })
+})

--- a/test/MachineVisualization.test.ts
+++ b/test/MachineVisualization.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Schema } from "effect"
+import { Cause, Effect, Schema } from "effect"
 import { Machine } from "../src/index.js"
 import { makeTextRenderer } from "./visualization/text.js"
 
@@ -90,9 +90,15 @@ const machine = Machine.make({
         states: {
           idle: {
             on: {
-              Start: ({ target }) =>
-                target.local.running(new Running({}), (running) => running.editing(new Editing({}))),
-              Refresh: () => undefined
+              Start: {
+                targets: ["application.workflow.running"],
+                transition: ({ target }) =>
+                  target.local.running(new Running({}), (running) => running.editing(new Editing({})))
+              },
+              Refresh: {
+                targets: [],
+                transition: () => undefined
+              }
             }
           },
           running: {
@@ -148,19 +154,19 @@ describe("Machine structural visualization", () => {
         source: "application.workflow.idle",
         trigger: { type: "event", event: "Start" },
         reenter: false,
-        target: { type: "dynamic" }
+        targets: { type: "declared", paths: ["application.workflow.running"] }
       },
       {
         source: "application.workflow.idle",
         trigger: { type: "event", event: "Refresh" },
         reenter: false,
-        target: { type: "dynamic" }
+        targets: { type: "declared", paths: [] }
       },
       {
         source: "application.connection.online",
         trigger: { type: "event", event: "Disconnect" },
         reenter: false,
-        target: { type: "dynamic" }
+        targets: { type: "dynamic" }
       }
     ])
   })
@@ -188,19 +194,19 @@ describe("Machine structural visualization", () => {
         source: "idle",
         trigger: { type: "event", event: "Refresh" },
         reenter: true,
-        target: { type: "dynamic" }
+        targets: { type: "dynamic" }
       },
       {
         source: "idle",
         trigger: { type: "always" },
         reenter: false,
-        target: { type: "dynamic" }
+        targets: { type: "dynamic" }
       },
       {
         source: "idle",
         trigger: { type: "done" },
         reenter: false,
-        target: { type: "dynamic" }
+        targets: { type: "dynamic" }
       }
     ])
   })
@@ -210,12 +216,12 @@ describe("Machine structural visualization", () => {
       renderMachine(machine, initial),
       [
         "inspection-example",
-        "● active  ○ inactive  ◇ registered triggers (targets resolve at runtime)",
+        "● active  ○ inactive  ◇ transition (→ declared, ∅ none, omitted dynamic)",
         "",
         "├─ ● application [parallel]",
         "│  ├─ ● workflow [compound, initial: idle]",
         "│  │  ├─ ● idle",
-        "│  │  │  └─ ◇ on: Start, Refresh",
+        "│  │  │  └─ ◇ on: Start → running, Refresh → ∅",
         "│  │  ├─ ○ running [compound, initial: editing]",
         "│  │  │  ├─ ○ editing",
         "│  │  │  └─ ○ complete [final]",
@@ -228,6 +234,78 @@ describe("Machine structural visualization", () => {
         "",
         "Candidate events: Start, Refresh, Disconnect"
       ].join("\n")
+    )
+  })
+
+  it.effect("accepts a concrete leaf beneath a declared compound target", () =>
+    Effect.gen(function*() {
+      const planned = yield* Machine.plan(machine, initial, new Start({}))
+
+      assert.deepStrictEqual(Machine.configuration(machine, planned.next).map((node) => node.path), [
+        "application",
+        "application.workflow",
+        "application.workflow.running",
+        "application.workflow.running.editing",
+        "application.connection",
+        "application.connection.online"
+      ])
+    }))
+
+  it.effect("rejects a runtime target outside its declaration", () =>
+    Effect.gen(function*() {
+      const unsafe = machine.handle({
+        application: {
+          states: {
+            workflow: {
+              states: {
+                idle: {
+                  on: {
+                    Start: {
+                      targets: ["application.workflow.idle"],
+                      transition: ({ target }) =>
+                        target.full.disabled(new Disabled({})) as unknown as Machine.Machine.Target<
+                          typeof States.states,
+                          "application.workflow.idle"
+                        >
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      })
+      const exit = yield* Effect.exit(Machine.plan(unsafe, initial, new Start({})))
+
+      assert.strictEqual(exit._tag, "Failure")
+      if (exit._tag === "Failure") {
+        assert(Cause.hasDies(exit.cause))
+        assert.include(Cause.pretty(exit.cause), "returned target \"disabled\" outside declared targets")
+      }
+    }))
+
+  it("rejects a declared path that is not a machine state", () => {
+    assert.throws(
+      () =>
+        machine.handle({
+          application: {
+            states: {
+              workflow: {
+                states: {
+                  idle: {
+                    on: {
+                      Start: {
+                        targets: ["missing"] as any,
+                        transition: () => undefined
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }),
+      /declares unknown target "missing"/
     )
   })
 })

--- a/test/visualization/text.ts
+++ b/test/visualization/text.ts
@@ -26,9 +26,14 @@ interface TransitionDefinition {
       readonly type: "done"
     }
   readonly reenter: boolean
-  readonly target: {
-    readonly type: "dynamic"
-  }
+  readonly targets:
+    | {
+      readonly type: "dynamic"
+    }
+    | {
+      readonly type: "declared"
+      readonly paths: ReadonlyArray<string>
+    }
 }
 
 interface InspectionApi<Machine, Snapshot> {
@@ -54,7 +59,15 @@ const triggerLabels = (definitions: ReadonlyArray<TransitionDefinition>): Readon
   const labels: Array<string> = []
   const events = definitions.flatMap((definition) =>
     definition.trigger.type === "event" ?
-      [`${String(definition.trigger.event)}${definition.reenter ? " [reenter]" : ""}`]
+      [
+        `${String(definition.trigger.event)}${definition.reenter ? " [reenter]" : ""}${
+          definition.targets.type === "declared"
+            ? definition.targets.paths.length === 0
+              ? " → ∅"
+              : ` → ${definition.targets.paths.map((path) => path.slice(path.lastIndexOf(".") + 1)).join(" | ")}`
+            : ""
+        }`
+      ]
       : []
   )
 
@@ -104,7 +117,7 @@ export const makeTextRenderer = <Machine extends MachineValue, Snapshot>(
 
   const lines = [
     machine.id ?? "Machine",
-    "● active  ○ inactive  ◇ registered triggers (targets resolve at runtime)",
+    "● active  ○ inactive  ◇ transition (→ declared, ∅ none, omitted dynamic)",
     ""
   ]
   const visit = (node: StateNode, prefix: string, isLast: boolean): void => {

--- a/test/visualization/text.ts
+++ b/test/visualization/text.ts
@@ -57,16 +57,16 @@ const nodeLabel = (node: StateNode, active: ReadonlySet<string>): string => {
 
 const triggerLabels = (definitions: ReadonlyArray<TransitionDefinition>): ReadonlyArray<string> => {
   const labels: Array<string> = []
+  const targets = (definition: TransitionDefinition): string =>
+    definition.targets.type === "dynamic" ?
+      ""
+      : definition.targets.paths.length === 0 ?
+      " → ∅"
+      : ` → ${definition.targets.paths.map((path) => path.slice(path.lastIndexOf(".") + 1)).join(" | ")}`
   const events = definitions.flatMap((definition) =>
     definition.trigger.type === "event" ?
       [
-        `${String(definition.trigger.event)}${definition.reenter ? " [reenter]" : ""}${
-          definition.targets.type === "declared"
-            ? definition.targets.paths.length === 0
-              ? " → ∅"
-              : ` → ${definition.targets.paths.map((path) => path.slice(path.lastIndexOf(".") + 1)).join(" | ")}`
-            : ""
-        }`
+        `${String(definition.trigger.event)}${definition.reenter ? " [reenter]" : ""}${targets(definition)}`
       ]
       : []
   )
@@ -76,9 +76,9 @@ const triggerLabels = (definitions: ReadonlyArray<TransitionDefinition>): Readon
   }
   for (const definition of definitions) {
     if (definition.trigger.type === "always") {
-      labels.push(`◇ always${definition.reenter ? " [reenter]" : ""}`)
+      labels.push(`◇ always${definition.reenter ? " [reenter]" : ""}${targets(definition)}`)
     } else if (definition.trigger.type === "done") {
-      labels.push(`◇ done${definition.reenter ? " [reenter]" : ""}`)
+      labels.push(`◇ done${definition.reenter ? " [reenter]" : ""}${targets(definition)}`)
     }
   }
   return labels

--- a/test/visualization/text.ts
+++ b/test/visualization/text.ts
@@ -1,0 +1,137 @@
+interface StateNode {
+  readonly path: string
+  readonly key: string
+  readonly type: "atomic" | "compound" | "parallel" | "final" | "history"
+  readonly history: "shallow" | "deep" | undefined
+  readonly parent: string | undefined
+  readonly children: ReadonlyArray<string>
+  readonly initial: string | undefined
+}
+
+interface MachineValue {
+  readonly id: string | undefined
+}
+
+interface TransitionDefinition {
+  readonly source: string
+  readonly trigger:
+    | {
+      readonly type: "event"
+      readonly event: PropertyKey
+    }
+    | {
+      readonly type: "always"
+    }
+    | {
+      readonly type: "done"
+    }
+  readonly reenter: boolean
+  readonly target: {
+    readonly type: "dynamic"
+  }
+}
+
+interface InspectionApi<Machine, Snapshot> {
+  readonly stateNodes: (machine: Machine) => ReadonlyArray<StateNode>
+  readonly transitionDefinitions: (machine: Machine) => ReadonlyArray<TransitionDefinition>
+  readonly configuration: (machine: Machine, snapshot: Snapshot) => ReadonlyArray<StateNode>
+  readonly enabled: (machine: Machine, snapshot: Snapshot) => ReadonlyArray<PropertyKey>
+}
+
+const nodeLabel = (node: StateNode, active: ReadonlySet<string>): string => {
+  const status = active.has(node.path) ? "●" : "○"
+  const details: Array<string> = node.type === "atomic" ? [] : [node.type]
+  if (node.initial !== undefined) {
+    details.push(`initial: ${node.initial.slice(node.path.length + 1)}`)
+  }
+  if (node.history !== undefined) {
+    details.push(node.history)
+  }
+  return details.length === 0 ? `${status} ${node.key}` : `${status} ${node.key} [${details.join(", ")}]`
+}
+
+const triggerLabels = (definitions: ReadonlyArray<TransitionDefinition>): ReadonlyArray<string> => {
+  const labels: Array<string> = []
+  const events = definitions.flatMap((definition) =>
+    definition.trigger.type === "event" ?
+      [`${String(definition.trigger.event)}${definition.reenter ? " [reenter]" : ""}`]
+      : []
+  )
+
+  if (events.length > 0) {
+    labels.push(`◇ on: ${events.join(", ")}`)
+  }
+  for (const definition of definitions) {
+    if (definition.trigger.type === "always") {
+      labels.push(`◇ always${definition.reenter ? " [reenter]" : ""}`)
+    } else if (definition.trigger.type === "done") {
+      labels.push(`◇ done${definition.reenter ? " [reenter]" : ""}`)
+    }
+  }
+  return labels
+}
+
+/**
+ * Builds an experimental text renderer around a machine module's public
+ * inspection functions. Keeping the module injectable lets examples use their
+ * installed package without publishing visualization code as part of core.
+ */
+export const makeTextRenderer = <Machine extends MachineValue, Snapshot>(
+  inspection: InspectionApi<Machine, Snapshot>
+) =>
+(
+  machine: Machine,
+  snapshot?: Snapshot
+): string => {
+  const nodes = inspection.stateNodes(machine)
+  const active = new Set(
+    snapshot === undefined ? [] : inspection.configuration(machine, snapshot).map((node) => node.path)
+  )
+  const children = new Map<string | undefined, Array<StateNode>>()
+  const transitions = new Map<string, Array<TransitionDefinition>>()
+
+  for (const node of nodes) {
+    const siblings = children.get(node.parent) ?? []
+    siblings.push(node)
+    children.set(node.parent, siblings)
+  }
+
+  for (const definition of inspection.transitionDefinitions(machine)) {
+    const registrations = transitions.get(definition.source) ?? []
+    registrations.push(definition)
+    transitions.set(definition.source, registrations)
+  }
+
+  const lines = [
+    machine.id ?? "Machine",
+    "● active  ○ inactive  ◇ registered triggers (targets resolve at runtime)",
+    ""
+  ]
+  const visit = (node: StateNode, prefix: string, isLast: boolean): void => {
+    lines.push(`${prefix}${isLast ? "└─" : "├─"} ${nodeLabel(node, active)}`)
+    const descendants = children.get(node.path) ?? []
+    const registrations = transitions.get(node.path) ?? []
+    const childPrefix = `${prefix}${isLast ? "   " : "│  "}`
+    const labels = triggerLabels(registrations)
+    const itemCount = labels.length + descendants.length
+    labels.forEach((label, index) => {
+      lines.push(`${childPrefix}${index === itemCount - 1 ? "└─" : "├─"} ${label}`)
+    })
+    descendants.forEach((child, index) => {
+      visit(child, childPrefix, labels.length + index === itemCount - 1)
+    })
+  }
+
+  const roots = children.get(undefined) ?? []
+  roots.forEach((root, index) => visit(root, "", index === roots.length - 1))
+
+  if (snapshot !== undefined) {
+    const candidates = inspection.enabled(machine, snapshot)
+    if (candidates.length === 0) {
+      lines.push("", "Candidate events: none")
+    } else {
+      lines.push("", `Candidate events: ${candidates.map(String).join(", ")}`)
+    }
+  }
+  return lines.join("\n")
+}

--- a/typetest/MachineInspection.tst.ts
+++ b/typetest/MachineInspection.tst.ts
@@ -1,10 +1,11 @@
-import { Schema } from "effect"
+import { Effect, Schema } from "effect"
 import { describe, expect, it } from "tstyche"
 import { Machine } from "../src/index.js"
 
 describe("Machine inspection", () => {
   class Root extends Schema.TaggedClass<Root>("Root")("Root", {}) {}
   class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", {}) {}
+  class Running extends Schema.TaggedClass<Running>("Running")("Running", {}) {}
   class Reset extends Schema.TaggedClass<Reset>("Reset")("Reset", {}) {}
 
   const States = Machine.defineStates({
@@ -41,6 +42,93 @@ describe("Machine inspection", () => {
     if (definition.trigger.type === "event") {
       expect(definition.trigger.event).type.toBe<"Reset">()
     }
-    expect(definition.target.type).type.toBe<"dynamic">()
+    expect(definition.targets).type.toBe<
+      | { readonly type: "dynamic" }
+      | { readonly type: "declared"; readonly paths: ReadonlyArray<"root" | "root.idle" | "root.recent"> }
+    >()
+  })
+
+  it("checks inferred transition results against declared targets", () => {
+    const FlatStates = Machine.defineStates({ idle: Idle, running: Running })
+    const flat = Machine.make({
+      states: FlatStates.states,
+      events: [Reset],
+      initial: () => FlatStates.initial.idle(new Idle({}))
+    })
+    const target = flat.makeTargetBuilder("idle")
+
+    const direct = {
+      idle: {
+        on: {
+          Reset: {
+            targets: ["running"],
+            transition: () => target.full.running(new Running({}))
+          }
+        }
+      }
+    } as const
+    const effectful = {
+      idle: {
+        on: {
+          Reset: {
+            targets: ["running"],
+            transition: () => Effect.succeed(target.full.running(new Running({})))
+          }
+        }
+      }
+    } as const
+    const constructed = {
+      idle: {
+        on: {
+          Reset: {
+            targets: ["running"],
+            transition: () => target.full.running.from()
+          }
+        }
+      }
+    } as const
+    const undeclared = {
+      idle: {
+        on: {
+          Reset: {
+            targets: ["idle"],
+            transition: () => target.full.running(new Running({}))
+          }
+        }
+      }
+    } as const
+    const multiple = {
+      idle: {
+        on: {
+          Reset: {
+            targets: ["idle", "running"],
+            transition: () =>
+              Math.random() > 0.5
+                ? target.full.idle(new Idle({}))
+                : target.full.running(new Running({}))
+          }
+        }
+      }
+    } as const
+    const partiallyUndeclared = {
+      idle: {
+        on: {
+          Reset: {
+            targets: ["running"],
+            transition: () =>
+              Math.random() > 0.5
+                ? target.full.idle(new Idle({}))
+                : target.full.running(new Running({}))
+          }
+        }
+      }
+    } as const
+
+    expect(flat.handle).type.toBeCallableWith(direct)
+    expect(flat.handle).type.toBeCallableWith(effectful)
+    expect(flat.handle).type.toBeCallableWith(constructed)
+    expect(flat.handle).type.toBeCallableWith(multiple)
+    expect(flat.handle).type.not.toBeCallableWith(undeclared)
+    expect(flat.handle).type.not.toBeCallableWith(partiallyUndeclared)
   })
 })

--- a/typetest/MachineInspection.tst.ts
+++ b/typetest/MachineInspection.tst.ts
@@ -1,0 +1,46 @@
+import { Schema } from "effect"
+import { describe, expect, it } from "tstyche"
+import { Machine } from "../src/index.js"
+
+describe("Machine inspection", () => {
+  class Root extends Schema.TaggedClass<Root>("Root")("Root", {}) {}
+  class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", {}) {}
+  class Reset extends Schema.TaggedClass<Reset>("Reset")("Reset", {}) {}
+
+  const States = Machine.defineStates({
+    root: {
+      schema: Root,
+      initial: "idle",
+      states: {
+        idle: Idle,
+        recent: { type: "history" }
+      }
+    }
+  })
+  const initial = States.initial.root(new Root({}), (root) => root.idle(new Idle({})))
+  const machine = Machine.make({
+    states: States.states,
+    events: [Reset],
+    initial: () => initial
+  }).handle({
+    root: {
+      on: {
+        Reset: () => undefined
+      }
+    }
+  })
+
+  it("preserves state paths for structural inspection", () => {
+    expect(Machine.stateNodes(machine)[0]!.path).type.toBe<"root" | "root.idle" | "root.recent">()
+    expect(Machine.configuration(machine, initial)[0]!.path).type.toBe<"root" | "root.idle">()
+  })
+
+  it("preserves source paths and event tags for transition inspection", () => {
+    const definition = Machine.transitionDefinitions(machine)[0]!
+    expect(definition.source).type.toBe<"root" | "root.idle">()
+    if (definition.trigger.type === "event") {
+      expect(definition.trigger.event).type.toBe<"Reset">()
+    }
+    expect(definition.target.type).type.toBe<"dynamic">()
+  })
+})

--- a/typetest/MachineInspection.tst.ts
+++ b/typetest/MachineInspection.tst.ts
@@ -123,12 +123,48 @@ describe("Machine inspection", () => {
         }
       }
     } as const
+    const always = {
+      idle: {
+        always: {
+          targets: ["running"],
+          transition: () => target.full.running(new Running({}))
+        }
+      }
+    } as const
+    const undeclaredAlways = {
+      idle: {
+        always: {
+          targets: ["idle"],
+          transition: () => target.full.running(new Running({}))
+        }
+      }
+    } as const
+    const onDone = {
+      idle: {
+        onDone: {
+          targets: ["running"],
+          transition: () => Effect.succeed(target.full.running(new Running({})))
+        }
+      }
+    } as const
+    const undeclaredOnDone = {
+      idle: {
+        onDone: {
+          targets: ["idle"],
+          transition: () => target.full.running(new Running({}))
+        }
+      }
+    } as const
 
     expect(flat.handle).type.toBeCallableWith(direct)
     expect(flat.handle).type.toBeCallableWith(effectful)
     expect(flat.handle).type.toBeCallableWith(constructed)
     expect(flat.handle).type.toBeCallableWith(multiple)
+    expect(flat.handle).type.toBeCallableWith(always)
+    expect(flat.handle).type.toBeCallableWith(onDone)
     expect(flat.handle).type.not.toBeCallableWith(undeclared)
     expect(flat.handle).type.not.toBeCallableWith(partiallyUndeclared)
+    expect(flat.handle).type.not.toBeCallableWith(undeclaredAlways)
+    expect(flat.handle).type.not.toBeCallableWith(undeclaredOnDone)
   })
 })


### PR DESCRIPTION
## Summary

- expose public getters for compiled state nodes, active snapshot configuration, and registered transition definitions without executing handlers
- allow object-form event, eventless, and completion handlers to declare an upper bound of target paths; inferred transition results are checked at compile time, while unknown declarations and unsafe runtime mismatches are rejected at runtime
- keep rendering outside core with an experimental text renderer that nests transitions beneath source states and distinguishes declared targets, no direct target, and dynamic handlers
- declare all 27 platformer transitions and cover its complete inspectable chart as an example of the API on a nested, parallel machine
- add a standalone planner visualizer that renders states and declared transitions, highlights the active configuration, and steps through enabled events with `Machine.plan`
- generate deterministic schema-valid event samples with `Schema.toArbitrary`, while allowing typed authored fixtures to override samples that need semantic values

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

The visualizer-only commit does not need an additional changeset.

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed

Additional validation:

- `pnpm check` passed with 226 runtime tests, 105 type tests, strict consumer validation, and package verification
- `pnpm perf:types` passed; `machine.handle` measures 21,266 instantiations
- `pnpm check` passed in `examples/platformer`
- `pnpm check` passed in `examples/visualizer` with 8 tests, TypeScript validation, and a production Vite build
- the visualizer was exercised in a browser through initialization and a planned transition with no console warnings or errors
