### PR TITLE
feat: complete media player playground example

### DIFF
--- a/.changeset/clean-scenarios-plan.md
+++ b/.changeset/clean-scenarios-plan.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Keep `MachineTest.run` service-free for machines with invoked effects, matching the pure `Machine.planInitial` and `Machine.plan` APIs it uses internally.

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -35,7 +35,9 @@ React-to-machine adapter is left for the exercise.
 The media player is a complete browser integration. `schemas.ts` owns its typed
 protocol, `service.ts` exposes the audio element and Web Audio graph as an
 Effect service, `invocations.ts` defines its state-scoped processes, and the
-React page translates DOM events into machine events. Its compound
+React adapter registers the audio element through the shared service runtime
+before translating playback events into machine events. `view.ts` exhaustively
+projects the typed parallel snapshot into the React-facing view model. Its compound
 `Ready` state models the loaded playback lifecycle inside a parallel `Player`:
 the transport region owns loading, playback, buffering, and failures while the
 settings region independently owns `Audible` and `Muted`.

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -28,9 +28,17 @@ Each starter keeps its machine definition next to its route component:
 - `src/examples/media-player`
 - `src/examples/worker-tabs`
 
-The first four route components are intentionally light: their domain schemas,
-events, and state topology are ready, while the React-to-machine adapter is left
-for the exercise.
+The turnstile, traffic light, and microwave route components are intentionally
+light: their domain schemas, events, and state topology are ready, while the
+React-to-machine adapter is left for the exercise.
+
+The media player is a complete browser integration. `schemas.ts` owns its typed
+protocol, `service.ts` exposes the audio element and Web Audio graph as an
+Effect service, `invocations.ts` defines its state-scoped processes, and the
+React page translates DOM events into machine events. Its compound
+`Ready` state models the loaded playback lifecycle inside a parallel `Player`:
+the transport region owns loading, playback, buffering, and failures while the
+settings region independently owns `Audible` and `Muted`.
 
 The workers route additionally contains:
 

--- a/examples/playground/src/examples/media-player/MediaPlayerPage.tsx
+++ b/examples/playground/src/examples/media-player/MediaPlayerPage.tsx
@@ -1,15 +1,41 @@
-import { useEffect, useState } from "react"
-import { ExamplePage, StarterPanel } from "../../components/ExamplePage.tsx"
-import { MediaPlayerMachine } from "./machine.ts"
+import { useAtomSet, useAtomValue } from "@effect/atom-react"
+import { Option } from "effect"
+import { AsyncResult } from "effect/unstable/reactivity"
+import { useCallback, useEffect, useState } from "react"
+import { ExamplePage } from "../../components/ExamplePage.tsx"
+import { mediaPlayerAtom } from "./atoms.ts"
+import { initialAudioSettings, initialPlaybackData, MediaPlayerEvent, MediaPlayerStates } from "./schemas.ts"
+
+interface AudioSource {
+  readonly name: string
+  readonly url: string
+}
+
+const formatTime = (seconds: number): string => {
+  if (!Number.isFinite(seconds)) return "0:00"
+
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = Math.floor(seconds % 60)
+  return `${minutes}:${String(remainingSeconds).padStart(2, "0")}`
+}
 
 export function MediaPlayerPage() {
-  void MediaPlayerMachine
+  const snapshotResult = useAtomValue(mediaPlayerAtom.snapshot)
+  const send = useAtomSet(mediaPlayerAtom.send)
+  const [source, setSource] = useState<AudioSource>()
 
-  const [source, setSource] = useState<string>()
+  const registerAudioElement = useCallback(
+    (audioRef: HTMLAudioElement | null) => {
+      if (audioRef !== null) {
+        send(MediaPlayerEvent.cases.AudioElementMounted.make({ audioRef }))
+      }
+    },
+    [send]
+  )
 
   useEffect(
     () => () => {
-      if (source !== undefined) URL.revokeObjectURL(source)
+      if (source !== undefined) URL.revokeObjectURL(source.url)
     },
     [source]
   )
@@ -17,33 +43,244 @@ export function MediaPlayerPage() {
   return (
     <ExamplePage
       title="Media player"
-      summary="Use a real audio element as an external system and translate its lifecycle events into a typed machine protocol."
+      summary="Coordinate a compound transport lifecycle and independent sound modes inside a parallel Effect statechart."
       machineFile="src/examples/media-player/machine.ts"
     >
-      <StarterPanel>
-        <label className="file-picker">
-          <span>Choose an audio file</span>
-          <input
-            type="file"
-            accept="audio/*"
-            onChange={(event) => {
-              const file = event.currentTarget.files?.[0]
-              if (file === undefined) return
-              if (source !== undefined) URL.revokeObjectURL(source)
-              setSource(URL.createObjectURL(file))
-            }}
-          />
-        </label>
-        <audio className="audio-player" src={source} controls preload="metadata">
-          Your browser does not support audio playback.
-        </audio>
-        <h2>Translate DOM events</h2>
-        <p>
-          The statechart separates playback and volume. Wire <code>playing</code>, <code>pause</code>,{" "}
-          <code>waiting</code>,{` `}
-          <code>canplay</code>, <code>ended</code>, and <code>error</code> into the prepared events.
-        </p>
-      </StarterPanel>
+      {AsyncResult.isInitial(snapshotResult) ?
+        <div className="media-player-message">Starting the media player machine…</div> :
+        AsyncResult.isFailure(snapshotResult) ?
+        <div className="media-player-message is-error">The media player machine failed to start.</div> :
+        (
+          (() => {
+            const runtimeSnapshot = snapshotResult.value
+            const snapshot = runtimeSnapshot.state
+            const paused = Option.getOrUndefined(
+              MediaPlayerStates.get(snapshot, "Player.transport.Ready.Paused")
+            )
+            const playing = Option.getOrUndefined(
+              MediaPlayerStates.get(snapshot, "Player.transport.Ready.Playing")
+            )
+            const buffering = Option.getOrUndefined(
+              MediaPlayerStates.get(snapshot, "Player.transport.Ready.Buffering")
+            )
+            const restarting = Option.getOrUndefined(
+              MediaPlayerStates.get(snapshot, "Player.transport.Ready.Restarting")
+            )
+            const ended = Option.getOrUndefined(
+              MediaPlayerStates.get(snapshot, "Player.transport.Ready.Ended")
+            )
+            const failed = Option.getOrUndefined(
+              MediaPlayerStates.get(snapshot, "Player.transport.Failed")
+            )
+            const audible = Option.getOrUndefined(
+              MediaPlayerStates.get(snapshot, "Player.settings.Audible")
+            )
+            const muted = Option.getOrUndefined(
+              MediaPlayerStates.get(snapshot, "Player.settings.Muted")
+            )
+            const playback = paused ?? playing ?? buffering ?? restarting ?? ended
+            const playbackData = playback ?? initialPlaybackData
+            const settings = audible ?? muted ?? initialAudioSettings
+            const isMuted = muted !== undefined
+            const isPaused = paused !== undefined
+            const isPlaying = playing !== undefined
+            const isBuffering = buffering !== undefined
+            const isEnded = ended !== undefined
+            const canPlay = isPaused || isEnded
+            const canPause = isPlaying || isBuffering
+            const canRestart = canPlay || canPause
+            const transportPath = isPlaying ?
+              "Player.transport.Ready.Playing"
+              : isBuffering ?
+              "Player.transport.Ready.Buffering"
+              : restarting !== undefined ?
+              "Player.transport.Ready.Restarting"
+              : isEnded ?
+              "Player.transport.Ready.Ended"
+              : isPaused ?
+              "Player.transport.Ready.Paused"
+              : failed !== undefined ?
+              "Player.transport.Failed"
+              : MediaPlayerStates.matches(snapshot, "Player.transport.Loading") ?
+              "Player.transport.Loading"
+              : "Player.transport.Empty"
+            const stateName = transportPath.slice(transportPath.lastIndexOf(".") + 1)
+            const settingsPath = isMuted ? "Player.settings.Muted" : "Player.settings.Audible"
+            const loudness = playing?.loudness ?? null
+            const loudnessLevel = Math.min(100, Math.round((loudness?.rms ?? 0) * 220))
+            const peakLevel = Math.min(100, Math.round((loudness?.peak ?? 0) * 100))
+
+            return (
+              <div className="media-player-console">
+                <header className="media-player-toolbar">
+                  <div>
+                    <p className="media-player-kicker">Effect audio session</p>
+                    <h2>{source?.name ?? "Choose a local audio track"}</h2>
+                  </div>
+                  <div className="media-player-toolbar-actions">
+                    <span className={`media-state-chip is-${stateName.toLowerCase()}`}>{stateName}</span>
+                    <label className="media-file-button">
+                      <span>{source === undefined ? "Choose audio" : "Replace audio"}</span>
+                      <input
+                        type="file"
+                        accept="audio/*"
+                        onChange={(event) => {
+                          const file = event.currentTarget.files?.[0]
+                          if (file === undefined) return
+                          const next = { name: file.name, url: URL.createObjectURL(file) }
+                          setSource(next)
+                          send(MediaPlayerEvent.cases.SourceSelected.make({ url: next.url }))
+                        }}
+                      />
+                    </label>
+                  </div>
+                </header>
+
+                <audio
+                  ref={registerAudioElement}
+                  className="media-audio-element"
+                  preload="auto"
+                  onWaiting={() => send(MediaPlayerEvent.cases.MediaWaiting.make({}))}
+                  onCanPlay={() => send(MediaPlayerEvent.cases.MediaCanPlay.make({}))}
+                  onError={({ currentTarget }) =>
+                    send(MediaPlayerEvent.cases.MediaFailed.make({
+                      message: currentTarget.error?.message ?? "The selected audio file could not be loaded"
+                    }))}
+                  onTimeUpdate={({ currentTarget }) =>
+                    send(MediaPlayerEvent.cases.TimeUpdated.make({ currentTime: currentTarget.currentTime }))}
+                  onEnded={({ currentTarget }) =>
+                    send(MediaPlayerEvent.cases.PlaybackEnded.make({ currentTime: currentTarget.currentTime }))}
+                />
+
+                <div className="media-player-layout">
+                  <section className="media-now-playing" aria-label="Playback controls">
+                    <div className={`media-artwork${isPlaying ? " is-playing" : ""}`} aria-hidden="true">
+                      <div className="media-record">
+                        <span />
+                      </div>
+                      <div className="media-tonearm" />
+                    </div>
+
+                    <div className="media-time-row">
+                      <span>Current time</span>
+                      <strong>{formatTime(playbackData.currentTime)}</strong>
+                    </div>
+
+                    <div className="media-controls">
+                      <button
+                        type="button"
+                        disabled={!canPlay || source === undefined}
+                        onClick={() => send(MediaPlayerEvent.cases.PlayRequested.make({}))}
+                      >
+                        Play
+                      </button>
+                      <button
+                        type="button"
+                        disabled={!canPause}
+                        onClick={() => send(MediaPlayerEvent.cases.PauseRequested.make({}))}
+                      >
+                        Pause
+                      </button>
+                      <button
+                        type="button"
+                        disabled={!canRestart}
+                        onClick={() => send(MediaPlayerEvent.cases.RestartRequested.make({}))}
+                      >
+                        Restart
+                      </button>
+                    </div>
+
+                    <section className="media-meter" aria-label="Live loudness">
+                      <div className="media-panel-heading">
+                        <span>Loudness</span>
+                        <strong>{loudness?.decibels.toFixed(1) ?? "-80.0"} dB</strong>
+                      </div>
+                      <div className="media-meter-track">
+                        <span className="media-meter-fill" style={{ width: `${loudnessLevel}%` }} />
+                        <span className="media-meter-peak" style={{ left: `${peakLevel}%` }} />
+                      </div>
+                      <p>RMS {loudnessLevel}% · Peak {peakLevel}%</p>
+                    </section>
+                  </section>
+
+                  <aside className="media-player-inspector">
+                    <section className="media-settings">
+                      <div className="media-panel-heading">
+                        <span>Audio settings</span>
+                        <strong>{isMuted ? "Muted" : "Audible"} · {Math.round(settings.volume * 100)}%</strong>
+                      </div>
+                      <label>
+                        <span>Volume</span>
+                        <input
+                          type="range"
+                          min="0"
+                          max="1"
+                          step="0.01"
+                          value={settings.volume}
+                          onChange={({ currentTarget }) =>
+                            send(MediaPlayerEvent.cases.VolumeChanged.make({
+                              volume: currentTarget.valueAsNumber
+                            }))}
+                        />
+                      </label>
+                      <label>
+                        <span>Muted</span>
+                        <input
+                          type="checkbox"
+                          checked={isMuted}
+                          onChange={({ currentTarget }) =>
+                            send(
+                              currentTarget.checked
+                                ? MediaPlayerEvent.cases.MuteRequested.make({})
+                                : MediaPlayerEvent.cases.UnmuteRequested.make({})
+                            )}
+                        />
+                      </label>
+                      <label>
+                        <span>Speed</span>
+                        <select
+                          value={settings.playbackRate}
+                          onChange={({ currentTarget }) =>
+                            send(MediaPlayerEvent.cases.PlaybackRateChanged.make({
+                              playbackRate: Number(currentTarget.value)
+                            }))}
+                        >
+                          <option value={0.75}>0.75x</option>
+                          <option value={1}>1x</option>
+                          <option value={1.25}>1.25x</option>
+                          <option value={1.5}>1.5x</option>
+                          <option value={2}>2x</option>
+                        </select>
+                      </label>
+                    </section>
+
+                    <section className="media-state-preview">
+                      <div className="media-panel-heading">
+                        <span>Machine snapshot</span>
+                        <strong>{runtimeSnapshot.status}</strong>
+                      </div>
+                      <pre>
+                      {JSON.stringify({
+                        status: runtimeSnapshot.status,
+                        states: {
+                          transport: transportPath,
+                          settings: settingsPath
+                        },
+                        data: {
+                          transport: playback ?? failed ?? null,
+                          settings
+                        }
+                      }, null, 2)}
+                      </pre>
+                    </section>
+
+                    {failed !== undefined && <p className="media-error-message" role="alert">{failed.message}</p>}
+                  </aside>
+                </div>
+              </div>
+            )
+          })()
+        )}
     </ExamplePage>
   )
 }

--- a/examples/playground/src/examples/media-player/MediaPlayerPage.tsx
+++ b/examples/playground/src/examples/media-player/MediaPlayerPage.tsx
@@ -1,10 +1,9 @@
 import { useAtomSet, useAtomValue } from "@effect/atom-react"
-import { Option } from "effect"
-import { AsyncResult } from "effect/unstable/reactivity"
+import { Match } from "effect"
 import { useCallback, useEffect, useState } from "react"
 import { ExamplePage } from "../../components/ExamplePage.tsx"
-import { mediaPlayerAtom } from "./atoms.ts"
-import { initialAudioSettings, initialPlaybackData, MediaPlayerEvent, MediaPlayerStates } from "./schemas.ts"
+import { mediaPlayerAtom, mediaPlayerViewAtom, registerMediaPlayerElement } from "./atoms.ts"
+import { MediaPlayerEvent } from "./schemas.ts"
 
 interface AudioSource {
   readonly name: string
@@ -20,17 +19,18 @@ const formatTime = (seconds: number): string => {
 }
 
 export function MediaPlayerPage() {
-  const snapshotResult = useAtomValue(mediaPlayerAtom.snapshot)
+  const viewResult = useAtomValue(mediaPlayerViewAtom)
   const send = useAtomSet(mediaPlayerAtom.send)
+  const register = useAtomSet(registerMediaPlayerElement)
   const [source, setSource] = useState<AudioSource>()
 
   const registerAudioElement = useCallback(
     (audioRef: HTMLAudioElement | null) => {
       if (audioRef !== null) {
-        send(MediaPlayerEvent.cases.AudioElementMounted.make({ audioRef }))
+        register(audioRef)
       }
     },
-    [send]
+    [register]
   )
 
   useEffect(
@@ -46,67 +46,13 @@ export function MediaPlayerPage() {
       summary="Coordinate a compound transport lifecycle and independent sound modes inside a parallel Effect statechart."
       machineFile="src/examples/media-player/machine.ts"
     >
-      {AsyncResult.isInitial(snapshotResult) ?
-        <div className="media-player-message">Starting the media player machine…</div> :
-        AsyncResult.isFailure(snapshotResult) ?
-        <div className="media-player-message is-error">The media player machine failed to start.</div> :
-        (
-          (() => {
-            const runtimeSnapshot = snapshotResult.value
-            const snapshot = runtimeSnapshot.state
-            const paused = Option.getOrUndefined(
-              MediaPlayerStates.get(snapshot, "Player.transport.Ready.Paused")
-            )
-            const playing = Option.getOrUndefined(
-              MediaPlayerStates.get(snapshot, "Player.transport.Ready.Playing")
-            )
-            const buffering = Option.getOrUndefined(
-              MediaPlayerStates.get(snapshot, "Player.transport.Ready.Buffering")
-            )
-            const restarting = Option.getOrUndefined(
-              MediaPlayerStates.get(snapshot, "Player.transport.Ready.Restarting")
-            )
-            const ended = Option.getOrUndefined(
-              MediaPlayerStates.get(snapshot, "Player.transport.Ready.Ended")
-            )
-            const failed = Option.getOrUndefined(
-              MediaPlayerStates.get(snapshot, "Player.transport.Failed")
-            )
-            const audible = Option.getOrUndefined(
-              MediaPlayerStates.get(snapshot, "Player.settings.Audible")
-            )
-            const muted = Option.getOrUndefined(
-              MediaPlayerStates.get(snapshot, "Player.settings.Muted")
-            )
-            const playback = paused ?? playing ?? buffering ?? restarting ?? ended
-            const playbackData = playback ?? initialPlaybackData
-            const settings = audible ?? muted ?? initialAudioSettings
-            const isMuted = muted !== undefined
-            const isPaused = paused !== undefined
-            const isPlaying = playing !== undefined
-            const isBuffering = buffering !== undefined
-            const isEnded = ended !== undefined
-            const canPlay = isPaused || isEnded
-            const canPause = isPlaying || isBuffering
-            const canRestart = canPlay || canPause
-            const transportPath = isPlaying ?
-              "Player.transport.Ready.Playing"
-              : isBuffering ?
-              "Player.transport.Ready.Buffering"
-              : restarting !== undefined ?
-              "Player.transport.Ready.Restarting"
-              : isEnded ?
-              "Player.transport.Ready.Ended"
-              : isPaused ?
-              "Player.transport.Ready.Paused"
-              : failed !== undefined ?
-              "Player.transport.Failed"
-              : MediaPlayerStates.matches(snapshot, "Player.transport.Loading") ?
-              "Player.transport.Loading"
-              : "Player.transport.Empty"
-            const stateName = transportPath.slice(transportPath.lastIndexOf(".") + 1)
-            const settingsPath = isMuted ? "Player.settings.Muted" : "Player.settings.Audible"
-            const loudness = playing?.loudness ?? null
+      {Match.value(viewResult).pipe(
+        Match.tagsExhaustive({
+          Initial: () => <div className="media-player-message">Starting the media player machine…</div>,
+          Failure: () => <div className="media-player-message is-error">The media player machine failed to start.</div>,
+          Success: ({ value: view }) => {
+            const { settings, status, transport } = view
+            const { canPause, canPlay, canRestart, isPlaying, loudness, playback } = transport
             const loudnessLevel = Math.min(100, Math.round((loudness?.rms ?? 0) * 220))
             const peakLevel = Math.min(100, Math.round((loudness?.peak ?? 0) * 100))
 
@@ -118,7 +64,7 @@ export function MediaPlayerPage() {
                     <h2>{source?.name ?? "Choose a local audio track"}</h2>
                   </div>
                   <div className="media-player-toolbar-actions">
-                    <span className={`media-state-chip is-${stateName.toLowerCase()}`}>{stateName}</span>
+                    <span className={`media-state-chip is-${transport.name.toLowerCase()}`}>{transport.name}</span>
                     <label className="media-file-button">
                       <span>{source === undefined ? "Choose audio" : "Replace audio"}</span>
                       <input
@@ -163,7 +109,7 @@ export function MediaPlayerPage() {
 
                     <div className="media-time-row">
                       <span>Current time</span>
-                      <strong>{formatTime(playbackData.currentTime)}</strong>
+                      <strong>{formatTime(playback.currentTime)}</strong>
                     </div>
 
                     <div className="media-controls">
@@ -207,7 +153,7 @@ export function MediaPlayerPage() {
                     <section className="media-settings">
                       <div className="media-panel-heading">
                         <span>Audio settings</span>
-                        <strong>{isMuted ? "Muted" : "Audible"} · {Math.round(settings.volume * 100)}%</strong>
+                        <strong>{settings.muted ? "Muted" : "Audible"} · {Math.round(settings.volume * 100)}%</strong>
                       </div>
                       <label>
                         <span>Volume</span>
@@ -227,7 +173,7 @@ export function MediaPlayerPage() {
                         <span>Muted</span>
                         <input
                           type="checkbox"
-                          checked={isMuted}
+                          checked={settings.muted}
                           onChange={({ currentTarget }) =>
                             send(
                               currentTarget.checked
@@ -257,30 +203,31 @@ export function MediaPlayerPage() {
                     <section className="media-state-preview">
                       <div className="media-panel-heading">
                         <span>Machine snapshot</span>
-                        <strong>{runtimeSnapshot.status}</strong>
+                        <strong>{status}</strong>
                       </div>
                       <pre>
                       {JSON.stringify({
-                        status: runtimeSnapshot.status,
+                        status,
                         states: {
-                          transport: transportPath,
-                          settings: settingsPath
+                          transport: transport.path,
+                          settings: settings.path
                         },
                         data: {
-                          transport: playback ?? failed ?? null,
-                          settings
+                          transport: transport.value,
+                          settings: settings.value
                         }
                       }, null, 2)}
                       </pre>
                     </section>
 
-                    {failed !== undefined && <p className="media-error-message" role="alert">{failed.message}</p>}
+                    {transport.error !== null && <p className="media-error-message" role="alert">{transport.error}</p>}
                   </aside>
                 </div>
               </div>
             )
-          })()
-        )}
+          }
+        })
+      )}
     </ExamplePage>
   )
 }

--- a/examples/playground/src/examples/media-player/atoms.ts
+++ b/examples/playground/src/examples/media-player/atoms.ts
@@ -1,0 +1,8 @@
+import { AtomMachine } from "@typeonce/effect-machine/reactivity"
+import { Atom } from "effect/unstable/reactivity"
+import { MediaPlayerMachine } from "./machine.ts"
+import { MediaPlayer } from "./service.ts"
+
+const mediaPlayerRuntime = Atom.runtime(MediaPlayer.layer)
+
+export const mediaPlayerAtom = AtomMachine.bind(mediaPlayerRuntime).make(MediaPlayerMachine)

--- a/examples/playground/src/examples/media-player/atoms.ts
+++ b/examples/playground/src/examples/media-player/atoms.ts
@@ -1,8 +1,22 @@
 import { AtomMachine } from "@typeonce/effect-machine/reactivity"
+import { Effect } from "effect"
 import { Atom } from "effect/unstable/reactivity"
 import { MediaPlayerMachine } from "./machine.ts"
 import { MediaPlayer } from "./service.ts"
+import { toMediaPlayerView } from "./view.ts"
 
 const mediaPlayerRuntime = Atom.runtime(MediaPlayer.layer)
 
 export const mediaPlayerAtom = AtomMachine.bind(mediaPlayerRuntime).make(MediaPlayerMachine)
+
+export const mediaPlayerViewAtom = Atom.mapResult(mediaPlayerAtom.snapshot, (snapshot) => ({
+  status: snapshot.status,
+  ...toMediaPlayerView(snapshot.state)
+}))
+
+export const registerMediaPlayerElement = mediaPlayerRuntime.fn((audioRef: HTMLAudioElement) =>
+  Effect.gen(function*() {
+    const mediaPlayer = yield* MediaPlayer
+    yield* mediaPlayer.register(audioRef)
+  })
+)

--- a/examples/playground/src/examples/media-player/invocations.ts
+++ b/examples/playground/src/examples/media-player/invocations.ts
@@ -1,6 +1,6 @@
 import { Machine } from "@typeonce/effect-machine"
 import { Data, Effect, Stream } from "effect"
-import { type LoudnessSample, MediaPlayerInternalEvent } from "./schemas.ts"
+import { type LoudnessSample, MediaPlayerInternalEvent, type SoundSettings, toAudioSettings } from "./schemas.ts"
 import { MediaPlayer, MediaPlayerError } from "./service.ts"
 
 export const loadAudio = (url: string) =>
@@ -43,6 +43,16 @@ export const restartAudio = Machine.invokeEffect({
   onSuccess: () => MediaPlayerInternalEvent.cases.RestartSucceeded.make({}),
   onFailure: (failure) => MediaPlayerInternalEvent.cases.OperationFailed.make({ message: failure.message })
 })
+
+export const applyAudioSettings = (settings: SoundSettings, muted: boolean) =>
+  Machine.invokeEffect({
+    id: "apply-audio-settings",
+    effect: Effect.gen(function*() {
+      const mediaPlayer = yield* MediaPlayer
+      yield* mediaPlayer.applySettings(toAudioSettings(settings, muted))
+    }),
+    onSuccess: () => undefined
+  })
 
 type LoudnessProcessState = Data.TaggedEnum<{
   Waiting: {}

--- a/examples/playground/src/examples/media-player/invocations.ts
+++ b/examples/playground/src/examples/media-player/invocations.ts
@@ -1,0 +1,78 @@
+import { Machine } from "@typeonce/effect-machine"
+import { Data, Effect, Stream } from "effect"
+import { type LoudnessSample, MediaPlayerInternalEvent } from "./schemas.ts"
+import { MediaPlayer, MediaPlayerError } from "./service.ts"
+
+export const loadAudio = (url: string) =>
+  Machine.invokeEffect({
+    id: "load-audio",
+    effect: Effect.gen(function*() {
+      const mediaPlayer = yield* MediaPlayer
+      yield* mediaPlayer.load(url)
+    }),
+    onSuccess: () => MediaPlayerInternalEvent.cases.LoadSucceeded.make({}),
+    onFailure: (failure) => MediaPlayerInternalEvent.cases.OperationFailed.make({ message: failure.message })
+  })
+
+export const pauseAudio = Machine.invokeEffect({
+  id: "pause-audio",
+  effect: Effect.gen(function*() {
+    const mediaPlayer = yield* MediaPlayer
+    yield* mediaPlayer.pause
+  }),
+  onSuccess: () => undefined,
+  onFailure: (failure) => MediaPlayerInternalEvent.cases.OperationFailed.make({ message: failure.message })
+})
+
+export const playAudio = Machine.invokeEffect({
+  id: "play-audio",
+  effect: Effect.gen(function*() {
+    const mediaPlayer = yield* MediaPlayer
+    yield* mediaPlayer.play
+  }),
+  onSuccess: () => undefined,
+  onFailure: (failure) => MediaPlayerInternalEvent.cases.OperationFailed.make({ message: failure.message })
+})
+
+export const restartAudio = Machine.invokeEffect({
+  id: "restart-audio",
+  effect: Effect.gen(function*() {
+    const mediaPlayer = yield* MediaPlayer
+    yield* mediaPlayer.restart
+  }),
+  onSuccess: () => MediaPlayerInternalEvent.cases.RestartSucceeded.make({}),
+  onFailure: (failure) => MediaPlayerInternalEvent.cases.OperationFailed.make({ message: failure.message })
+})
+
+type LoudnessProcessState = Data.TaggedEnum<{
+  Waiting: {}
+  Measured: { readonly sample: LoudnessSample }
+  Failed: { readonly failure: MediaPlayerError }
+}>
+
+const LoudnessProcessState = Data.taggedEnum<LoudnessProcessState>()
+
+export const analyzeAudio = Machine.invoke({
+  id: "analyze-audio",
+  src: () =>
+    Machine.logic<LoudnessProcessState, never, void, never, MediaPlayer>({
+      initial: LoudnessProcessState.Waiting(),
+      run: ({ setState }) =>
+        Effect.gen(function*() {
+          const mediaPlayer = yield* MediaPlayer
+
+          yield* mediaPlayer.loudness.pipe(
+            Stream.runForEach((sample) => setState(LoudnessProcessState.Measured({ sample }))),
+            Effect.catch((failure) =>
+              setState(LoudnessProcessState.Failed({ failure })).pipe(Effect.andThen(Effect.never))
+            )
+          )
+        })
+    }),
+  snapshot: ({ snapshot }) =>
+    LoudnessProcessState.$match(snapshot.state, {
+      Waiting: () => undefined,
+      Measured: ({ sample }) => MediaPlayerInternalEvent.cases.LoudnessMeasured.make(sample),
+      Failed: ({ failure }) => MediaPlayerInternalEvent.cases.OperationFailed.make({ message: failure.message })
+    })
+})

--- a/examples/playground/src/examples/media-player/machine.test.ts
+++ b/examples/playground/src/examples/media-player/machine.test.ts
@@ -1,20 +1,23 @@
 import { assert, describe, it } from "@effect/vitest"
 import { MachineTest } from "@typeonce/effect-machine/testing"
 import { Effect, Graph } from "effect"
-import { MediaPlayerEvent, MediaPlayerMachine } from "./machine.ts"
+import { MediaPlayerMachine } from "./machine.ts"
+import { MediaPlayerEvent } from "./schemas.ts"
 
 const everyPublicEvent = [
   MediaPlayerEvent.cases.SourceSelected.make({ url: "https://example.com/audio.mp3" }),
   MediaPlayerEvent.cases.PlayRequested.make({}),
   MediaPlayerEvent.cases.PauseRequested.make({}),
-  MediaPlayerEvent.cases.MediaPlaying.make({}),
-  MediaPlayerEvent.cases.MediaPaused.make({}),
+  MediaPlayerEvent.cases.RestartRequested.make({}),
   MediaPlayerEvent.cases.MediaWaiting.make({}),
   MediaPlayerEvent.cases.MediaCanPlay.make({}),
-  MediaPlayerEvent.cases.MediaEnded.make({}),
+  MediaPlayerEvent.cases.PlaybackEnded.make({ currentTime: 42 }),
+  MediaPlayerEvent.cases.TimeUpdated.make({ currentTime: 21 }),
   MediaPlayerEvent.cases.MediaFailed.make({ message: "unsupported codec" }),
   MediaPlayerEvent.cases.VolumeChanged.make({ volume: 0.4 }),
-  MediaPlayerEvent.cases.MuteToggled.make({})
+  MediaPlayerEvent.cases.PlaybackRateChanged.make({ playbackRate: 1.5 }),
+  MediaPlayerEvent.cases.MuteRequested.make({}),
+  MediaPlayerEvent.cases.UnmuteRequested.make({})
 ]
 
 const generated = MachineTest.scenarios(MediaPlayerMachine, {
@@ -32,12 +35,8 @@ describe("media-player statechart model", () => {
         Effect.tap((trace) =>
           Effect.sync(() => {
             assert.strictEqual(trace.final.path, "Player")
-            assert.strictEqual(trace.final.states.playback.state.path, "Player.playback.Empty")
-            const volume = trace.final.states.volume.state
-            if (volume.path !== "Player.volume.Audible") {
-              throw new Error(`Expected Audible, received ${volume.path}`)
-            }
-            assert.strictEqual(volume.value.volume, 1)
+            assert.strictEqual(trace.final.states.transport.state.path.startsWith("Player.transport."), true)
+            assert.strictEqual(trace.final.states.settings.state.path.startsWith("Player.settings."), true)
           })
         ),
         Effect.asVoid
@@ -45,36 +44,26 @@ describe("media-player statechart model", () => {
     { fastCheck: { numRuns: 100, seed: 24_061 } }
   )
 
-  it.effect("makes the current behavior gaps explicit through coverage", () =>
+  it.effect("covers the public protocol and its reachable states", () =>
     Effect.gen(function*() {
       const trace = yield* MachineTest.run(MediaPlayerMachine, { events: everyPublicEvent })
       yield* MachineTest.verify(MediaPlayerMachine, trace)
 
       const coverage = MachineTest.coverage(MediaPlayerMachine, trace)
 
-      assert.strictEqual(coverage.events.missing, 0)
       assert.strictEqual(coverage.events.hit, everyPublicEvent.length)
-      assert.strictEqual(coverage.transitions.total, 0)
-      assert.strictEqual(coverage.logicalConfigurations.hit, 1)
-      assert.deepStrictEqual(coverage.states.activation.hits.map(({ path }) => path), [
-        "Player",
-        "Player.playback",
-        "Player.playback.Empty",
-        "Player.volume",
-        "Player.volume.Audible"
-      ])
-      assert.deepStrictEqual(coverage.states.activation.misses.map(({ path }) => path), [
-        "Player.playback.Loading",
-        "Player.playback.Paused",
-        "Player.playback.Playing",
-        "Player.playback.Buffering",
-        "Player.playback.Ended",
-        "Player.playback.Failed",
-        "Player.volume.Muted"
-      ])
+      assert.strictEqual(coverage.events.missing, 0)
+      assert.strictEqual(coverage.transitions.hit > 0, true)
+
+      const activated = new Set(coverage.states.activation.hits.map(({ path }) => path))
+      assert.strictEqual(activated.has("Player.transport.Empty"), true)
+      assert.strictEqual(activated.has("Player.transport.Loading"), true)
+      assert.strictEqual(activated.has("Player.transport.Failed"), true)
+      assert.strictEqual(activated.has("Player.settings.Audible"), true)
+      assert.strictEqual(activated.has("Player.settings.Muted"), true)
     }))
 
-  it.effect("records ignored events without inventing new logical configurations", () =>
+  it.effect("records every planned event in the observed graph", () =>
     Effect.gen(function*() {
       const trace = yield* MachineTest.run(MediaPlayerMachine, { events: everyPublicEvent })
       const observed = yield* MachineTest.observedGraph(MediaPlayerMachine, trace)
@@ -82,19 +71,9 @@ describe("media-player statechart model", () => {
         ({ data }) => data._tag === "Event"
       )
 
-      assert.strictEqual(Graph.nodeCount(observed.graph), 1)
+      assert.strictEqual(Graph.nodeCount(observed.graph) > 1, true)
       assert.strictEqual(Graph.edgeCount(observed.graph), everyPublicEvent.length + 1)
       assert.strictEqual(eventEdges.length, everyPublicEvent.length)
-      assert.strictEqual(eventEdges.every(({ source, target }) => source === target), true)
       assert.strictEqual(observed.starts.length, 1)
-
-      const node = Array.from(observed.graph)[0]![1]
-      assert.deepStrictEqual(node.configuration, [
-        "Player",
-        "Player.playback",
-        "Player.playback.Empty",
-        "Player.volume",
-        "Player.volume.Audible"
-      ])
     }))
 })

--- a/examples/playground/src/examples/media-player/machine.ts
+++ b/examples/playground/src/examples/media-player/machine.ts
@@ -1,105 +1,309 @@
 import { Machine } from "@typeonce/effect-machine"
-import { Schema } from "effect"
-
-export const MediaPlayerState = Schema.TaggedUnion({
-  Player: {},
-  playback: {},
-  Empty: {},
-  Loading: {},
-  Paused: {},
-  Playing: {},
-  Buffering: {},
-  Ended: {},
-  Failed: { message: Schema.String },
-  volume: {},
-  Audible: { volume: Schema.Number },
-  Muted: { previousVolume: Schema.Number }
-})
-
-export const MediaPlayerEvent = Schema.TaggedUnion({
-  SourceSelected: { url: Schema.String },
-  PlayRequested: {},
-  PauseRequested: {},
-  MediaPlaying: {},
-  MediaPaused: {},
-  MediaWaiting: {},
-  MediaCanPlay: {},
-  MediaEnded: {},
-  MediaFailed: { message: Schema.String },
-  VolumeChanged: { volume: Schema.Number },
-  MuteToggled: {}
-})
-
-export const MediaPlayerStates = Machine.defineStates({
-  Player: {
-    schema: MediaPlayerState.cases.Player,
-    type: "parallel",
-    states: {
-      playback: {
-        schema: MediaPlayerState.cases.playback,
-        initial: "Empty",
-        states: {
-          Empty: MediaPlayerState.cases.Empty,
-          Loading: MediaPlayerState.cases.Loading,
-          Paused: MediaPlayerState.cases.Paused,
-          Playing: MediaPlayerState.cases.Playing,
-          Buffering: MediaPlayerState.cases.Buffering,
-          Ended: MediaPlayerState.cases.Ended,
-          Failed: MediaPlayerState.cases.Failed
-        }
-      },
-      volume: {
-        schema: MediaPlayerState.cases.volume,
-        initial: "Audible",
-        states: {
-          Audible: MediaPlayerState.cases.Audible,
-          Muted: MediaPlayerState.cases.Muted
-        }
-      }
-    }
-  }
-})
+import { Effect } from "effect"
+import { analyzeAudio, loadAudio, pauseAudio, playAudio, restartAudio } from "./invocations.ts"
+import {
+  initialAudioSettings,
+  initialPlaybackData,
+  MediaPlayerEvent,
+  MediaPlayerInternalEvent,
+  MediaPlayerState,
+  MediaPlayerStates,
+  toAudioSettings,
+  updatePlaybackData
+} from "./schemas.ts"
+import { MediaPlayer } from "./service.ts"
 
 const initialPlayer = () =>
   MediaPlayerStates.initial.Player(MediaPlayerState.cases.Player.make({}), (player) =>
     player
-      .playback(
-        MediaPlayerState.cases.playback.make({}),
-        (playback) => playback.Empty(MediaPlayerState.cases.Empty.make({}))
+      .transport(
+        MediaPlayerState.cases.Transport.make({}),
+        (transport) => transport.Empty(MediaPlayerState.cases.Empty.make({}))
       )
-      .volume(
-        MediaPlayerState.cases.volume.make({}),
-        (volume) => volume.Audible(MediaPlayerState.cases.Audible.make({ volume: 1 }))
+      .settings(
+        MediaPlayerState.cases.Settings.make({}),
+        (settings) =>
+          settings.Audible(MediaPlayerState.cases.Audible.make({
+            volume: initialAudioSettings.volume,
+            playbackRate: initialAudioSettings.playbackRate
+          }))
       ))
 
-/**
- * The browser event protocol and parallel topology are ready. Keep calls to
- * HTMLAudioElement.play/pause in the React adapter (or staged actions), and
- * feed resulting DOM events back into this machine.
- */
 export const MediaPlayerMachine = Machine.make({
   id: "MediaPlayer",
   states: MediaPlayerStates.states,
   events: [MediaPlayerEvent],
+  internalEvents: [MediaPlayerInternalEvent],
   initial: initialPlayer
 }).handle({
   Player: {
+    on: {
+      AudioElementMounted: ({ event }) =>
+        Machine.action(
+          Effect.gen(function*() {
+            const mediaPlayer = yield* MediaPlayer
+            yield* mediaPlayer.register(event.audioRef)
+          })
+        )
+    },
     states: {
-      playback: {
+      transport: {
+        on: {
+          SourceSelected: {
+            reenter: true,
+            transition: ({ event, target }) =>
+              target.local.Loading(MediaPlayerState.cases.Loading.make({ url: event.url }))
+          },
+
+          MediaFailed: ({ event, target }) =>
+            target.local.Failed(MediaPlayerState.cases.Failed.make({ message: event.message })),
+
+          OperationFailed: ({ event, target }) =>
+            target.local.Failed(MediaPlayerState.cases.Failed.make({ message: event.message }))
+        },
         states: {
           Empty: {},
-          Loading: {},
-          Paused: {},
-          Playing: {},
-          Buffering: {},
-          Ended: {},
-          Failed: {}
+
+          Loading: {
+            invoke: ({ state }) => loadAudio(state.url),
+            on: {
+              LoadSucceeded: ({ target }) =>
+                target.local.Ready(
+                  MediaPlayerState.cases.Ready.make({}),
+                  (ready) => ready.Paused(MediaPlayerState.cases.Paused.make(initialPlaybackData))
+                )
+            }
+          },
+
+          Ready: {
+            states: {
+              Paused: {
+                invoke: pauseAudio,
+                on: {
+                  PlayRequested: ({ state, target }) =>
+                    target.local.Playing(
+                      MediaPlayerState.cases.Playing.make({
+                        ...updatePlaybackData(state, {}),
+                        loudness: null
+                      })
+                    ),
+
+                  RestartRequested: ({ state, target }) =>
+                    target.local.Restarting(
+                      MediaPlayerState.cases.Restarting.make(updatePlaybackData(state, {}))
+                    )
+                }
+              },
+
+              Playing: {
+                invoke: [playAudio, analyzeAudio],
+                on: {
+                  PauseRequested: ({ state, target }) =>
+                    target.local.Paused(
+                      MediaPlayerState.cases.Paused.make(updatePlaybackData(state, {}))
+                    ),
+
+                  RestartRequested: ({ state, target }) =>
+                    target.local.Restarting(
+                      MediaPlayerState.cases.Restarting.make(updatePlaybackData(state, {}))
+                    ),
+
+                  MediaWaiting: ({ state, target }) =>
+                    target.local.Buffering(
+                      MediaPlayerState.cases.Buffering.make(updatePlaybackData(state, {}))
+                    ),
+
+                  PlaybackEnded: ({ event, state, target }) =>
+                    target.local.Ended(
+                      MediaPlayerState.cases.Ended.make(
+                        updatePlaybackData(state, { currentTime: event.currentTime })
+                      )
+                    ),
+
+                  TimeUpdated: ({ event, state, target }) =>
+                    target.local.Playing(
+                      MediaPlayerState.cases.Playing.make({
+                        currentTime: event.currentTime,
+                        loudness: state.loudness
+                      })
+                    ),
+
+                  LoudnessMeasured: ({ event, state, target }) =>
+                    target.local.Playing(
+                      MediaPlayerState.cases.Playing.make({
+                        currentTime: state.currentTime,
+                        loudness: {
+                          rms: event.rms,
+                          peak: event.peak,
+                          decibels: event.decibels
+                        }
+                      })
+                    )
+                }
+              },
+
+              Buffering: {
+                on: {
+                  MediaCanPlay: ({ state, target }) =>
+                    target.local.Playing(
+                      MediaPlayerState.cases.Playing.make({
+                        ...updatePlaybackData(state, {}),
+                        loudness: null
+                      })
+                    ),
+
+                  PauseRequested: ({ state, target }) =>
+                    target.local.Paused(
+                      MediaPlayerState.cases.Paused.make(updatePlaybackData(state, {}))
+                    ),
+
+                  RestartRequested: ({ state, target }) =>
+                    target.local.Restarting(
+                      MediaPlayerState.cases.Restarting.make(updatePlaybackData(state, {}))
+                    ),
+
+                  PlaybackEnded: ({ event, state, target }) =>
+                    target.local.Ended(
+                      MediaPlayerState.cases.Ended.make(
+                        updatePlaybackData(state, { currentTime: event.currentTime })
+                      )
+                    ),
+
+                  TimeUpdated: ({ event, state, target }) =>
+                    target.local.Buffering(
+                      MediaPlayerState.cases.Buffering.make(
+                        updatePlaybackData(state, { currentTime: event.currentTime })
+                      )
+                    )
+                }
+              },
+
+              Restarting: {
+                invoke: restartAudio,
+                on: {
+                  RestartSucceeded: ({ target }) =>
+                    target.local.Playing(
+                      MediaPlayerState.cases.Playing.make({ currentTime: 0, loudness: null })
+                    ),
+
+                  TimeUpdated: ({ event, state, target }) =>
+                    target.local.Restarting(
+                      MediaPlayerState.cases.Restarting.make(
+                        updatePlaybackData(state, { currentTime: event.currentTime })
+                      )
+                    )
+                }
+              },
+
+              Ended: {
+                on: {
+                  PlayRequested: ({ state, target }) =>
+                    target.local.Restarting(
+                      MediaPlayerState.cases.Restarting.make(updatePlaybackData(state, {}))
+                    ),
+
+                  RestartRequested: ({ state, target }) =>
+                    target.local.Restarting(
+                      MediaPlayerState.cases.Restarting.make(updatePlaybackData(state, {}))
+                    )
+                }
+              }
+            }
+          },
+
+          Failed: {
+            invoke: ({ state }) =>
+              Machine.invoke({
+                id: "report-error",
+                src: () =>
+                  Machine.effect(
+                    Effect.gen(function*() {
+                      const mediaPlayer = yield* MediaPlayer
+                      yield* mediaPlayer.reportError(state.message)
+                    })
+                  )
+              })
+          }
         }
       },
-      volume: {
+
+      settings: {
         states: {
-          Audible: {},
-          Muted: {}
+          Audible: {
+            on: {
+              VolumeChanged: ({ event, state, target }) => {
+                const next = { volume: event.volume, playbackRate: state.playbackRate }
+                return Machine.action(
+                  Effect.gen(function*() {
+                    const mediaPlayer = yield* MediaPlayer
+                    yield* mediaPlayer.applySettings(toAudioSettings(next, false))
+                  }),
+                  target.local.Audible(MediaPlayerState.cases.Audible.make(next))
+                )
+              },
+
+              PlaybackRateChanged: ({ event, state, target }) => {
+                const next = { volume: state.volume, playbackRate: event.playbackRate }
+                return Machine.action(
+                  Effect.gen(function*() {
+                    const mediaPlayer = yield* MediaPlayer
+                    yield* mediaPlayer.applySettings(toAudioSettings(next, false))
+                  }),
+                  target.local.Audible(MediaPlayerState.cases.Audible.make(next))
+                )
+              },
+
+              MuteRequested: ({ state, target }) =>
+                Machine.action(
+                  Effect.gen(function*() {
+                    const mediaPlayer = yield* MediaPlayer
+                    yield* mediaPlayer.applySettings(toAudioSettings(state, true))
+                  }),
+                  target.local.Muted(MediaPlayerState.cases.Muted.make({
+                    volume: state.volume,
+                    playbackRate: state.playbackRate
+                  }))
+                )
+            }
+          },
+
+          Muted: {
+            on: {
+              VolumeChanged: ({ event, state, target }) => {
+                const next = { volume: event.volume, playbackRate: state.playbackRate }
+                return Machine.action(
+                  Effect.gen(function*() {
+                    const mediaPlayer = yield* MediaPlayer
+                    yield* mediaPlayer.applySettings(toAudioSettings(next, true))
+                  }),
+                  target.local.Muted(MediaPlayerState.cases.Muted.make(next))
+                )
+              },
+
+              PlaybackRateChanged: ({ event, state, target }) => {
+                const next = { volume: state.volume, playbackRate: event.playbackRate }
+                return Machine.action(
+                  Effect.gen(function*() {
+                    const mediaPlayer = yield* MediaPlayer
+                    yield* mediaPlayer.applySettings(toAudioSettings(next, true))
+                  }),
+                  target.local.Muted(MediaPlayerState.cases.Muted.make(next))
+                )
+              },
+
+              UnmuteRequested: ({ state, target }) =>
+                Machine.action(
+                  Effect.gen(function*() {
+                    const mediaPlayer = yield* MediaPlayer
+                    yield* mediaPlayer.applySettings(toAudioSettings(state, false))
+                  }),
+                  target.local.Audible(MediaPlayerState.cases.Audible.make({
+                    volume: state.volume,
+                    playbackRate: state.playbackRate
+                  }))
+                )
+            }
+          }
         }
       }
     }

--- a/examples/playground/src/examples/media-player/machine.ts
+++ b/examples/playground/src/examples/media-player/machine.ts
@@ -1,6 +1,6 @@
 import { Machine } from "@typeonce/effect-machine"
 import { Effect } from "effect"
-import { analyzeAudio, loadAudio, pauseAudio, playAudio, restartAudio } from "./invocations.ts"
+import { analyzeAudio, applyAudioSettings, loadAudio, pauseAudio, playAudio, restartAudio } from "./invocations.ts"
 import {
   initialAudioSettings,
   initialPlaybackData,
@@ -8,7 +8,6 @@ import {
   MediaPlayerInternalEvent,
   MediaPlayerState,
   MediaPlayerStates,
-  toAudioSettings,
   updatePlaybackData
 } from "./schemas.ts"
 import { MediaPlayer } from "./service.ts"
@@ -37,15 +36,6 @@ export const MediaPlayerMachine = Machine.make({
   initial: initialPlayer
 }).handle({
   Player: {
-    on: {
-      AudioElementMounted: ({ event }) =>
-        Machine.action(
-          Effect.gen(function*() {
-            const mediaPlayer = yield* MediaPlayer
-            yield* mediaPlayer.register(event.audioRef)
-          })
-        )
-    },
     states: {
       transport: {
         on: {
@@ -230,78 +220,60 @@ export const MediaPlayerMachine = Machine.make({
       settings: {
         states: {
           Audible: {
+            invoke: ({ state }) => applyAudioSettings(state, false),
             on: {
-              VolumeChanged: ({ event, state, target }) => {
-                const next = { volume: event.volume, playbackRate: state.playbackRate }
-                return Machine.action(
-                  Effect.gen(function*() {
-                    const mediaPlayer = yield* MediaPlayer
-                    yield* mediaPlayer.applySettings(toAudioSettings(next, false))
-                  }),
-                  target.local.Audible(MediaPlayerState.cases.Audible.make(next))
-                )
+              VolumeChanged: {
+                reenter: true,
+                transition: ({ event, state, target }) =>
+                  target.local.Audible(MediaPlayerState.cases.Audible.make({
+                    volume: event.volume,
+                    playbackRate: state.playbackRate
+                  }))
               },
 
-              PlaybackRateChanged: ({ event, state, target }) => {
-                const next = { volume: state.volume, playbackRate: event.playbackRate }
-                return Machine.action(
-                  Effect.gen(function*() {
-                    const mediaPlayer = yield* MediaPlayer
-                    yield* mediaPlayer.applySettings(toAudioSettings(next, false))
-                  }),
-                  target.local.Audible(MediaPlayerState.cases.Audible.make(next))
-                )
+              PlaybackRateChanged: {
+                reenter: true,
+                transition: ({ event, state, target }) =>
+                  target.local.Audible(MediaPlayerState.cases.Audible.make({
+                    volume: state.volume,
+                    playbackRate: event.playbackRate
+                  }))
               },
 
               MuteRequested: ({ state, target }) =>
-                Machine.action(
-                  Effect.gen(function*() {
-                    const mediaPlayer = yield* MediaPlayer
-                    yield* mediaPlayer.applySettings(toAudioSettings(state, true))
-                  }),
-                  target.local.Muted(MediaPlayerState.cases.Muted.make({
-                    volume: state.volume,
-                    playbackRate: state.playbackRate
-                  }))
-                )
+                target.local.Muted(MediaPlayerState.cases.Muted.make({
+                  volume: state.volume,
+                  playbackRate: state.playbackRate
+                }))
             }
           },
 
           Muted: {
+            invoke: ({ state }) => applyAudioSettings(state, true),
             on: {
-              VolumeChanged: ({ event, state, target }) => {
-                const next = { volume: event.volume, playbackRate: state.playbackRate }
-                return Machine.action(
-                  Effect.gen(function*() {
-                    const mediaPlayer = yield* MediaPlayer
-                    yield* mediaPlayer.applySettings(toAudioSettings(next, true))
-                  }),
-                  target.local.Muted(MediaPlayerState.cases.Muted.make(next))
-                )
+              VolumeChanged: {
+                reenter: true,
+                transition: ({ event, state, target }) =>
+                  target.local.Muted(MediaPlayerState.cases.Muted.make({
+                    volume: event.volume,
+                    playbackRate: state.playbackRate
+                  }))
               },
 
-              PlaybackRateChanged: ({ event, state, target }) => {
-                const next = { volume: state.volume, playbackRate: event.playbackRate }
-                return Machine.action(
-                  Effect.gen(function*() {
-                    const mediaPlayer = yield* MediaPlayer
-                    yield* mediaPlayer.applySettings(toAudioSettings(next, true))
-                  }),
-                  target.local.Muted(MediaPlayerState.cases.Muted.make(next))
-                )
+              PlaybackRateChanged: {
+                reenter: true,
+                transition: ({ event, state, target }) =>
+                  target.local.Muted(MediaPlayerState.cases.Muted.make({
+                    volume: state.volume,
+                    playbackRate: event.playbackRate
+                  }))
               },
 
               UnmuteRequested: ({ state, target }) =>
-                Machine.action(
-                  Effect.gen(function*() {
-                    const mediaPlayer = yield* MediaPlayer
-                    yield* mediaPlayer.applySettings(toAudioSettings(state, false))
-                  }),
-                  target.local.Audible(MediaPlayerState.cases.Audible.make({
-                    volume: state.volume,
-                    playbackRate: state.playbackRate
-                  }))
-                )
+                target.local.Audible(MediaPlayerState.cases.Audible.make({
+                  volume: state.volume,
+                  playbackRate: state.playbackRate
+                }))
             }
           }
         }

--- a/examples/playground/src/examples/media-player/schemas.ts
+++ b/examples/playground/src/examples/media-player/schemas.ts
@@ -1,0 +1,175 @@
+import { Machine } from "@typeonce/effect-machine"
+import { Schema } from "effect"
+
+export interface AudioSettings {
+  readonly volume: number
+  readonly muted: boolean
+  readonly playbackRate: number
+}
+
+export interface SoundSettings {
+  readonly volume: number
+  readonly playbackRate: number
+}
+
+export interface LoudnessSample {
+  readonly rms: number
+  readonly peak: number
+  readonly decibels: number
+}
+
+export interface PlaybackData {
+  readonly currentTime: number
+}
+
+export interface PlayingData extends PlaybackData {
+  readonly loudness: LoudnessSample | null
+}
+
+const Loudness = Schema.Struct({
+  rms: Schema.Number,
+  peak: Schema.Number,
+  decibels: Schema.Number
+})
+
+const playbackFields = { currentTime: Schema.Number }
+
+const soundSettingsFields = {
+  volume: Schema.Number,
+  playbackRate: Schema.Number
+}
+
+export const MediaPlayerState = Schema.TaggedUnion({
+  Player: {},
+
+  Transport: {},
+
+  Empty: {},
+
+  Loading: { url: Schema.String },
+
+  Ready: {},
+
+  Paused: playbackFields,
+
+  Playing: {
+    ...playbackFields,
+    loudness: Schema.NullOr(Loudness)
+  },
+
+  Buffering: playbackFields,
+
+  Restarting: playbackFields,
+
+  Ended: playbackFields,
+
+  Failed: { message: Schema.String },
+
+  Settings: {},
+
+  Audible: soundSettingsFields,
+
+  Muted: soundSettingsFields
+})
+
+const AudioElement = Schema.instanceOf(HTMLAudioElement)
+
+export const MediaPlayerEvent = Schema.TaggedUnion({
+  AudioElementMounted: { audioRef: AudioElement },
+  SourceSelected: { url: Schema.String },
+  PlayRequested: {},
+  PauseRequested: {},
+  RestartRequested: {},
+  MediaWaiting: {},
+  MediaCanPlay: {},
+  PlaybackEnded: { currentTime: Schema.Number },
+  TimeUpdated: { currentTime: Schema.Number },
+  MediaFailed: { message: Schema.String },
+  VolumeChanged: { volume: Schema.Number },
+  PlaybackRateChanged: { playbackRate: Schema.Number },
+  MuteRequested: {},
+  UnmuteRequested: {}
+})
+
+export const MediaPlayerInternalEvent = Schema.TaggedUnion({
+  LoadSucceeded: {},
+  RestartSucceeded: {},
+  LoudnessMeasured: {
+    rms: Schema.Number,
+    peak: Schema.Number,
+    decibels: Schema.Number
+  },
+  OperationFailed: { message: Schema.String }
+})
+
+export const MediaPlayerStates = Machine.defineStates({
+  Player: {
+    schema: MediaPlayerState.cases.Player,
+    type: "parallel",
+    states: {
+      transport: {
+        schema: MediaPlayerState.cases.Transport,
+        initial: "Empty",
+        states: {
+          Empty: MediaPlayerState.cases.Empty,
+
+          Loading: MediaPlayerState.cases.Loading,
+
+          Ready: {
+            schema: MediaPlayerState.cases.Ready,
+            initial: "Paused",
+            states: {
+              Paused: MediaPlayerState.cases.Paused,
+
+              Playing: MediaPlayerState.cases.Playing,
+
+              Buffering: MediaPlayerState.cases.Buffering,
+
+              Restarting: MediaPlayerState.cases.Restarting,
+
+              Ended: MediaPlayerState.cases.Ended
+            }
+          },
+
+          Failed: MediaPlayerState.cases.Failed
+        }
+      },
+
+      settings: {
+        schema: MediaPlayerState.cases.Settings,
+        initial: "Audible",
+        states: {
+          Audible: MediaPlayerState.cases.Audible,
+
+          Muted: MediaPlayerState.cases.Muted
+        }
+      }
+    }
+  }
+})
+
+export const initialPlaybackData: PlaybackData = {
+  currentTime: 0
+}
+
+export const initialAudioSettings: AudioSettings = {
+  volume: 1,
+  muted: false,
+  playbackRate: 1
+}
+
+export const updatePlaybackData = (
+  state: PlaybackData,
+  patch: Partial<PlaybackData>
+): PlaybackData => ({
+  currentTime: patch.currentTime ?? state.currentTime
+})
+
+export const toAudioSettings = (
+  settings: SoundSettings,
+  muted: boolean
+): AudioSettings => ({
+  volume: settings.volume,
+  muted,
+  playbackRate: settings.playbackRate
+})

--- a/examples/playground/src/examples/media-player/schemas.ts
+++ b/examples/playground/src/examples/media-player/schemas.ts
@@ -72,10 +72,7 @@ export const MediaPlayerState = Schema.TaggedUnion({
   Muted: soundSettingsFields
 })
 
-const AudioElement = Schema.instanceOf(HTMLAudioElement)
-
 export const MediaPlayerEvent = Schema.TaggedUnion({
-  AudioElementMounted: { audioRef: AudioElement },
   SourceSelected: { url: Schema.String },
   PlayRequested: {},
   PauseRequested: {},

--- a/examples/playground/src/examples/media-player/service.ts
+++ b/examples/playground/src/examples/media-player/service.ts
@@ -1,0 +1,314 @@
+import { Context, Data, Effect, Layer, Schedule, Stream, SynchronizedRef } from "effect"
+import { type AudioSettings, initialAudioSettings, type LoudnessSample } from "./schemas.ts"
+
+export class MediaPlayerError extends Data.TaggedError("MediaPlayerError")<{
+  readonly operation: "load" | "play" | "pause" | "restart" | "analyze"
+  readonly message: string
+}> {}
+
+type MediaGraph = Data.TaggedEnum<{
+  Empty: {
+    readonly settings: AudioSettings
+  }
+  Registered: {
+    readonly audioRef: HTMLAudioElement
+    readonly audioContext: AudioContext | null
+    readonly settings: AudioSettings
+  }
+  Loaded: {
+    readonly audioRef: HTMLAudioElement
+    readonly audioContext: AudioContext
+    readonly trackSource: MediaElementAudioSourceNode
+    readonly analyserNode: AnalyserNode
+    readonly settings: AudioSettings
+  }
+}>
+
+const MediaGraph = Data.taggedEnum<MediaGraph>()
+
+type BrowserWindow = Window & {
+  readonly webkitAudioContext?: typeof AudioContext
+}
+
+const error = (
+  operation: MediaPlayerError["operation"],
+  message: string
+): MediaPlayerError => new MediaPlayerError({ operation, message })
+
+const applySettingsToElement = (
+  audioRef: HTMLAudioElement,
+  settings: AudioSettings
+): void => {
+  audioRef.volume = settings.volume
+  audioRef.muted = settings.muted
+  audioRef.playbackRate = settings.playbackRate
+}
+
+const waitForMedia = (
+  audioRef: HTMLAudioElement,
+  url: string
+): Effect.Effect<void, MediaPlayerError> =>
+  Effect.callback<void, MediaPlayerError>((resume) => {
+    const cleanup = () => {
+      audioRef.removeEventListener("loadeddata", onLoaded)
+      audioRef.removeEventListener("error", onError)
+    }
+    const onLoaded = () => {
+      cleanup()
+      resume(Effect.void)
+    }
+    const onError = () => {
+      cleanup()
+      resume(Effect.fail(error("load", audioRef.error?.message ?? "The selected audio file could not be loaded")))
+    }
+
+    audioRef.addEventListener("loadeddata", onLoaded, { once: true })
+    audioRef.addEventListener("error", onError, { once: true })
+
+    try {
+      audioRef.src = url
+      audioRef.load()
+    } catch {
+      onError()
+    }
+
+    return Effect.sync(cleanup)
+  })
+
+const releaseGraph = (graphRef: SynchronizedRef.SynchronizedRef<MediaGraph>) =>
+  SynchronizedRef.updateEffect(graphRef, (graph) =>
+    Effect.gen(function*() {
+      if (graph._tag === "Loaded") {
+        yield* Effect.sync(() => {
+          graph.trackSource.disconnect()
+          graph.analyserNode.disconnect()
+        })
+      }
+
+      const audioContext = graph._tag === "Empty" ? null : graph.audioContext
+
+      if (audioContext !== null && audioContext.state !== "closed") {
+        yield* Effect.tryPromise({
+          try: () => audioContext.close(),
+          catch: () => undefined
+        }).pipe(Effect.ignore)
+      }
+
+      return MediaGraph.Empty({ settings: graph.settings })
+    }))
+
+export class MediaPlayer extends Context.Service<MediaPlayer>()(
+  "effect-machine/playground/MediaPlayer",
+  {
+    make: Effect.acquireRelease(
+      Effect.gen(function*() {
+        const graphRef = yield* SynchronizedRef.make<MediaGraph>(
+          MediaGraph.Empty({ settings: initialAudioSettings })
+        )
+
+        const service = {
+          register: (nextAudioRef: HTMLAudioElement) =>
+            SynchronizedRef.updateEffect(graphRef, (graph) => {
+              if (graph._tag !== "Empty" && graph.audioRef === nextAudioRef) {
+                return Effect.sync(() => {
+                  applySettingsToElement(nextAudioRef, graph.settings)
+                  return graph
+                })
+              }
+
+              return Effect.sync(() => {
+                if (graph._tag === "Loaded") {
+                  graph.trackSource.disconnect()
+                  graph.analyserNode.disconnect()
+                }
+
+                applySettingsToElement(nextAudioRef, graph.settings)
+
+                return MediaGraph.Registered({
+                  audioRef: nextAudioRef,
+                  audioContext: graph._tag === "Empty" ? null : graph.audioContext,
+                  settings: graph.settings
+                })
+              })
+            }),
+
+          load: (url: string) =>
+            SynchronizedRef.updateEffect(
+              graphRef,
+              (graph): Effect.Effect<MediaGraph, MediaPlayerError> =>
+                Effect.gen(function*() {
+                  if (graph._tag === "Empty") {
+                    return yield* Effect.fail(error("load", "The audio element is not ready"))
+                  }
+
+                  yield* waitForMedia(graph.audioRef, url)
+
+                  if (graph._tag === "Loaded") return graph
+
+                  const AudioContextConstructor = window.AudioContext ?? (window as BrowserWindow).webkitAudioContext
+
+                  if (AudioContextConstructor === undefined) {
+                    return yield* Effect.fail(error("load", "Web Audio is not supported by this browser"))
+                  }
+
+                  return yield* Effect.try({
+                    try: () => {
+                      const audioContext = graph.audioContext === null || graph.audioContext.state === "closed"
+                        ? new AudioContextConstructor()
+                        : graph.audioContext
+                      const trackSource = audioContext.createMediaElementSource(graph.audioRef)
+                      const analyserNode = audioContext.createAnalyser()
+
+                      analyserNode.fftSize = 256
+                      trackSource.connect(analyserNode)
+                      analyserNode.connect(audioContext.destination)
+
+                      return MediaGraph.Loaded({
+                        audioRef: graph.audioRef,
+                        audioContext,
+                        trackSource,
+                        analyserNode,
+                        settings: graph.settings
+                      })
+                    },
+                    catch: () => error("load", "The audio graph could not be connected")
+                  })
+                })
+            ),
+
+          applySettings: (settings: AudioSettings) =>
+            SynchronizedRef.updateEffect(graphRef, (graph) =>
+              Effect.sync(() => {
+                if (graph._tag !== "Empty") {
+                  applySettingsToElement(graph.audioRef, settings)
+                }
+
+                return MediaGraph.$match(graph, {
+                  Empty: () => MediaGraph.Empty({ settings }),
+                  Registered: ({ audioRef, audioContext }) =>
+                    MediaGraph.Registered({ audioRef, audioContext, settings }),
+                  Loaded: ({ audioRef, audioContext, trackSource, analyserNode }) =>
+                    MediaGraph.Loaded({ audioRef, audioContext, trackSource, analyserNode, settings })
+                })
+              })),
+
+          play: SynchronizedRef.updateEffect(
+            graphRef,
+            (graph): Effect.Effect<MediaGraph, MediaPlayerError> =>
+              Effect.gen(function*() {
+                if (graph._tag !== "Loaded") {
+                  return yield* Effect.fail(error("play", "The audio graph is not ready"))
+                }
+
+                if (graph.audioContext.state === "suspended") {
+                  yield* Effect.tryPromise({
+                    try: () => graph.audioContext.resume(),
+                    catch: () => error("play", "The audio context could not be resumed")
+                  })
+                }
+
+                yield* Effect.tryPromise({
+                  try: () => graph.audioRef.play(),
+                  catch: () => error("play", "Playback could not be started")
+                })
+
+                return graph
+              })
+          ),
+
+          pause: SynchronizedRef.updateEffect(
+            graphRef,
+            (graph): Effect.Effect<MediaGraph, MediaPlayerError> =>
+              Effect.gen(function*() {
+                if (graph._tag === "Empty") {
+                  return yield* Effect.fail(error("pause", "The audio element is not ready"))
+                }
+
+                yield* Effect.try({
+                  try: () => graph.audioRef.pause(),
+                  catch: () => error("pause", "Playback could not be paused")
+                })
+
+                return graph
+              })
+          ),
+
+          restart: SynchronizedRef.updateEffect(
+            graphRef,
+            (graph): Effect.Effect<MediaGraph, MediaPlayerError> =>
+              Effect.gen(function*() {
+                if (graph._tag !== "Loaded") {
+                  return yield* Effect.fail(error("restart", "The audio graph is not ready"))
+                }
+
+                if (graph.audioContext.state === "suspended") {
+                  yield* Effect.tryPromise({
+                    try: () => graph.audioContext.resume(),
+                    catch: () => error("restart", "The audio context could not be resumed")
+                  })
+                }
+
+                yield* Effect.tryPromise({
+                  try: async () => {
+                    graph.audioRef.currentTime = 0
+                    await graph.audioRef.play()
+                  },
+                  catch: () => error("restart", "Playback could not be restarted")
+                })
+
+                return graph
+              })
+          ),
+
+          loudness: Stream.unwrap(
+            Effect.gen(function*() {
+              const graph = yield* SynchronizedRef.get(graphRef)
+
+              if (graph._tag !== "Loaded") {
+                return yield* Effect.fail(error("analyze", "The audio analyser is not ready"))
+              }
+
+              const samples = new Uint8Array(graph.analyserNode.fftSize)
+
+              return Stream.fromEffectSchedule(
+                Effect.sync(() => {
+                  graph.analyserNode.getByteTimeDomainData(samples)
+
+                  let sum = 0
+                  let peak = 0
+
+                  for (const value of samples) {
+                    const normalized = (value - 128) / 128
+                    const absolute = Math.abs(normalized)
+
+                    sum += normalized * normalized
+                    peak = Math.max(peak, absolute)
+                  }
+
+                  const rms = Math.sqrt(sum / samples.length)
+
+                  return {
+                    rms,
+                    peak,
+                    decibels: 20 * Math.log10(Math.max(rms, 0.0001))
+                  } satisfies LoudnessSample
+                }),
+                Schedule.spaced("100 millis")
+              )
+            })
+          ),
+
+          reportError: (message: string) =>
+            Effect.sync(() => {
+              console.error(`[media-player] ${message}`)
+            })
+        }
+
+        return { graphRef, service }
+      }),
+      ({ graphRef }) => releaseGraph(graphRef)
+    ).pipe(Effect.map(({ service }) => service))
+  }
+) {
+  static readonly layer = Layer.effect(this)(this.make)
+}

--- a/examples/playground/src/examples/media-player/view.ts
+++ b/examples/playground/src/examples/media-player/view.ts
@@ -1,0 +1,154 @@
+import type { Machine } from "@typeonce/effect-machine"
+import { Match } from "effect"
+import { MediaPlayerMachine } from "./machine.ts"
+import { initialPlaybackData, type LoudnessSample, type PlaybackData } from "./schemas.ts"
+
+type MediaPlayerSnapshot = Machine.Machine.Snapshot<Machine.Machine.States<typeof MediaPlayerMachine>>
+type TransportSnapshot = MediaPlayerSnapshot["states"]["transport"]["state"]
+type ReadySnapshot = Extract<TransportSnapshot, { readonly path: "Player.transport.Ready" }>["state"]
+type SettingsSnapshot = MediaPlayerSnapshot["states"]["settings"]["state"]
+
+export type MediaPlayerTransportPath =
+  | Exclude<TransportSnapshot["path"], "Player.transport.Ready">
+  | ReadySnapshot["path"]
+
+export interface MediaPlayerTransportView {
+  readonly path: MediaPlayerTransportPath
+  readonly name: "Empty" | "Loading" | "Paused" | "Playing" | "Buffering" | "Restarting" | "Ended" | "Failed"
+  readonly value: TransportSnapshot["value"] | ReadySnapshot["value"]
+  readonly playback: PlaybackData
+  readonly loudness: LoudnessSample | null
+  readonly error: string | null
+  readonly isPlaying: boolean
+  readonly isBuffering: boolean
+  readonly canPlay: boolean
+  readonly canPause: boolean
+  readonly canRestart: boolean
+}
+
+export interface MediaPlayerSettingsView {
+  readonly path: SettingsSnapshot["path"]
+  readonly value: SettingsSnapshot["value"]
+  readonly volume: number
+  readonly playbackRate: number
+  readonly muted: boolean
+}
+
+export interface MediaPlayerView {
+  readonly transport: MediaPlayerTransportView
+  readonly settings: MediaPlayerSettingsView
+}
+
+const transportDefaults = {
+  playback: initialPlaybackData,
+  loudness: null,
+  error: null,
+  isPlaying: false,
+  isBuffering: false,
+  canPlay: false,
+  canPause: false,
+  canRestart: false
+} as const
+
+const toReadyView = (snapshot: ReadySnapshot): MediaPlayerTransportView =>
+  Match.value(snapshot).pipe(
+    Match.discriminatorsExhaustive("path")({
+      "Player.transport.Ready.Paused": ({ path, value }) => ({
+        ...transportDefaults,
+        path,
+        name: "Paused" as const,
+        value,
+        playback: value,
+        canPlay: true,
+        canRestart: true
+      }),
+      "Player.transport.Ready.Playing": ({ path, value }) => ({
+        ...transportDefaults,
+        path,
+        name: "Playing" as const,
+        value,
+        playback: value,
+        loudness: value.loudness,
+        isPlaying: true,
+        canPause: true,
+        canRestart: true
+      }),
+      "Player.transport.Ready.Buffering": ({ path, value }) => ({
+        ...transportDefaults,
+        path,
+        name: "Buffering" as const,
+        value,
+        playback: value,
+        isBuffering: true,
+        canPause: true,
+        canRestart: true
+      }),
+      "Player.transport.Ready.Restarting": ({ path, value }) => ({
+        ...transportDefaults,
+        path,
+        name: "Restarting" as const,
+        value,
+        playback: value
+      }),
+      "Player.transport.Ready.Ended": ({ path, value }) => ({
+        ...transportDefaults,
+        path,
+        name: "Ended" as const,
+        value,
+        playback: value,
+        canPlay: true,
+        canRestart: true
+      })
+    })
+  )
+
+const toTransportView = (snapshot: TransportSnapshot): MediaPlayerTransportView =>
+  Match.value(snapshot).pipe(
+    Match.discriminatorsExhaustive("path")({
+      "Player.transport.Empty": ({ path, value }) => ({
+        ...transportDefaults,
+        path,
+        name: "Empty" as const,
+        value
+      }),
+      "Player.transport.Loading": ({ path, value }) => ({
+        ...transportDefaults,
+        path,
+        name: "Loading" as const,
+        value
+      }),
+      "Player.transport.Ready": ({ state }) => toReadyView(state),
+      "Player.transport.Failed": ({ path, value }) => ({
+        ...transportDefaults,
+        path,
+        name: "Failed" as const,
+        value,
+        error: value.message
+      })
+    })
+  )
+
+const toSettingsView = (snapshot: SettingsSnapshot): MediaPlayerSettingsView =>
+  Match.value(snapshot).pipe(
+    Match.discriminatorsExhaustive("path")({
+      "Player.settings.Audible": ({ path, value }) => ({
+        path,
+        value,
+        volume: value.volume,
+        playbackRate: value.playbackRate,
+        muted: false
+      }),
+      "Player.settings.Muted": ({ path, value }) => ({
+        path,
+        value,
+        volume: value.volume,
+        playbackRate: value.playbackRate,
+        muted: true
+      })
+    })
+  )
+
+export const toMediaPlayerView = (snapshot: MediaPlayerSnapshot): MediaPlayerView => ({
+  transport: toTransportView(snapshot.states.transport.state),
+  settings: toSettingsView(snapshot.states.settings.state)
+})

--- a/examples/playground/src/router.tsx
+++ b/examples/playground/src/router.tsx
@@ -27,8 +27,8 @@ const examples = [
   {
     to: "/media-player" as const,
     title: "Media player",
-    description: "Connect a real audio element lifecycle to a typed statechart.",
-    concepts: ["DOM events", "parallel concerns"]
+    description: "Coordinate parallel transport and sound modes with state-scoped Effects.",
+    concepts: ["parallel states", "compound states", "Effect services"]
   },
   {
     to: "/worker-tabs" as const,

--- a/examples/playground/src/styles.css
+++ b/examples/playground/src/styles.css
@@ -362,6 +362,356 @@ h1 {
   margin-bottom: 0.5rem;
 }
 
+.media-player-message {
+  display: grid;
+  min-height: 25rem;
+  place-items: center;
+  color: #aeb8ca;
+}
+
+.media-player-message.is-error,
+.media-error-message {
+  color: #ff9ea6;
+}
+
+.media-player-console {
+  min-height: 25rem;
+  padding: clamp(1rem, 3vw, 2rem);
+}
+
+.media-player-toolbar,
+.media-player-toolbar-actions,
+.media-panel-heading,
+.media-time-row,
+.media-controls {
+  display: flex;
+  align-items: center;
+}
+
+.media-player-toolbar {
+  gap: 1.5rem;
+  justify-content: space-between;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid #2c3547;
+}
+
+.media-player-toolbar h2 {
+  max-width: 32rem;
+  margin: 0;
+  overflow: hidden;
+  font-size: clamp(1.15rem, 2vw, 1.5rem);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.media-player-kicker {
+  margin-bottom: 0.35rem;
+  color: #7785a1;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.7rem;
+  font-weight: 750;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.media-player-toolbar-actions {
+  gap: 0.75rem;
+  flex: none;
+}
+
+.media-state-chip {
+  padding: 0.42rem 0.65rem;
+  border: 1px solid #485573;
+  border-radius: 999px;
+  color: #aeb9ce;
+  background: #171d28;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.media-state-chip.is-playing {
+  border-color: rgb(66 214 163 / 55%);
+  color: #79e4bf;
+  box-shadow: 0 0 1.2rem rgb(66 214 163 / 14%);
+}
+
+.media-state-chip.is-loading,
+.media-state-chip.is-buffering,
+.media-state-chip.is-restarting {
+  border-color: rgb(244 190 91 / 55%);
+  color: #f4c978;
+}
+
+.media-state-chip.is-ended {
+  border-color: rgb(161 132 255 / 55%);
+  color: #c0aaff;
+}
+
+.media-state-chip.is-failed {
+  border-color: rgb(255 113 126 / 55%);
+  color: #ff9ea6;
+}
+
+.media-file-button {
+  position: relative;
+  padding: 0.62rem 0.8rem;
+  overflow: hidden;
+  border: 1px solid #5065b0;
+  border-radius: 0.55rem;
+  color: #dbe1ff;
+  background: #29355b;
+  font-size: 0.76rem;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.media-file-button:hover {
+  background: #344476;
+}
+
+.media-file-button input,
+.media-audio-element {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.media-player-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(18rem, 0.8fr);
+  gap: 1rem;
+  padding-top: 1rem;
+}
+
+.media-now-playing,
+.media-settings,
+.media-state-preview {
+  border: 1px solid #2e384b;
+  border-radius: 0.9rem;
+  background: rgb(17 23 33 / 88%);
+}
+
+.media-now-playing {
+  display: grid;
+  grid-template-columns: minmax(10rem, 15rem) minmax(12rem, 1fr);
+  gap: 1.25rem;
+  align-content: center;
+  min-height: 29rem;
+  padding: clamp(1rem, 3vw, 2rem);
+}
+
+.media-artwork {
+  position: relative;
+  display: grid;
+  grid-row: span 3;
+  aspect-ratio: 1;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid #39465f;
+  border-radius: 1rem;
+  background:
+    radial-gradient(circle at 28% 20%, rgb(128 146 255 / 38%), transparent 38%),
+    radial-gradient(circle at 80% 88%, rgb(66 214 163 / 24%), transparent 35%), #161c27;
+}
+
+.media-record {
+  position: relative;
+  display: grid;
+  width: 72%;
+  aspect-ratio: 1;
+  place-items: center;
+  border-radius: 50%;
+  background:
+    repeating-radial-gradient(circle, transparent 0 5px, rgb(255 255 255 / 8%) 6px 7px),
+    radial-gradient(circle, #7e91ff 0 13%, #111722 14% 100%);
+  box-shadow: 0 1.4rem 2.5rem rgb(0 0 0 / 42%);
+}
+
+.media-record span {
+  width: 5%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: #dce1ee;
+}
+
+.media-artwork.is-playing .media-record {
+  animation: media-spin 5s linear infinite;
+}
+
+.media-tonearm {
+  position: absolute;
+  top: 13%;
+  right: 12%;
+  width: 0.45rem;
+  height: 48%;
+  border-radius: 999px;
+  background: #a7b0bf;
+  box-shadow: 0 0 0 0.25rem #313b4d;
+  transform: rotate(18deg);
+  transform-origin: top;
+}
+
+@keyframes media-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.media-time-row,
+.media-panel-heading {
+  justify-content: space-between;
+}
+
+.media-time-row {
+  align-self: end;
+  color: #8f9aaf;
+  font-size: 0.8rem;
+}
+
+.media-time-row strong {
+  color: #f2f5fa;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 2rem;
+  letter-spacing: -0.04em;
+}
+
+.media-controls {
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.media-controls button {
+  flex: 1 1 5.5rem;
+}
+
+.media-controls button:disabled {
+  border-color: #2b3240;
+  color: #626d80;
+  background: #181d26;
+  cursor: not-allowed;
+}
+
+.media-meter {
+  align-self: start;
+  padding-top: 1rem;
+  border-top: 1px solid #2c3545;
+}
+
+.media-panel-heading {
+  gap: 1rem;
+  color: #8f9aaf;
+  font-size: 0.77rem;
+}
+
+.media-panel-heading strong {
+  color: #dfe5f0;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.72rem;
+}
+
+.media-meter-track {
+  position: relative;
+  height: 0.72rem;
+  margin-top: 0.8rem;
+  border-radius: 999px;
+  background: #242c3a;
+}
+
+.media-meter-fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #42d6a3, #d4dc69, #ff7a84);
+  transition: width 100ms linear;
+}
+
+.media-meter-peak {
+  position: absolute;
+  top: -0.18rem;
+  width: 2px;
+  height: 1.08rem;
+  background: #fff;
+  transition: left 100ms linear;
+}
+
+.media-meter p {
+  margin: 0.55rem 0 0;
+  color: #737f93;
+  font-size: 0.7rem;
+}
+
+.media-player-inspector {
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+}
+
+.media-settings,
+.media-state-preview {
+  display: grid;
+  gap: 1rem;
+  padding: 1.1rem;
+}
+
+.media-settings label {
+  display: grid;
+  grid-template-columns: 4.5rem minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: center;
+  color: #a7b0c1;
+  font-size: 0.78rem;
+}
+
+.media-settings input[type="range"] {
+  width: 100%;
+  accent-color: #7e91ff;
+}
+
+.media-settings input[type="checkbox"] {
+  justify-self: start;
+  accent-color: #7e91ff;
+}
+
+.media-settings select {
+  width: 100%;
+  padding: 0.45rem 0.55rem;
+  border: 1px solid #3a465d;
+  border-radius: 0.4rem;
+  color: #e5e9f2;
+  background: #1d2532;
+  font: inherit;
+}
+
+.media-state-preview pre {
+  max-height: 16rem;
+  margin: 0;
+  padding: 0.9rem;
+  overflow: auto;
+  border: 1px solid #283143;
+  border-radius: 0.5rem;
+  color: #95e0c4;
+  background: #0c1119;
+  font-size: 0.67rem;
+  line-height: 1.55;
+}
+
+.media-error-message {
+  margin: 0;
+  padding: 0.8rem 1rem;
+  border: 1px solid rgb(255 113 126 / 28%);
+  border-radius: 0.65rem;
+  background: rgb(255 113 126 / 8%);
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
 .transport-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -419,12 +769,32 @@ h1 {
   }
 
   .example-grid,
-  .transport-grid {
+  .transport-grid,
+  .media-player-layout {
     grid-template-columns: 1fr;
+  }
+
+  .media-player-toolbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .media-player-toolbar-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .media-now-playing {
+    grid-template-columns: 1fr;
+  }
+
+  .media-artwork {
+    grid-row: auto;
+    width: min(100%, 17rem);
+    justify-self: center;
   }
 
   .example-card {
     min-height: 17rem;
   }
 }
-

--- a/src/testing/MachineTest.ts
+++ b/src/testing/MachineTest.ts
@@ -105,14 +105,6 @@ type StateNodePath<M extends AnyMachine> = Machine.Machine.StateNodeIdentifier<M
 
 type IsAny<A> = 0 extends (1 & A) ? true : false
 
-type ExcludeCompatibleRuntime<Requirements, Events, Emits> = Requirements extends Machine.Runtime.Requirement<
-  infer RequiredEvents,
-  infer RequiredEmits
-> ? IsAny<Requirements> extends true ? Requirements
-  : [RequiredEvents] extends [Events] ? [RequiredEmits] extends [Emits] ? never : Requirements
-  : Requirements
-  : Requirements
-
 type ReadyMachine<M extends AnyMachine> =
   & M
   & EnsureExecutable<
@@ -389,14 +381,16 @@ export type RunError<M extends AnyMachine> =
 /**
  * Services required while planning a complete scenario.
  *
+ * Scenario execution delegates exclusively to the service-free `planInitial`
+ * and `plan` APIs. Invoke services and managed runtime capabilities belong to
+ * later execution, not synchronous planning.
+ *
  * @category models
  * @since 4.0.0
  */
-export type RunServices<M extends AnyMachine> = ExcludeCompatibleRuntime<
-  Machine.PlanningServices<Machine.Machine.InitialServices<M> | Machine.Machine.Services<M>>,
-  Machine.Machine.Event<M>,
-  Machine.Machine.Emit<M>
->
+export type RunServices<M extends AnyMachine> = IsAny<
+  Machine.PlanningServices<Machine.Machine.InitialServices<M> | Machine.Machine.Services<M>>
+> extends true ? Machine.PlanningServices<Machine.Machine.InitialServices<M> | Machine.Machine.Services<M>> : never
 
 /**
  * Executes a generated scenario exclusively through `planInitial` and `plan`.

--- a/typetest/testing/MachineTest.tst.ts
+++ b/typetest/testing/MachineTest.tst.ts
@@ -92,6 +92,30 @@ describe("MachineTest", () => {
     >()
   })
 
+  it("does not require invoke services while planning scenarios", () => {
+    class InvokeRequirement extends Context.Service<InvokeRequirement, string>()("InvokeRequirement") {}
+    const invokedMachine = Machine.make({
+      states: States.states,
+      events: [PublicEvent],
+      initial: () => States.initial.idle(new Idle({}))
+    }).handle({
+      idle: {
+        invoke: Machine.invokeEffect({
+          id: "service-backed-invoke",
+          effect: Effect.gen(function*() {
+            yield* InvokeRequirement
+          }),
+          onSuccess: () => undefined
+        })
+      }
+    })
+
+    const executed = MachineTest.run(invokedMachine, { events: [] })
+
+    expect<Effect.Services<typeof executed>>().type.toBe<never>()
+    expect<MachineTest.RunServices<typeof invokedMachine>>().type.toBe<never>()
+  })
+
   it("keeps runtime commands on the public event protocol", () => {
     const generated = MachineTest.runtimeCommands(machine)
     expect(generated.arbitrary).type.toBe<


### PR DESCRIPTION
## Summary

- turn the media player starter into a complete browser integration backed by a parallel, compound statechart
- model browser work as state-scoped Effect invocations and register the audio element through the shared React adapter runtime
- project typed transport and settings snapshots into one React-facing view atom with exhaustive path matching
- keep `MachineTest.run` service-free for machines with invoked effects, matching the pure planning APIs it executes
- add playback controls, live loudness visualization, machine-state inspection, responsive styling, tests, and updated documentation

## Root cause

The original implementation used the removed `Machine.action` API, evaluated `HTMLAudioElement` while loading tests in Node, and retained placeholder tests for the old state/event topology. `MachineTest.run` also leaked invoke and internal runtime services in its public Effect requirement despite executing only pure planning.

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

Added `.changeset/clean-scenarios-plan.md` for the `MachineTest.run` service-inference fix.

## Validation

- [x] `pnpm check`
- [x] `pnpm check` in `examples/playground`
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed

`pnpm perf:types` passes within every configured instantiation budget.
