### PR TITLE
Add Effect-native machine testing infrastructure

### DIFF
--- a/.changeset/brave-machines-observe.md
+++ b/.changeset/brave-machines-observe.md
@@ -1,0 +1,7 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Add an Effect-native `@typeonce/effect-machine/testing` entrypoint with schema-derived scenarios, replayable planner traces, independent statechart law and finite-model verification for compound, parallel, and history states, trace coverage, observed Effect graphs, and live runtime command models.
+
+Expose retained planner transition evidence and correct reentry boundaries, simultaneous parallel target application, and recorded nested-history restoration through inactive ancestors.

--- a/README.md
+++ b/README.md
@@ -254,6 +254,12 @@ machine.handle({
 })
 ```
 
+A recorded nested history can rebuild inactive ancestors when it is restored.
+There is one current first-use boundary: if no history record exists, a nested
+history fallback constructs only its direct owner's snapshot and cannot
+reconstruct values for inactive ancestors above that owner. Those ancestors
+must already be active when that nested fallback is targeted.
+
 Deep history restores every remembered descendant value. Shallow history
 restores the parent and direct-child values, then follows normal initial paths.
 Only compound or parallel states that shallow restoration can enter implicitly

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -256,6 +256,11 @@ payment: {
 }
 ```
 
+A recorded nested history can rebuild inactive ancestors. A first-use fallback
+cannot: it constructs the history node's direct parent snapshot, so it cannot
+currently reconstruct values for inactive ancestors above that owner. Those
+ancestors must already be active when an unrecorded nested history is targeted.
+
 The machine's readiness type tracks missing defaults and shallow initializers.
 History is an overwriteable register, not a stack: restoration does not consume
 it, and the next parent exit replaces it. Entry actions and invokes run again;
@@ -268,7 +273,7 @@ prior effects, actors, and timers are not rewound.
 | `target.local`   | The destination is inside the nearest compound scope containing the source | The compound value, active ancestors, and unrelated parallel regions              |
 | `target.branch`  | The destination is elsewhere under the active top-level root               | Omitted current ancestor values and parallel regions                              |
 | `target.full`    | The destination may be under any top-level root                            | Nothing is inferred for a newly selected root; build its complete active snapshot |
-| `target.history` | The destination is a declared history pseudo-state                         | Its parent's remembered configuration, or its default before the first capture    |
+| `target.history` | The destination is a declared history pseudo-state                         | Its parent's remembered configuration, or its default before the first capture; an unrecorded nested fallback requires ancestors above its owner to be active |
 
 Entering an inactive parallel state through `target.local` or `target.branch`
 requires a complete callback with one selection per region. A parallel state

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -6,10 +6,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "build": "pnpm typecheck && vite build",
     "preview": "vite preview",
-    "check": "pnpm build"
+    "check": "pnpm test && pnpm build"
   },
   "dependencies": {
     "@effect/atom-react": "4.0.0-beta.102",
@@ -21,11 +22,13 @@
     "scheduler": "0.27.0"
   },
   "devDependencies": {
+    "@effect/vitest": "4.0.0-beta.102",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.2",
     "@vitejs/plugin-react": "6.0.4",
     "typescript": "6.0.3",
-    "vite": "8.1.5"
+    "vite": "8.1.5",
+    "vitest": "4.1.10"
   },
   "packageManager": "pnpm@10.17.1",
   "engines": {

--- a/examples/playground/pnpm-lock.yaml
+++ b/examples/playground/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
         specifier: 0.27.0
         version: 0.27.0
     devDependencies:
+      '@effect/vitest':
+        specifier: 4.0.0-beta.102
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102)(vitest@4.1.10(vite@8.1.5(yaml@2.9.0)))
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
@@ -48,6 +51,9 @@ importers:
       vite:
         specifier: 8.1.5
         version: 8.1.5(yaml@2.9.0)
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(vite@8.1.5(yaml@2.9.0))
 
 packages:
 
@@ -58,6 +64,12 @@ packages:
       react: ^19.2.4
       scheduler: '*'
 
+  '@effect/vitest@4.0.0-beta.102':
+    resolution: {integrity: sha512-4dipFAYG6imOzrY3zy3BgzCJkbb9xESyzUef0WSx8bsK0/SpITqbJpdwKeOyDWLZ+rimjua8IbTFMAde865pIQ==}
+    peerDependencies:
+      effect: 4.0.0-beta.102
+      vitest: ^3.0.0 || ^4.0.0
+
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
@@ -66,6 +78,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
@@ -241,6 +256,15 @@ packages:
     peerDependencies:
       effect: 4.0.0-beta.102
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/react-dom@19.2.2':
     resolution: {integrity: sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==}
     peerDependencies:
@@ -262,6 +286,46 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
@@ -274,6 +338,16 @@ packages:
 
   effect@4.0.0-beta.102:
     resolution: {integrity: sha512-z8Y+Q76Hh/kjLFZrXu8tGn6e+tDsg45R+UHhxd190pXxD53OGwf/G/zDxXTkse4HJ5mobNZfitLfUCp4fMvu6w==}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fast-check@4.9.0:
     resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
@@ -381,6 +455,9 @@ packages:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   msgpackr-extract@3.0.4:
     resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
     hasBin: true
@@ -399,6 +476,13 @@ packages:
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -441,13 +525,33 @@ packages:
     resolution: {integrity: sha512-TBwwKfscTEgnBEWmYKKeCcmCGmrJi0LV6qNUY//WBA3MDesh/zfn+KOMq/ckpxM4gZ0ouAE706A1eenekM2sug==}
     engines: {node: '>=10'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   toml@4.3.0:
     resolution: {integrity: sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==}
@@ -513,6 +617,52 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -525,6 +675,11 @@ snapshots:
       effect: 4.0.0-beta.102
       react: 19.2.7
       scheduler: 0.27.0
+
+  '@effect/vitest@4.0.0-beta.102(effect@4.0.0-beta.102)(vitest@4.1.10(vite@8.1.5(yaml@2.9.0)))':
+    dependencies:
+      effect: 4.0.0-beta.102
+      vitest: 4.1.10(vite@8.1.5(yaml@2.9.0))
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -541,6 +696,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true
@@ -658,6 +815,15 @@ snapshots:
     dependencies:
       effect: 4.0.0-beta.102
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
   '@types/react-dom@19.2.2(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
@@ -670,6 +836,53 @@ snapshots:
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.5(yaml@2.9.0)
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.1.5(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
+  assertion-error@2.0.1: {}
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-es@3.1.1: {}
 
@@ -689,6 +902,14 @@ snapshots:
       toml: 4.3.0
       uuid: 14.0.1
       yaml: 2.9.0
+
+  es-module-lexer@2.3.1: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
 
   fast-check@4.9.0:
     dependencies:
@@ -758,6 +979,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.33.0
       lightningcss-win32-x64-msvc: 1.33.0
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   msgpackr-extract@3.0.4:
     dependencies:
       node-gyp-build-optional-packages: 5.2.2
@@ -782,6 +1007,10 @@ snapshots:
     dependencies:
       detect-libc: 2.1.2
     optional: true
+
+  obug@2.1.4: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -831,12 +1060,24 @@ snapshots:
 
   seroval@1.6.0: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   toml@4.3.0: {}
 
@@ -861,5 +1102,35 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
       yaml: 2.9.0
+
+  vitest@4.1.10(vite@8.1.5(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.1.5(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   yaml@2.9.0: {}

--- a/examples/playground/src/examples/media-player/machine.test.ts
+++ b/examples/playground/src/examples/media-player/machine.test.ts
@@ -1,0 +1,100 @@
+import { assert, describe, it } from "@effect/vitest"
+import { MachineTest } from "@typeonce/effect-machine/testing"
+import { Effect, Graph } from "effect"
+import { MediaPlayerEvent, MediaPlayerMachine } from "./machine.ts"
+
+const everyPublicEvent = [
+  MediaPlayerEvent.cases.SourceSelected.make({ url: "https://example.com/audio.mp3" }),
+  MediaPlayerEvent.cases.PlayRequested.make({}),
+  MediaPlayerEvent.cases.PauseRequested.make({}),
+  MediaPlayerEvent.cases.MediaPlaying.make({}),
+  MediaPlayerEvent.cases.MediaPaused.make({}),
+  MediaPlayerEvent.cases.MediaWaiting.make({}),
+  MediaPlayerEvent.cases.MediaCanPlay.make({}),
+  MediaPlayerEvent.cases.MediaEnded.make({}),
+  MediaPlayerEvent.cases.MediaFailed.make({ message: "unsupported codec" }),
+  MediaPlayerEvent.cases.VolumeChanged.make({ volume: 0.4 }),
+  MediaPlayerEvent.cases.MuteToggled.make({})
+]
+
+const generated = MachineTest.scenarios(MediaPlayerMachine, {
+  minEvents: 0,
+  maxEvents: 30
+})
+
+describe("media-player statechart model", () => {
+  it.effect.prop(
+    "keeps every schema-generated scenario structurally valid",
+    { scenario: generated.arbitrary },
+    ({ scenario }) =>
+      MachineTest.run(MediaPlayerMachine, scenario).pipe(
+        Effect.tap((trace) => MachineTest.verify(MediaPlayerMachine, trace)),
+        Effect.tap((trace) =>
+          Effect.sync(() => {
+            assert.strictEqual(trace.final.path, "Player")
+            assert.strictEqual(trace.final.states.playback.state.path, "Player.playback.Empty")
+            const volume = trace.final.states.volume.state
+            if (volume.path !== "Player.volume.Audible") {
+              throw new Error(`Expected Audible, received ${volume.path}`)
+            }
+            assert.strictEqual(volume.value.volume, 1)
+          })
+        ),
+        Effect.asVoid
+      ),
+    { fastCheck: { numRuns: 100, seed: 24_061 } }
+  )
+
+  it.effect("makes the current behavior gaps explicit through coverage", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(MediaPlayerMachine, { events: everyPublicEvent })
+      yield* MachineTest.verify(MediaPlayerMachine, trace)
+
+      const coverage = MachineTest.coverage(MediaPlayerMachine, trace)
+
+      assert.strictEqual(coverage.events.missing, 0)
+      assert.strictEqual(coverage.events.hit, everyPublicEvent.length)
+      assert.strictEqual(coverage.transitions.total, 0)
+      assert.strictEqual(coverage.logicalConfigurations.hit, 1)
+      assert.deepStrictEqual(coverage.states.activation.hits.map(({ path }) => path), [
+        "Player",
+        "Player.playback",
+        "Player.playback.Empty",
+        "Player.volume",
+        "Player.volume.Audible"
+      ])
+      assert.deepStrictEqual(coverage.states.activation.misses.map(({ path }) => path), [
+        "Player.playback.Loading",
+        "Player.playback.Paused",
+        "Player.playback.Playing",
+        "Player.playback.Buffering",
+        "Player.playback.Ended",
+        "Player.playback.Failed",
+        "Player.volume.Muted"
+      ])
+    }))
+
+  it.effect("records ignored events without inventing new logical configurations", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(MediaPlayerMachine, { events: everyPublicEvent })
+      const observed = yield* MachineTest.observedGraph(MediaPlayerMachine, trace)
+      const eventEdges = Array.from(Graph.edges(observed.graph), ([, edge]) => edge).filter(
+        ({ data }) => data._tag === "Event"
+      )
+
+      assert.strictEqual(Graph.nodeCount(observed.graph), 1)
+      assert.strictEqual(Graph.edgeCount(observed.graph), everyPublicEvent.length + 1)
+      assert.strictEqual(eventEdges.length, everyPublicEvent.length)
+      assert.strictEqual(eventEdges.every(({ source, target }) => source === target), true)
+      assert.strictEqual(observed.starts.length, 1)
+
+      const node = Array.from(observed.graph)[0]![1]
+      assert.deepStrictEqual(node.configuration, [
+        "Player",
+        "Player.playback",
+        "Player.playback.Empty",
+        "Player.volume",
+        "Player.volume.Audible"
+      ])
+    }))
+})

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
       "types": "./dist/cluster.d.ts",
       "import": "./dist/cluster.js"
     },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "import": "./dist/testing.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/scripts/fixtures/consumer/consumer.ts
+++ b/scripts/fixtures/consumer/consumer.ts
@@ -1,6 +1,7 @@
 import { Machine } from "@typeonce/effect-machine"
 import { ClusterMachine } from "@typeonce/effect-machine/cluster"
 import { AtomMachine } from "@typeonce/effect-machine/reactivity"
+import { MachineTest } from "@typeonce/effect-machine/testing"
 import { Effect, Schema } from "effect"
 
 const State = Schema.TaggedUnion({
@@ -54,6 +55,7 @@ const invoked = Machine.invokeEffect({
 })
 const delayed = Machine.after("1 second", InternalEvent.cases.Loaded.make({ value: "late" }))
 const staged = Machine.action(Effect.succeed(undefined), "next" as const)
+const generated = MachineTest.scenarios(machine, { minEvents: 1, maxEvents: 2 })
 
 type InputEvent = Machine.Machine.InputEvent<typeof machine>
 type HandledEvent = Machine.Machine.Event<typeof machine>
@@ -64,4 +66,17 @@ const loaded: HandledEvent = InternalEvent.cases.Loaded.make({ value: "ready" })
 // @ts-expect-error Internal events cannot cross the public input boundary.
 const invalidInput: InputEvent = loaded
 
-void [atoms, idleAtom, loadingAtom, invalidSelector, cluster, invoked, delayed, staged, start, loaded, invalidInput]
+void [
+  atoms,
+  idleAtom,
+  loadingAtom,
+  invalidSelector,
+  cluster,
+  invoked,
+  delayed,
+  staged,
+  generated,
+  start,
+  loaded,
+  invalidInput
+]

--- a/scripts/fixtures/consumer/runtime.mjs
+++ b/scripts/fixtures/consumer/runtime.mjs
@@ -2,7 +2,9 @@ import assert from "node:assert/strict"
 import { Machine } from "@typeonce/effect-machine"
 import { AtomMachine } from "@typeonce/effect-machine/reactivity"
 import { ClusterMachine } from "@typeonce/effect-machine/cluster"
+import { MachineTest } from "@typeonce/effect-machine/testing"
 
 assert.equal(typeof Machine.make, "function")
 assert.equal(typeof AtomMachine.make, "function")
 assert.equal(typeof ClusterMachine.make, "function")
+assert.equal(typeof MachineTest.scenarios, "function")

--- a/scripts/pack-check.mjs
+++ b/scripts/pack-check.mjs
@@ -25,6 +25,8 @@ try {
     "package/dist/reactivity.d.ts",
     "package/dist/cluster.js",
     "package/dist/cluster.d.ts",
+    "package/dist/testing.js",
+    "package/dist/testing.d.ts",
     "package/package.json",
     "package/README.md",
     "package/docs/agent-guide.md",

--- a/scripts/test-consumer.mjs
+++ b/scripts/test-consumer.mjs
@@ -51,7 +51,7 @@ try {
   }
   run(process.execPath, [join(consumer, "runtime.mjs")], { cwd: consumer })
 
-  console.log("packed root, reactivity, and cluster entrypoints passed strict consumer validation")
+  console.log("packed root, reactivity, cluster, and testing entrypoints passed strict consumer validation")
 } finally {
   await rm(destination, { recursive: true, force: true })
 }

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -1856,6 +1856,9 @@ export declare namespace Machine {
    *
    * History nodes are transition targets only. They never become active and
    * therefore do not declare a state value schema or lifecycle handlers.
+   * A recorded nested history can rebuild inactive ancestors. Before the
+   * first capture, however, a nested history fallback cannot reconstruct
+   * values for inactive ancestors above its direct owner.
    *
    * @category models
    * @since 4.0.0
@@ -2072,6 +2075,27 @@ export declare namespace Machine {
     readonly trigger: TransitionTrigger<EventTag>
     readonly reenter: boolean
     readonly targets: TransitionTargets<TargetPath>
+  }
+
+  /**
+   * Transition retained after hierarchy precedence and conflict resolution for
+   * one planned microstep.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface RetainedTransition<
+    SourcePath extends string = string,
+    EventTag extends PropertyKey = PropertyKey,
+    TargetPath extends string = SourcePath
+  > {
+    readonly source: SourcePath
+    readonly trigger: TransitionTrigger<EventTag>
+    readonly reenter: boolean
+    /** Path returned by the handler, including a history pseudo-state. */
+    readonly target: TargetPath | undefined
+    /** Concrete path used after resolving history, otherwise equal to `target`. */
+    readonly resolvedTarget: TargetPath | undefined
   }
 
   /**
@@ -3679,7 +3703,14 @@ export declare namespace Machine {
     readonly parent: ParentId
   }
 
-  /** Typed fallback evaluated when a history node has no record yet. */
+  /**
+   * Typed fallback evaluated when a history node has no record yet.
+   *
+   * The fallback constructs the history node's direct parent snapshot. It
+   * cannot currently provide values for inactive ancestors above that parent,
+   * so first-use fallback to a nested history requires those ancestors to
+   * already be active. Recorded nested history does not have this limitation.
+   */
   export type HistoryDefaultHandler<
     States extends StateSchemas,
     Events extends ReadonlyArray<TaggedSchema>,
@@ -5938,9 +5969,11 @@ export const invokeMachine: {
  * **Details**
  *
  * The returned plan contains the settled initial snapshot, staged actions,
- * emitted events, and optional final output. Planning may evaluate transition
- * logic and follow completion, eventless, and raised-event steps, but it does
- * not execute effects passed to `action`.
+ * emitted events, optional final output, and every startup microstep. Planning
+ * may evaluate transition logic and follow completion, eventless, and
+ * raised-event steps, but it does not execute effects passed to `action`.
+ * `startingState` and `initialEntryPaths` describe the normalized
+ * configuration before entry callbacks and settlement begin.
  *
  * **Gotchas**
  *
@@ -5989,11 +6022,32 @@ export const planInitial: <
   ...args: [...Machine.InputArgs<Input>]
 ) => Effect.Effect<
   & {
+    readonly startingState: Machine.Snapshot<States>
+    readonly initialEntryPaths: ReadonlyArray<Machine.StateIdentifier<States>>
     readonly state: Machine.Snapshot<States>
     readonly actions: ReadonlyArray<
       Effect.Effect<void, ActionError<InitialR | R>, ActionServices<InitialR | R>>
     >
     readonly emittedEvents: ReadonlyArray<Machine.EmitOf<Emits>>
+    readonly microsteps: ReadonlyArray<{
+      readonly next: Machine.Snapshot<States>
+      readonly event: Machine.EventOf<Events> | InitialEvent
+      readonly transitions: ReadonlyArray<
+        Machine.RetainedTransition<
+          Machine.StateIdentifier<States>,
+          Machine.TagOf<Events[number]>,
+          Machine.StateNodeIdentifier<States>
+        >
+      >
+      readonly actions: ReadonlyArray<
+        Effect.Effect<void, ActionError<InitialR | R>, ActionServices<InitialR | R>>
+      >
+      readonly raisedEvents: ReadonlyArray<Machine.EventOf<Events>>
+      readonly emittedEvents: ReadonlyArray<Machine.EmitOf<Emits>>
+      readonly exitPaths: ReadonlyArray<string>
+      readonly entryPaths: ReadonlyArray<string>
+      readonly changed: boolean
+    }>
   }
   & (
     | {
@@ -6187,6 +6241,13 @@ export const plan: <
     readonly microsteps: ReadonlyArray<{
       readonly next: Machine.Snapshot<States>
       readonly event: Machine.EventOf<Events> | InitialEvent
+      readonly transitions: ReadonlyArray<
+        Machine.RetainedTransition<
+          Machine.StateIdentifier<States>,
+          Machine.TagOf<Events[number]>,
+          Machine.StateNodeIdentifier<States>
+        >
+      >
       readonly actions: ReadonlyArray<Effect.Effect<void, ActionError<R>, ActionServices<R>>>
       readonly raisedEvents: ReadonlyArray<Machine.EventOf<Events>>
       readonly emittedEvents: ReadonlyArray<Machine.EmitOf<Emits>>

--- a/src/MachineTest.ts
+++ b/src/MachineTest.ts
@@ -151,21 +151,36 @@ export type ScenarioOptions<M extends AnyMachine> =
       readonly inputArbitrary?: FastCheck.Arbitrary<InputValue<M>>
     })
 
-/** Diagnostics for one schema-derived arbitrary. */
+/**
+ * Diagnostics for one schema-derived arbitrary.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface SchemaArbitraryDiagnostic {
   readonly boundary: "input" | "event"
   readonly index: number | undefined
   readonly report: Schema.Annotations.ToArbitrary.Report
 }
 
-/** Diagnostics describing how a scenario arbitrary was assembled. */
+/**
+ * Diagnostics describing how a scenario arbitrary was assembled.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ScenarioDiagnostics {
   readonly input: "none" | "schema" | "override"
   readonly events: "empty" | "schema" | "override"
   readonly schemas: ReadonlyArray<SchemaArbitraryDiagnostic>
 }
 
-/** A scenario arbitrary together with schema-derivation diagnostics. */
+/**
+ * A scenario arbitrary together with schema-derivation diagnostics.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface Scenarios<M extends AnyMachine> {
   readonly arbitrary: FastCheck.Arbitrary<Scenario<M>>
   readonly diagnostics: ScenarioDiagnostics
@@ -272,7 +287,12 @@ export const scenarios = <M extends AnyMachine>(
   }
 }
 
-/** Completion information retained by an initial or event plan. */
+/**
+ * Completion information retained by an initial or event plan.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export type PlanCompletion<M extends AnyMachine> =
   | {
     readonly done: true
@@ -283,7 +303,12 @@ export type PlanCompletion<M extends AnyMachine> =
     readonly output: undefined
   }
 
-/** One public planned microstep, including retained post-conflict transitions. */
+/**
+ * One public planned microstep, including retained post-conflict transitions.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface Microstep<
   M extends AnyMachine,
   Requirements = Machine.Machine.Services<M>
@@ -307,7 +332,12 @@ export interface Microstep<
   readonly changed: boolean
 }
 
-/** The complete data returned while planning machine startup. */
+/**
+ * The complete data returned while planning machine startup.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export type InitialPlan<M extends AnyMachine> =
   & {
     readonly startingState: Machine.Machine.Snapshot<Machine.Machine.States<M>>
@@ -327,7 +357,12 @@ export type InitialPlan<M extends AnyMachine> =
   }
   & PlanCompletion<M>
 
-/** The complete data returned while planning one public event. */
+/**
+ * The complete data returned while planning one public event.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export type EventPlan<M extends AnyMachine> =
   & {
     readonly next: Machine.Machine.Snapshot<Machine.Machine.States<M>>
@@ -343,7 +378,12 @@ export type EventPlan<M extends AnyMachine> =
   }
   & PlanCompletion<M>
 
-/** Startup portion of an executable planner trace. */
+/**
+ * Startup portion of an executable planner trace.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface InitialTrace<M extends AnyMachine> {
   readonly plan: InitialPlan<M>
   readonly startingState: Machine.Machine.Snapshot<Machine.Machine.States<M>>
@@ -352,7 +392,12 @@ export interface InitialTrace<M extends AnyMachine> {
   readonly configuration: ReadonlyArray<StatePath<M>>
 }
 
-/** One event portion of an executable planner trace. */
+/**
+ * One event portion of an executable planner trace.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface TraceStep<M extends AnyMachine> {
   readonly index: number
   readonly before: Machine.Machine.Snapshot<Machine.Machine.States<M>>
@@ -363,7 +408,12 @@ export interface TraceStep<M extends AnyMachine> {
   readonly afterConfiguration: ReadonlyArray<StatePath<M>>
 }
 
-/** A scenario and every plan produced by executing it without running actions. */
+/**
+ * A scenario and every plan produced by executing it without running actions.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface Trace<M extends AnyMachine> {
   readonly scenario: Scenario<M>
   readonly initial: InitialTrace<M>
@@ -437,7 +487,12 @@ export type RunFailure<Cause, M extends AnyMachine = AnyMachine> =
     readonly cause: Cause
   }
 
-/** Errors that can be produced while planning a complete scenario. */
+/**
+ * Errors that can be produced while planning a complete scenario.
+ *
+ * @category errors
+ * @since 4.0.0
+ */
 export type RunError<M extends AnyMachine> =
   | Machine.Machine.InitialError<M>
   | Machine.Machine.Error<M>
@@ -445,7 +500,12 @@ export type RunError<M extends AnyMachine> =
   | Machine.MachineSchemaDecodeError
   | Machine.StartupError
 
-/** Services required while planning a complete scenario. */
+/**
+ * Services required while planning a complete scenario.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export type RunServices<M extends AnyMachine> = ExcludeCompatibleRuntime<
   Machine.PlanningServices<Machine.Machine.InitialServices<M> | Machine.Machine.Services<M>>,
   Machine.Machine.Event<M>,
@@ -738,7 +798,12 @@ const makeStructuralIdentityIndex = () => {
   }
 }
 
-/** A deterministic hit/miss summary for a finite set declared by a machine. */
+/**
+ * A deterministic hit/miss summary for a finite set declared by a machine.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface CoverageSummary<Item> {
   readonly total: number
   readonly hit: number
@@ -747,20 +812,35 @@ export interface CoverageSummary<Item> {
   readonly misses: ReadonlyArray<Item>
 }
 
-/** One active (non-history) state node in a state coverage summary. */
+/**
+ * One active (non-history) state node in a state coverage summary.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface StateCoverageItem<Path extends string = string> {
   readonly path: Path
   readonly type: Exclude<Machine.Machine.StateNode["type"], "history">
 }
 
-/** State activation and lifecycle coverage. */
+/**
+ * State activation and lifecycle coverage.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface StateCoverage<Path extends string = string> {
   readonly activation: CoverageSummary<StateCoverageItem<Path>>
   readonly entry: CoverageSummary<StateCoverageItem<Path>>
   readonly exit: CoverageSummary<StateCoverageItem<Path>>
 }
 
-/** One stable transition-definition identity in definition order. */
+/**
+ * One stable transition-definition identity in definition order.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface TransitionCoverageItem<
   SourcePath extends string = string,
   EventTag extends PropertyKey = PropertyKey,
@@ -774,13 +854,23 @@ export interface TransitionCoverageItem<
   readonly targets: Machine.Machine.TransitionTargets<TargetPath>
 }
 
-/** One public event tag declared by the machine. */
+/**
+ * One public event tag declared by the machine.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface EventCoverageItem<Tag extends PropertyKey = PropertyKey> {
   readonly tag: Tag
   readonly count: number
 }
 
-/** Public event coverage, including events that no transition retained. */
+/**
+ * Public event coverage, including events that no transition retained.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export type EventCoverage<Tag extends PropertyKey = PropertyKey> =
   | {
     readonly available: true
@@ -806,21 +896,36 @@ export type EventCoverage<Tag extends PropertyKey = PropertyKey> =
     }>
   }
 
-/** Trace-derived scenario counts. There is no finite declared scenario space. */
+/**
+ * Trace-derived scenario counts. There is no finite declared scenario space.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ScenarioCoverage {
   readonly traces: number
   readonly events: number
   readonly empty: number
 }
 
-/** Trace-derived logical configuration counts. There is no claimed exhaustive total. */
+/**
+ * Trace-derived logical configuration counts. There is no claimed exhaustive total.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface LogicalConfigurationCoverage {
   readonly observations: number
   readonly hit: number
   readonly identities: ReadonlyArray<string>
 }
 
-/** Directly observed startup and microstep evidence. */
+/**
+ * Directly observed startup and microstep evidence.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface MicrostepCoverageEvidence {
   readonly total: number
   readonly changed: number
@@ -832,14 +937,24 @@ export interface MicrostepCoverageEvidence {
   readonly doneTriggered: number
 }
 
-/** Directly observed completion evidence. */
+/**
+ * Directly observed completion evidence.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface CompletionCoverageEvidence<Path extends string = string> {
   readonly donePlans: number
   readonly recordObservations: number
   readonly paths: ReadonlyArray<Path>
 }
 
-/** Directly observed history records and history-target transitions. */
+/**
+ * Directly observed history records and history-target transitions.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface HistoryCoverageEvidence<Path extends string = string> {
   readonly recordObservations: number
   readonly recorded: ReadonlyArray<{
@@ -850,7 +965,12 @@ export interface HistoryCoverageEvidence<Path extends string = string> {
   readonly resolvedTargets: number
 }
 
-/** Coverage computed only from observable machine definitions and planner traces. */
+/**
+ * Coverage computed only from observable machine definitions and planner traces.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface Coverage<M extends AnyMachine> {
   readonly states: StateCoverage<StatePath<M>>
   readonly transitions: CoverageSummary<
@@ -1189,7 +1309,12 @@ export const coverage = <M extends AnyMachine>(
   } as Coverage<M>
 }
 
-/** The observation roles summarized for one logical graph node. */
+/**
+ * The observation roles summarized for one logical graph node.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ObservedGraphNodeObservations {
   readonly total: number
   readonly startup: number
@@ -1197,7 +1322,12 @@ export interface ObservedGraphNodeObservations {
   readonly microstep: number
 }
 
-/** One full encoded logical snapshot stored in the observed Effect graph. */
+/**
+ * One full encoded logical snapshot stored in the observed Effect graph.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ObservedGraphNode<M extends AnyMachine> {
   readonly id: string
   readonly snapshot: Machine.Machine.Snapshot<Machine.Machine.States<M>>
@@ -1206,7 +1336,12 @@ export interface ObservedGraphNode<M extends AnyMachine> {
   readonly observations: ObservedGraphNodeObservations
 }
 
-/** Retained evidence for one microstep inside an observed graph edge. */
+/**
+ * Retained evidence for one microstep inside an observed graph edge.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ObservedGraphMicrostep<M extends AnyMachine> {
   readonly next: string
   readonly event: Machine.Machine.Event<M> | Machine.InitialEvent
@@ -1218,7 +1353,12 @@ export interface ObservedGraphMicrostep<M extends AnyMachine> {
   readonly changed: boolean
 }
 
-/** A startup or public-event macrostep retained by the observed graph. */
+/**
+ * A startup or public-event macrostep retained by the observed graph.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export type ObservedGraphEdge<M extends AnyMachine> =
   | {
     readonly _tag: "Startup"
@@ -1235,7 +1375,12 @@ export type ObservedGraphEdge<M extends AnyMachine> =
     readonly completion: PlanCompletion<M>
   }
 
-/** An Effect directed graph plus stable indexes useful to graph algorithms. */
+/**
+ * An Effect directed graph plus stable indexes useful to graph algorithms.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ObservedGraph<M extends AnyMachine> {
   readonly graph: Graph.DirectedGraph<ObservedGraphNode<M>, ObservedGraphEdge<M>>
   readonly nodesById: ReadonlyMap<string, Graph.NodeIndex>

--- a/src/MachineTest.ts
+++ b/src/MachineTest.ts
@@ -1,0 +1,2480 @@
+/**
+ * Property-based scenario generation and planner trace utilities.
+ *
+ * @since 4.0.0
+ */
+
+import * as Data from "effect/Data"
+import * as Effect from "effect/Effect"
+import * as Graph from "effect/Graph"
+import * as Schema from "effect/Schema"
+import * as SchemaAST from "effect/SchemaAST"
+import { FastCheck } from "effect/testing"
+import type { FiniteModel } from "./internal/machineTestFiniteModel.js"
+import * as ReferenceModel from "./internal/machineTestReferenceModel.js"
+import * as Machine from "./Machine.js"
+
+export {
+  advanceCommand,
+  checkpointCommand,
+  formatRuntimeTranscript,
+  runRuntimeCommands,
+  type RuntimeAssertionContext,
+  type RuntimeCommand,
+  type RuntimeCommandActual,
+  RuntimeCommandFailure,
+  type RuntimeCommandRecord,
+  type RuntimeCommandResult,
+  type RuntimeCommands,
+  runtimeCommands,
+  type RuntimeCommandsDiagnostics,
+  type RuntimeCommandsOptions,
+  type RuntimeInspectionContext,
+  type RuntimeModelOptions,
+  type RuntimeModelStep,
+  RuntimeObservationError,
+  RuntimeSynchronization,
+  type RuntimeTranscript,
+  sendCommand,
+  stopCommand
+} from "./internal/machineTestRuntime.js"
+
+export {
+  compileModel,
+  type FiniteAtomicState,
+  type FiniteCompoundState,
+  type FiniteFinalState,
+  type FiniteHistoryMutation,
+  type FiniteHistoryScenario,
+  type FiniteHistoryState,
+  type FiniteHistoryTransfer,
+  type FiniteModel,
+  type FiniteModelDiagnostics,
+  type FiniteModelOptions,
+  type FiniteModels,
+  finiteModels,
+  type FiniteParallelState,
+  type FiniteState,
+  type FiniteTransition
+} from "./internal/machineTestFiniteModel.js"
+
+export {
+  ModelVerificationError,
+  type ModelVerificationField,
+  type ModelVerificationLocation,
+  type ModelVerificationMismatch,
+  type ReferenceCompletion,
+  type ReferenceHistoryRecord,
+  type ReferenceInitialStep,
+  type ReferenceMicrostep,
+  type ReferenceState,
+  type ReferenceStateValue,
+  type ReferenceStep,
+  type ReferenceTrace,
+  type ReferenceTransition
+} from "./internal/machineTestReferenceModel.js"
+
+/**
+ * Purely interprets a finite hierarchical model without compiling a
+ * machine.
+ *
+ * @category verification
+ * @since 4.0.0
+ */
+export const interpretModel = ReferenceModel.interpretModel
+
+type AnyMachine = Machine.Machine.Any
+
+type InputValue<M extends AnyMachine> = Machine.Machine.Input<M>["Type"]
+
+type StatePath<M extends AnyMachine> = Machine.Machine.StateIdentifier<Machine.Machine.States<M>>
+
+type StateNodePath<M extends AnyMachine> = Machine.Machine.StateNodeIdentifier<Machine.Machine.States<M>>
+
+type IsAny<A> = 0 extends (1 & A) ? true : false
+
+type ExcludeCompatibleRuntime<Requirements, Events, Emits> = Requirements extends Machine.Runtime.Requirement<
+  infer RequiredEvents,
+  infer RequiredEmits
+> ? IsAny<Requirements> extends true ? Requirements
+  : [RequiredEvents] extends [Events] ? [RequiredEmits] extends [Emits] ? never : Requirements
+  : Requirements
+  : Requirements
+
+type ReadyMachine<M extends AnyMachine> =
+  & M
+  & Machine.Machine.EnsureOutputImplementations<
+    Machine.Machine.States<M>,
+    Machine.Machine.OutputStates<M>
+  >
+  & Machine.Machine.EnsureHistoryImplementations<
+    Machine.Machine.States<M>,
+    Machine.Machine.UnhandledStates<M>
+  >
+
+/**
+ * A generated public-input scenario for a machine.
+ *
+ * Machines without an input schema omit `input`; machines with one retain its
+ * exact decoded type. Events use only the public input protocol.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type Scenario<M extends AnyMachine> = Machine.Machine.Input<M> extends typeof Schema.Void ? {
+    readonly events: ReadonlyArray<Machine.Machine.InputEvent<M>>
+  }
+  : {
+    readonly input: InputValue<M>
+    readonly events: ReadonlyArray<Machine.Machine.InputEvent<M>>
+  }
+
+/**
+ * Options for schema-derived scenario generation.
+ *
+ * `inputArbitrary` and `eventsArbitrary` replace their complete generated
+ * value. An events override therefore owns its own length distribution.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type ScenarioOptions<M extends AnyMachine> =
+  & {
+    readonly minEvents?: number
+    readonly maxEvents?: number
+    readonly eventsArbitrary?: FastCheck.Arbitrary<ReadonlyArray<Machine.Machine.InputEvent<M>>>
+  }
+  & (Machine.Machine.Input<M> extends typeof Schema.Void ? {
+      readonly inputArbitrary?: never
+    }
+    : {
+      readonly inputArbitrary?: FastCheck.Arbitrary<InputValue<M>>
+    })
+
+/** Diagnostics for one schema-derived arbitrary. */
+export interface SchemaArbitraryDiagnostic {
+  readonly boundary: "input" | "event"
+  readonly index: number | undefined
+  readonly report: Schema.Annotations.ToArbitrary.Report
+}
+
+/** Diagnostics describing how a scenario arbitrary was assembled. */
+export interface ScenarioDiagnostics {
+  readonly input: "none" | "schema" | "override"
+  readonly events: "empty" | "schema" | "override"
+  readonly schemas: ReadonlyArray<SchemaArbitraryDiagnostic>
+}
+
+/** A scenario arbitrary together with schema-derivation diagnostics. */
+export interface Scenarios<M extends AnyMachine> {
+  readonly arbitrary: FastCheck.Arbitrary<Scenario<M>>
+  readonly diagnostics: ScenarioDiagnostics
+}
+
+const validateLength = (name: "minEvents" | "maxEvents", value: number): void => {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`MachineTest.scenarios expected ${name} to be a non-negative safe integer`)
+  }
+}
+
+/**
+ * Derives valid machine inputs and public events from their schemas.
+ *
+ * Unsupported schema derivations fail immediately through `Schema.toArbitrary`.
+ * Non-fatal derivation warnings are returned instead of being hidden.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const scenarios = <M extends AnyMachine>(
+  machine: M,
+  options: ScenarioOptions<M> = {} as ScenarioOptions<M>
+): Scenarios<M> => {
+  const minEvents = options.minEvents ?? 0
+  const maxEvents = options.maxEvents ?? 50
+  if (options.eventsArbitrary === undefined) {
+    validateLength("minEvents", minEvents)
+    validateLength("maxEvents", maxEvents)
+    if (minEvents > maxEvents) {
+      throw new Error("MachineTest.scenarios expected minEvents to be less than or equal to maxEvents")
+    }
+    if (machine.events.length === 0 && minEvents > 0) {
+      throw new Error(
+        "MachineTest.scenarios cannot generate a non-empty event sequence for a machine without public events"
+      )
+    }
+  }
+
+  const diagnostics: Array<SchemaArbitraryDiagnostic> = []
+  const eventArbitraries = options.eventsArbitrary === undefined
+    ? machine.events.map((schema, index) => {
+      const derived = Schema.toArbitrary(schema, { report: true })
+      diagnostics.push({
+        boundary: "event",
+        index,
+        report: derived.report
+      })
+      return derived.value as FastCheck.Arbitrary<Machine.Machine.InputEvent<M>>
+    })
+    : []
+
+  const eventsArbitrary = options.eventsArbitrary ?? (eventArbitraries.length === 0
+    ? FastCheck.constant<ReadonlyArray<Machine.Machine.InputEvent<M>>>([])
+    : FastCheck.array(
+      FastCheck.oneof(
+        ...eventArbitraries as [
+          FastCheck.Arbitrary<Machine.Machine.InputEvent<M>>,
+          ...Array<FastCheck.Arbitrary<Machine.Machine.InputEvent<M>>>
+        ]
+      ),
+      { minLength: minEvents, maxLength: maxEvents }
+    ))
+
+  if (machine.input === undefined || machine.input === Schema.Void) {
+    if (options.inputArbitrary !== undefined) {
+      throw new Error("MachineTest.scenarios cannot override input for a machine without an input schema")
+    }
+    return {
+      arbitrary: eventsArbitrary.map((events) => ({ events }) as Scenario<M>),
+      diagnostics: {
+        input: "none",
+        events: options.eventsArbitrary !== undefined ? "override" : eventArbitraries.length === 0 ? "empty" : "schema",
+        schemas: diagnostics
+      }
+    }
+  }
+
+  let inputArbitrary: FastCheck.Arbitrary<InputValue<M>>
+  if (options.inputArbitrary !== undefined) {
+    inputArbitrary = options.inputArbitrary
+  } else {
+    const derived = Schema.toArbitrary(machine.input, { report: true })
+    diagnostics.unshift({
+      boundary: "input",
+      index: undefined,
+      report: derived.report
+    })
+    inputArbitrary = derived.value as FastCheck.Arbitrary<InputValue<M>>
+  }
+
+  return {
+    arbitrary: FastCheck.tuple(inputArbitrary, eventsArbitrary).map(([input, events]) =>
+      ({
+        input,
+        events
+      }) as Scenario<M>
+    ),
+    diagnostics: {
+      input: options.inputArbitrary !== undefined ? "override" : "schema",
+      events: options.eventsArbitrary !== undefined ? "override" : eventArbitraries.length === 0 ? "empty" : "schema",
+      schemas: diagnostics
+    }
+  }
+}
+
+/** Completion information retained by an initial or event plan. */
+export type PlanCompletion<M extends AnyMachine> =
+  | {
+    readonly done: true
+    readonly output: Machine.Machine.Output<M>
+  }
+  | {
+    readonly done: false
+    readonly output: undefined
+  }
+
+/** One public planned microstep, including retained post-conflict transitions. */
+export interface Microstep<
+  M extends AnyMachine,
+  Requirements = Machine.Machine.Services<M>
+> {
+  readonly next: Machine.Machine.Snapshot<Machine.Machine.States<M>>
+  readonly event: Machine.Machine.Event<M> | Machine.InitialEvent
+  readonly transitions: ReadonlyArray<
+    Machine.Machine.RetainedTransition<
+      StatePath<M>,
+      Machine.Machine.TagOf<Machine.Machine.Events<M>[number]>,
+      StateNodePath<M>
+    >
+  >
+  readonly actions: ReadonlyArray<
+    Effect.Effect<void, Machine.ActionError<Requirements>, Machine.ActionServices<Requirements>>
+  >
+  readonly raisedEvents: ReadonlyArray<Machine.Machine.Event<M>>
+  readonly emittedEvents: ReadonlyArray<Machine.Machine.Emit<M>>
+  readonly exitPaths: ReadonlyArray<string>
+  readonly entryPaths: ReadonlyArray<string>
+  readonly changed: boolean
+}
+
+/** The complete data returned while planning machine startup. */
+export type InitialPlan<M extends AnyMachine> =
+  & {
+    readonly startingState: Machine.Machine.Snapshot<Machine.Machine.States<M>>
+    readonly initialEntryPaths: ReadonlyArray<StatePath<M>>
+    readonly state: Machine.Machine.Snapshot<Machine.Machine.States<M>>
+    readonly actions: ReadonlyArray<
+      Effect.Effect<
+        void,
+        Machine.ActionError<Machine.Machine.InitialServices<M> | Machine.Machine.Services<M>>,
+        Machine.ActionServices<Machine.Machine.InitialServices<M> | Machine.Machine.Services<M>>
+      >
+    >
+    readonly emittedEvents: ReadonlyArray<Machine.Machine.Emit<M>>
+    readonly microsteps: ReadonlyArray<
+      Microstep<M, Machine.Machine.InitialServices<M> | Machine.Machine.Services<M>>
+    >
+  }
+  & PlanCompletion<M>
+
+/** The complete data returned while planning one public event. */
+export type EventPlan<M extends AnyMachine> =
+  & {
+    readonly next: Machine.Machine.Snapshot<Machine.Machine.States<M>>
+    readonly actions: ReadonlyArray<
+      Effect.Effect<
+        void,
+        Machine.ActionError<Machine.Machine.Services<M>>,
+        Machine.ActionServices<Machine.Machine.Services<M>>
+      >
+    >
+    readonly emittedEvents: ReadonlyArray<Machine.Machine.Emit<M>>
+    readonly microsteps: ReadonlyArray<Microstep<M>>
+  }
+  & PlanCompletion<M>
+
+/** Startup portion of an executable planner trace. */
+export interface InitialTrace<M extends AnyMachine> {
+  readonly plan: InitialPlan<M>
+  readonly startingState: Machine.Machine.Snapshot<Machine.Machine.States<M>>
+  readonly startingConfiguration: ReadonlyArray<StatePath<M>>
+  readonly initialEntryPaths: ReadonlyArray<StatePath<M>>
+  readonly configuration: ReadonlyArray<StatePath<M>>
+}
+
+/** One event portion of an executable planner trace. */
+export interface TraceStep<M extends AnyMachine> {
+  readonly index: number
+  readonly before: Machine.Machine.Snapshot<Machine.Machine.States<M>>
+  readonly beforeConfiguration: ReadonlyArray<StatePath<M>>
+  readonly event: Machine.Machine.InputEvent<M>
+  readonly plan: EventPlan<M>
+  readonly after: Machine.Machine.Snapshot<Machine.Machine.States<M>>
+  readonly afterConfiguration: ReadonlyArray<StatePath<M>>
+}
+
+/** A scenario and every plan produced by executing it without running actions. */
+export interface Trace<M extends AnyMachine> {
+  readonly scenario: Scenario<M>
+  readonly initial: InitialTrace<M>
+  readonly steps: ReadonlyArray<TraceStep<M>>
+  readonly final: Machine.Machine.Snapshot<Machine.Machine.States<M>>
+  readonly finalConfiguration: ReadonlyArray<StatePath<M>>
+}
+
+/**
+ * Checks a real planner trace against the independent finite statechart model
+ * interpreter.
+ *
+ * The oracle does not import the machine compiler, planner, snapshot helpers,
+ * or target builders. It compares semantic projections of the public trace
+ * and accumulates every disagreement in one structured error.
+ *
+ * @category verification
+ * @since 4.0.0
+ */
+export const verifyModel = <M extends AnyMachine>(
+  model: FiniteModel,
+  actualTrace: Trace<M>
+): Effect.Effect<void, ReferenceModel.ModelVerificationError> => ReferenceModel.verifyModelTrace(model, actualTrace)
+
+const rawConfigurationPaths = <M extends AnyMachine>(
+  machine: M,
+  snapshot: Machine.Machine.Snapshot<Machine.Machine.States<M>>
+): ReadonlyArray<StatePath<M>> => {
+  const active = new Set<string>()
+  const visit = (current: unknown): void => {
+    if (typeof current !== "object" || current === null) return
+    const value = current as Record<string, unknown>
+    if (typeof value.path === "string") active.add(value.path)
+    if (value.state !== undefined) visit(value.state)
+    if (typeof value.states === "object" && value.states !== null) {
+      for (const child of Object.values(value.states)) visit(child)
+    }
+  }
+  visit(snapshot)
+  return Machine.stateNodes(machine)
+    .filter((node) => node.type !== "history" && active.has(node.path))
+    .map((node) => node.path) as ReadonlyArray<StatePath<M>>
+}
+
+/**
+ * A typed planning failure together with every successfully completed trace
+ * segment preceding it.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type RunFailure<Cause, M extends AnyMachine = AnyMachine> =
+  | {
+    readonly _tag: "MachineTestRunFailure"
+    readonly scenario: Scenario<M>
+    readonly phase: "initial"
+    readonly eventIndex: undefined
+    readonly event: undefined
+    readonly initial: undefined
+    readonly steps: readonly []
+    readonly cause: Cause
+  }
+  | {
+    readonly _tag: "MachineTestRunFailure"
+    readonly scenario: Scenario<M>
+    readonly phase: "event"
+    readonly eventIndex: number
+    readonly event: Machine.Machine.InputEvent<M>
+    readonly initial: InitialTrace<M>
+    readonly steps: ReadonlyArray<TraceStep<M>>
+    readonly cause: Cause
+  }
+
+/** Errors that can be produced while planning a complete scenario. */
+export type RunError<M extends AnyMachine> =
+  | Machine.Machine.InitialError<M>
+  | Machine.Machine.Error<M>
+  | Machine.InfiniteTransitionError
+  | Machine.MachineSchemaDecodeError
+  | Machine.StartupError
+
+/** Services required while planning a complete scenario. */
+export type RunServices<M extends AnyMachine> = ExcludeCompatibleRuntime<
+  Machine.PlanningServices<Machine.Machine.InitialServices<M> | Machine.Machine.Services<M>>,
+  Machine.Machine.Event<M>,
+  Machine.Machine.Emit<M>
+>
+
+/**
+ * Executes a generated scenario exclusively through `planInitial` and `plan`.
+ *
+ * Staged actions are retained in each plan but are never executed. Every event
+ * is planned, including events that occur after a terminal configuration.
+ * Typed planning errors retain the scenario and successfully completed prefix
+ * in a `RunFailure`.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const run: <M extends AnyMachine>(
+  machine: ReadyMachine<M>,
+  scenario: Scenario<M>
+) => Effect.Effect<Trace<M>, RunFailure<RunError<M>, M>, RunServices<M>> = Effect.fnUntraced(function*<
+  M extends AnyMachine
+>(
+  machine: ReadyMachine<M>,
+  scenario: Scenario<M>
+) {
+  const initialEffect = (machine.input === undefined || machine.input === Schema.Void
+    ? (Machine.planInitial as any)(machine)
+    : (Machine.planInitial as any)(machine, (scenario as { readonly input: InputValue<M> }).input)) as Effect.Effect<
+      InitialPlan<M>,
+      RunError<M>,
+      RunServices<M>
+    >
+  const initial = yield* initialEffect.pipe(
+    Effect.mapError((cause): RunFailure<RunError<M>, M> => ({
+      _tag: "MachineTestRunFailure",
+      scenario,
+      phase: "initial",
+      eventIndex: undefined,
+      event: undefined,
+      initial: undefined,
+      steps: [],
+      cause
+    }))
+  )
+  const initialConfiguration = rawConfigurationPaths(machine, initial.state)
+  const initialTrace: InitialTrace<M> = {
+    plan: initial,
+    startingState: initial.startingState,
+    startingConfiguration: rawConfigurationPaths(machine, initial.startingState),
+    initialEntryPaths: initial.initialEntryPaths,
+    configuration: initialConfiguration
+  }
+  const steps: Array<TraceStep<M>> = []
+  let current = initial.state
+
+  for (let index = 0; index < scenario.events.length; index++) {
+    const event = scenario.events[index]
+    const before = current
+    const beforeConfiguration = rawConfigurationPaths(machine, before)
+    const plan = yield* ((Machine.plan as any)(machine, before, event) as Effect.Effect<
+      EventPlan<M>,
+      RunError<M>,
+      RunServices<M>
+    >).pipe(
+      Effect.mapError((cause): RunFailure<RunError<M>, M> => ({
+        _tag: "MachineTestRunFailure",
+        scenario,
+        phase: "event",
+        eventIndex: index,
+        event,
+        initial: initialTrace,
+        steps: steps.slice(),
+        cause
+      }))
+    )
+    current = plan.next
+    steps.push({
+      index,
+      before,
+      beforeConfiguration,
+      event,
+      plan,
+      after: current,
+      afterConfiguration: rawConfigurationPaths(machine, current)
+    } as TraceStep<M>)
+  }
+
+  return {
+    scenario,
+    initial: initialTrace,
+    steps,
+    final: current,
+    finalConfiguration: rawConfigurationPaths(machine, current)
+  } as Trace<M>
+}) as any
+
+const canonicalize = (value: unknown, active: WeakSet<object>): unknown => {
+  if (value === undefined) return { $undefined: true }
+  if (typeof value === "bigint") return { $bigint: String(value) }
+  if (typeof value === "symbol") return { $symbol: String(value) }
+  if (typeof value === "function") return { $function: value.name || "anonymous" }
+  if (typeof value !== "object" || value === null) return value
+  if (active.has(value)) return { $circular: true }
+  active.add(value)
+  let result: unknown
+  if (value instanceof Error) {
+    result = {
+      $error: value.name,
+      message: value.message,
+      ...Object.fromEntries(
+        Object.keys(value).sort().map((
+          key
+        ) => [key, canonicalize((value as unknown as Record<string, unknown>)[key], active)])
+      )
+    }
+  } else if (Array.isArray(value)) {
+    result = value.map((item) => canonicalize(item, active))
+  } else if (value instanceof Date) {
+    result = { $date: value.toISOString() }
+  } else if (value instanceof Map) {
+    result = {
+      $map: Array.from(value, ([key, item]) => [canonicalize(key, active), canonicalize(item, active)]).sort((a, b) =>
+        JSON.stringify(a).localeCompare(JSON.stringify(b))
+      )
+    }
+  } else if (value instanceof Set) {
+    result = {
+      $set: Array.from(value, (item) => canonicalize(item, active)).sort((a, b) =>
+        JSON.stringify(a).localeCompare(JSON.stringify(b))
+      )
+    }
+  } else {
+    result = Object.fromEntries(
+      Object.keys(value).sort().map((key) => [key, canonicalize((value as Record<string, unknown>)[key], active)])
+    )
+  }
+  active.delete(value)
+  return result
+}
+
+const formatValue = (value: unknown): string => JSON.stringify(canonicalize(value, new WeakSet()))
+
+const structuralFingerprint = (value: unknown): string => {
+  const references = new WeakMap<object, number>()
+  let nextReference = 0
+  const visit = (current: unknown): unknown => {
+    if (current === undefined) return ["undefined"]
+    if (current === null) return ["null"]
+    if (typeof current === "number") {
+      if (Number.isNaN(current)) return ["number", "NaN"]
+      if (Object.is(current, -0)) return ["number", "-0"]
+      return ["number", current]
+    }
+    if (typeof current === "bigint") return ["bigint", String(current)]
+    if (typeof current === "symbol") {
+      return [
+        "symbol",
+        Symbol.keyFor(current) === undefined ? "local" : "global",
+        Symbol.keyFor(current) ?? current.description
+      ]
+    }
+    if (typeof current === "function") return ["function", current.name, current.length]
+    if (typeof current !== "object") return [typeof current, current]
+
+    const existing = references.get(current)
+    if (existing !== undefined) return ["reference", existing]
+    const reference = nextReference++
+    references.set(current, reference)
+
+    if (Array.isArray(current)) return ["array", reference, current.map(visit)]
+    if (current instanceof Date) return ["date", reference, current.getTime()]
+    if (current instanceof RegExp) return ["regexp", reference, current.source, current.flags]
+    if (current instanceof ArrayBuffer) {
+      return ["array-buffer", reference, Array.from(new Uint8Array(current))]
+    }
+    if (typeof SharedArrayBuffer !== "undefined" && current instanceof SharedArrayBuffer) {
+      return ["shared-array-buffer", reference, Array.from(new Uint8Array(current))]
+    }
+    if (ArrayBuffer.isView(current)) {
+      return [
+        "array-buffer-view",
+        reference,
+        current.constructor.name,
+        current.byteOffset,
+        current.byteLength,
+        Array.from(new Uint8Array(current.buffer, current.byteOffset, current.byteLength))
+      ]
+    }
+    if (current instanceof Error) {
+      return ["error", reference, current.name, current.message, visit(Object.fromEntries(Object.entries(current)))]
+    }
+    if (current instanceof Map) {
+      return ["map", reference, Array.from(current, ([key, item]) => [visit(key), visit(item)])]
+    }
+    if (current instanceof Set) return ["set", reference, Array.from(current, visit)]
+
+    const stringKeys = Object.getOwnPropertyNames(current).sort()
+    const symbolKeys = Object.getOwnPropertySymbols(current).sort((left, right) =>
+      String(Symbol.keyFor(left) ?? left.description).localeCompare(String(Symbol.keyFor(right) ?? right.description))
+    )
+    return [
+      "object",
+      reference,
+      Object.getPrototypeOf(current)?.constructor?.name ?? null,
+      stringKeys.map((key) => [key, visit((current as Record<string, unknown>)[key])]),
+      symbolKeys.map((key) => [visit(key), visit((current as Record<symbol, unknown>)[key])])
+    ]
+  }
+  return JSON.stringify(visit(value))
+}
+
+const structurallyEqual = (left: unknown, right: unknown): boolean => {
+  const leftToRight = new WeakMap<object, object>()
+  const rightToLeft = new WeakMap<object, object>()
+  const compare = (a: unknown, b: unknown): boolean => {
+    if (Object.is(a, b)) return true
+    if (typeof a !== typeof b || a === null || b === null) return false
+    if (typeof a !== "object" || typeof b !== "object") return false
+    const knownRight = leftToRight.get(a)
+    const knownLeft = rightToLeft.get(b)
+    if (knownRight !== undefined || knownLeft !== undefined) return knownRight === b && knownLeft === a
+    leftToRight.set(a, b)
+    rightToLeft.set(b, a)
+
+    if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) return false
+    if (a instanceof Date && b instanceof Date) return a.getTime() === b.getTime()
+    if (a instanceof RegExp && b instanceof RegExp) return a.source === b.source && a.flags === b.flags
+    if (a instanceof ArrayBuffer && b instanceof ArrayBuffer) {
+      return a.byteLength === b.byteLength &&
+        new Uint8Array(a).every((byte, index) => byte === new Uint8Array(b)[index])
+    }
+    if (
+      typeof SharedArrayBuffer !== "undefined" && a instanceof SharedArrayBuffer && b instanceof SharedArrayBuffer
+    ) {
+      return a.byteLength === b.byteLength &&
+        new Uint8Array(a).every((byte, index) => byte === new Uint8Array(b)[index])
+    }
+    if (ArrayBuffer.isView(a) && ArrayBuffer.isView(b)) {
+      if (a.constructor !== b.constructor || a.byteOffset !== b.byteOffset || a.byteLength !== b.byteLength) {
+        return false
+      }
+      const leftBytes = new Uint8Array(a.buffer, a.byteOffset, a.byteLength)
+      const rightBytes = new Uint8Array(b.buffer, b.byteOffset, b.byteLength)
+      return leftBytes.every((byte, index) => byte === rightBytes[index])
+    }
+    if (a instanceof Error && b instanceof Error && (a.name !== b.name || a.message !== b.message)) return false
+    if (a instanceof Map && b instanceof Map) {
+      if (a.size !== b.size) return false
+      const leftEntries = Array.from(a)
+      const rightEntries = Array.from(b)
+      return leftEntries.every(([key, item], index) =>
+        compare(key, rightEntries[index]![0]) && compare(item, rightEntries[index]![1])
+      )
+    }
+    if (a instanceof Set && b instanceof Set) {
+      if (a.size !== b.size) return false
+      const rightValues = Array.from(b)
+      return Array.from(a).every((item, index) => compare(item, rightValues[index]))
+    }
+    if (Array.isArray(a) !== Array.isArray(b)) return false
+    if (!Array.isArray(a) && Object.getPrototypeOf(a) !== Object.prototype && Object.getPrototypeOf(a) !== null) {
+      return false
+    }
+
+    const leftKeys = Reflect.ownKeys(a).sort((first, second) => String(first).localeCompare(String(second)))
+    const rightKeys = Reflect.ownKeys(b).sort((first, second) => String(first).localeCompare(String(second)))
+    return leftKeys.length === rightKeys.length &&
+      leftKeys.every((key, index) =>
+        Object.is(key, rightKeys[index]) && compare(
+          (a as Record<PropertyKey, unknown>)[key],
+          (b as Record<PropertyKey, unknown>)[rightKeys[index]!]
+        )
+      )
+  }
+  return compare(left, right)
+}
+
+const makeStructuralIdentityIndex = () => {
+  const buckets = new Map<string, Array<{ readonly id: string; readonly value: unknown }>>()
+  return (value: unknown): string => {
+    const fingerprint = structuralFingerprint(value)
+    let bucket = buckets.get(fingerprint)
+    if (bucket === undefined) buckets.set(fingerprint, bucket = [])
+    const existing = bucket.find((candidate) => structurallyEqual(candidate.value, value))
+    if (existing !== undefined) return existing.id
+    const id = bucket.length === 0 ? fingerprint : `${fingerprint}#collision:${bucket.length}`
+    bucket.push({ id, value })
+    return id
+  }
+}
+
+/** A deterministic hit/miss summary for a finite set declared by a machine. */
+export interface CoverageSummary<Item> {
+  readonly total: number
+  readonly hit: number
+  readonly missing: number
+  readonly hits: ReadonlyArray<Item>
+  readonly misses: ReadonlyArray<Item>
+}
+
+/** One active (non-history) state node in a state coverage summary. */
+export interface StateCoverageItem<Path extends string = string> {
+  readonly path: Path
+  readonly type: Exclude<Machine.Machine.StateNode["type"], "history">
+}
+
+/** State activation and lifecycle coverage. */
+export interface StateCoverage<Path extends string = string> {
+  readonly activation: CoverageSummary<StateCoverageItem<Path>>
+  readonly entry: CoverageSummary<StateCoverageItem<Path>>
+  readonly exit: CoverageSummary<StateCoverageItem<Path>>
+}
+
+/** One stable transition-definition identity in definition order. */
+export interface TransitionCoverageItem<
+  SourcePath extends string = string,
+  EventTag extends PropertyKey = PropertyKey,
+  TargetPath extends string = SourcePath
+> {
+  readonly id: string
+  readonly index: number
+  readonly source: SourcePath
+  readonly trigger: Machine.Machine.TransitionTrigger<EventTag>
+  readonly reenter: boolean
+  readonly targets: Machine.Machine.TransitionTargets<TargetPath>
+}
+
+/** One public event tag declared by the machine. */
+export interface EventCoverageItem<Tag extends PropertyKey = PropertyKey> {
+  readonly tag: Tag
+  readonly count: number
+}
+
+/** Public event coverage, including events that no transition retained. */
+export type EventCoverage<Tag extends PropertyKey = PropertyKey> =
+  | {
+    readonly available: true
+    readonly total: number
+    readonly hit: number
+    readonly missing: number
+    readonly hits: ReadonlyArray<EventCoverageItem<Tag>>
+    readonly misses: ReadonlyArray<EventCoverageItem<Tag>>
+    readonly observed: ReadonlyArray<EventCoverageItem<Tag>>
+    readonly diagnostics: readonly []
+  }
+  | {
+    readonly available: false
+    readonly total: undefined
+    readonly hit: undefined
+    readonly missing: undefined
+    readonly hits: undefined
+    readonly misses: undefined
+    readonly observed: ReadonlyArray<EventCoverageItem<Tag>>
+    readonly diagnostics: ReadonlyArray<{
+      readonly schemaIndex: number
+      readonly message: string
+    }>
+  }
+
+/** Trace-derived scenario counts. There is no finite declared scenario space. */
+export interface ScenarioCoverage {
+  readonly traces: number
+  readonly events: number
+  readonly empty: number
+}
+
+/** Trace-derived logical configuration counts. There is no claimed exhaustive total. */
+export interface LogicalConfigurationCoverage {
+  readonly observations: number
+  readonly hit: number
+  readonly identities: ReadonlyArray<string>
+}
+
+/** Directly observed startup and microstep evidence. */
+export interface MicrostepCoverageEvidence {
+  readonly total: number
+  readonly changed: number
+  readonly targetless: number
+  readonly raised: number
+  readonly emitted: number
+  readonly eventTriggered: number
+  readonly alwaysTriggered: number
+  readonly doneTriggered: number
+}
+
+/** Directly observed completion evidence. */
+export interface CompletionCoverageEvidence<Path extends string = string> {
+  readonly donePlans: number
+  readonly recordObservations: number
+  readonly paths: ReadonlyArray<Path>
+}
+
+/** Directly observed history records and history-target transitions. */
+export interface HistoryCoverageEvidence<Path extends string = string> {
+  readonly recordObservations: number
+  readonly recorded: ReadonlyArray<{
+    readonly path: Path
+    readonly modes: ReadonlyArray<"shallow" | "deep">
+  }>
+  readonly targets: number
+  readonly resolvedTargets: number
+}
+
+/** Coverage computed only from observable machine definitions and planner traces. */
+export interface Coverage<M extends AnyMachine> {
+  readonly states: StateCoverage<StatePath<M>>
+  readonly transitions: CoverageSummary<
+    TransitionCoverageItem<
+      StatePath<M>,
+      Machine.Machine.TagOf<Machine.Machine.Events<M>[number]>,
+      StateNodePath<M>
+    >
+  >
+  readonly events: EventCoverage<Machine.Machine.TagOf<Machine.Machine.InputEvents<M>[number]>>
+  readonly scenarios: ScenarioCoverage
+  readonly logicalConfigurations: LogicalConfigurationCoverage
+  readonly startup: {
+    readonly traces: number
+    readonly withMicrosteps: number
+  }
+  readonly microsteps: MicrostepCoverageEvidence
+  readonly completion: CompletionCoverageEvidence<StatePath<M>>
+  readonly history: HistoryCoverageEvidence<StateNodePath<M>>
+}
+
+const coverageSummary = <Item>(declared: ReadonlyArray<Item>, hit: ReadonlySet<number>): CoverageSummary<Item> => {
+  const hits: Array<Item> = []
+  const misses: Array<Item> = []
+  declared.forEach((item, index) => (hit.has(index) ? hits : misses).push(item))
+  return {
+    total: declared.length,
+    hit: hits.length,
+    missing: misses.length,
+    hits,
+    misses
+  }
+}
+
+const normalizeTraces = <M extends AnyMachine>(
+  traceOrTraces: Trace<M> | ReadonlyArray<Trace<M>>
+): ReadonlyArray<Trace<M>> =>
+  Array.isArray(traceOrTraces) ? traceOrTraces as ReadonlyArray<Trace<M>> : [traceOrTraces as Trace<M>]
+
+const sameCoverageTrigger = (
+  left: Machine.Machine.TransitionTrigger,
+  right: Machine.Machine.TransitionTrigger
+): boolean =>
+  left.type === right.type && (left.type !== "event" || right.type === "event" && left.event === right.event)
+
+const targetWithinDeclaredBounds = (
+  target: string | undefined,
+  bounds: Machine.Machine.TransitionTargets
+): boolean =>
+  target === undefined || bounds.type === "dynamic" ||
+  bounds.paths.some((path) => target === path || target.startsWith(`${path}.`))
+
+const finiteTagValues = (ast: SchemaAST.AST): ReadonlyArray<PropertyKey> | undefined => {
+  if (SchemaAST.isLiteral(ast)) {
+    return typeof ast.literal === "string" || typeof ast.literal === "number" ? [ast.literal] : undefined
+  }
+  if (SchemaAST.isUniqueSymbol(ast)) return [ast.symbol]
+  if (SchemaAST.isUnion(ast)) {
+    const values: Array<PropertyKey> = []
+    for (const member of ast.types) {
+      const memberValues = finiteTagValues(member)
+      if (memberValues === undefined) return undefined
+      for (const value of memberValues) if (!values.includes(value)) values.push(value)
+    }
+    return values
+  }
+  if (SchemaAST.isObjects(ast)) {
+    const tag = ast.propertySignatures.find(({ name }) => name === "_tag")?.type
+    return tag === undefined ? undefined : finiteTagValues(tag)
+  }
+  if (SchemaAST.isDeclaration(ast)) {
+    const sentinels = ast.annotations?.["~sentinels"]
+    if (Array.isArray(sentinels)) {
+      const tag = sentinels.find((sentinel): sentinel is { readonly key: "_tag"; readonly literal: PropertyKey } =>
+        typeof sentinel === "object" && sentinel !== null && sentinel.key === "_tag" &&
+        (typeof sentinel.literal === "string" ||
+          typeof sentinel.literal === "number" ||
+          typeof sentinel.literal === "symbol")
+      )
+      if (tag !== undefined) return [tag.literal]
+    }
+    for (const parameter of ast.typeParameters) {
+      const values = finiteTagValues(parameter)
+      if (values !== undefined) return values
+    }
+  }
+  if (SchemaAST.isSuspend(ast)) return finiteTagValues(ast.thunk())
+  return undefined
+}
+
+const publicEventTags = <M extends AnyMachine>(machine: M): {
+  readonly tags: ReadonlyArray<Machine.Machine.TagOf<Machine.Machine.InputEvents<M>[number]>>
+  readonly diagnostics: ReadonlyArray<{ readonly schemaIndex: number; readonly message: string }>
+} => {
+  const tags: Array<Machine.Machine.TagOf<Machine.Machine.InputEvents<M>[number]>> = []
+  const diagnostics: Array<{ readonly schemaIndex: number; readonly message: string }> = []
+  machine.events.forEach((schema, schemaIndex) => {
+    const values = finiteTagValues(SchemaAST.toType(schema.ast))
+    if (values === undefined) {
+      diagnostics.push({
+        schemaIndex,
+        message: "The decoded _tag schema is not a finite literal, unique symbol, or finite union"
+      })
+      return
+    }
+    for (const value of values) {
+      const tag = value as Machine.Machine.TagOf<Machine.Machine.InputEvents<M>[number]>
+      if (!tags.includes(tag)) tags.push(tag)
+    }
+  })
+  return { tags, diagnostics }
+}
+
+/**
+ * Computes deterministic, definition-aware coverage from completed planner
+ * traces. Finite declared sets report hits and misses; scenarios and logical
+ * configurations report observations only because their complete spaces are
+ * generally infinite.
+ *
+ * @category verification
+ * @since 4.0.0
+ */
+export const coverage = <M extends AnyMachine>(
+  machine: M,
+  traceOrTraces: Trace<M> | ReadonlyArray<Trace<M>>
+): Coverage<M> => {
+  const traces = normalizeTraces(traceOrTraces)
+  const stateNodes = Machine.stateNodes(machine)
+  const activeNodes = stateNodes.filter((node) => node.type !== "history").map(
+    (node): StateCoverageItem<StatePath<M>> => ({
+      path: node.path as StatePath<M>,
+      type: node.type as StateCoverageItem["type"]
+    })
+  )
+  const activeIndex = new Map<string, number>(activeNodes.map((node, index) => [node.path, index]))
+  const activationHits = new Set<number>()
+  const entryHits = new Set<number>()
+  const exitHits = new Set<number>()
+
+  const definitions = Machine.transitionDefinitions(machine).map(
+    (
+      definition,
+      index
+    ): TransitionCoverageItem<
+      StatePath<M>,
+      Machine.Machine.TagOf<Machine.Machine.Events<M>[number]>,
+      StateNodePath<M>
+    > => ({
+      id: `transition:${index}:${formatValue(definition)}`,
+      index,
+      source: definition.source,
+      trigger: definition.trigger,
+      reenter: definition.reenter,
+      targets: definition.targets
+    })
+  )
+  const transitionHits = new Set<number>()
+
+  const declaredEvents = publicEventTags(machine)
+  const declaredEventTags = declaredEvents.tags
+  const eventCounts = new Map<PropertyKey, number>(declaredEventTags.map((tag) => [tag, 0]))
+  const logicalConfigurationIdentities = new Set<string>()
+  const logicalConfigurationIdentity = makeStructuralIdentityIndex()
+  let configurationObservations = 0
+  let scenarioEvents = 0
+  let emptyScenarios = 0
+  let startupWithMicrosteps = 0
+  let microsteps = 0
+  let changedMicrosteps = 0
+  let targetlessTransitions = 0
+  let raisedEvents = 0
+  let emittedEvents = 0
+  let eventTriggered = 0
+  let alwaysTriggered = 0
+  let doneTriggered = 0
+  let donePlans = 0
+  let completionRecordObservations = 0
+  const completionPaths = new Set<string>()
+  let historyRecordObservations = 0
+  const historyModes = new Map<string, Set<"shallow" | "deep">>()
+  let historyTargets = 0
+  let resolvedHistoryTargets = 0
+  const nodeByPath = new Map(stateNodes.map((node) => [node.path, node]))
+
+  const hitPaths = (paths: ReadonlyArray<string>, hits: Set<number>): void => {
+    for (const path of paths) {
+      const index = activeIndex.get(path)
+      if (index !== undefined) hits.add(index)
+    }
+  }
+
+  const observeSnapshot = (snapshot: Machine.Machine.Snapshot<Machine.Machine.States<M>>): void => {
+    const paths = rawConfigurationPaths(machine, snapshot) as ReadonlyArray<string>
+    hitPaths(paths, activationHits)
+    configurationObservations += 1
+    logicalConfigurationIdentities.add(logicalConfigurationIdentity(snapshot))
+    const metadata = snapshot as unknown as {
+      readonly completed?: ReadonlyArray<{ readonly path: string }>
+      readonly history?: Readonly<Record<string, { readonly mode: "shallow" | "deep" }>>
+    }
+    for (const completion of metadata.completed ?? []) {
+      completionRecordObservations += 1
+      completionPaths.add(completion.path)
+    }
+    for (const [path, record] of Object.entries(metadata.history ?? {})) {
+      historyRecordObservations += 1
+      let modes = historyModes.get(path)
+      if (modes === undefined) historyModes.set(path, modes = new Set())
+      modes.add(record.mode)
+    }
+  }
+
+  const observeMicrostep = (microstep: Microstep<M, any>): void => {
+    microsteps += 1
+    if (microstep.changed) changedMicrosteps += 1
+    raisedEvents += microstep.raisedEvents.length
+    emittedEvents += microstep.emittedEvents.length
+    hitPaths(microstep.entryPaths, entryHits)
+    hitPaths(microstep.exitPaths, exitHits)
+    observeSnapshot(microstep.next)
+    for (const retained of microstep.transitions) {
+      if (retained.target === undefined) targetlessTransitions += 1
+      if (retained.trigger.type === "event") eventTriggered += 1
+      else if (retained.trigger.type === "always") alwaysTriggered += 1
+      else doneTriggered += 1
+      if (retained.target !== undefined && nodeByPath.get(retained.target)?.type === "history") {
+        historyTargets += 1
+        if (retained.resolvedTarget !== undefined) resolvedHistoryTargets += 1
+      }
+      const definitionIndex = definitions.findIndex((definition) =>
+        definition.source === retained.source &&
+        definition.reenter === retained.reenter &&
+        sameCoverageTrigger(definition.trigger, retained.trigger) &&
+        targetWithinDeclaredBounds(retained.target, definition.targets)
+      )
+      if (definitionIndex !== -1) transitionHits.add(definitionIndex)
+    }
+  }
+
+  for (const trace of traces) {
+    scenarioEvents += trace.scenario.events.length
+    if (trace.scenario.events.length === 0) emptyScenarios += 1
+    for (const event of trace.scenario.events) {
+      const tag = event._tag
+      eventCounts.set(tag, (eventCounts.get(tag) ?? 0) + 1)
+    }
+
+    observeSnapshot(trace.initial.startingState)
+    hitPaths(trace.initial.initialEntryPaths, entryHits)
+    if (trace.initial.plan.microsteps.length > 0) startupWithMicrosteps += 1
+    for (const microstep of trace.initial.plan.microsteps) observeMicrostep(microstep)
+    observeSnapshot(trace.initial.plan.state)
+    if (trace.initial.plan.done) donePlans += 1
+
+    for (const step of trace.steps) {
+      observeSnapshot(step.before)
+      for (const microstep of step.plan.microsteps) observeMicrostep(microstep)
+      observeSnapshot(step.after)
+      if (step.plan.done) donePlans += 1
+    }
+  }
+
+  const eventItems = declaredEventTags.map((tag): EventCoverageItem<any> => ({
+    tag,
+    count: eventCounts.get(tag) ?? 0
+  }))
+  const eventHits = eventItems.filter(({ count }) => count > 0)
+  const eventMisses = eventItems.filter(({ count }) => count === 0)
+
+  return {
+    states: {
+      activation: coverageSummary(activeNodes, activationHits),
+      entry: coverageSummary(activeNodes, entryHits),
+      exit: coverageSummary(activeNodes, exitHits)
+    },
+    transitions: coverageSummary(definitions, transitionHits),
+    events: declaredEvents.diagnostics.length === 0
+      ? {
+        available: true,
+        total: eventItems.length,
+        hit: eventHits.length,
+        missing: eventMisses.length,
+        hits: eventHits,
+        misses: eventMisses,
+        observed: eventItems,
+        diagnostics: []
+      }
+      : {
+        available: false,
+        total: undefined,
+        hit: undefined,
+        missing: undefined,
+        hits: undefined,
+        misses: undefined,
+        observed: Array.from(eventCounts, ([tag, count]) => ({ tag, count })) as ReadonlyArray<EventCoverageItem<any>>,
+        diagnostics: declaredEvents.diagnostics
+      },
+    scenarios: {
+      traces: traces.length,
+      events: scenarioEvents,
+      empty: emptyScenarios
+    },
+    logicalConfigurations: {
+      observations: configurationObservations,
+      hit: logicalConfigurationIdentities.size,
+      identities: Array.from(logicalConfigurationIdentities).sort()
+    },
+    startup: {
+      traces: traces.length,
+      withMicrosteps: startupWithMicrosteps
+    },
+    microsteps: {
+      total: microsteps,
+      changed: changedMicrosteps,
+      targetless: targetlessTransitions,
+      raised: raisedEvents,
+      emitted: emittedEvents,
+      eventTriggered,
+      alwaysTriggered,
+      doneTriggered
+    },
+    completion: {
+      donePlans,
+      recordObservations: completionRecordObservations,
+      paths: Array.from(completionPaths).sort() as unknown as ReadonlyArray<StatePath<M>>
+    },
+    history: {
+      recordObservations: historyRecordObservations,
+      recorded: Array.from(historyModes, ([path, modes]) => ({
+        path: path as StateNodePath<M>,
+        modes: Array.from(modes).sort()
+      })).sort((left, right) => left.path.localeCompare(right.path)),
+      targets: historyTargets,
+      resolvedTargets: resolvedHistoryTargets
+    }
+  } as Coverage<M>
+}
+
+/** The observation roles summarized for one logical graph node. */
+export interface ObservedGraphNodeObservations {
+  readonly total: number
+  readonly startup: number
+  readonly event: number
+  readonly microstep: number
+}
+
+/** One full encoded logical snapshot stored in the observed Effect graph. */
+export interface ObservedGraphNode<M extends AnyMachine> {
+  readonly id: string
+  readonly snapshot: Machine.Machine.Snapshot<Machine.Machine.States<M>>
+  readonly encoded: Machine.Machine.EncodedSnapshot
+  readonly configuration: ReadonlyArray<StatePath<M>>
+  readonly observations: ObservedGraphNodeObservations
+}
+
+/** Retained evidence for one microstep inside an observed graph edge. */
+export interface ObservedGraphMicrostep<M extends AnyMachine> {
+  readonly next: string
+  readonly event: Machine.Machine.Event<M> | Machine.InitialEvent
+  readonly transitions: Microstep<M, any>["transitions"]
+  readonly raisedEvents: ReadonlyArray<Machine.Machine.Event<M>>
+  readonly emittedEvents: ReadonlyArray<Machine.Machine.Emit<M>>
+  readonly exitPaths: ReadonlyArray<StatePath<M>>
+  readonly entryPaths: ReadonlyArray<StatePath<M>>
+  readonly changed: boolean
+}
+
+/** A startup or public-event macrostep retained by the observed graph. */
+export type ObservedGraphEdge<M extends AnyMachine> =
+  | {
+    readonly _tag: "Startup"
+    readonly traceIndex: number
+    readonly microsteps: ReadonlyArray<ObservedGraphMicrostep<M>>
+    readonly completion: PlanCompletion<M>
+  }
+  | {
+    readonly _tag: "Event"
+    readonly traceIndex: number
+    readonly eventIndex: number
+    readonly event: Machine.Machine.InputEvent<M>
+    readonly microsteps: ReadonlyArray<ObservedGraphMicrostep<M>>
+    readonly completion: PlanCompletion<M>
+  }
+
+/** An Effect directed graph plus stable indexes useful to graph algorithms. */
+export interface ObservedGraph<M extends AnyMachine> {
+  readonly graph: Graph.DirectedGraph<ObservedGraphNode<M>, ObservedGraphEdge<M>>
+  readonly nodesById: ReadonlyMap<string, Graph.NodeIndex>
+  /** Settled post-startup nodes from which public event paths begin. */
+  readonly starts: ReadonlyArray<Graph.NodeIndex>
+  /** Pre-settled startup sources connected to `starts` by `Startup` edges. */
+  readonly startupSources: ReadonlyArray<Graph.NodeIndex>
+}
+
+type SnapshotObservationRole = "startup" | "event" | "microstep"
+
+interface SnapshotOccurrence<M extends AnyMachine> {
+  readonly snapshot: Machine.Machine.Snapshot<Machine.Machine.States<M>>
+  readonly role: SnapshotObservationRole
+}
+
+interface GraphMicrostepDraft<M extends AnyMachine> {
+  readonly nextOccurrence: number
+  readonly microstep: Microstep<M, any>
+}
+
+type GraphEdgeDraftData<M extends AnyMachine> = ObservedGraphEdge<M> extends infer Edge
+  ? Edge extends ObservedGraphEdge<M> ? Omit<Edge, "microsteps"> & {
+      readonly microsteps: ReadonlyArray<GraphMicrostepDraft<M>>
+    }
+  : never
+  : never
+
+interface GraphEdgeDraft<M extends AnyMachine> {
+  readonly sourceOccurrence: number
+  readonly targetOccurrence: number
+  readonly edge: GraphEdgeDraftData<M>
+}
+
+/**
+ * Converts concrete planner traces into an observed logical-state graph.
+ * Nodes are deduplicated by the public snapshot encoding and every edge is a
+ * concrete startup or public-event macrostep. This intentionally does not
+ * claim to be a static or exhaustive graph of the machine.
+ *
+ * @category verification
+ * @since 4.0.0
+ */
+export const observedGraph: <M extends AnyMachine>(
+  machine: M,
+  traceOrTraces: Trace<M> | ReadonlyArray<Trace<M>>
+) => Effect.Effect<
+  ObservedGraph<M>,
+  Machine.MachineSchemaEncodeError,
+  Machine.Machine.SnapshotEncodingServices<Machine.Machine.States<M>>
+> = Effect.fnUntraced(function*<M extends AnyMachine>(
+  machine: M,
+  traceOrTraces: Trace<M> | ReadonlyArray<Trace<M>>
+) {
+  const traces = normalizeTraces(traceOrTraces)
+  const occurrences: Array<SnapshotOccurrence<M>> = []
+  const edgeDrafts: Array<GraphEdgeDraft<M>> = []
+  const startOccurrences: Array<number> = []
+  const startupSourceOccurrences: Array<number> = []
+  const addOccurrence = (
+    snapshot: Machine.Machine.Snapshot<Machine.Machine.States<M>>,
+    role: SnapshotObservationRole
+  ): number => {
+    const index = occurrences.length
+    occurrences.push({ snapshot, role })
+    return index
+  }
+  const addMicrosteps = (microsteps: ReadonlyArray<Microstep<M, any>>): ReadonlyArray<GraphMicrostepDraft<M>> =>
+    microsteps.map((microstep) => ({
+      nextOccurrence: addOccurrence(microstep.next, "microstep"),
+      microstep
+    }))
+
+  traces.forEach((trace, traceIndex) => {
+    const start = addOccurrence(trace.initial.startingState, "startup")
+    startupSourceOccurrences.push(start)
+    const startupMicrosteps = addMicrosteps(trace.initial.plan.microsteps)
+    const initialized = addOccurrence(trace.initial.plan.state, "startup")
+    startOccurrences.push(initialized)
+    edgeDrafts.push({
+      sourceOccurrence: start,
+      targetOccurrence: initialized,
+      edge: {
+        _tag: "Startup",
+        traceIndex,
+        microsteps: startupMicrosteps,
+        completion: trace.initial.plan.done
+          ? { done: true, output: trace.initial.plan.output }
+          : { done: false, output: undefined }
+      }
+    })
+
+    for (const step of trace.steps) {
+      const before = addOccurrence(step.before, "event")
+      const stepMicrosteps = addMicrosteps(step.plan.microsteps)
+      const after = addOccurrence(step.after, "event")
+      edgeDrafts.push({
+        sourceOccurrence: before,
+        targetOccurrence: after,
+        edge: {
+          _tag: "Event",
+          traceIndex,
+          eventIndex: step.index,
+          event: step.event,
+          microsteps: stepMicrosteps,
+          completion: step.plan.done
+            ? { done: true, output: step.plan.output }
+            : { done: false, output: undefined }
+        }
+      })
+    }
+  })
+
+  const encoded = yield* Effect.forEach(
+    occurrences,
+    ({ snapshot }) =>
+      (Machine.encodeSnapshot as any)(machine, snapshot) as Effect.Effect<
+        Machine.Machine.EncodedSnapshot,
+        Machine.MachineSchemaEncodeError,
+        Machine.Machine.SnapshotEncodingServices<Machine.Machine.States<M>>
+      >
+  )
+  const encodedIdentity = makeStructuralIdentityIndex()
+  const occurrenceIds = encoded.map(encodedIdentity)
+  const grouped = new Map<string, {
+    readonly encoded: Machine.Machine.EncodedSnapshot
+    readonly snapshot: Machine.Machine.Snapshot<Machine.Machine.States<M>>
+    startup: number
+    event: number
+    microstep: number
+  }>()
+  occurrences.forEach((occurrence, index) => {
+    const id = occurrenceIds[index]!
+    let group = grouped.get(id)
+    if (group === undefined) {
+      grouped.set(
+        id,
+        group = {
+          encoded: encoded[index]!,
+          snapshot: occurrence.snapshot,
+          startup: 0,
+          event: 0,
+          microstep: 0
+        }
+      )
+    }
+    group[occurrence.role] += 1
+  })
+
+  const nodesById = new Map<string, Graph.NodeIndex>()
+  const graph = Graph.directed<ObservedGraphNode<M>, ObservedGraphEdge<M>>((mutable) => {
+    for (const [id, group] of grouped) {
+      const node = Graph.addNode(mutable, {
+        id,
+        snapshot: group.snapshot,
+        encoded: group.encoded,
+        configuration: group.encoded.active.map(({ path }) => path) as unknown as ReadonlyArray<StatePath<M>>,
+        observations: {
+          total: group.startup + group.event + group.microstep,
+          startup: group.startup,
+          event: group.event,
+          microstep: group.microstep
+        }
+      })
+      nodesById.set(id, node)
+    }
+    for (const draft of edgeDrafts) {
+      const source = nodesById.get(occurrenceIds[draft.sourceOccurrence]!)!
+      const target = nodesById.get(occurrenceIds[draft.targetOccurrence]!)!
+      Graph.addEdge(mutable, source, target, {
+        ...draft.edge,
+        microsteps: draft.edge.microsteps.map(({ microstep, nextOccurrence }) => ({
+          next: occurrenceIds[nextOccurrence]!,
+          event: microstep.event,
+          transitions: microstep.transitions,
+          raisedEvents: microstep.raisedEvents,
+          emittedEvents: microstep.emittedEvents,
+          exitPaths: microstep.exitPaths as ReadonlyArray<StatePath<M>>,
+          entryPaths: microstep.entryPaths as ReadonlyArray<StatePath<M>>,
+          changed: microstep.changed
+        }))
+      } as ObservedGraphEdge<M>)
+    }
+  })
+  return {
+    graph,
+    nodesById,
+    starts: Array.from(new Set(startOccurrences.map((index) => nodesById.get(occurrenceIds[index]!)!))),
+    startupSources: Array.from(
+      new Set(startupSourceOccurrences.map((index) => nodesById.get(occurrenceIds[index]!)!))
+    )
+  }
+}) as any
+
+/**
+ * Independently checked families of planner laws.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type VerificationLawGroup =
+  | "configuration"
+  | "microsteps"
+  | "completion"
+  | "history"
+  | "targetBounds"
+
+/**
+ * Stable identifiers for individual planner laws.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type VerificationLaw =
+  | "configuration.shape"
+  | "configuration.path"
+  | "configuration.schema"
+  | "configuration.hierarchy"
+  | "configuration.compound"
+  | "configuration.parallel"
+  | "configuration.duplicate"
+  | "configuration.trace"
+  | "microsteps.unique"
+  | "microsteps.order"
+  | "microsteps.activeBefore"
+  | "microsteps.activeAfter"
+  | "microsteps.changed"
+  | "microsteps.continuity"
+  | "microsteps.reentry"
+  | "completion.record"
+  | "completion.output"
+  | "completion.done"
+  | "history.record"
+  | "history.mode"
+  | "history.path"
+  | "history.value"
+  | "history.shallow"
+  | "history.deep"
+  | "targetBounds.definition"
+  | "targetBounds.target"
+
+/**
+ * One independently observed violation in a planner trace.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface VerificationViolation {
+  readonly law: VerificationLaw
+  /** `undefined` identifies startup; otherwise this is the scenario event index. */
+  readonly eventIndex: number | undefined
+  readonly microstepIndex?: number
+  readonly path?: string
+  readonly message: string
+}
+
+/**
+ * All violations found while checking one trace.
+ *
+ * @category errors
+ * @since 4.0.0
+ */
+export class VerificationError extends Data.TaggedError("MachineTestVerificationError")<{
+  readonly violations: ReadonlyArray<VerificationViolation>
+}> {}
+
+/**
+ * Selects law families for the single canonical verifier. All run by default.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface VerifyOptions {
+  readonly laws?: ReadonlyArray<VerificationLawGroup>
+}
+
+interface VerificationLocation {
+  readonly eventIndex: number | undefined
+  readonly microstepIndex?: number
+}
+
+interface SnapshotInspection {
+  readonly active: ReadonlySet<string>
+  readonly paths: ReadonlyArray<string>
+  readonly values: ReadonlyMap<string, unknown>
+  readonly root: Record<string, unknown> | undefined
+}
+
+type PublicStateNode = Machine.Machine.StateNode<string>
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const hasOwn = (value: object, key: PropertyKey): boolean => Object.prototype.hasOwnProperty.call(value, key)
+
+const sameValue = (left: unknown, right: unknown): boolean => formatValue(left) === formatValue(right)
+
+const samePaths = (left: ReadonlyArray<string>, right: ReadonlyArray<string>): boolean =>
+  left.length === right.length && left.every((path, index) => path === right[index])
+
+const sameTrigger = (
+  left: Machine.Machine.TransitionTrigger,
+  right: Machine.Machine.TransitionTrigger
+): boolean =>
+  left.type === right.type && (left.type !== "event" || right.type === "event" && left.event === right.event)
+
+const makeNodeUtilities = (nodes: ReadonlyArray<PublicStateNode>) => {
+  const byPath = new Map(nodes.map((node) => [node.path, node]))
+  const depth = (path: string): number => {
+    let current = byPath.get(path)
+    let result = 0
+    const seen = new Set<string>()
+    while (current !== undefined && !seen.has(current.path)) {
+      seen.add(current.path)
+      result += 1
+      current = current.parent === undefined ? undefined : byPath.get(current.parent)
+    }
+    return result
+  }
+  const isDescendantOrSelf = (path: string, ancestor: string): boolean => {
+    let current = byPath.get(path)
+    const seen = new Set<string>()
+    while (current !== undefined && !seen.has(current.path)) {
+      if (current.path === ancestor) return true
+      seen.add(current.path)
+      current = current.parent === undefined ? undefined : byPath.get(current.parent)
+    }
+    return false
+  }
+  const ancestors = (path: string): ReadonlyArray<string> => {
+    const result: Array<string> = []
+    let current = byPath.get(path)
+    const seen = new Set<string>()
+    while (current !== undefined && !seen.has(current.path)) {
+      seen.add(current.path)
+      result.unshift(current.path)
+      current = current.parent === undefined ? undefined : byPath.get(current.parent)
+    }
+    return result
+  }
+  return { ancestors, byPath, depth, isDescendantOrSelf }
+}
+
+/**
+ * Verifies an executed trace using only public machine inspection and raw
+ * snapshot data. The verifier deliberately does not reuse planner
+ * normalization, encoding, finality, or other internal helpers.
+ *
+ * Every selected law is evaluated and returned in one structured error so a
+ * shrunk property-test counterexample retains all relevant evidence.
+ *
+ * @category verification
+ * @since 4.0.0
+ */
+export const verify = <M extends AnyMachine>(
+  machine: M,
+  trace: Trace<M>,
+  options: VerifyOptions = {}
+): Effect.Effect<void, VerificationError> => {
+  const selected = new Set<VerificationLawGroup>(
+    options.laws ?? ["configuration", "microsteps", "completion", "history", "targetBounds"]
+  )
+  const nodes = Machine.stateNodes(machine) as ReadonlyArray<PublicStateNode>
+  const definitions = Machine.transitionDefinitions(machine)
+  const { ancestors, byPath, depth, isDescendantOrSelf } = makeNodeUtilities(nodes)
+  const violations: Array<VerificationViolation> = []
+
+  const add = (
+    law: VerificationLaw,
+    location: VerificationLocation,
+    message: string,
+    path?: string
+  ): void => {
+    violations.push({
+      law,
+      eventIndex: location.eventIndex,
+      ...(location.microstepIndex === undefined ? {} : { microstepIndex: location.microstepIndex }),
+      ...(path === undefined ? {} : { path }),
+      message
+    })
+  }
+
+  const schemaMatches = (schema: Schema.Top | undefined, value: unknown): boolean => {
+    if (schema === undefined) return false
+    try {
+      return Schema.is(schema)(value)
+    } catch {
+      return false
+    }
+  }
+
+  const inspectSnapshot = (
+    snapshot: unknown,
+    location: VerificationLocation,
+    label: string
+  ): SnapshotInspection => {
+    const active = new Set<string>()
+    const paths: Array<string> = []
+    const values = new Map<string, unknown>()
+    const reportConfiguration = selected.has("configuration")
+    const root = isRecord(snapshot) ? snapshot : undefined
+
+    const visit = (current: unknown, expectedParent: string | undefined, expectedPath?: string): void => {
+      if (!isRecord(current)) {
+        if (reportConfiguration) {
+          add("configuration.shape", location, `${label} must contain an object snapshot`)
+        }
+        return
+      }
+      if (typeof current.path !== "string") {
+        if (reportConfiguration) {
+          add("configuration.path", location, `${label} contains a snapshot without a string path`)
+        }
+        return
+      }
+      const path = current.path
+      if (active.has(path)) {
+        if (reportConfiguration) {
+          add("configuration.duplicate", location, `${label} activates state "${path}" more than once`, path)
+        }
+        return
+      }
+      active.add(path)
+      paths.push(path)
+      values.set(path, current.value)
+
+      const node = byPath.get(path)
+      if (node === undefined) {
+        if (reportConfiguration) {
+          add("configuration.path", location, `${label} activates unknown state "${path}"`, path)
+        }
+        if (isRecord(current.state)) visit(current.state, path)
+        if (isRecord(current.states)) {
+          for (const child of Object.values(current.states)) visit(child, path)
+        }
+        return
+      }
+      if (expectedPath !== undefined && path !== expectedPath && reportConfiguration) {
+        add(
+          "configuration.hierarchy",
+          location,
+          `${label} expected region "${expectedPath}" but found "${path}"`,
+          path
+        )
+      }
+      if (node.parent !== expectedParent && reportConfiguration) {
+        add(
+          "configuration.hierarchy",
+          location,
+          expectedParent === undefined
+            ? `${label} root state "${path}" is not a machine root`
+            : `${label} state "${path}" is not a direct child of "${expectedParent}"`,
+          path
+        )
+      }
+      if (node.type === "history") {
+        if (reportConfiguration) {
+          add("configuration.path", location, `${label} activates history pseudo-state "${path}"`, path)
+        }
+        return
+      }
+      if (reportConfiguration && !schemaMatches(node.schema, current.value)) {
+        add("configuration.schema", location, `${label} value for "${path}" does not match its schema`, path)
+      }
+
+      if (node.type === "compound") {
+        if (!isRecord(current.state)) {
+          if (reportConfiguration) {
+            add(
+              "configuration.compound",
+              location,
+              `${label} compound state "${path}" must have exactly one child`,
+              path
+            )
+          }
+        } else {
+          visit(current.state, path)
+        }
+        if (hasOwn(current, "states") && reportConfiguration) {
+          add("configuration.compound", location, `${label} compound state "${path}" contains parallel regions`, path)
+        }
+        return
+      }
+
+      if (node.type === "parallel") {
+        if (!isRecord(current.states)) {
+          if (reportConfiguration) {
+            add("configuration.parallel", location, `${label} parallel state "${path}" has no region map`, path)
+          }
+          return
+        }
+        const expectedKeys = new Set<string>()
+        for (const childPath of node.children) {
+          const child = byPath.get(childPath)
+          if (child === undefined) continue
+          expectedKeys.add(child.key)
+          if (!hasOwn(current.states, child.key)) {
+            if (reportConfiguration) {
+              add(
+                "configuration.parallel",
+                location,
+                `${label} parallel state "${path}" omits region "${child.key}"`,
+                childPath
+              )
+            }
+          } else {
+            visit(current.states[child.key], path, child.path)
+          }
+        }
+        for (const key of Object.keys(current.states)) {
+          if (!expectedKeys.has(key)) {
+            if (reportConfiguration) {
+              add(
+                "configuration.parallel",
+                location,
+                `${label} parallel state "${path}" contains extra region "${key}"`,
+                path
+              )
+            }
+            visit(current.states[key], path)
+          }
+        }
+        if (hasOwn(current, "state") && reportConfiguration) {
+          add("configuration.parallel", location, `${label} parallel state "${path}" contains a compound child`, path)
+        }
+        return
+      }
+
+      if ((hasOwn(current, "state") || hasOwn(current, "states")) && reportConfiguration) {
+        add("configuration.shape", location, `${label} leaf state "${path}" contains active children`, path)
+      }
+    }
+
+    visit(snapshot, undefined)
+    return { active, paths, values, root }
+  }
+
+  const validateTraceConfiguration = (
+    expected: SnapshotInspection,
+    actual: ReadonlyArray<string>,
+    location: VerificationLocation,
+    label: string
+  ): void => {
+    if (selected.has("configuration") && !samePaths(expected.paths, actual)) {
+      add(
+        "configuration.trace",
+        location,
+        `${label} configuration [${actual.join(", ")}] does not match snapshot [${expected.paths.join(", ")}]`
+      )
+    }
+  }
+
+  const validateHistory = (
+    snapshot: SnapshotInspection,
+    location: VerificationLocation,
+    label: string
+  ): void => {
+    if (!selected.has("history") || snapshot.root === undefined || !hasOwn(snapshot.root, "history")) return
+    const history = snapshot.root.history
+    if (!isRecord(history)) {
+      add("history.record", location, `${label} history metadata must be a record`)
+      return
+    }
+    for (const [historyPath, unknownEntry] of Object.entries(history)) {
+      const historyNode = byPath.get(historyPath)
+      if (historyNode === undefined || historyNode.type !== "history" || historyNode.parent === undefined) {
+        add("history.path", location, `${label} contains unknown history record "${historyPath}"`, historyPath)
+        continue
+      }
+      if (!isRecord(unknownEntry)) {
+        add("history.record", location, `${label} history record "${historyPath}" must be an object`, historyPath)
+        continue
+      }
+      const entry = unknownEntry
+      if (entry.mode !== historyNode.history) {
+        add(
+          "history.mode",
+          location,
+          `${label} history record "${historyPath}" has mode "${
+            String(entry.mode)
+          }", expected "${historyNode.history}"`,
+          historyPath
+        )
+      }
+      if (!Array.isArray(entry.active) || !entry.active.every((path) => typeof path === "string")) {
+        add(
+          "history.record",
+          location,
+          `${label} history record "${historyPath}" must contain string paths`,
+          historyPath
+        )
+        continue
+      }
+      if (!isRecord(entry.values)) {
+        add(
+          "history.record",
+          location,
+          `${label} history record "${historyPath}" must contain a values record`,
+          historyPath
+        )
+        continue
+      }
+
+      const rememberedPaths = entry.active as ReadonlyArray<string>
+      const remembered = new Set<string>()
+      for (const path of rememberedPaths) {
+        if (remembered.has(path)) {
+          add("history.path", location, `${label} history record "${historyPath}" repeats "${path}"`, path)
+          continue
+        }
+        remembered.add(path)
+        const node = byPath.get(path)
+        if (node === undefined || node.type === "history") {
+          add(
+            "history.path",
+            location,
+            `${label} history record "${historyPath}" contains invalid state "${path}"`,
+            path
+          )
+          continue
+        }
+        const inOwnerSubtree = isDescendantOrSelf(path, historyNode.parent)
+        const inOwnerAncestry = ancestors(historyNode.parent).includes(path)
+        if (!inOwnerSubtree && !inOwnerAncestry) {
+          add(
+            "history.path",
+            location,
+            `${label} history record "${historyPath}" contains state "${path}" outside its owner`,
+            path
+          )
+        }
+        if (!hasOwn(entry.values, path)) {
+          add("history.value", location, `${label} history record "${historyPath}" omits value for "${path}"`, path)
+        } else if (!schemaMatches(node.schema, entry.values[path])) {
+          add(
+            "history.value",
+            location,
+            `${label} history value for "${path}" does not match its state schema`,
+            path
+          )
+        }
+        if (
+          entry.mode === "shallow" && isDescendantOrSelf(path, historyNode.parent) && path !== historyNode.parent &&
+          node.parent !== historyNode.parent
+        ) {
+          add(
+            "history.shallow",
+            location,
+            `${label} shallow history record "${historyPath}" contains deep descendant "${path}"`,
+            path
+          )
+        }
+      }
+      for (const path of Object.keys(entry.values)) {
+        if (!remembered.has(path)) {
+          add("history.value", location, `${label} history record "${historyPath}" has extra value "${path}"`, path)
+        }
+      }
+      if (entry.mode === "deep") {
+        for (const path of remembered) {
+          if (!isDescendantOrSelf(path, historyNode.parent) || path === historyNode.parent) continue
+          let parent: string | undefined = byPath.get(path)?.parent
+          while (parent !== undefined && isDescendantOrSelf(parent, historyNode.parent)) {
+            if (!remembered.has(parent)) {
+              add(
+                "history.deep",
+                location,
+                `${label} deep history record "${historyPath}" remembers "${path}" without ancestor "${parent}"`,
+                path
+              )
+            }
+            if (parent === historyNode.parent) break
+            parent = byPath.get(parent)?.parent
+          }
+        }
+      }
+      for (const ancestor of ancestors(historyNode.parent)) {
+        if (!remembered.has(ancestor)) {
+          add(
+            "history.path",
+            location,
+            `${label} history record "${historyPath}" omits owner ancestry state "${ancestor}"`,
+            ancestor
+          )
+        }
+      }
+
+      const validateRememberedControl = (path: string, recurse: boolean): void => {
+        const node = byPath.get(path)
+        if (node === undefined) return
+        const activeChildren = node.children.filter((child) => remembered.has(child))
+        if (node.type === "compound") {
+          if (activeChildren.length !== 1) {
+            add(
+              entry.mode === "deep" ? "history.deep" : "history.shallow",
+              location,
+              `${label} history record "${historyPath}" must remember one child of compound state "${path}"`,
+              path
+            )
+          } else if (recurse) {
+            validateRememberedControl(activeChildren[0], true)
+          }
+        } else if (node.type === "parallel") {
+          for (const child of node.children) {
+            if (!remembered.has(child)) {
+              add(
+                entry.mode === "deep" ? "history.deep" : "history.shallow",
+                location,
+                `${label} history record "${historyPath}" omits parallel region "${child}"`,
+                child
+              )
+            } else if (recurse) {
+              validateRememberedControl(child, true)
+            }
+          }
+        }
+      }
+      validateRememberedControl(historyNode.parent, entry.mode === "deep")
+    }
+  }
+
+  const isCompletedControl = (path: string, active: ReadonlySet<string>): boolean => {
+    if (!active.has(path)) return false
+    const node = byPath.get(path)
+    if (node === undefined) return false
+    if (node.type === "final") return true
+    if (node.type === "compound") {
+      const child = node.children.find((candidate) => active.has(candidate))
+      return child !== undefined && byPath.get(child)?.type === "final"
+    }
+    if (node.type === "parallel") {
+      return node.children.length > 0 && node.children.every((child) => isCompletedControl(child, active))
+    }
+    return false
+  }
+
+  const completionSchema = (path: string, active: ReadonlySet<string>): Schema.Top | undefined => {
+    const node = byPath.get(path)
+    if (node === undefined) return undefined
+    if (node.type === "compound") {
+      const child = node.children.find((candidate) => active.has(candidate))
+      return child === undefined ? undefined : completionSchema(child, active)
+    }
+    return node.output ?? Schema.Void
+  }
+
+  const validateCompletions = (
+    snapshot: SnapshotInspection,
+    location: VerificationLocation,
+    label: string,
+    settled: boolean
+  ): ReadonlyMap<string, unknown> => {
+    const result = new Map<string, unknown>()
+    if (!selected.has("completion") || snapshot.root === undefined) {
+      return result
+    }
+    if (hasOwn(snapshot.root, "completed")) {
+      const completed = snapshot.root.completed
+      if (!Array.isArray(completed)) {
+        add("completion.record", location, `${label} completed metadata must be an array`)
+      } else {
+        for (const unknownEntry of completed) {
+          if (!isRecord(unknownEntry) || typeof unknownEntry.path !== "string") {
+            add("completion.record", location, `${label} contains an invalid completion record`)
+            continue
+          }
+          const path = unknownEntry.path
+          if (result.has(path)) {
+            add("completion.record", location, `${label} repeats completion "${path}"`, path)
+            continue
+          }
+          result.set(path, unknownEntry.output)
+          if (!snapshot.active.has(path) || !isCompletedControl(path, snapshot.active)) {
+            add("completion.record", location, `${label} completion "${path}" is not actively complete`, path)
+            continue
+          }
+          const schema = completionSchema(path, snapshot.active)
+          if (!schemaMatches(schema, unknownEntry.output)) {
+            add(
+              "completion.output",
+              location,
+              `${label} completion output for "${path}" does not match its schema`,
+              path
+            )
+          }
+        }
+      }
+    }
+    if (settled) {
+      for (const path of snapshot.paths) {
+        if (isCompletedControl(path, snapshot.active) && !result.has(path)) {
+          add("completion.record", location, `${label} omits settled completion "${path}"`, path)
+        }
+      }
+    }
+    return result
+  }
+
+  const validateSnapshotMetadata = (
+    snapshot: SnapshotInspection,
+    location: VerificationLocation,
+    label: string,
+    settled = false
+  ): ReadonlyMap<string, unknown> => {
+    validateHistory(snapshot, location, label)
+    return validateCompletions(snapshot, location, label, settled)
+  }
+
+  const sameControl = (left: SnapshotInspection, right: SnapshotInspection): boolean => {
+    if (!samePaths(left.paths, right.paths)) return false
+    for (const path of left.paths) {
+      if (!sameValue(left.values.get(path), right.values.get(path))) return false
+    }
+    return sameValue(left.root?.history, right.root?.history)
+  }
+
+  const sameActivePaths = (left: SnapshotInspection, right: SnapshotInspection): boolean =>
+    left.active.size === right.active.size && Array.from(left.active).every((path) => right.active.has(path))
+
+  const sortedPaths = (paths: ReadonlyArray<string>, direction: "entry" | "exit"): ReadonlyArray<string> =>
+    [...new Set(paths)].sort((left, right) => {
+      const depthDifference = direction === "entry" ? depth(left) - depth(right) : depth(right) - depth(left)
+      if (depthDifference !== 0) return depthDifference
+      const leftOrder = byPath.get(left)?.order ?? Number.MAX_SAFE_INTEGER
+      const rightOrder = byPath.get(right)?.order ?? Number.MAX_SAFE_INTEGER
+      return direction === "entry" ? leftOrder - rightOrder : rightOrder - leftOrder
+    })
+
+  const validateTransitionBounds = (
+    transition: Microstep<M>["transitions"][number],
+    location: VerificationLocation
+  ): void => {
+    if (!selected.has("targetBounds")) return
+    const definition = definitions.find((candidate) =>
+      candidate.source === transition.source && candidate.reenter === transition.reenter &&
+      sameTrigger(candidate.trigger, transition.trigger)
+    )
+    if (definition === undefined) {
+      add(
+        "targetBounds.definition",
+        location,
+        `retained transition from "${transition.source}" has no public definition`,
+        transition.source
+      )
+      return
+    }
+    if (transition.target === undefined || definition.targets.type === "dynamic") return
+    if (!definition.targets.paths.some((bound) => isDescendantOrSelf(String(transition.target), String(bound)))) {
+      add(
+        "targetBounds.target",
+        location,
+        `transition target "${String(transition.target)}" is outside declared bounds ` +
+          `[${definition.targets.paths.join(", ")}]`,
+        String(transition.target)
+      )
+    }
+  }
+
+  const validateMicrostep = (
+    microstep: Microstep<M, any>,
+    before: SnapshotInspection,
+    after: SnapshotInspection,
+    location: VerificationLocation
+  ): void => {
+    if (selected.has("microsteps")) {
+      const uniqueExit = new Set(microstep.exitPaths)
+      const uniqueEntry = new Set(microstep.entryPaths)
+      const reentering = microstep.transitions.filter((transition) => transition.reenter)
+      const inReentryScope = (
+        path: string,
+        transition: Microstep<M>["transitions"][number]
+      ): boolean => {
+        const target = transition.target === undefined ? undefined : byPath.get(String(transition.target))
+        if (target?.type === "history" && target.parent !== undefined && before.active.has(target.parent)) {
+          return isDescendantOrSelf(path, target.parent)
+        }
+        const parent = byPath.get(String(transition.source))?.parent
+        return parent === undefined || path !== parent && isDescendantOrSelf(path, parent)
+      }
+      const commonLifecycleExplained = (path: string): boolean =>
+        microstep.transitions.some((transition) => {
+          if (transition.reenter) {
+            const target = transition.target === undefined ? undefined : byPath.get(String(transition.target))
+            if (target?.type === "history" && target.parent !== undefined && before.active.has(target.parent)) {
+              // Reentry into an active history owner has a dedicated boundary:
+              // only the owner subtree is exited and entered, regardless of
+              // the ordinary source/resolved-target LCA.
+              return isDescendantOrSelf(path, target.parent)
+            }
+            if (inReentryScope(path, transition)) return true
+          }
+          if (transition.resolvedTarget === undefined) return false
+          const sourceAncestors = ancestors(String(transition.source))
+          const targetAncestors = ancestors(String(transition.resolvedTarget))
+          let boundary: string | undefined
+          for (let index = 0; index < Math.min(sourceAncestors.length, targetAncestors.length); index++) {
+            if (sourceAncestors[index] !== targetAncestors[index]) break
+            boundary = sourceAncestors[index]
+          }
+          return boundary === undefined || path !== boundary && isDescendantOrSelf(path, boundary)
+        })
+      if (uniqueExit.size !== microstep.exitPaths.length) {
+        add("microsteps.unique", location, "microstep exit paths contain duplicates")
+      }
+      if (uniqueEntry.size !== microstep.entryPaths.length) {
+        add("microsteps.unique", location, "microstep entry paths contain duplicates")
+      }
+      if (!samePaths(microstep.exitPaths, sortedPaths(microstep.exitPaths, "exit"))) {
+        add("microsteps.order", location, "microstep exit paths are not deepest-first in reverse document order")
+      }
+      if (!samePaths(microstep.entryPaths, sortedPaths(microstep.entryPaths, "entry"))) {
+        add("microsteps.order", location, "microstep entry paths are not parent-first in document order")
+      }
+      for (const path of microstep.exitPaths) {
+        if (!before.active.has(path)) {
+          add("microsteps.activeBefore", location, `microstep exits inactive state "${path}"`, path)
+        }
+      }
+      for (const path of microstep.entryPaths) {
+        if (!after.active.has(path)) {
+          add("microsteps.activeAfter", location, `microstep enters state "${path}" absent from its next state`, path)
+        }
+      }
+      for (const path of before.paths) {
+        if (!after.active.has(path) && !uniqueExit.has(path)) {
+          add("microsteps.activeBefore", location, `removed state "${path}" is missing from exit paths`, path)
+        }
+      }
+      for (const path of after.paths) {
+        if (!before.active.has(path) && !uniqueEntry.has(path)) {
+          add("microsteps.activeAfter", location, `added state "${path}" is missing from entry paths`, path)
+        }
+      }
+      for (const transition of reentering) {
+        for (const path of before.paths) {
+          if (inReentryScope(path, transition) && !uniqueExit.has(path)) {
+            add(
+              "microsteps.reentry",
+              location,
+              `reentering transition from "${String(transition.source)}" omits exit lifecycle for "${path}"`,
+              path
+            )
+          }
+        }
+        for (const path of after.paths) {
+          if (inReentryScope(path, transition) && !uniqueEntry.has(path)) {
+            add(
+              "microsteps.reentry",
+              location,
+              `reentering transition from "${String(transition.source)}" omits entry lifecycle for "${path}"`,
+              path
+            )
+          }
+        }
+      }
+      for (const path of before.paths) {
+        if (!after.active.has(path) || !uniqueExit.has(path) && !uniqueEntry.has(path)) continue
+        if (!commonLifecycleExplained(path)) {
+          add(
+            "microsteps.reentry",
+            location,
+            `common state "${path}" has lifecycle without a reentering transition`,
+            path
+          )
+        } else if (!uniqueExit.has(path) || !uniqueEntry.has(path)) {
+          add(
+            "microsteps.reentry",
+            location,
+            `reentered common state "${path}" must have both exit and entry lifecycle`,
+            path
+          )
+        }
+      }
+      if (!microstep.changed) {
+        if (microstep.exitPaths.length > 0 || microstep.entryPaths.length > 0) {
+          add("microsteps.changed", location, "unchanged microstep contains entry or exit paths")
+        }
+        if (!sameActivePaths(before, after)) {
+          add("microsteps.changed", location, "unchanged microstep changes its active state paths")
+        }
+      } else if (
+        microstep.exitPaths.length === 0 && microstep.entryPaths.length === 0 && sameActivePaths(before, after)
+      ) {
+        add("microsteps.changed", location, "changed microstep has no control-state change or reentry evidence")
+      }
+      for (const transition of microstep.transitions) {
+        if (!before.active.has(String(transition.source))) {
+          add(
+            "microsteps.activeBefore",
+            location,
+            `transition source "${String(transition.source)}" is inactive before the microstep`,
+            String(transition.source)
+          )
+        }
+        if (
+          transition.resolvedTarget !== undefined && !after.active.has(String(transition.resolvedTarget)) &&
+          microstep.transitions.length === 1
+        ) {
+          add(
+            "microsteps.activeAfter",
+            location,
+            `resolved target "${String(transition.resolvedTarget)}" is inactive after the microstep`,
+            String(transition.resolvedTarget)
+          )
+        }
+      }
+    }
+    for (const transition of microstep.transitions) validateTransitionBounds(transition, location)
+  }
+
+  const validatePlanCompletion = (
+    plan: PlanCompletion<M>,
+    snapshot: SnapshotInspection,
+    completions: ReadonlyMap<string, unknown>,
+    location: VerificationLocation,
+    label: string
+  ): void => {
+    if (!selected.has("completion")) return
+    const rootPath = snapshot.paths.find((path) => byPath.get(path)?.parent === undefined)
+    const hasRootDoneTransition = rootPath !== undefined &&
+      definitions.some((definition) => definition.source === rootPath && definition.trigger.type === "done")
+    const terminal = rootPath !== undefined && isCompletedControl(rootPath, snapshot.active) && !hasRootDoneTransition
+    if (plan.done !== terminal) {
+      add(
+        "completion.done",
+        location,
+        `${label} reports done=${String(plan.done)} for terminal=${String(terminal)}`,
+        rootPath
+      )
+    }
+    if (plan.done) {
+      if (rootPath === undefined || !completions.has(rootPath)) {
+        add("completion.output", location, `${label} done plan has no root completion output`, rootPath)
+      } else if (!sameValue(plan.output, completions.get(rootPath))) {
+        add("completion.output", location, `${label} output differs from its root completion`, rootPath)
+      }
+    } else if (plan.output !== undefined) {
+      add("completion.output", location, `${label} non-done plan exposes an output`, rootPath)
+    }
+  }
+
+  const initialLocation: VerificationLocation = { eventIndex: undefined }
+  const starting = inspectSnapshot(trace.initial.startingState, initialLocation, "initial starting state")
+  validateSnapshotMetadata(starting, initialLocation, "initial starting state")
+  validateTraceConfiguration(
+    starting,
+    trace.initial.startingConfiguration as ReadonlyArray<string>,
+    initialLocation,
+    "initial starting"
+  )
+  if (selected.has("microsteps")) {
+    if (new Set(trace.initial.initialEntryPaths).size !== trace.initial.initialEntryPaths.length) {
+      add("microsteps.unique", initialLocation, "initial entry paths contain duplicates")
+    }
+    if (!samePaths(trace.initial.initialEntryPaths as ReadonlyArray<string>, starting.paths)) {
+      add(
+        "microsteps.order",
+        initialLocation,
+        "initial entry paths do not cover the starting configuration in definition order"
+      )
+    }
+  }
+
+  let current = starting
+  for (let index = 0; index < trace.initial.plan.microsteps.length; index++) {
+    const location: VerificationLocation = { eventIndex: undefined, microstepIndex: index }
+    const microstep = trace.initial.plan.microsteps[index]
+    const next = inspectSnapshot(microstep.next, location, `initial microstep ${index} next state`)
+    validateSnapshotMetadata(next, location, `initial microstep ${index} next state`)
+    validateMicrostep(microstep, current, next, location)
+    current = next
+  }
+  const initialState = inspectSnapshot(trace.initial.plan.state, initialLocation, "initial plan state")
+  const initialCompletions = validateSnapshotMetadata(initialState, initialLocation, "initial plan state", true)
+  if (selected.has("microsteps") && !sameControl(current, initialState)) {
+    add("microsteps.continuity", initialLocation, "initial plan state does not continue from its final microstep")
+  }
+  validatePlanCompletion(trace.initial.plan, initialState, initialCompletions, initialLocation, "initial plan")
+  validateTraceConfiguration(
+    initialState,
+    trace.initial.configuration as ReadonlyArray<string>,
+    initialLocation,
+    "initial"
+  )
+  if (selected.has("microsteps") && !sameValue(trace.initial.startingState, trace.initial.plan.startingState)) {
+    add("microsteps.continuity", initialLocation, "initial trace starting state differs from its plan")
+  }
+  if (
+    selected.has("microsteps") &&
+    !samePaths(trace.initial.initialEntryPaths as ReadonlyArray<string>, trace.initial.plan.initialEntryPaths)
+  ) {
+    add("microsteps.continuity", initialLocation, "initial trace entry paths differ from its plan")
+  }
+
+  let previous = initialState
+  for (let eventIndex = 0; eventIndex < trace.steps.length; eventIndex++) {
+    const step = trace.steps[eventIndex]
+    const location: VerificationLocation = { eventIndex }
+    const before = inspectSnapshot(step.before, location, `event ${eventIndex} before state`)
+    validateSnapshotMetadata(before, location, `event ${eventIndex} before state`, true)
+    validateTraceConfiguration(
+      before,
+      step.beforeConfiguration as ReadonlyArray<string>,
+      location,
+      `event ${eventIndex} before`
+    )
+    if (selected.has("microsteps")) {
+      if (step.index !== eventIndex) {
+        add("microsteps.continuity", location, `trace step index ${step.index} does not equal ${eventIndex}`)
+      }
+      if (!sameValue(previous.root, before.root)) {
+        add("microsteps.continuity", location, `event ${eventIndex} before state does not equal the previous state`)
+      }
+      if (!sameValue(step.event, trace.scenario.events[eventIndex])) {
+        add("microsteps.continuity", location, `event ${eventIndex} differs from its scenario event`)
+      }
+    }
+
+    current = before
+    for (let microstepIndex = 0; microstepIndex < step.plan.microsteps.length; microstepIndex++) {
+      const microstepLocation: VerificationLocation = { eventIndex, microstepIndex }
+      const microstep = step.plan.microsteps[microstepIndex]
+      const next = inspectSnapshot(
+        microstep.next,
+        microstepLocation,
+        `event ${eventIndex} microstep ${microstepIndex} next state`
+      )
+      validateSnapshotMetadata(next, microstepLocation, `event ${eventIndex} microstep ${microstepIndex} next state`)
+      validateMicrostep(microstep, current, next, microstepLocation)
+      current = next
+    }
+
+    const plannedNext = inspectSnapshot(step.plan.next, location, `event ${eventIndex} plan next state`)
+    const completions = validateSnapshotMetadata(plannedNext, location, `event ${eventIndex} plan next state`, true)
+    if (selected.has("microsteps") && !sameControl(current, plannedNext)) {
+      add(
+        "microsteps.continuity",
+        location,
+        `event ${eventIndex} plan next state does not continue its final microstep`
+      )
+    }
+    validatePlanCompletion(step.plan, plannedNext, completions, location, `event ${eventIndex} plan`)
+
+    const after = inspectSnapshot(step.after, location, `event ${eventIndex} after state`)
+    validateSnapshotMetadata(after, location, `event ${eventIndex} after state`, true)
+    validateTraceConfiguration(
+      after,
+      step.afterConfiguration as ReadonlyArray<string>,
+      location,
+      `event ${eventIndex} after`
+    )
+    if (selected.has("microsteps") && !sameValue(step.plan.next, step.after)) {
+      add("microsteps.continuity", location, `event ${eventIndex} after state differs from its plan next state`)
+    }
+    previous = after
+  }
+
+  const finalEventIndex = trace.steps.length === 0 ? undefined : trace.steps.length - 1
+  const finalLocation: VerificationLocation = { eventIndex: finalEventIndex }
+  const final = inspectSnapshot(trace.final, finalLocation, "trace final state")
+  validateSnapshotMetadata(final, finalLocation, "trace final state", true)
+  validateTraceConfiguration(final, trace.finalConfiguration as ReadonlyArray<string>, finalLocation, "final")
+  if (selected.has("microsteps") && !sameValue(previous.root, final.root)) {
+    add("microsteps.continuity", finalLocation, "trace final state differs from its final planned state")
+  }
+
+  return violations.length === 0 ? Effect.void : Effect.fail(new VerificationError({ violations }))
+}
+
+const formatConfiguration = (paths: ReadonlyArray<string>): string => `[${paths.join(", ")}]`
+
+const formatMicrosteps = <M extends AnyMachine>(microsteps: ReadonlyArray<Microstep<M, any>>): Array<string> =>
+  microsteps.map((microstep, index) => {
+    const transitions = microstep.transitions.map((transition) => ({
+      source: transition.source,
+      trigger: transition.trigger,
+      reenter: transition.reenter,
+      target: transition.target,
+      resolvedTarget: transition.resolvedTarget
+    }))
+    return `  microstep ${index}: event=${formatValue(microstep.event)} changed=${String(microstep.changed)} ` +
+      `transitions=${formatValue(transitions)} exit=${formatConfiguration(microstep.exitPaths)} ` +
+      `entry=${formatConfiguration(microstep.entryPaths)} actions=${microstep.actions.length} ` +
+      `raised=${formatValue(microstep.raisedEvents)} emitted=${formatValue(microstep.emittedEvents)} ` +
+      `next=${formatValue(microstep.next)}`
+  })
+
+const formatInitial = <M extends AnyMachine>(initial: InitialTrace<M>): Array<string> => [
+  `initial: startingConfiguration=${formatConfiguration(initial.startingConfiguration)} ` +
+  `startingState=${formatValue(initial.startingState)} initialEntry=${
+    formatConfiguration(initial.initialEntryPaths)
+  } ` +
+  `configuration=${formatConfiguration(initial.configuration)} state=${formatValue(initial.plan.state)} ` +
+  `done=${String(initial.plan.done)} output=${formatValue(initial.plan.output)} ` +
+  `actions=${initial.plan.actions.length} emitted=${formatValue(initial.plan.emittedEvents)}`,
+  ...formatMicrosteps(initial.plan.microsteps)
+]
+
+const formatStep = <M extends AnyMachine>(step: TraceStep<M>): Array<string> => [
+  `step ${step.index}: event=${formatValue(step.event)} before=${formatConfiguration(step.beforeConfiguration)} ` +
+  `after=${formatConfiguration(step.afterConfiguration)} state=${formatValue(step.after)} ` +
+  `done=${String(step.plan.done)} output=${formatValue(step.plan.output)} ` +
+  `actions=${step.plan.actions.length} emitted=${formatValue(step.plan.emittedEvents)}`,
+  ...formatMicrosteps(step.plan.microsteps)
+]
+
+const isRunFailure = <M extends AnyMachine, Cause>(
+  trace: Trace<M> | RunFailure<Cause, M>
+): trace is RunFailure<Cause, M> => "_tag" in trace && trace._tag === "MachineTestRunFailure"
+
+/**
+ * Formats a trace as deterministic, line-oriented counterexample evidence.
+ *
+ * Object keys and map/set entries are canonicalized. Deferred effects are
+ * represented by counts so formatting never evaluates or inspects actions.
+ * Failures include their original cause and every available successful prefix.
+ *
+ * @category formatting
+ * @since 4.0.0
+ */
+export const formatTrace = <M extends AnyMachine, Cause>(trace: Trace<M> | RunFailure<Cause, M>): string => {
+  const lines = [`scenario: ${formatValue(trace.scenario)}`]
+  if (isRunFailure(trace)) {
+    if (trace.initial !== undefined) {
+      lines.push(...formatInitial(trace.initial))
+      for (const step of trace.steps) {
+        lines.push(...formatStep(step))
+      }
+    }
+    lines.push(
+      `failure: phase=${trace.phase} eventIndex=${formatValue(trace.eventIndex)} ` +
+        `event=${formatValue(trace.event)} cause=${formatValue(trace.cause)}`
+    )
+    return lines.join("\n")
+  }
+  lines.push(...formatInitial(trace.initial))
+  for (const step of trace.steps) {
+    lines.push(...formatStep(step))
+  }
+  lines.push(`final: configuration=${formatConfiguration(trace.finalConfiguration)} state=${formatValue(trace.final)}`)
+  return lines.join("\n")
+}

--- a/src/internal/machineModel.ts
+++ b/src/internal/machineModel.ts
@@ -1164,18 +1164,27 @@ export const configurationFromTargetSnapshotEffect = Effect.fnUntraced(function*
     const ancestorNode = getNode(machine, ancestor)
     if (ancestorNode.type === "parallel") {
       for (const child of ancestorNode.children) {
-        if (pathSet.has(child) || !current.active.has(child)) {
+        if (pathSet.has(child)) continue
+        if (current.active.has(child)) {
+          for (const activePath of current.active) {
+            if (isPathInSubtree(activePath, child)) {
+              active.add(activePath)
+              if (current.values.has(activePath)) {
+                values.set(activePath, current.values.get(activePath))
+              }
+              if (current.outputs.has(activePath)) {
+                outputs.set(activePath, current.outputs.get(activePath))
+              }
+            }
+          }
           continue
         }
-        for (const activePath of current.active) {
-          if (isPathInSubtree(activePath, child)) {
-            active.add(activePath)
-            if (current.values.has(activePath)) {
-              values.set(activePath, current.values.get(activePath))
-            }
-            if (current.outputs.has(activePath)) {
-              outputs.set(activePath, current.outputs.get(activePath))
-            }
+        if (providedValues !== undefined && hasOwn(providedValues, child)) {
+          for (const [providedPath, providedValue] of Object.entries(providedValues)) {
+            if (!isPathInSubtree(providedPath, child)) continue
+            const providedNode = getNode(machine, providedPath)
+            active.add(providedPath)
+            values.set(providedPath, yield* decodeStateValue(machine, providedNode, providedValue))
           }
         }
       }

--- a/src/internal/machinePlanner.ts
+++ b/src/internal/machinePlanner.ts
@@ -195,6 +195,13 @@ export const runtimeFor = <Events, Emits>(): Effect.Effect<
 export type MicrostepPlan<State, Event, E, R> = {
   readonly next: State
   readonly event: Event | MachineInitialEvent
+  readonly transitions: ReadonlyArray<{
+    readonly source: string
+    readonly trigger: Machine.TransitionTrigger
+    readonly reenter: boolean
+    readonly target: string | undefined
+    readonly resolvedTarget: string | undefined
+  }>
   readonly actions: ReadonlyArray<Effect.Effect<void, E, R>>
   readonly raisedEvents: ReadonlyArray<Event>
   readonly emittedEvents: ReadonlyArray<unknown>
@@ -445,8 +452,12 @@ const resolveHistoryTarget = Effect.fnUntraced(function*(
     // regions must be initialized when the ancestor is re-entered.
     const completed = yield* completeHistoryConfiguration(machine, restored, event)
     const snapshot = snapshotFromConfigurationAtPath(machine, completed.configuration, target.parent)
+    const values = Object.fromEntries(completed.configuration.values)
     return {
-      target: makeTarget(target.parent as any, snapshot.value as any, { snapshot: snapshot as any }),
+      target: makeTarget(target.parent as any, snapshot.value as any, {
+        snapshot: snapshot as any,
+        values: values as any
+      }),
       actions: completed.actions,
       raisedEvents: completed.raisedEvents,
       emittedEvents: completed.emittedEvents
@@ -488,6 +499,11 @@ type SelectedTransition<States extends Machine.StateSchemas, E, R, Context> = {
 
 type EvaluatedTransition<States extends Machine.StateSchemas, Event, E, R, Context> = {
   readonly selection: SelectedTransition<States, E, R, Context>
+  readonly unresolvedTarget:
+    | Machine.Snapshot<States>
+    | Machine.Target<States, Machine.StateIdentifier<States>>
+    | Machine.HistoryTarget<States, Machine.HistoryIdentifier<States>>
+    | undefined
   readonly target:
     | Machine.Snapshot<States>
     | Machine.Target<States, Machine.StateIdentifier<States>>
@@ -526,6 +542,16 @@ const getLeastCommonAncestor = (
     ancestor = leftPath[index]
   }
   return ancestor
+}
+
+const broadenTransitionBoundary = (
+  naturalBoundary: string | undefined,
+  reentryBoundary: string | undefined
+): string | undefined => {
+  if (naturalBoundary === undefined || reentryBoundary === undefined) return undefined
+  return naturalBoundary === reentryBoundary || isDescendantOf(naturalBoundary, reentryBoundary)
+    ? reentryBoundary
+    : naturalBoundary
 }
 
 const getExitPaths = (
@@ -875,8 +901,14 @@ const selectEventTransitions = <
 }
 
 const getTargetNodePath = <const States extends Machine.StateSchemas>(
-  target: Machine.Snapshot<States> | Machine.Target<States, Machine.StateIdentifier<States>>
+  target:
+    | Machine.Snapshot<States>
+    | Machine.Target<States, Machine.StateIdentifier<States>>
+    | Machine.HistoryTarget<States, Machine.HistoryIdentifier<States>>
 ): string => {
+  if (isHistoryTarget(target)) {
+    return String(target.path)
+  }
   if (isTarget(target)) {
     return String(target.path)
   }
@@ -1003,6 +1035,7 @@ const collectEvaluatedTransition = Effect.fnUntraced(function*<
     : transitionResult.state as
       | Machine.Snapshot<States>
       | Machine.Target<States, Machine.StateIdentifier<States>>
+      | Machine.HistoryTarget<States, Machine.HistoryIdentifier<States>>
   validateDeclaredTransitionTarget(
     selection.sourcePath,
     selection.trigger,
@@ -1040,9 +1073,15 @@ const collectEvaluatedTransition = Effect.fnUntraced(function*<
       (selection.context as any).event
     )
   }
-  const target = historyResolution === undefined ? unresolvedTarget : historyResolution.target as
-    | Machine.Snapshot<States>
-    | Machine.Target<States, Machine.StateIdentifier<States>>
+  const target: Machine.Snapshot<States> | Machine.Target<States, Machine.StateIdentifier<States>> | undefined =
+    historyResolution === undefined
+      ? unresolvedTarget as
+        | Machine.Snapshot<States>
+        | Machine.Target<States, Machine.StateIdentifier<States>>
+        | undefined
+      : historyResolution.target as
+        | Machine.Snapshot<States>
+        | Machine.Target<States, Machine.StateIdentifier<States>>
   const targetPath = target === undefined ? undefined : getTargetNodePath(target)
   const stateAfterTransition = target === undefined
     ? state
@@ -1052,6 +1091,7 @@ const collectEvaluatedTransition = Effect.fnUntraced(function*<
   if (!changed) {
     return {
       selection,
+      unresolvedTarget,
       target,
       actions: [...transitionResult.actions, ...(historyResolution?.actions ?? [])],
       raisedEvents: [...transitionResult.raisedEvents, ...(historyResolution?.raisedEvents ?? [])],
@@ -1062,12 +1102,17 @@ const collectEvaluatedTransition = Effect.fnUntraced(function*<
     } as EvaluatedTransition<States, Event, E, R, Context>
   }
 
-  const boundary = selection.transition.reenter
+  const naturalBoundary = targetPath === undefined
     ? getNode(machine, selection.sourcePath).parent
-    : getLeastCommonAncestor(machine, stateIdentifier, targetPath!)
+    : getLeastCommonAncestor(machine, stateIdentifier, targetPath)
+  const reentryBoundary = getNode(machine, selection.sourcePath).parent
+  const boundary = selection.transition.reenter
+    ? broadenTransitionBoundary(naturalBoundary, reentryBoundary)
+    : naturalBoundary
 
   return {
     selection,
+    unresolvedTarget,
     target,
     actions: [...transitionResult.actions, ...(historyResolution?.actions ?? [])],
     raisedEvents: [...transitionResult.raisedEvents, ...(historyResolution?.raisedEvents ?? [])],
@@ -1237,6 +1282,8 @@ export const planInitial: <
       : result
     const configuration = yield* normalizeConfigurationEffect<States>(machine, state as Machine.Snapshot<States>)
     validateInitialConfiguration(machine, configuration)
+    const startingState = snapshotFromConfiguration<States>(machine, configuration)
+    const initialEntryPaths = getInitialEntryPaths(machine, configuration)
     const actions = yield* deferredActions.read
     const raisedEvents = yield* deferredRaisedEvents.read
     const emittedEvents = yield* deferredRaisedEvents.readEmitted
@@ -1244,7 +1291,7 @@ export const planInitial: <
       const entry = yield* collectStateActions<States, Events, Emits, E, R>(
         machine,
         configuration,
-        getInitialEntryPaths(machine, configuration),
+        initialEntryPaths,
         InitialEvent,
         "entry"
       )
@@ -1264,12 +1311,25 @@ export const planInitial: <
     >)
 
     const planned = {
+      startingState,
+      initialEntryPaths,
       state: snapshotFromConfiguration<States>(machine, settled.next),
       actions: [
         ...actions,
         ...settled.actions
       ] as ReadonlyArray<Effect.Effect<void, InitialE | MachineSchemaDecodeError | StartupError, InitialR | R>>,
-      emittedEvents: settled.emittedEvents as ReadonlyArray<Machine.EmitOf<Emits>>
+      emittedEvents: settled.emittedEvents as ReadonlyArray<Machine.EmitOf<Emits>>,
+      microsteps: settled.microsteps.map((step) => ({
+        next: snapshotFromConfiguration<States>(machine, step.next),
+        event: step.event,
+        transitions: step.transitions,
+        actions: step.actions,
+        raisedEvents: step.raisedEvents,
+        emittedEvents: step.emittedEvents,
+        exitPaths: step.exitPaths,
+        entryPaths: step.entryPaths,
+        changed: step.changed
+      }))
     }
     return settled.done
       ? { ...planned, done: true as const, output: settled.output }
@@ -1369,6 +1429,7 @@ const microstep: <
     return {
       next: state,
       event,
+      transitions: [],
       actions: [],
       raisedEvents: [],
       emittedEvents: [],
@@ -1392,8 +1453,24 @@ const microstep: <
 
   const transitions = removeConflictingTransitions(machine, evaluatedTransitions)
   const sortedTransitions = sortEvaluatedTransitions(machine, transitions)
+  const retainedTransitions = sortedTransitions.map((transition) => ({
+    source: transition.selection.sourcePath,
+    trigger: transition.selection.trigger,
+    reenter: transition.selection.transition.reenter,
+    target: transition.unresolvedTarget === undefined ? undefined : getTargetNodePath(transition.unresolvedTarget),
+    resolvedTarget: transition.target === undefined ? undefined : getTargetNodePath(transition.target)
+  }))
   let stateAfterTransition = state
-  for (const transition of sortedTransitions) {
+  // Value-only targets are evaluated against the original configuration. If
+  // one is applied after a control-changing transition, it can resurrect a
+  // branch that the changing transition exited. Apply value-only updates
+  // first so later control targets remain authoritative while still
+  // preserving updates made in unaffected parallel regions.
+  const targetApplicationOrder = [
+    ...sortedTransitions.filter((transition) => !transition.changed),
+    ...sortedTransitions.filter((transition) => transition.changed)
+  ]
+  for (const transition of targetApplicationOrder) {
     if (transition.target !== undefined) {
       stateAfterTransition = yield* normalizeTargetConfigurationEffect<States>(
         machine,
@@ -1415,6 +1492,7 @@ const microstep: <
     return {
       next: stateAfterTransition,
       event,
+      transitions: retainedTransitions,
       actions: transitionActions,
       raisedEvents: transitionRaisedEvents,
       emittedEvents: transitionEmittedEvents,
@@ -1445,6 +1523,7 @@ const microstep: <
   return {
     next: stateAfterTransition,
     event,
+    transitions: retainedTransitions,
     actions: [...exit.actions, ...transitionActions, ...entry.actions] as ReadonlyArray<
       Effect.Effect<void, E, R>
     >,
@@ -1717,6 +1796,7 @@ const macrostep: <
     microsteps: settled.microsteps.map((step) => ({
       next: snapshotFromConfiguration<States>(machine, step.next),
       event: step.event,
+      transitions: step.transitions,
       actions: step.actions,
       raisedEvents: step.raisedEvents,
       emittedEvents: step.emittedEvents,

--- a/src/internal/machineTestFiniteModel.ts
+++ b/src/internal/machineTestFiniteModel.ts
@@ -1,0 +1,1217 @@
+/**
+ * Finite hierarchical, parallel, and history statechart models used by the public testing
+ * module.
+ *
+ * This module intentionally compiles through the public Machine API. It must
+ * not share planner helpers with the implementation that later reference
+ * models are expected to check.
+ *
+ * @internal
+ */
+
+import * as Schema from "effect/Schema"
+import { FastCheck } from "effect/testing"
+import * as Machine from "../Machine.js"
+
+/**
+ * An atomic state in a finite generated model.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface FiniteAtomicState {
+  readonly _tag: "Atomic"
+  readonly key: string
+  /** Deterministic payload accepted by this state's generated schema. */
+  readonly value: number
+}
+
+/**
+ * A final state in a finite generated model.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface FiniteFinalState {
+  readonly _tag: "Final"
+  readonly key: string
+  /** Deterministic payload accepted by this state's generated schema. */
+  readonly value: number
+  /** Deterministic value returned by this state's output handler. */
+  readonly output: string
+}
+
+/**
+ * A compound state in a finite generated model.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface FiniteCompoundState {
+  readonly _tag: "Compound"
+  readonly key: string
+  /** Deterministic payload accepted by this state's generated schema. */
+  readonly value: number
+  /** Key of the direct child entered by default. */
+  readonly initial: string
+  readonly states: ReadonlyArray<FiniteState>
+}
+
+/**
+ * A parallel state in a finite generated model.
+ *
+ * Every direct child is an orthogonal region and is active whenever the
+ * parallel state is active. The output is deterministic so completion can be
+ * compared without sharing executable callbacks with the reference model.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface FiniteParallelState {
+  readonly _tag: "Parallel"
+  readonly key: string
+  /** Deterministic payload accepted by this state's generated schema. */
+  readonly value: number
+  /** Deterministic value returned after every region completes. */
+  readonly output: string
+  /** Between two and three orthogonal region nodes. */
+  readonly states: ReadonlyArray<FiniteState>
+}
+
+/**
+ * A shallow or deep history pseudo-state in a finite generated model.
+ *
+ * History states never carry values, become active, or act as transition
+ * sources. `fallback` is a concrete descendant of the direct compound or
+ * parallel owner and is used only before that history register is captured.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface FiniteHistoryState {
+  readonly _tag: "History"
+  readonly key: string
+  readonly history: "shallow" | "deep"
+  readonly fallback: string
+}
+
+/**
+ * A finite model state.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type FiniteState =
+  | FiniteAtomicState
+  | FiniteFinalState
+  | FiniteCompoundState
+  | FiniteParallelState
+  | FiniteHistoryState
+
+/**
+ * One deterministic event transition in a finite generated model.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface FiniteTransition {
+  readonly source: string
+  readonly event: string
+  /** Omission represents a targetless transition. */
+  readonly target?: string
+  /** Optional schema-valid value supplied for the declared target state. */
+  readonly targetValue?: number
+  readonly reenter: boolean
+}
+
+/**
+ * The exact generated transition that changes a value before history capture.
+ *
+ * The source and target are the same active atomic state. `value` is distinct
+ * from that state's generated default value.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface FiniteHistoryMutation {
+  readonly source: string
+  readonly event: string
+  readonly target: string
+  readonly value: number
+}
+
+/**
+ * One exact transition in a generated history witness.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface FiniteHistoryTransfer {
+  readonly source: string
+  readonly event: string
+  readonly target: string
+}
+
+/**
+ * A replayable value-mutation, capture, and restoration witness generated for
+ * one history pseudo-state.
+ *
+ * `events` is exactly `[mutation.event, leave.event, resume.event]`. Replaying
+ * it changes a schema-valid atomic value, exits the history owner through its
+ * root, and restores the remembered non-default value through `history`.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface FiniteHistoryScenario {
+  readonly history: string
+  readonly owner: string
+  readonly historyType: "shallow" | "deep"
+  readonly mutation: FiniteHistoryMutation
+  readonly leave: FiniteHistoryTransfer
+  readonly resume: FiniteHistoryTransfer
+  readonly events: readonly [mutation: string, leave: string, resume: string]
+}
+
+/**
+ * A small immutable statechart model suitable for generation and shrinking.
+ *
+ * State paths use dot-separated state keys. Transitions are unique by
+ * source/event pair. A transition may target any state under its source root,
+ * or a different root as a complete configuration.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface FiniteModel {
+  readonly roots: ReadonlyArray<FiniteState>
+  /** Key of the root entered during startup. */
+  readonly initial: string
+  readonly events: ReadonlyArray<string>
+  readonly transitions: ReadonlyArray<FiniteTransition>
+  /** Exact value-sensitive history witnesses attached by `finiteModels`. */
+  readonly historyScenarios?: ReadonlyArray<FiniteHistoryScenario>
+}
+
+/**
+ * Limits controlling finite model generation.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface FiniteModelOptions {
+  /** Maximum number of root states. Always between one and three. */
+  readonly maxRoots?: 1 | 2 | 3
+  /** Maximum state-tree depth, counting a root as depth one. */
+  readonly maxDepth?: number
+  /** Maximum number of direct children in a compound state. */
+  readonly maxChildren?: number
+  /** Maximum number of regions in a parallel state. Always two or three. */
+  readonly maxParallelRegions?: 2 | 3
+  /** Maximum number of distinct public event tags. */
+  readonly maxEvents?: number
+  /** Maximum number of source/event transition registrations. */
+  readonly maxTransitions?: number
+  /** Maximum number of history pseudo-states added to one generated model. */
+  readonly maxHistoryStates?: number
+}
+
+/**
+ * Resolved limits and structural guarantees for a finite model arbitrary.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface FiniteModelDiagnostics {
+  readonly limits: {
+    readonly maxRoots: 1 | 2 | 3
+    readonly maxDepth: number
+    readonly maxChildren: number
+    readonly maxParallelRegions: 2 | 3
+    readonly maxEvents: number
+    readonly maxTransitions: number
+    readonly maxHistoryStates: number
+  }
+  readonly guarantees: {
+    readonly compoundOnly: false
+    readonly parallelStates: true
+    readonly historyStates: true
+    readonly historyLeaveResumeSequences: true
+    readonly historyValueScenarios: true
+    readonly structurallyValid: true
+    readonly shrinkPreservesValidity: true
+    readonly eventlessTransitions: false
+  }
+}
+
+/**
+ * A finite model arbitrary and the exact limits used to construct it.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface FiniteModels {
+  readonly arbitrary: FastCheck.Arbitrary<FiniteModel>
+  readonly diagnostics: FiniteModelDiagnostics
+}
+
+interface RawAtomicState {
+  readonly _tag: "Atomic"
+}
+
+interface RawFinalState {
+  readonly _tag: "Final"
+}
+
+interface RawCompoundState {
+  readonly _tag: "Compound"
+  readonly initialIndex: number
+  readonly states: ReadonlyArray<RawState>
+}
+
+interface RawParallelState {
+  readonly _tag: "Parallel"
+  readonly states: ReadonlyArray<RawState>
+}
+
+type RawState = RawAtomicState | RawFinalState | RawCompoundState | RawParallelState
+
+interface FlatFiniteState {
+  readonly node: FiniteState
+  readonly path: string
+  readonly parent: string | undefined
+  readonly root: string
+}
+
+interface TransitionCandidate {
+  readonly source: string
+  readonly event: string
+  readonly targets: ReadonlyArray<string>
+}
+
+const defaults = {
+  maxRoots: 3 as const,
+  maxDepth: 3,
+  maxChildren: 3,
+  maxParallelRegions: 3 as const,
+  maxEvents: 3,
+  maxTransitions: 12,
+  maxHistoryStates: 2
+}
+
+const validateLimit = (name: string, value: number, maximum: number): void => {
+  if (!Number.isSafeInteger(value) || value < 1 || value > maximum) {
+    throw new Error(`MachineTest.finiteModels expected ${name} to be an integer between 1 and ${maximum}`)
+  }
+}
+
+const resolveOptions = (options: FiniteModelOptions): FiniteModelDiagnostics["limits"] => {
+  const limits = {
+    maxRoots: options.maxRoots ?? defaults.maxRoots,
+    maxDepth: options.maxDepth ?? defaults.maxDepth,
+    maxChildren: options.maxChildren ?? defaults.maxChildren,
+    maxParallelRegions: options.maxParallelRegions ?? defaults.maxParallelRegions,
+    maxEvents: options.maxEvents ?? defaults.maxEvents,
+    maxTransitions: options.maxTransitions ?? defaults.maxTransitions,
+    maxHistoryStates: options.maxHistoryStates ?? defaults.maxHistoryStates
+  }
+  validateLimit("maxRoots", limits.maxRoots, 3)
+  validateLimit("maxDepth", limits.maxDepth, 6)
+  validateLimit("maxChildren", limits.maxChildren, 4)
+  validateLimit("maxParallelRegions", limits.maxParallelRegions, 3)
+  if (limits.maxParallelRegions < 2) {
+    throw new Error("MachineTest.finiteModels expected maxParallelRegions to be two or three")
+  }
+  validateLimit("maxEvents", limits.maxEvents, 8)
+  validateLimit("maxTransitions", limits.maxTransitions, 256)
+  if (!Number.isSafeInteger(limits.maxHistoryStates) || limits.maxHistoryStates < 0 || limits.maxHistoryStates > 8) {
+    throw new Error("MachineTest.finiteModels expected maxHistoryStates to be an integer between 0 and 8")
+  }
+  return limits
+}
+
+const rawStateArbitrary = (
+  depth: number,
+  limits: FiniteModelDiagnostics["limits"]
+): FastCheck.Arbitrary<RawState> => {
+  const leaf = FastCheck.boolean().map((final): RawState => final ? { _tag: "Final" } : { _tag: "Atomic" })
+  if (depth >= limits.maxDepth) return leaf
+
+  const nested = rawStateArbitrary(depth + 1, limits)
+  const compound = FastCheck.array(nested, {
+    minLength: 1,
+    maxLength: limits.maxChildren
+  }).chain((states) =>
+    FastCheck.integer({ min: 0, max: states.length - 1 }).map((initialIndex): RawCompoundState => ({
+      _tag: "Compound",
+      initialIndex,
+      states
+    }))
+  )
+  const parallel = FastCheck.array(nested, {
+    minLength: 2,
+    maxLength: limits.maxParallelRegions
+  }).map((states): RawParallelState => ({ _tag: "Parallel", states }))
+  return FastCheck.oneof(leaf, compound, parallel)
+}
+
+const normalizeStates = (raw: ReadonlyArray<RawState>): ReadonlyArray<FiniteState> => {
+  let value = 0
+  const visit = (states: ReadonlyArray<RawState>, parentPath: string): ReadonlyArray<FiniteState> =>
+    states.map((state, index) => {
+      const key = `state${index}`
+      const path = parentPath === "" ? key : `${parentPath}.${key}`
+      const currentValue = value++
+      if (state._tag === "Atomic") {
+        return Object.freeze({ _tag: "Atomic", key, value: currentValue })
+      }
+      if (state._tag === "Final") {
+        return Object.freeze({
+          _tag: "Final",
+          key,
+          value: currentValue,
+          output: `output:${path}`
+        })
+      }
+      const children = visit(state.states, path)
+      if (state._tag === "Parallel") {
+        return Object.freeze({
+          _tag: "Parallel",
+          key,
+          value: currentValue,
+          output: `output:${path}`,
+          states: Object.freeze(children.slice())
+        })
+      }
+      return Object.freeze({
+        _tag: "Compound",
+        key,
+        value: currentValue,
+        initial: children[state.initialIndex]!.key,
+        states: Object.freeze(children.slice())
+      })
+    })
+  return Object.freeze(visit(raw, "").slice())
+}
+
+const flattenStates = (roots: ReadonlyArray<FiniteState>): ReadonlyArray<FlatFiniteState> => {
+  const flattened: Array<FlatFiniteState> = []
+  const visit = (states: ReadonlyArray<FiniteState>, parent: string | undefined, root: string | undefined): void => {
+    for (const node of states) {
+      const path = parent === undefined ? node.key : `${parent}.${node.key}`
+      const nodeRoot = root ?? path
+      flattened.push({ node, path, parent, root: nodeRoot })
+      if (node._tag === "Compound" || node._tag === "Parallel") visit(node.states, path, nodeRoot)
+    }
+  }
+  visit(roots, undefined, undefined)
+  return flattened
+}
+
+const isPathInSubtree = (path: string, root: string): boolean => path === root || path.startsWith(`${root}.`)
+
+const initialLeaves = (
+  states: ReadonlyMap<string, FlatFiniteState>,
+  path: string
+): ReadonlyArray<string> => {
+  const state = states.get(path)!
+  if (state.node._tag === "Compound") {
+    return initialLeaves(states, `${path}.${state.node.initial}`)
+  }
+  if (state.node._tag === "Parallel") {
+    return state.node.states
+      .filter((child) => child._tag !== "History")
+      .flatMap((child) => initialLeaves(states, `${path}.${child.key}`))
+  }
+  return state.node._tag === "Atomic" ? [path] : []
+}
+
+const addGeneratedHistory = (
+  roots: ReadonlyArray<FiniteState>,
+  initial: string,
+  maxHistoryStates: number,
+  maxTransitions: number,
+  events: ReadonlyArray<string>,
+  decisions: ReadonlyArray<"shallow" | "deep">
+): {
+  readonly roots: ReadonlyArray<FiniteState>
+  readonly scenarios: ReadonlyArray<FiniteHistoryScenario>
+} => {
+  if (maxHistoryStates === 0 || maxTransitions < 2 || decisions.length === 0) {
+    return { roots, scenarios: [] }
+  }
+  const flattened = flattenStates(roots)
+  const byPath = new Map(flattened.map((state) => [state.path, state]))
+  const initialActiveLeaves = initialLeaves(byPath, initial)
+  const initialActive = new Set(initialActiveLeaves.flatMap((leaf) => {
+    const parts = leaf.split(".")
+    return parts.map((_, index) => parts.slice(0, index + 1).join("."))
+  }))
+  const outside = roots
+    .filter((root) => root.key !== initial)
+    .map((root) => ({ root, leaves: initialLeaves(byPath, root.key) }))
+    .find(({ leaves }) => leaves.length > 0)
+  if (outside === undefined) return { roots, scenarios: [] }
+
+  const eligible = flattened.filter((state) =>
+    initialActive.has(state.path) &&
+    (state.node._tag === "Compound" || state.node._tag === "Parallel") &&
+    initialLeaves(byPath, state.path).length > 0
+  )
+  const count = Math.min(
+    maxHistoryStates,
+    decisions.length,
+    Math.floor(events.length / 2),
+    Math.floor(maxTransitions / 3),
+    eligible.length
+  )
+  const selected = eligible.slice(0, count).map((owner, index) => {
+    const composite = owner.node as FiniteCompoundState | FiniteParallelState
+    const directAtomic = composite._tag === "Compound"
+      ? composite.states.find((child) => child.key === composite.initial && child._tag === "Atomic")
+      : composite.states.find((child) => child._tag === "Atomic")
+    const historyType = decisions[index] === "shallow" && directAtomic !== undefined ? "shallow" : "deep"
+    const mutationSource = historyType === "shallow"
+      ? `${owner.path}.${directAtomic!.key}`
+      : initialLeaves(byPath, owner.path)[0]!
+    const fallbackChild = composite._tag === "Compound"
+      ? composite.states.find((child) => child.key === composite.initial)!
+      : composite.states.find((child) => child._tag !== "History")!
+    const history: FiniteHistoryState = Object.freeze({
+      _tag: "History",
+      key: `history${index}`,
+      history: historyType,
+      fallback: `${owner.path}.${fallbackChild.key}`
+    })
+    return { owner, history, mutationSource }
+  })
+  const byOwner = new Map(selected.map(({ history, owner }) => [owner.path, history]))
+  const decorate = (states: ReadonlyArray<FiniteState>, parent: string | undefined): ReadonlyArray<FiniteState> =>
+    Object.freeze(states.map((state): FiniteState => {
+      const path = parent === undefined ? state.key : `${parent}.${state.key}`
+      if (state._tag !== "Compound" && state._tag !== "Parallel") return state
+      const children = decorate(state.states, path)
+      const history = byOwner.get(path)
+      return Object.freeze({
+        ...state,
+        states: Object.freeze(history === undefined ? children.slice() : [...children, history])
+      })
+    }))
+  const decorated = decorate(roots, undefined)
+  return {
+    roots: decorated,
+    scenarios: selected.map(({ history, mutationSource, owner }, index): FiniteHistoryScenario => {
+      const historyPath = `${owner.path}.${history.key}`
+      const leaveEvent = events[index]!
+      const mutationEvent = events[count + index]!
+      const mutationValue = (byPath.get(mutationSource)!.node as FiniteAtomicState).value + 10_000 + index
+      return Object.freeze({
+        history: historyPath,
+        owner: owner.path,
+        historyType: history.history,
+        mutation: Object.freeze({
+          source: mutationSource,
+          event: mutationEvent,
+          target: mutationSource,
+          value: mutationValue
+        }),
+        leave: Object.freeze({
+          source: initialLeaves(byPath, owner.path)[0]!,
+          event: leaveEvent,
+          target: outside.root.key
+        }),
+        resume: Object.freeze({
+          source: outside.leaves[0]!,
+          event: leaveEvent,
+          target: historyPath
+        }),
+        events: Object.freeze([mutationEvent, leaveEvent, leaveEvent]) as readonly [string, string, string]
+      })
+    })
+  }
+}
+
+const freezeModel = (
+  roots: ReadonlyArray<FiniteState>,
+  initial: string,
+  events: ReadonlyArray<string>,
+  transitions: ReadonlyArray<FiniteTransition>,
+  historyScenarios: ReadonlyArray<FiniteHistoryScenario> = []
+): FiniteModel =>
+  Object.freeze({
+    roots,
+    initial,
+    events: Object.freeze(events.slice()),
+    transitions: Object.freeze(transitions.map((transition) => Object.freeze(transition))),
+    historyScenarios: Object.freeze(historyScenarios.slice())
+  })
+
+const makeTransitionArbitrary = (
+  roots: ReadonlyArray<FiniteState>,
+  events: ReadonlyArray<string>,
+  maxTransitions: number,
+  historyScenarios: ReadonlyArray<FiniteHistoryScenario> = []
+): FastCheck.Arbitrary<ReadonlyArray<FiniteTransition>> => {
+  const states = flattenStates(roots)
+  const sourceOrder = new Map(states.map((state, index) => [state.path, index]))
+  const orderTransitions = (transitions: ReadonlyArray<FiniteTransition>): ReadonlyArray<FiniteTransition> =>
+    transitions.slice().sort((left, right) =>
+      sourceOrder.get(left.source)! - sourceOrder.get(right.source)! ||
+      events.indexOf(left.event) - events.indexOf(right.event)
+    )
+  const active = states.filter(({ node }) => node._tag !== "Final" && node._tag !== "History")
+  const mandatory = historyScenarios.flatMap((scenario): ReadonlyArray<FiniteTransition> => [
+    {
+      source: scenario.mutation.source,
+      event: scenario.mutation.event,
+      target: scenario.mutation.target,
+      targetValue: scenario.mutation.value,
+      reenter: false
+    },
+    {
+      source: scenario.leave.source,
+      event: scenario.leave.event,
+      target: scenario.leave.target,
+      reenter: false
+    },
+    {
+      source: scenario.resume.source,
+      event: scenario.resume.event,
+      target: scenario.resume.target,
+      reenter: false
+    }
+  ])
+  const mandatoryRegistrations = new Set(mandatory.map(({ source, event }) => `${source}\u0000${event}`))
+  const reservedEvents = new Set(
+    historyScenarios.flatMap(({ leave, mutation }) => [leave.event, mutation.event])
+  )
+  const candidates = active.flatMap(({ path: source, root }) =>
+    events.map((event): TransitionCandidate => ({
+      source,
+      event,
+      // `branch` addresses the source root while `full` replaces another root.
+      // Same-root targets may select any state, including a parallel state or
+      // a compound state whose initial descent enters a parallel state. The
+      // compiler expands those targets into every required orthogonal region.
+      targets: states.filter((target) =>
+        target.node._tag !== "History" && (target.root === root || target.parent === undefined)
+      )
+        .map(({ path }) => path)
+    }))
+  ).filter(({ source, event }) =>
+    !mandatoryRegistrations.has(`${source}\u0000${event}`) &&
+    !reservedEvents.has(event)
+  )
+
+  return FastCheck.subarray(candidates, {
+    minLength: 0,
+    maxLength: Math.min(maxTransitions - mandatory.length, candidates.length)
+  }).chain((selected) => {
+    if (selected.length === 0) {
+      return FastCheck.constant<ReadonlyArray<FiniteTransition>>(orderTransitions(mandatory))
+    }
+    const decisions = selected.map((candidate) =>
+      FastCheck.record({
+        targetIndex: FastCheck.integer({ min: 0, max: candidate.targets.length }),
+        targetValueOffset: FastCheck.integer({ min: 0, max: 2 }),
+        reenter: FastCheck.boolean()
+      })
+    )
+    return FastCheck.tuple(...decisions).map((values) =>
+      orderTransitions([
+        ...mandatory,
+        ...selected.map((candidate, index): FiniteTransition => {
+          const decision = values[index]!
+          const target = decision.targetIndex === 0 ? undefined : candidate.targets[decision.targetIndex - 1]
+          const targetState = target === undefined ? undefined : states.find(({ path }) => path === target)
+          const targetValue = targetState?.node._tag === "Atomic" &&
+              decision.targetValueOffset !== 0
+            ? targetState.node.value + decision.targetValueOffset
+            : undefined
+          return target === undefined
+            ? { source: candidate.source, event: candidate.event, reenter: decision.reenter }
+            : {
+              source: candidate.source,
+              event: candidate.event,
+              target,
+              ...(targetValue === undefined ? {} : { targetValue }),
+              reenter: decision.reenter
+            }
+        })
+      ])
+    )
+  })
+}
+
+/**
+ * Generates bounded, structurally valid hierarchical statechart
+ * models.
+ *
+ * Generation is composed from shrinkable topology, initial-state, event, and
+ * transition decisions. Paths and transition candidates are rebuilt after a
+ * topology shrink, so a shrink can never retain a dangling source or target.
+ * Eventless transitions are intentionally outside this model stage.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const finiteModels = (options: FiniteModelOptions = {}): FiniteModels => {
+  const limits = resolveOptions(options)
+  const rawRoots = FastCheck.array(rawStateArbitrary(1, limits), {
+    minLength: 1,
+    maxLength: limits.maxRoots
+  })
+  const arbitrary = rawRoots.chain((raw) => {
+    const activeRoots = normalizeStates(raw)
+    return FastCheck.tuple(
+      FastCheck.integer({ min: 0, max: activeRoots.length - 1 }),
+      FastCheck.integer({ min: 1, max: limits.maxEvents }),
+      FastCheck.array(FastCheck.constantFrom("shallow" as const, "deep" as const), {
+        minLength: 0,
+        maxLength: limits.maxHistoryStates
+      })
+    ).chain(([initialIndex, eventCount, historyDecisions]) => {
+      const events = Array.from({ length: eventCount }, (_, index) => `Event${index}`)
+      const initial = activeRoots[initialIndex]!.key
+      const generated = addGeneratedHistory(
+        activeRoots,
+        initial,
+        limits.maxHistoryStates,
+        limits.maxTransitions,
+        events,
+        historyDecisions
+      )
+      return makeTransitionArbitrary(generated.roots, events, limits.maxTransitions, generated.scenarios).map(
+        (transitions) => freezeModel(generated.roots, initial, events, transitions, generated.scenarios)
+      )
+    })
+  })
+
+  return {
+    arbitrary,
+    diagnostics: {
+      limits,
+      guarantees: {
+        compoundOnly: false,
+        parallelStates: true,
+        historyStates: true,
+        historyLeaveResumeSequences: true,
+        historyValueScenarios: true,
+        structurallyValid: true,
+        shrinkPreservesValidity: true,
+        eventlessTransitions: false
+      }
+    }
+  }
+}
+
+const isValidKey = (key: string): boolean => /^[A-Za-z_][A-Za-z0-9_]*$/.test(key)
+
+const validateModel = (model: FiniteModel): ReadonlyArray<FlatFiniteState> => {
+  if (!Array.isArray(model.roots) || model.roots.length < 1 || model.roots.length > 3) {
+    throw new Error("MachineTest.compileModel expected between one and three root states")
+  }
+  const visit = (states: ReadonlyArray<FiniteState>, parent: string | undefined): void => {
+    if (states.length === 0) {
+      throw new Error(`MachineTest.compileModel expected ${parent ?? "the model"} to contain a state`)
+    }
+    const siblingKeys = new Set<string>()
+    for (const node of states) {
+      if (!isValidKey(node.key)) {
+        throw new Error(`MachineTest.compileModel received invalid state key "${node.key}"`)
+      }
+      if (siblingKeys.has(node.key)) {
+        throw new Error(`MachineTest.compileModel received duplicate state key "${node.key}"`)
+      }
+      siblingKeys.add(node.key)
+      const path = parent === undefined ? node.key : `${parent}.${node.key}`
+      if (node._tag !== "History" && !Number.isSafeInteger(node.value)) {
+        throw new Error(`MachineTest.compileModel expected state "${path}" value to be a safe integer`)
+      }
+      if (node._tag === "History") {
+        if (parent === undefined) {
+          throw new Error(`MachineTest.compileModel received root history state "${path}"`)
+        }
+        if (node.history !== "shallow" && node.history !== "deep") {
+          throw new Error(`MachineTest.compileModel received invalid history mode at "${path}"`)
+        }
+        continue
+      }
+      if (node._tag === "Compound") {
+        if (!node.states.some((child) => child.key === node.initial && child._tag !== "History")) {
+          throw new Error(`MachineTest.compileModel received unknown initial child "${node.initial}" for "${path}"`)
+        }
+        visit(node.states, path)
+      } else if (node._tag === "Parallel") {
+        const regions = node.states.filter((child) => child._tag !== "History")
+        if (regions.length < 2 || regions.length > 3) {
+          throw new Error(`MachineTest.compileModel expected parallel state "${path}" to contain two or three regions`)
+        }
+        if (typeof node.output !== "string") {
+          throw new Error(`MachineTest.compileModel expected parallel state "${path}" output to be a string`)
+        }
+        visit(node.states, path)
+      } else if (node._tag === "Final" && typeof node.output !== "string") {
+        throw new Error(`MachineTest.compileModel expected final state "${path}" output to be a string`)
+      } else if (node._tag !== "Atomic" && node._tag !== "Final") {
+        throw new Error(`MachineTest.compileModel received unsupported state type at "${path}"`)
+      }
+    }
+  }
+  visit(model.roots, undefined)
+
+  if (!model.roots.some((root) => root.key === model.initial)) {
+    throw new Error(`MachineTest.compileModel received unknown initial root "${model.initial}"`)
+  }
+  const events = new Set<string>()
+  for (const event of model.events) {
+    if (typeof event !== "string" || event.length === 0 || events.has(event)) {
+      throw new Error(`MachineTest.compileModel received invalid or duplicate event tag "${String(event)}"`)
+    }
+    events.add(event)
+  }
+  if (events.size === 0) {
+    throw new Error("MachineTest.compileModel expected at least one event tag")
+  }
+
+  const flattened = flattenStates(model.roots)
+  const byPath = new Map(flattened.map((state) => [state.path, state]))
+  for (const state of flattened) {
+    if (state.node._tag !== "History") continue
+    const owner = state.parent === undefined ? undefined : byPath.get(state.parent)
+    const fallback = byPath.get(state.node.fallback)
+    if (
+      owner === undefined ||
+      (owner.node._tag !== "Compound" && owner.node._tag !== "Parallel") ||
+      fallback === undefined ||
+      fallback.node._tag === "History" ||
+      fallback.path === owner.path ||
+      !isPathInSubtree(fallback.path, owner.path)
+    ) {
+      throw new Error(
+        `MachineTest.compileModel expected history state "${state.path}" fallback to be a concrete descendant of "${state.parent}"`
+      )
+    }
+  }
+  const registrations = new Set<string>()
+  const transitionsByRegistration = new Map<string, FiniteTransition>()
+  for (const transition of model.transitions) {
+    const source = byPath.get(transition.source)
+    if (source === undefined || source.node._tag === "Final" || source.node._tag === "History") {
+      throw new Error(`MachineTest.compileModel received invalid transition source "${transition.source}"`)
+    }
+    if (!events.has(transition.event)) {
+      throw new Error(`MachineTest.compileModel received unknown transition event "${transition.event}"`)
+    }
+    const registration = `${transition.source}\u0000${transition.event}`
+    if (registrations.has(registration)) {
+      throw new Error(
+        `MachineTest.compileModel received duplicate transition for "${transition.source}" on "${transition.event}"`
+      )
+    }
+    registrations.add(registration)
+    transitionsByRegistration.set(registration, transition)
+    if (transition.target !== undefined) {
+      const target = byPath.get(transition.target)
+      if (target === undefined) {
+        throw new Error(`MachineTest.compileModel received unknown transition target "${transition.target}"`)
+      }
+      if (target.node._tag !== "History" && target.root !== source.root && target.parent !== undefined) {
+        throw new Error(
+          `MachineTest.compileModel expected cross-root target "${transition.target}" to select its root "${target.root}"`
+        )
+      }
+    }
+    if (
+      transition.targetValue !== undefined &&
+      (!Number.isSafeInteger(transition.targetValue) || transition.target === undefined ||
+        byPath.get(transition.target)?.node._tag === "History")
+    ) {
+      throw new Error(
+        `MachineTest.compileModel received invalid target value for transition from "${transition.source}"`
+      )
+    }
+  }
+  const initiallyActiveLeaves = initialLeaves(byPath, model.initial)
+  const initiallyActive = new Set(initiallyActiveLeaves.flatMap((leaf) => {
+    const parts = leaf.split(".")
+    return parts.map((_, index) => parts.slice(0, index + 1).join("."))
+  }))
+  const scenarioHistories = new Set<string>()
+  const scenarioEvents = new Set<string>()
+  const scenarioRegistrations = new Set<string>()
+  for (const scenario of model.historyScenarios ?? []) {
+    const history = byPath.get(scenario.history)
+    const mutationState = byPath.get(scenario.mutation.source)
+    if (
+      history?.node._tag !== "History" || history.parent !== scenario.owner ||
+      history.node.history !== scenario.historyType
+    ) {
+      throw new Error(`MachineTest.compileModel received invalid history scenario for "${scenario.history}"`)
+    }
+    if (scenarioHistories.has(scenario.history)) {
+      throw new Error(`MachineTest.compileModel received duplicate history scenario for "${scenario.history}"`)
+    }
+    scenarioHistories.add(scenario.history)
+    const owner = byPath.get(scenario.owner)!
+    const ownerNode = owner.node
+    let expectedMutationSource: string | undefined
+    if (scenario.historyType === "deep") {
+      expectedMutationSource = initialLeaves(byPath, owner.path)[0]
+    } else if (ownerNode._tag === "Compound") {
+      if (ownerNode.states.some((child) => child.key === ownerNode.initial && child._tag === "Atomic")) {
+        expectedMutationSource = `${owner.path}.${ownerNode.initial}`
+      }
+    } else if (ownerNode._tag === "Parallel") {
+      const directAtomic = ownerNode.states.find((child) => child._tag === "Atomic")
+      if (directAtomic !== undefined) expectedMutationSource = `${owner.path}.${directAtomic.key}`
+    }
+    if (
+      mutationState?.node._tag !== "Atomic" || scenario.mutation.target !== scenario.mutation.source ||
+      scenario.mutation.value === mutationState.node.value || !initiallyActive.has(mutationState.path) ||
+      scenario.mutation.source !== expectedMutationSource
+    ) {
+      throw new Error(`MachineTest.compileModel received invalid history mutation for "${scenario.history}"`)
+    }
+    if (
+      !Array.isArray(scenario.events) || scenario.events.length !== 3 ||
+      scenario.resume.target !== scenario.history || scenario.leave.event !== scenario.resume.event ||
+      scenario.events[0] !== scenario.mutation.event || scenario.events[1] !== scenario.leave.event ||
+      scenario.events[2] !== scenario.resume.event
+    ) {
+      throw new Error(`MachineTest.compileModel received inconsistent history events for "${scenario.history}"`)
+    }
+    const expectedOutside = model.roots
+      .filter((root) => root.key !== model.initial)
+      .find((root) => initialLeaves(byPath, root.key).length > 0)
+    if (
+      scenario.leave.source !== initialLeaves(byPath, owner.path)[0] ||
+      scenario.leave.target !== expectedOutside?.key ||
+      scenario.resume.source !==
+        (expectedOutside === undefined ? undefined : initialLeaves(byPath, expectedOutside.key)[0])
+    ) {
+      throw new Error(`MachineTest.compileModel received invalid history transfer for "${scenario.history}"`)
+    }
+    const expectedTransitions: ReadonlyArray<readonly [FiniteHistoryTransfer | FiniteHistoryMutation, number?]> = [
+      [scenario.mutation, scenario.mutation.value],
+      [scenario.leave],
+      [scenario.resume]
+    ]
+    if (scenarioEvents.has(scenario.mutation.event) || scenarioEvents.has(scenario.leave.event)) {
+      throw new Error(`MachineTest.compileModel received duplicate history scenario event for "${scenario.history}"`)
+    }
+    scenarioEvents.add(scenario.mutation.event)
+    scenarioEvents.add(scenario.leave.event)
+    for (const [expected, targetValue] of expectedTransitions) {
+      const registration = `${expected.source}\u0000${expected.event}`
+      if (scenarioRegistrations.has(registration)) {
+        throw new Error(`MachineTest.compileModel received duplicate history witness for "${scenario.history}"`)
+      }
+      scenarioRegistrations.add(registration)
+      const transition = transitionsByRegistration.get(registration)
+      if (
+        transition?.target !== expected.target || transition.reenter || transition.targetValue !== targetValue
+      ) {
+        throw new Error(`MachineTest.compileModel could not replay history scenario for "${scenario.history}"`)
+      }
+    }
+  }
+  return flattened
+}
+
+const stateTag = (path: string): string => `State_${path.replaceAll(".", "_")}`
+
+const stateValue = (
+  state: FlatFiniteState,
+  value?: number
+): { readonly _tag: string; readonly value: number } => {
+  if (state.node._tag === "History") {
+    throw new Error(`MachineTest.compileModel cannot construct a value for history state "${state.path}"`)
+  }
+  return { _tag: stateTag(state.path), value: value ?? state.node.value }
+}
+
+const runtimeTargetPath = (
+  byPath: ReadonlyMap<string, FlatFiniteState>,
+  sourcePath: string,
+  requestedPath: string
+): string => {
+  const source = byPath.get(sourcePath)!
+  const requested = byPath.get(requestedPath)!
+  if (requested.node._tag === "History") return requested.parent!
+  if (source.root !== requested.root) return requested.path
+
+  const initial = (path: string): string => {
+    const current = byPath.get(path)!
+    if (current.node._tag === "Parallel") {
+      if (sourcePath !== current.path && !sourcePath.startsWith(`${current.path}.`)) {
+        return current.path
+      }
+      const child = sourcePath === current.path
+        ? current.node.states[0]!.key
+        : sourcePath.slice(current.path.length + 1).split(".")[0]!
+      return initial(`${current.path}.${child}`)
+    }
+    return current.node._tag === "Compound" ? initial(`${current.path}.${current.node.initial}`) : current.path
+  }
+  const inspect = (path: string): string => {
+    const current = byPath.get(path)!
+    if (
+      current.node._tag === "Parallel" && sourcePath !== current.path && !sourcePath.startsWith(`${current.path}.`)
+    ) {
+      return current.path
+    }
+    if (current.path === requestedPath) return initial(current.path)
+    const next = requestedPath.slice(current.path.length + 1).split(".")[0]!
+    return inspect(`${current.path}.${next}`)
+  }
+  return inspect(source.root)
+}
+
+const makeStateTree = (
+  states: ReadonlyArray<FiniteState>,
+  parent: string | undefined
+): Record<string, Machine.Machine.TaggedSchema | Machine.Machine.StateNodeConfig> => {
+  const tree: Record<string, Machine.Machine.TaggedSchema | Machine.Machine.StateNodeConfig> = Object.create(null)
+  for (const node of states) {
+    const path = parent === undefined ? node.key : `${parent}.${node.key}`
+    if (node._tag === "History") {
+      tree[node.key] = {
+        type: "history",
+        ...(node.history === "deep" ? { history: "deep" } : {})
+      }
+      continue
+    }
+    const schema = Schema.TaggedStruct(stateTag(path), { value: Schema.Number })
+    if (node._tag === "Atomic") {
+      tree[node.key] = schema
+    } else if (node._tag === "Final") {
+      tree[node.key] = { schema, type: "final", output: Schema.Literal(node.output) }
+    } else if (node._tag === "Compound") {
+      tree[node.key] = {
+        schema,
+        initial: node.initial,
+        states: makeStateTree(node.states, path)
+      }
+    } else {
+      tree[node.key] = {
+        schema,
+        type: "parallel",
+        output: Schema.Literal(node.output),
+        states: makeStateTree(node.states, path)
+      }
+    }
+  }
+  return tree
+}
+
+const selectSnapshot = (
+  builder: Record<string, any>,
+  path: string,
+  byPath: ReadonlyMap<string, FlatFiniteState>,
+  requestedParts: ReadonlyArray<string> | undefined,
+  index: number,
+  sourcePath?: string,
+  requestedValue?: number
+): unknown => {
+  const state = byPath.get(path)!
+  if (state.node._tag === "History") {
+    throw new Error(`MachineTest.compileModel cannot construct active history state "${path}"`)
+  }
+  const method = builder[state.node.key] as (value: unknown, selector?: (builder: any) => unknown) => unknown
+  const value = stateValue(state, path === requestedParts?.join(".") ? requestedValue : undefined)
+  if (state.node._tag === "Atomic" || state.node._tag === "Final") return method(value)
+
+  const requestedChild = requestedParts?.[index + 1]
+  if (state.node._tag === "Parallel") {
+    const parallel = state.node
+    const sourceInside = sourcePath === path || sourcePath?.startsWith(`${path}.`) === true
+    if (sourceInside) {
+      const childKey = requestedChild ?? (sourcePath === path
+        ? parallel.states.find((child) => child._tag !== "History")!.key
+        : sourcePath!.slice(path.length + 1).split(".")[0]!)
+      return method(
+        value,
+        (children: Record<string, any>) =>
+          selectSnapshot(
+            children,
+            `${path}.${childKey}`,
+            byPath,
+            requestedChild === undefined ? undefined : requestedParts,
+            index + 1,
+            sourcePath,
+            requestedValue
+          )
+      )
+    }
+    return method(value, (children: Record<string, any>) => {
+      let selected: unknown = children
+      for (const child of parallel.states.filter((child) => child._tag !== "History")) {
+        const isRequestedRegion = requestedChild === child.key
+        selected = selectSnapshot(
+          selected as Record<string, any>,
+          `${path}.${child.key}`,
+          byPath,
+          isRequestedRegion ? requestedParts : undefined,
+          index + 1,
+          sourcePath,
+          requestedValue
+        )
+      }
+      return selected
+    })
+  }
+
+  const childKey = requestedChild ?? state.node.initial
+  const childPath = `${path}.${childKey}`
+  return method(
+    value,
+    (children: Record<string, any>) =>
+      selectSnapshot(
+        children,
+        childPath,
+        byPath,
+        requestedChild === undefined ? undefined : requestedParts,
+        index + 1,
+        sourcePath,
+        requestedValue
+      )
+  )
+}
+
+const findSnapshot = (snapshot: unknown, path: string): unknown => {
+  if (typeof snapshot !== "object" || snapshot === null) return undefined
+  const current = snapshot as Record<string, unknown>
+  if (current.path === path) return snapshot
+  if (current.state !== undefined) {
+    const found = findSnapshot(current.state, path)
+    if (found !== undefined) return found
+  }
+  if (typeof current.states === "object" && current.states !== null) {
+    for (const child of Object.values(current.states)) {
+      const found = findSnapshot(child, path)
+      if (found !== undefined) return found
+    }
+  }
+  return undefined
+}
+
+const selectHistoryTarget = (builder: Record<string, any>, path: string): unknown => {
+  const parts = path.split(".")
+  let current: any = builder
+  for (let index = 0; index < parts.length - 1; index++) current = current[parts[index]!]
+  return current[parts[parts.length - 1]!]()
+}
+
+const makeHandlers = (
+  states: ReadonlyArray<FiniteState>,
+  parent: string | undefined,
+  byPath: ReadonlyMap<string, FlatFiniteState>,
+  transitions: ReadonlyMap<string, FiniteTransition>
+): Record<string, unknown> => {
+  const handlers: Record<string, unknown> = Object.create(null)
+  for (const node of states) {
+    const path = parent === undefined ? node.key : `${parent}.${node.key}`
+    if (node._tag === "History") continue
+    if (node._tag === "Final") {
+      handlers[node.key] = { output: () => node.output }
+      continue
+    }
+    const on: Record<string, unknown> = Object.create(null)
+    for (const [registration, transition] of transitions) {
+      if (!registration.startsWith(`${path}\u0000`)) continue
+      on[transition.event] = {
+        reenter: transition.reenter,
+        ...(transition.target === undefined
+          ? {}
+          : {
+            targets: [
+              byPath.get(transition.target)!.node._tag === "History"
+                ? transition.target
+                : runtimeTargetPath(byPath, path, transition.target)
+            ]
+          }),
+        transition: ({ target }: { readonly target: Record<string, Record<string, any>> }) => {
+          if (transition.target === undefined) return undefined
+          const targetState = byPath.get(transition.target)!
+          if (targetState.node._tag === "History") return selectHistoryTarget(target.history, targetState.path)
+          const parts = transition.target.split(".")
+          const builder = targetState.root === byPath.get(path)!.root ? target.branch : target.full
+          return selectSnapshot(builder, parts[0]!, byPath, parts, 0, path, transition.targetValue)
+        }
+      }
+    }
+    const history = node._tag === "Compound" || node._tag === "Parallel"
+      ? Object.fromEntries(node.states.flatMap((child) => {
+        if (child._tag !== "History") return []
+        return [[child.key, {
+          default: ({ target }: { readonly target: Record<string, any> }) => {
+            const fallback = byPath.get(child.fallback)!
+            const parts = child.fallback.split(".")
+            const completeRoot = selectSnapshot(target, fallback.root, byPath, parts, 0)
+            const selected = findSnapshot(completeRoot, path)
+            if (selected === undefined) {
+              throw new Error(
+                `MachineTest.compileModel could not construct history fallback for "${path}.${child.key}"`
+              )
+            }
+            return selected
+          }
+        }]]
+      }))
+      : {}
+    handlers[node.key] = {
+      ...(Object.keys(on).length === 0 ? {} : { on }),
+      ...(node._tag === "Compound" || node._tag === "Parallel"
+        ? {
+          ...(node._tag === "Parallel" ? { output: () => node.output } : {}),
+          ...(Object.keys(history).length === 0 ? {} : { history }),
+          ...(node._tag === "Compound"
+            ? {
+              initial: () => stateValue(byPath.get(`${path}.${node.initial}`)!)
+            }
+            : {
+              initial: () =>
+                Object.fromEntries(
+                  node.states
+                    .filter((child) => child._tag !== "History")
+                    .map((child) => [child.key, stateValue(byPath.get(`${path}.${child.key}`)!)])
+                )
+            }),
+          states: makeHandlers(node.states, path, byPath, transitions)
+        }
+        : {})
+    }
+  }
+  return handlers
+}
+
+/**
+ * Compiles a finite model into a real machine using only public definition,
+ * construction, and handler APIs.
+ *
+ * Hand-authored models are validated before compilation. This compiler is a
+ * testing adapter, not the independent reference interpreter used by later
+ * conformance stages.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const compileModel = (model: FiniteModel): Machine.Machine.Any => {
+  const flattened = validateModel(model)
+  const byPath = new Map(flattened.map((state) => [state.path, state]))
+  const stateTree = makeStateTree(model.roots, undefined)
+  const defined = Machine.defineStates(stateTree as any)
+  const eventSchemas = model.events.map((event) => Schema.TaggedStruct(event, {}))
+  const initial = byPath.get(model.initial)!
+  const machine = Machine.make({
+    states: defined.states as any,
+    events: eventSchemas as any,
+    initial: () => selectSnapshot(defined.initial as any, initial.path, byPath, [initial.path], 0) as any
+  })
+  const transitions = new Map(model.transitions.map((transition) => [
+    `${transition.source}\u0000${transition.event}`,
+    transition
+  ]))
+  return machine.handle(makeHandlers(model.roots, undefined, byPath, transitions) as any) as Machine.Machine.Any
+}

--- a/src/internal/machineTestReferenceModel.ts
+++ b/src/internal/machineTestReferenceModel.ts
@@ -20,26 +20,46 @@ import type {
   FiniteTransition
 } from "./machineTestFiniteModel.js"
 
-/** The deterministic value assigned to one active finite-model state. */
+/**
+ * The deterministic value assigned to one active finite-model state.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ReferenceStateValue {
   readonly _tag: string
   readonly value: number
 }
 
-/** One output retained for an actively completed state. */
+/**
+ * One output retained for an actively completed state.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ReferenceCompletion {
   readonly path: string
   readonly output: string
 }
 
-/** One independently captured shallow or deep history register. */
+/**
+ * One independently captured shallow or deep history register.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ReferenceHistoryRecord {
   readonly mode: "shallow" | "deep"
   readonly active: ReadonlyArray<string>
   readonly values: Readonly<Record<string, ReferenceStateValue>>
 }
 
-/** An independently interpreted finite-model configuration. */
+/**
+ * An independently interpreted finite-model configuration.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ReferenceState {
   /** Active ancestors and leaf in state-definition order. */
   readonly activePaths: ReadonlyArray<string>
@@ -53,7 +73,12 @@ export interface ReferenceState {
   readonly output: string | undefined
 }
 
-/** One transition retained by the independent reference step. */
+/**
+ * One transition retained by the independent reference step.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ReferenceTransition {
   readonly source: string
   readonly trigger: {
@@ -65,7 +90,12 @@ export interface ReferenceTransition {
   readonly resolvedTarget: string | undefined
 }
 
-/** The independently calculated planner microstep for one selected event. */
+/**
+ * The independently calculated planner microstep for one selected event.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ReferenceMicrostep {
   readonly next: ReferenceState
   readonly event: string
@@ -75,7 +105,12 @@ export interface ReferenceMicrostep {
   readonly changed: boolean
 }
 
-/** Startup semantics calculated without executing the real machine. */
+/**
+ * Startup semantics calculated without executing the real machine.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ReferenceInitialStep {
   readonly startingState: ReferenceState
   readonly initialEntryPaths: ReadonlyArray<string>
@@ -85,7 +120,12 @@ export interface ReferenceInitialStep {
   readonly output: string | undefined
 }
 
-/** One public event interpreted against a reference configuration. */
+/**
+ * One public event interpreted against a reference configuration.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ReferenceStep {
   readonly index: number
   readonly event: string
@@ -96,7 +136,12 @@ export interface ReferenceStep {
   readonly output: string | undefined
 }
 
-/** A complete, pure interpretation of a finite model and event sequence. */
+/**
+ * A complete, pure interpretation of a finite model and event sequence.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ReferenceTrace {
   readonly events: ReadonlyArray<string>
   readonly initial: ReferenceInitialStep
@@ -104,7 +149,12 @@ export interface ReferenceTrace {
   readonly final: ReferenceState
 }
 
-/** Location of one planner/reference disagreement. */
+/**
+ * Location of one planner/reference disagreement.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ModelVerificationLocation {
   readonly phase: "initial" | "event" | "final"
   readonly eventIndex?: number
@@ -121,7 +171,12 @@ type ModelStateField =
   | "step.after"
   | "trace.final"
 
-/** Stable semantic observation compared by the finite-model oracle. */
+/**
+ * Stable semantic observation compared by the finite-model oracle.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export type ModelVerificationField =
   | `${ModelStateField}.${"activePaths" | "values" | "completions" | "history"}`
   | "event.tag"
@@ -147,7 +202,12 @@ export type ModelVerificationField =
   | "step.plan.output"
   | "trace.finalConfiguration"
 
-/** One structured semantic disagreement with the independent interpreter. */
+/**
+ * One structured semantic disagreement with the independent interpreter.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface ModelVerificationMismatch {
   readonly location: ModelVerificationLocation
   /** Stable dotted field identifying the compared observation. */
@@ -157,7 +217,12 @@ export interface ModelVerificationMismatch {
   readonly message: string
 }
 
-/** All semantic disagreements found for one finite-model trace. */
+/**
+ * All semantic disagreements found for one finite-model trace.
+ *
+ * @category errors
+ * @since 4.0.0
+ */
 export class ModelVerificationError extends Data.TaggedError("MachineTestModelVerificationError")<{
   readonly mismatches: ReadonlyArray<ModelVerificationMismatch>
 }> {}

--- a/src/internal/machineTestReferenceModel.ts
+++ b/src/internal/machineTestReferenceModel.ts
@@ -1,0 +1,1214 @@
+/**
+ * Independent hierarchical, parallel, and history statechart semantics for finite test
+ * models.
+ *
+ * This module deliberately knows nothing about `Machine`, its snapshots, the
+ * finite-model compiler, target builders, or planner internals. The actual
+ * planner trace is treated as opaque data and projected structurally only at
+ * the comparison boundary.
+ *
+ * @internal
+ */
+
+import * as Data from "effect/Data"
+import * as Effect from "effect/Effect"
+import type {
+  FiniteCompoundState,
+  FiniteHistoryState,
+  FiniteModel,
+  FiniteState,
+  FiniteTransition
+} from "./machineTestFiniteModel.js"
+
+/** The deterministic value assigned to one active finite-model state. */
+export interface ReferenceStateValue {
+  readonly _tag: string
+  readonly value: number
+}
+
+/** One output retained for an actively completed state. */
+export interface ReferenceCompletion {
+  readonly path: string
+  readonly output: string
+}
+
+/** One independently captured shallow or deep history register. */
+export interface ReferenceHistoryRecord {
+  readonly mode: "shallow" | "deep"
+  readonly active: ReadonlyArray<string>
+  readonly values: Readonly<Record<string, ReferenceStateValue>>
+}
+
+/** An independently interpreted finite-model configuration. */
+export interface ReferenceState {
+  /** Active ancestors and leaf in state-definition order. */
+  readonly activePaths: ReadonlyArray<string>
+  /** Deterministic state values keyed by active state path. */
+  readonly values: Readonly<Record<string, ReferenceStateValue>>
+  /** Completed final and compound paths in completion order. */
+  readonly completions: ReadonlyArray<ReferenceCompletion>
+  /** Logical history registers keyed by history pseudo-state path. */
+  readonly history: Readonly<Record<string, ReferenceHistoryRecord>>
+  readonly status: "active" | "done"
+  readonly output: string | undefined
+}
+
+/** One transition retained by the independent reference step. */
+export interface ReferenceTransition {
+  readonly source: string
+  readonly trigger: {
+    readonly type: "event"
+    readonly event: string
+  }
+  readonly reenter: boolean
+  readonly target: string | undefined
+  readonly resolvedTarget: string | undefined
+}
+
+/** The independently calculated planner microstep for one selected event. */
+export interface ReferenceMicrostep {
+  readonly next: ReferenceState
+  readonly event: string
+  readonly transitions: ReadonlyArray<ReferenceTransition>
+  readonly exitPaths: ReadonlyArray<string>
+  readonly entryPaths: ReadonlyArray<string>
+  readonly changed: boolean
+}
+
+/** Startup semantics calculated without executing the real machine. */
+export interface ReferenceInitialStep {
+  readonly startingState: ReferenceState
+  readonly initialEntryPaths: ReadonlyArray<string>
+  readonly state: ReferenceState
+  readonly microsteps: readonly []
+  readonly done: boolean
+  readonly output: string | undefined
+}
+
+/** One public event interpreted against a reference configuration. */
+export interface ReferenceStep {
+  readonly index: number
+  readonly event: string
+  readonly before: ReferenceState
+  readonly microsteps: ReadonlyArray<ReferenceMicrostep>
+  readonly after: ReferenceState
+  readonly done: boolean
+  readonly output: string | undefined
+}
+
+/** A complete, pure interpretation of a finite model and event sequence. */
+export interface ReferenceTrace {
+  readonly events: ReadonlyArray<string>
+  readonly initial: ReferenceInitialStep
+  readonly steps: ReadonlyArray<ReferenceStep>
+  readonly final: ReferenceState
+}
+
+/** Location of one planner/reference disagreement. */
+export interface ModelVerificationLocation {
+  readonly phase: "initial" | "event" | "final"
+  readonly eventIndex?: number
+  readonly microstepIndex?: number
+}
+
+type ModelStateField =
+  | "initial.startingState"
+  | "initial.plan.startingState"
+  | "initial.plan.state"
+  | "step.before"
+  | "microstep.next"
+  | "step.plan.next"
+  | "step.after"
+  | "trace.final"
+
+/** Stable semantic observation compared by the finite-model oracle. */
+export type ModelVerificationField =
+  | `${ModelStateField}.${"activePaths" | "values" | "completions" | "history"}`
+  | "event.tag"
+  | "initial.startingConfiguration"
+  | "initial.initialEntryPaths"
+  | "initial.plan.initialEntryPaths"
+  | "initial.configuration"
+  | "initial.plan.microsteps"
+  | "initial.plan.done"
+  | "initial.plan.output"
+  | "trace.steps.length"
+  | "step.index"
+  | "step.event"
+  | "step.beforeConfiguration"
+  | "step.plan.microsteps.length"
+  | "microstep.event"
+  | "microstep.transitions"
+  | "microstep.exitPaths"
+  | "microstep.entryPaths"
+  | "microstep.changed"
+  | "step.afterConfiguration"
+  | "step.plan.done"
+  | "step.plan.output"
+  | "trace.finalConfiguration"
+
+/** One structured semantic disagreement with the independent interpreter. */
+export interface ModelVerificationMismatch {
+  readonly location: ModelVerificationLocation
+  /** Stable dotted field identifying the compared observation. */
+  readonly field: ModelVerificationField
+  readonly expected: unknown
+  readonly actual: unknown
+  readonly message: string
+}
+
+/** All semantic disagreements found for one finite-model trace. */
+export class ModelVerificationError extends Data.TaggedError("MachineTestModelVerificationError")<{
+  readonly mismatches: ReadonlyArray<ModelVerificationMismatch>
+}> {}
+
+interface IndexedState {
+  readonly node: FiniteState
+  readonly path: string
+  readonly parent: string | undefined
+  readonly root: string
+  readonly depth: number
+  readonly order: number
+  readonly children: ReadonlyArray<string>
+}
+
+interface ModelIndex {
+  readonly ordered: ReadonlyArray<IndexedState>
+  readonly byPath: ReadonlyMap<string, IndexedState>
+  readonly transitions: ReadonlyMap<string, FiniteTransition>
+  readonly histories: ReadonlyArray<IndexedState & { readonly node: FiniteHistoryState }>
+}
+
+const ControlOrder: unique symbol = Symbol("MachineTestReferenceControlOrder")
+
+type InternalReferenceState = ReferenceState & {
+  readonly [ControlOrder]: ReadonlyArray<string>
+}
+
+const withControlOrder = (
+  state: ReferenceState,
+  order: ReadonlyArray<string>
+): InternalReferenceState => {
+  Object.defineProperty(state, ControlOrder, { value: order.slice(), enumerable: false })
+  return state as InternalReferenceState
+}
+
+const controlOrder = (state: ReferenceState): ReadonlyArray<string> =>
+  ControlOrder in state ? (state as InternalReferenceState)[ControlOrder] : state.activePaths
+
+const stateTag = (path: string): string => `State_${path.replaceAll(".", "_")}`
+
+/**
+ * Builds the oracle's own state index. This traversal intentionally duplicates
+ * the structural work performed by the compiler instead of importing it.
+ */
+const indexModel = (model: FiniteModel): ModelIndex => {
+  const ordered: Array<IndexedState> = []
+  const visit = (
+    states: ReadonlyArray<FiniteState>,
+    parent: string | undefined,
+    root: string | undefined,
+    depth: number
+  ): void => {
+    for (const node of states) {
+      const path = parent === undefined ? node.key : `${parent}.${node.key}`
+      const nodeRoot = root ?? path
+      ordered.push({
+        node,
+        path,
+        parent,
+        root: nodeRoot,
+        depth,
+        order: ordered.length,
+        children: node._tag === "Compound" || node._tag === "Parallel"
+          ? node.states.filter((child) => child._tag !== "History").map((child) => `${path}.${child.key}`)
+          : []
+      })
+      if (node._tag === "Compound" || node._tag === "Parallel") {
+        visit(node.states, path, nodeRoot, depth + 1)
+      }
+    }
+  }
+  visit(model.roots, undefined, undefined, 1)
+  const byPath = new Map(ordered.map((state) => [state.path, state]))
+  const transitions = new Map(
+    model.transitions.map((transition) => [`${transition.source}\u0000${transition.event}`, transition])
+  )
+  const histories = ordered.filter(
+    (state): state is IndexedState & { readonly node: FiniteHistoryState } => state.node._tag === "History"
+  )
+  return { ordered, byPath, transitions, histories }
+}
+
+const getState = (index: ModelIndex, path: string): IndexedState => {
+  const state = index.byPath.get(path)
+  if (state === undefined) {
+    throw new Error(`MachineTest.interpretModel received unknown state path "${path}"`)
+  }
+  return state
+}
+
+const activeValue = (state: IndexedState, value?: number): ReferenceStateValue => {
+  if (state.node._tag === "History") {
+    throw new Error(`MachineTest.interpretModel cannot activate history state "${state.path}"`)
+  }
+  return { _tag: stateTag(state.path), value: value ?? state.node.value }
+}
+
+const applyTargetValue = (
+  index: ModelIndex,
+  state: ReferenceState,
+  transition: FiniteTransition
+): ReferenceState => {
+  if (transition.targetValue === undefined || transition.target === undefined) return state
+  const target = getState(index, transition.target)
+  if (target.node._tag === "History" || !state.activePaths.includes(target.path)) return state
+  return withControlOrder({
+    ...state,
+    values: { ...state.values, [target.path]: activeValue(target, transition.targetValue) }
+  }, controlOrder(state))
+}
+
+const pathsToRoot = (index: ModelIndex, path: string): ReadonlyArray<string> => {
+  const paths: Array<string> = []
+  let current: IndexedState | undefined = getState(index, path)
+  while (current !== undefined) {
+    paths.unshift(current.path)
+    current = current.parent === undefined ? undefined : getState(index, current.parent)
+  }
+  return paths
+}
+
+const initialChildPath = (state: IndexedState): string => {
+  const node = state.node as FiniteCompoundState
+  const child = node.states.find((candidate) => candidate.key === node.initial)
+  if (child === undefined) {
+    throw new Error(`MachineTest.interpretModel received unknown initial child "${node.initial}" for "${state.path}"`)
+  }
+  return `${state.path}.${child.key}`
+}
+
+const expandInitial = (index: ModelIndex, path: string): ReadonlyArray<string> => {
+  const current = getState(index, path)
+  if (current.node._tag === "Compound") {
+    return [current.path, ...expandInitial(index, initialChildPath(current))]
+  }
+  if (current.node._tag === "Parallel") {
+    return [
+      current.path,
+      ...current.children.flatMap((child) => expandInitial(index, child))
+    ]
+  }
+  return [current.path]
+}
+
+const makeUnsettledState = (index: ModelIndex, target: string): ReferenceState => {
+  const activePaths = [...pathsToRoot(index, target).slice(0, -1), ...expandInitial(index, target)]
+  const values: Record<string, ReferenceStateValue> = {}
+  for (const path of activePaths) {
+    values[path] = activeValue(getState(index, path))
+  }
+  return withControlOrder({
+    activePaths,
+    values,
+    completions: [],
+    history: {},
+    status: "active",
+    output: undefined
+  }, activePaths)
+}
+
+const directActiveChild = (
+  index: ModelIndex,
+  state: ReferenceState,
+  parent: string
+): IndexedState | undefined => {
+  const parentState = getState(index, parent)
+  return parentState.children
+    .map((path) => getState(index, path))
+    .find((child) => state.activePaths.includes(child.path))
+}
+
+const settleCompletions = (index: ModelIndex, state: ReferenceState): ReferenceState => {
+  const completions = [...state.completions]
+  const outputs = new Map(completions.map((completion) => [completion.path, completion.output]))
+  const complete = (path: string): string | undefined => {
+    if (outputs.has(path)) return outputs.get(path)
+    const current = getState(index, path)
+    let output: string | undefined
+    if (current.node._tag === "Final") {
+      output = current.node.output
+    } else if (current.node._tag === "Compound") {
+      const child = directActiveChild(index, state, current.path)
+      if (child?.node._tag !== "Final") return undefined
+      output = complete(child.path)
+    } else if (current.node._tag === "Parallel") {
+      for (const childPath of current.children) {
+        if (!state.activePaths.includes(childPath) || complete(childPath) === undefined) {
+          return undefined
+        }
+      }
+      output = current.node.output
+    }
+    if (output !== undefined) {
+      outputs.set(path, output)
+      completions.push({ path, output })
+    }
+    return output
+  }
+  const deepestFirst = state.activePaths.slice().sort((left, right) => {
+    const leftState = getState(index, left)
+    const rightState = getState(index, right)
+    return rightState.depth - leftState.depth || leftState.order - rightState.order
+  })
+
+  for (const path of deepestFirst) {
+    complete(path)
+  }
+
+  const root = state.activePaths.find((path) => getState(index, path).parent === undefined)
+  const output = root === undefined ? undefined : outputs.get(root)
+  return withControlOrder({
+    ...state,
+    completions,
+    status: output === undefined ? "active" : "done",
+    output
+  }, controlOrder(state))
+}
+
+const samePaths = (left: ReadonlyArray<string>, right: ReadonlyArray<string>): boolean =>
+  left.length === right.length && left.every((path, index) => path === right[index])
+
+const leastCommonAncestor = (index: ModelIndex, left: string, right: string): string | undefined => {
+  const leftPaths = pathsToRoot(index, left)
+  const rightPaths = pathsToRoot(index, right)
+  let result: string | undefined
+  for (let position = 0; position < Math.min(leftPaths.length, rightPaths.length); position++) {
+    if (leftPaths[position] !== rightPaths[position]) break
+    result = leftPaths[position]
+  }
+  return result
+}
+
+const isDescendant = (index: ModelIndex, path: string, ancestor: string): boolean => {
+  let parent = getState(index, path).parent
+  while (parent !== undefined) {
+    if (parent === ancestor) return true
+    parent = getState(index, parent).parent
+  }
+  return false
+}
+
+const broadenBoundary = (
+  index: ModelIndex,
+  natural: string | undefined,
+  reentry: string | undefined
+): string | undefined => {
+  if (natural === undefined || reentry === undefined) return undefined
+  return natural === reentry || isDescendant(index, natural, reentry) ? reentry : natural
+}
+
+const lifecyclePaths = (
+  index: ModelIndex,
+  activePaths: ReadonlyArray<string>,
+  boundary: string | undefined,
+  direction: "entry" | "exit"
+): ReadonlyArray<string> =>
+  activePaths
+    .filter((path) => boundary === undefined || isDescendant(index, path, boundary))
+    .sort((left, right) => {
+      const leftState = getState(index, left)
+      const rightState = getState(index, right)
+      const depth = direction === "entry"
+        ? leftState.depth - rightState.depth
+        : rightState.depth - leftState.depth
+      if (depth !== 0) return depth
+      return direction === "entry"
+        ? leftState.order - rightState.order
+        : rightState.order - leftState.order
+    })
+
+interface SelectedTransition {
+  readonly transition: FiniteTransition
+  readonly leaf: string
+}
+
+interface EvaluatedTransition extends SelectedTransition {
+  readonly next: ReferenceState
+  readonly targetPath: string | undefined
+  readonly changed: boolean
+  readonly exitPaths: ReadonlyArray<string>
+  readonly entryPaths: ReadonlyArray<string>
+}
+
+const activeLeaves = (index: ModelIndex, state: ReferenceState): ReadonlyArray<string> =>
+  state.activePaths.filter((path) => {
+    const current = getState(index, path)
+    return current.children.every((child) => !state.activePaths.includes(child))
+  })
+
+const selectTransitions = (
+  index: ModelIndex,
+  state: ReferenceState,
+  event: string
+): ReadonlyArray<SelectedTransition> => {
+  const selections: Array<SelectedTransition> = []
+  const selectedSources = new Set<string>()
+  for (const leaf of activeLeaves(index, state)) {
+    const candidates = pathsToRoot(index, leaf).slice().reverse()
+    for (const source of candidates) {
+      const transition = index.transitions.get(`${source}\u0000${event}`)
+      if (transition === undefined) continue
+      if (!selectedSources.has(source)) {
+        selectedSources.add(source)
+        selections.push({ transition, leaf })
+      }
+      break
+    }
+  }
+  return selections.filter(({ transition }) =>
+    !selections.some(({ transition: other }) =>
+      other.source !== transition.source && isDescendant(index, other.source, transition.source)
+    )
+  )
+}
+
+const runtimeTargetPath = (index: ModelIndex, transition: FiniteTransition): string | undefined => {
+  if (transition.target === undefined) return undefined
+  const source = getState(index, transition.source)
+  const target = getState(index, transition.target)
+  if (target.node._tag === "History") return target.parent
+  // A same-root branch builder identifies the concrete initialized leaf. A
+  // full builder replaces the root with a complete snapshot and identifies
+  // that snapshot's root even when it contains initialized descendants.
+  if (source.root !== target.root) return target.path
+
+  const initial = (path: string): string => {
+    const current = getState(index, path)
+    if (current.node._tag === "Parallel") {
+      if (transition.source !== current.path && !transition.source.startsWith(`${current.path}.`)) {
+        return current.path
+      }
+      const child = transition.source === current.path
+        ? current.children[0]!
+        : current.children.find((candidate) => isPathInSubtree(transition.source, candidate))!
+      return initial(child)
+    }
+    return current.node._tag === "Compound" ? initial(initialChildPath(current)) : current.path
+  }
+  const inspect = (path: string): string => {
+    const current = getState(index, path)
+    if (
+      current.node._tag === "Parallel" && transition.source !== current.path &&
+      !transition.source.startsWith(`${current.path}.`)
+    ) {
+      return current.path
+    }
+    if (current.path === target.path) return initial(current.path)
+    const next = target.path.slice(current.path.length + 1).split(".")[0]!
+    return inspect(`${current.path}.${next}`)
+  }
+  return inspect(source.root)
+}
+
+const isPathInSubtree = (path: string, root: string): boolean => path === root || path.startsWith(`${root}.`)
+
+const expandSelection = (
+  index: ModelIndex,
+  path: string,
+  requested: string
+): ReadonlyArray<string> => {
+  const current = getState(index, path)
+  if (current.node._tag === "History") return []
+  if (current.node._tag === "Compound") {
+    const selected = current.children.find((child) => isPathInSubtree(requested, child)) ?? initialChildPath(current)
+    return [current.path, ...expandSelection(index, selected, requested)]
+  }
+  if (current.node._tag === "Parallel") {
+    return [
+      current.path,
+      ...current.children.flatMap((child) =>
+        expandSelection(index, child, isPathInSubtree(requested, child) ? requested : child)
+      )
+    ]
+  }
+  return [current.path]
+}
+
+const makeHistoryConfiguration = (
+  index: ModelIndex,
+  current: ReferenceState,
+  owner: string,
+  activePaths: ReadonlyArray<string>,
+  rememberedValues: Readonly<Record<string, ReferenceStateValue>>,
+  history: Readonly<Record<string, ReferenceHistoryRecord>>
+): ReferenceState => {
+  const active = new Set(activePaths)
+  const ownerAncestors = pathsToRoot(index, owner)
+  const ownerAncestry = new Set(ownerAncestors)
+
+  // Parallel ancestors outside the owner retain active sibling regions. When
+  // the owner belongs to an inactive root, those regions follow initial entry.
+  for (const ancestorPath of ownerAncestors) {
+    const ancestor = getState(index, ancestorPath)
+    if (ancestor.node._tag !== "Parallel") continue
+    const selectedRegion = ancestor.children.find((child) => ownerAncestry.has(child))
+    for (const region of ancestor.children) {
+      if (region === selectedRegion || active.has(region)) continue
+      const retained = current.activePaths.filter((path) => isPathInSubtree(path, region))
+      for (const path of retained.length === 0 ? expandInitial(index, region) : retained) active.add(path)
+    }
+  }
+
+  const ordered = index.ordered
+    .filter(({ node, path }) => node._tag !== "History" && active.has(path))
+    .map(({ path }) => path)
+  const values: Record<string, ReferenceStateValue> = {}
+  for (const path of ordered) {
+    values[path] = rememberedValues[path] ?? current.values[path] ?? activeValue(getState(index, path))
+  }
+  const completions = current.completions.filter(({ path }) => active.has(path) && !isPathInSubtree(path, owner))
+  return withControlOrder({
+    activePaths: ordered,
+    values,
+    completions,
+    history,
+    status: "active",
+    output: undefined
+  }, ordered)
+}
+
+const captureHistory = (
+  index: ModelIndex,
+  current: ReferenceState,
+  next: ReferenceState,
+  exitPaths: ReadonlyArray<string>
+): ReferenceState => {
+  if (exitPaths.length === 0) return next
+  const exited = new Set(exitPaths)
+  const history: Record<string, ReferenceHistoryRecord> = { ...next.history }
+  for (const state of index.histories) {
+    const owner = state.parent!
+    if (!exited.has(owner)) continue
+    const active = current.activePaths.filter((path) =>
+      pathsToRoot(index, owner).includes(path) || path === owner ||
+      (state.node.history === "deep"
+        ? isPathInSubtree(path, owner)
+        : getState(index, path).parent === owner)
+    )
+    const values: Record<string, ReferenceStateValue> = {}
+    for (const path of active) values[path] = current.values[path]!
+    history[state.path] = {
+      mode: state.node.history,
+      active,
+      values
+    }
+  }
+  return withControlOrder({ ...next, history }, controlOrder(next))
+}
+
+const restoreHistory = (
+  index: ModelIndex,
+  current: ReferenceState,
+  historyState: IndexedState & { readonly node: FiniteHistoryState }
+): ReferenceState => {
+  const owner = historyState.parent!
+  const record = current.history[historyState.path]
+  if (record === undefined) {
+    const active = [
+      ...pathsToRoot(index, owner).slice(0, -1),
+      ...expandSelection(index, owner, historyState.node.fallback)
+    ]
+    const values: Record<string, ReferenceStateValue> = {}
+    for (const path of active) values[path] = activeValue(getState(index, path))
+    return makeHistoryConfiguration(index, current, owner, active, values, current.history)
+  }
+
+  const active = new Set(record.active)
+  if (record.mode === "shallow") {
+    for (const child of getState(index, owner).children) {
+      if (!active.has(child)) continue
+      for (const path of expandInitial(index, child).slice(1)) active.add(path)
+    }
+  }
+  return makeHistoryConfiguration(index, current, owner, Array.from(active), record.values, current.history)
+}
+
+const resolveHistoryState = (
+  index: ModelIndex,
+  before: ReferenceState,
+  transition: FiniteTransition,
+  leaf: string
+): ReferenceState => {
+  const historyState = getState(index, transition.target!) as IndexedState & { readonly node: FiniteHistoryState }
+  const owner = historyState.parent!
+  const reenteredOwner = transition.reenter && before.activePaths.includes(owner)
+  const provisionalBoundary = transition.reenter
+    ? getState(index, transition.source).parent
+    : leastCommonAncestor(index, leaf, owner)
+  const provisionalExitPaths = reenteredOwner
+    ? lifecyclePaths(
+      index,
+      before.activePaths.filter((path) => isPathInSubtree(path, owner)),
+      undefined,
+      "exit"
+    )
+    : lifecyclePaths(index, before.activePaths, provisionalBoundary, "exit")
+  const stateAtResolution = provisionalExitPaths.includes(owner)
+    ? captureHistory(index, before, before, provisionalExitPaths)
+    : before
+  return restoreHistory(index, stateAtResolution, historyState)
+}
+
+const targetState = (
+  index: ModelIndex,
+  before: ReferenceState,
+  transition: FiniteTransition,
+  leaf: string = transition.source
+): ReferenceState => {
+  if (transition.target === undefined) return before
+  const source = getState(index, transition.source)
+  const target = getState(index, transition.target)
+  if (target.node._tag === "History") return resolveHistoryState(index, before, transition, leaf)
+  if (source.root !== target.root) {
+    const unsettled = makeUnsettledState(index, target.path)
+    return applyTargetValue(
+      index,
+      withControlOrder({ ...unsettled, history: before.history }, controlOrder(unsettled)),
+      transition
+    )
+  }
+
+  const actualTarget = runtimeTargetPath(index, transition)!
+  const actualNode = getState(index, actualTarget)
+  // A returned parallel target is an upper bound carrying a complete nested
+  // snapshot: retain the more specific declared descendant for that snapshot.
+  // Conversely, a branch target may resolve a declared compound/parallel
+  // ancestor to the concrete initialized leaf selected inside the source
+  // region. In both cases the deeper path describes the control change.
+  const configurationTarget = actualNode.depth >= target.depth ? actualTarget : target.path
+  const active = new Set<string>([
+    ...pathsToRoot(index, configurationTarget).slice(0, -1),
+    ...expandInitial(index, configurationTarget)
+  ])
+  const retainedValuePaths = new Set(
+    pathsToRoot(index, configurationTarget)
+      .slice(0, -1)
+      .filter((path) => before.activePaths.includes(path))
+  )
+  const retainedCompletionPaths: Array<string> = []
+  const order: Array<string> = actualNode.node._tag === "Parallel"
+    ? [
+      ...index.ordered
+        .filter(({ path }) => active.has(path) && isPathInSubtree(path, actualTarget))
+        .map(({ path }) => path),
+      ...pathsToRoot(index, actualTarget).slice(0, -1)
+    ]
+    : pathsToRoot(index, actualTarget).slice()
+  const targetAncestors = pathsToRoot(index, configurationTarget)
+  for (const ancestorPath of targetAncestors) {
+    const ancestor = getState(index, ancestorPath)
+    if (ancestor.node._tag !== "Parallel") continue
+    const selectedRegion = ancestor.children.find((child) => isPathInSubtree(configurationTarget, child))
+    const sourceInside = transition.source === ancestor.path || transition.source.startsWith(`${ancestor.path}.`)
+    for (const region of ancestor.children) {
+      if (region === selectedRegion) continue
+      if (sourceInside && before.activePaths.includes(region)) {
+        for (const path of controlOrder(before)) {
+          if (isPathInSubtree(path, region)) {
+            active.add(path)
+            retainedValuePaths.add(path)
+            if (!order.includes(path)) order.push(path)
+            if (
+              before.completions.some((completion) => completion.path === path) &&
+              !retainedCompletionPaths.includes(path)
+            ) {
+              retainedCompletionPaths.push(path)
+            }
+          }
+        }
+      } else {
+        for (const path of expandInitial(index, region)) {
+          active.add(path)
+          if (!order.includes(path)) order.push(path)
+        }
+      }
+    }
+  }
+  if (actualNode.node._tag === "Parallel") {
+    const subtreeOrder = index.ordered
+      .filter(({ path }) => active.has(path) && isPathInSubtree(path, actualTarget))
+      .map(({ path }) => path)
+    const outsideOrder = order.filter((path) => !isPathInSubtree(path, actualTarget))
+    order.splice(0, order.length, ...subtreeOrder, ...outsideOrder)
+  }
+
+  const activePaths = index.ordered.filter(({ path }) => active.has(path)).map(({ path }) => path)
+  const values: Record<string, ReferenceStateValue> = {}
+  for (const path of activePaths) {
+    values[path] = retainedValuePaths.has(path) && before.values[path] !== undefined
+      ? before.values[path]
+      : activeValue(getState(index, path))
+  }
+  return applyTargetValue(
+    index,
+    withControlOrder({
+      activePaths,
+      values,
+      completions: retainedCompletionPaths.flatMap((path) => {
+        const completion = before.completions.find((candidate) => candidate.path === path)
+        return completion === undefined ? [] : [completion]
+      }),
+      history: before.history,
+      status: "active",
+      output: undefined
+    }, order),
+    transition
+  )
+}
+
+const transitionRecord = (index: ModelIndex, transition: FiniteTransition): ReferenceTransition => ({
+  source: transition.source,
+  trigger: { type: "event", event: transition.event },
+  reenter: transition.reenter,
+  // Retain the target identity returned by the compiler's selected builder;
+  // the finite AST keeps the broader declared bound separately.
+  target: transition.target !== undefined && getState(index, transition.target).node._tag === "History"
+    ? transition.target
+    : runtimeTargetPath(index, transition),
+  resolvedTarget: runtimeTargetPath(index, transition)
+})
+
+const evaluateTransition = (
+  index: ModelIndex,
+  before: ReferenceState,
+  selection: SelectedTransition
+): EvaluatedTransition => {
+  const { transition } = selection
+  const targetPath = runtimeTargetPath(index, transition)
+  const next = targetState(index, before, transition, selection.leaf)
+  const changed = transition.reenter || !samePaths(before.activePaths, next.activePaths)
+  if (!changed) {
+    return { ...selection, next, targetPath, changed, exitPaths: [], entryPaths: [] }
+  }
+  const naturalBoundary = targetPath === undefined
+    ? getState(index, transition.source).parent
+    : leastCommonAncestor(index, selection.leaf, targetPath)
+  const boundary = transition.reenter
+    ? broadenBoundary(index, naturalBoundary, getState(index, transition.source).parent)
+    : naturalBoundary
+  const historyTarget = transition.target === undefined ? undefined : getState(index, transition.target)
+  const reenteredHistoryOwner = historyTarget?.node._tag === "History" && transition.reenter &&
+    historyTarget.parent !== undefined && before.activePaths.includes(historyTarget.parent)
+  return {
+    ...selection,
+    next,
+    targetPath,
+    changed,
+    exitPaths: reenteredHistoryOwner
+      ? lifecyclePaths(
+        index,
+        before.activePaths.filter((path) => isPathInSubtree(path, historyTarget.parent!)),
+        undefined,
+        "exit"
+      )
+      : lifecyclePaths(index, before.activePaths, boundary, "exit"),
+    entryPaths: reenteredHistoryOwner
+      ? lifecyclePaths(
+        index,
+        next.activePaths.filter((path) => isPathInSubtree(path, historyTarget.parent!)),
+        undefined,
+        "entry"
+      )
+      : lifecyclePaths(index, next.activePaths, boundary, "entry")
+  }
+}
+
+const hasPathIntersection = (left: ReadonlyArray<string>, right: ReadonlyArray<string>): boolean =>
+  left.some((path) => right.includes(path))
+
+const sortByDocumentOrder = <A extends { readonly transition: FiniteTransition }>(
+  index: ModelIndex,
+  transitions: Iterable<A>
+): ReadonlyArray<A> =>
+  Array.from(transitions).sort((left, right) =>
+    getState(index, left.transition.source).order - getState(index, right.transition.source).order
+  )
+
+const removeConflicts = (
+  index: ModelIndex,
+  transitions: ReadonlyArray<EvaluatedTransition>
+): ReadonlyArray<EvaluatedTransition> => {
+  const retained: Array<EvaluatedTransition> = []
+  for (const transition of sortByDocumentOrder(index, transitions)) {
+    let preempted = false
+    const remove = new Set<EvaluatedTransition>()
+    for (const other of retained) {
+      if (!hasPathIntersection(transition.exitPaths, other.exitPaths)) continue
+      if (isDescendant(index, transition.transition.source, other.transition.source)) {
+        remove.add(other)
+      } else {
+        preempted = true
+        break
+      }
+    }
+    if (preempted) continue
+    for (const other of remove) retained.splice(retained.indexOf(other), 1)
+    retained.push(transition)
+  }
+  return retained
+}
+
+const stepModel = (
+  index: ModelIndex,
+  before: ReferenceState,
+  event: string,
+  stepIndex: number
+): ReferenceStep => {
+  // Public events delivered after terminal completion are observed but cannot
+  // select another transition.
+  if (before.status === "done") {
+    return {
+      index: stepIndex,
+      event,
+      before,
+      microsteps: [],
+      after: before,
+      done: true,
+      output: before.output
+    }
+  }
+
+  const selected = selectTransitions(index, before, event)
+  if (selected.length === 0) {
+    return {
+      index: stepIndex,
+      event,
+      before,
+      microsteps: [],
+      after: before,
+      done: false,
+      output: undefined
+    }
+  }
+
+  const retained = removeConflicts(index, selected.map((selection) => evaluateTransition(index, before, selection)))
+  const sorted = sortByDocumentOrder(index, retained)
+  let next = before
+  const applicationOrder = [
+    ...sorted.filter((transition) => !transition.changed),
+    ...sorted.filter((transition) => transition.changed)
+  ]
+  for (const evaluated of applicationOrder) {
+    next = targetState(index, next, evaluated.transition, evaluated.leaf)
+  }
+  const changed = sorted.some((transition) => transition.changed)
+  const exitPaths = lifecyclePaths(index, sorted.flatMap((transition) => transition.exitPaths), undefined, "exit")
+  const entryPaths = lifecyclePaths(index, sorted.flatMap((transition) => transition.entryPaths), undefined, "entry")
+  next = captureHistory(index, before, next, exitPaths)
+
+  const microstep: ReferenceMicrostep = {
+    next,
+    event,
+    transitions: sorted.map(({ transition }) => transitionRecord(index, transition)),
+    exitPaths,
+    entryPaths,
+    changed
+  }
+  const after = settleCompletions(index, next)
+  return {
+    index: stepIndex,
+    event,
+    before,
+    microsteps: [microstep],
+    after,
+    done: after.status === "done",
+    output: after.output
+  }
+}
+
+/**
+ * Purely interprets a hierarchical finite model without compiling or
+ * executing a `Machine`.
+ *
+ * @category verification
+ * @since 4.0.0
+ */
+export const interpretModel = (
+  model: FiniteModel,
+  events: ReadonlyArray<string>
+): ReferenceTrace => {
+  const index = indexModel(model)
+  const initialRoot = getState(index, model.initial)
+  if (initialRoot.parent !== undefined) {
+    throw new Error(`MachineTest.interpretModel expected initial state "${model.initial}" to be a root`)
+  }
+  const startingState = makeUnsettledState(index, model.initial)
+  const initialState = settleCompletions(index, startingState)
+  const initial: ReferenceInitialStep = {
+    startingState,
+    initialEntryPaths: startingState.activePaths,
+    state: initialState,
+    microsteps: [],
+    done: initialState.status === "done",
+    output: initialState.output
+  }
+  const steps: Array<ReferenceStep> = []
+  let current = initialState
+  for (let eventIndex = 0; eventIndex < events.length; eventIndex++) {
+    const step = stepModel(index, current, events[eventIndex]!, eventIndex)
+    steps.push(step)
+    current = step.after
+  }
+  return {
+    events: events.slice(),
+    initial,
+    steps,
+    final: current
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+interface ActualStateProjection {
+  readonly activePaths: ReadonlyArray<string>
+  readonly values: Readonly<Record<string, unknown>>
+  readonly completions: ReadonlyArray<unknown>
+  readonly history: unknown
+}
+
+const projectState = (snapshot: unknown): ActualStateProjection => {
+  const activePaths: Array<string> = []
+  const values: Record<string, unknown> = {}
+  const visit = (current: unknown): void => {
+    if (!isRecord(current)) return
+    if (typeof current.path === "string") {
+      activePaths.push(current.path)
+      values[current.path] = current.value
+    }
+    if (current.state !== undefined) visit(current.state)
+    if (isRecord(current.states)) {
+      for (const child of Object.values(current.states)) visit(child)
+    }
+  }
+  visit(snapshot)
+  return {
+    activePaths,
+    values,
+    completions: isRecord(snapshot) && Array.isArray(snapshot.completed) ? snapshot.completed : [],
+    history: isRecord(snapshot) && isRecord(snapshot.history) ? snapshot.history : {}
+  }
+}
+
+const canonicalize = (value: unknown): unknown => {
+  if (value === undefined) return { $undefined: true }
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (!isRecord(value)) return value
+  return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonicalize(value[key])]))
+}
+
+const equal = (left: unknown, right: unknown): boolean =>
+  JSON.stringify(canonicalize(left)) === JSON.stringify(canonicalize(right))
+
+const get = (value: unknown, key: string): unknown => isRecord(value) ? value[key] : undefined
+
+const array = (value: unknown): ReadonlyArray<unknown> => Array.isArray(value) ? value : []
+
+const eventTag = (value: unknown): string | undefined => {
+  if (typeof value === "string") return value
+  const tag = get(value, "_tag")
+  return typeof tag === "string" ? tag : undefined
+}
+
+const completionOrderIndependent = (values: ReadonlyArray<unknown>): ReadonlyArray<unknown> =>
+  values.slice().sort((left, right) => {
+    const leftPath = get(left, "path")
+    const rightPath = get(right, "path")
+    return String(leftPath).localeCompare(String(rightPath))
+  })
+
+const historyOrderIndependent = (value: unknown): unknown => {
+  if (!isRecord(value)) return value
+  return Object.fromEntries(
+    Object.keys(value).sort().map((path) => {
+      const record = value[path]
+      if (!isRecord(record)) return [path, record]
+      const active = array(record.active).slice().sort((left, right) => String(left).localeCompare(String(right)))
+      return [path, { mode: record.mode, active, values: record.values }]
+    })
+  )
+}
+
+const projectTransition = (value: unknown): unknown => {
+  if (!isRecord(value)) return value
+  const trigger = get(value, "trigger")
+  return {
+    source: value.source,
+    trigger: isRecord(trigger)
+      ? { type: trigger.type, ...(trigger.type === "event" ? { event: trigger.event } : {}) }
+      : trigger,
+    reenter: value.reenter,
+    target: value.target,
+    resolvedTarget: value.resolvedTarget
+  }
+}
+
+/**
+ * Compares an opaque executable planner trace with the independent finite
+ * reference interpreter. The function accumulates every mismatch so shrunk
+ * counterexamples preserve the full semantic difference.
+ *
+ * @internal The public wrapper narrows `actualTrace` to `MachineTest.Trace`.
+ */
+export const verifyModelTrace = (
+  model: FiniteModel,
+  actualTrace: unknown
+): Effect.Effect<void, ModelVerificationError> => {
+  const mismatches: Array<ModelVerificationMismatch> = []
+  const add = (
+    location: ModelVerificationLocation,
+    field: ModelVerificationField,
+    expected: unknown,
+    actual: unknown
+  ): void => {
+    if (equal(expected, actual)) return
+    mismatches.push({
+      location,
+      field,
+      expected,
+      actual,
+      message: `${field} differs from the independent finite-model interpretation`
+    })
+  }
+
+  const scenario = get(actualTrace, "scenario")
+  const actualEvents = array(get(scenario, "events"))
+  const tags = actualEvents.map(eventTag)
+  for (let index = 0; index < tags.length; index++) {
+    if (tags[index] === undefined) {
+      add({ phase: "event", eventIndex: index }, "event.tag", "a string _tag", tags[index])
+    }
+  }
+  const reference = interpretModel(model, tags.map((tag) => tag ?? "<invalid-event>"))
+  const actualInitial = get(actualTrace, "initial")
+  const actualInitialPlan = get(actualInitial, "plan")
+  const initialLocation: ModelVerificationLocation = { phase: "initial" }
+
+  const compareState = (
+    location: ModelVerificationLocation,
+    field: ModelStateField,
+    expected: ReferenceState,
+    actual: unknown
+  ): void => {
+    const projected = projectState(actual)
+    add(location, `${field}.activePaths`, expected.activePaths, projected.activePaths)
+    add(location, `${field}.values`, expected.values, projected.values)
+    // Completion records are a logical cache. Their array insertion order can
+    // change when an unaffected parallel region is copied through a target,
+    // but path/output membership is the observable semantic contract.
+    add(
+      location,
+      `${field}.completions`,
+      completionOrderIndependent(expected.completions),
+      completionOrderIndependent(projected.completions)
+    )
+    add(
+      location,
+      `${field}.history`,
+      historyOrderIndependent(expected.history),
+      historyOrderIndependent(projected.history)
+    )
+  }
+
+  compareState(
+    initialLocation,
+    "initial.startingState",
+    reference.initial.startingState,
+    get(actualInitial, "startingState")
+  )
+  compareState(
+    initialLocation,
+    "initial.plan.startingState",
+    reference.initial.startingState,
+    get(actualInitialPlan, "startingState")
+  )
+  add(
+    initialLocation,
+    "initial.startingConfiguration",
+    reference.initial.startingState.activePaths,
+    get(actualInitial, "startingConfiguration")
+  )
+  add(
+    initialLocation,
+    "initial.initialEntryPaths",
+    reference.initial.initialEntryPaths,
+    get(actualInitial, "initialEntryPaths")
+  )
+  add(
+    initialLocation,
+    "initial.plan.initialEntryPaths",
+    reference.initial.initialEntryPaths,
+    get(actualInitialPlan, "initialEntryPaths")
+  )
+  compareState(initialLocation, "initial.plan.state", reference.initial.state, get(actualInitialPlan, "state"))
+  add(
+    initialLocation,
+    "initial.configuration",
+    reference.initial.state.activePaths,
+    get(actualInitial, "configuration")
+  )
+  add(initialLocation, "initial.plan.microsteps", reference.initial.microsteps, get(actualInitialPlan, "microsteps"))
+  add(initialLocation, "initial.plan.done", reference.initial.done, get(actualInitialPlan, "done"))
+  add(initialLocation, "initial.plan.output", reference.initial.output, get(actualInitialPlan, "output"))
+
+  const actualSteps = array(get(actualTrace, "steps"))
+  add({ phase: "final" }, "trace.steps.length", reference.steps.length, actualSteps.length)
+  for (let stepIndex = 0; stepIndex < reference.steps.length; stepIndex++) {
+    const expected = reference.steps[stepIndex]!
+    const actual = actualSteps[stepIndex]
+    const location: ModelVerificationLocation = { phase: "event", eventIndex: stepIndex }
+    const actualPlan = get(actual, "plan")
+    add(location, "step.index", expected.index, get(actual, "index"))
+    add(location, "step.event", expected.event, eventTag(get(actual, "event")))
+    compareState(location, "step.before", expected.before, get(actual, "before"))
+    add(location, "step.beforeConfiguration", expected.before.activePaths, get(actual, "beforeConfiguration"))
+
+    const actualMicrosteps = array(get(actualPlan, "microsteps"))
+    add(location, "step.plan.microsteps.length", expected.microsteps.length, actualMicrosteps.length)
+    for (let microstepIndex = 0; microstepIndex < expected.microsteps.length; microstepIndex++) {
+      const expectedMicrostep = expected.microsteps[microstepIndex]!
+      const actualMicrostep = actualMicrosteps[microstepIndex]
+      const microstepLocation: ModelVerificationLocation = {
+        phase: "event",
+        eventIndex: stepIndex,
+        microstepIndex
+      }
+      compareState(microstepLocation, "microstep.next", expectedMicrostep.next, get(actualMicrostep, "next"))
+      add(microstepLocation, "microstep.event", expectedMicrostep.event, eventTag(get(actualMicrostep, "event")))
+      add(
+        microstepLocation,
+        "microstep.transitions",
+        expectedMicrostep.transitions,
+        array(get(actualMicrostep, "transitions")).map(projectTransition)
+      )
+      add(microstepLocation, "microstep.exitPaths", expectedMicrostep.exitPaths, get(actualMicrostep, "exitPaths"))
+      add(microstepLocation, "microstep.entryPaths", expectedMicrostep.entryPaths, get(actualMicrostep, "entryPaths"))
+      add(microstepLocation, "microstep.changed", expectedMicrostep.changed, get(actualMicrostep, "changed"))
+    }
+
+    compareState(location, "step.plan.next", expected.after, get(actualPlan, "next"))
+    compareState(location, "step.after", expected.after, get(actual, "after"))
+    add(location, "step.afterConfiguration", expected.after.activePaths, get(actual, "afterConfiguration"))
+    add(location, "step.plan.done", expected.done, get(actualPlan, "done"))
+    add(location, "step.plan.output", expected.output, get(actualPlan, "output"))
+  }
+
+  const finalLocation: ModelVerificationLocation = { phase: "final" }
+  compareState(finalLocation, "trace.final", reference.final, get(actualTrace, "final"))
+  add(finalLocation, "trace.finalConfiguration", reference.final.activePaths, get(actualTrace, "finalConfiguration"))
+
+  return mismatches.length === 0
+    ? Effect.void
+    : Effect.fail(new ModelVerificationError({ mismatches }))
+}

--- a/src/internal/machineTestRuntime.ts
+++ b/src/internal/machineTestRuntime.ts
@@ -18,7 +18,12 @@ import * as Machine from "../Machine.js"
 
 type AnyMachine = Machine.Machine.Any
 
-/** A command applied to a running machine during model-based testing. */
+/**
+ * A command applied to a running machine during model-based testing.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export type RuntimeCommand<Event> =
   | {
     readonly _tag: "Send"
@@ -36,31 +41,54 @@ export type RuntimeCommand<Event> =
     readonly label: string | undefined
   }
 
-/** Constructs a command that sends one public event. */
+/**
+ * Constructs a command that sends one public event.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
 export const sendCommand = <Event>(event: Event): RuntimeCommand<Event> => ({
   _tag: "Send",
   event
 })
 
-/** Constructs a command that advances Effect's `TestClock`. */
+/**
+ * Constructs a command that advances Effect's `TestClock`.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
 export const advanceCommand = <Event = never>(duration: Duration.Input): RuntimeCommand<Event> => ({
   _tag: "Advance",
   duration
 })
 
-/** Constructs an idempotent command that stops the machine. */
+/**
+ * Constructs an idempotent command that stops the machine.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
 export const stopCommand = <Event = never>(): RuntimeCommand<Event> => ({ _tag: "Stop" })
 
 /**
  * Constructs a no-op command used to synchronize with work enqueued by earlier
  * commands. Its behavior is selected by the reference-model step.
+ *
+ * @category constructors
+ * @since 4.0.0
  */
 export const checkpointCommand = <Event = never>(label?: string): RuntimeCommand<Event> => ({
   _tag: "Checkpoint",
   label
 })
 
-/** The result of executing one runtime command. */
+/**
+ * The result of executing one runtime command.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export type RuntimeCommandResult =
   | { readonly _tag: "SendAccepted" }
   | { readonly _tag: "SendRejected"; readonly error: Machine.StoppedError }
@@ -76,6 +104,9 @@ export type RuntimeCommandResult =
  * `Until` also consumes intermediate snapshots and is useful for a checkpoint
  * after several queued sends. `Current` is only a sample; it should be used
  * when the model already knows there is no outstanding asynchronous work.
+ *
+ * @category models
+ * @since 4.0.0
  */
 export type RuntimeSynchronization<State, Error, Output> =
   | { readonly _tag: "None" }
@@ -86,7 +117,12 @@ export type RuntimeSynchronization<State, Error, Output> =
     readonly predicate: (snapshot: Machine.RuntimeSnapshot<State, Error, Output>) => boolean
   }
 
-/** Constructors for runtime synchronization policies. */
+/**
+ * Constructors for runtime synchronization policies.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
 export const RuntimeSynchronization = {
   none: { _tag: "None" } as const,
   current: { _tag: "Current" } as const,
@@ -96,14 +132,24 @@ export const RuntimeSynchronization = {
   ): RuntimeSynchronization<State, Error, Output> => ({ _tag: "Until", predicate })
 } as const
 
-/** The pure/reference-model result for one runtime command. */
+/**
+ * The pure/reference-model result for one runtime command.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface RuntimeModelStep<Model, Expected, State, Error, Output> {
   readonly model: Model
   readonly expected: Expected
   readonly synchronize: RuntimeSynchronization<State, Error, Output>
 }
 
-/** Actual evidence made available to a runtime command assertion. */
+/**
+ * Actual evidence made available to a runtime command assertion.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface RuntimeCommandActual<State, Error, Output, Observed> {
   readonly result: RuntimeCommandResult
   readonly snapshot: Machine.RuntimeSnapshot<State, Error, Output> | undefined
@@ -111,7 +157,12 @@ export interface RuntimeCommandActual<State, Error, Output, Observed> {
   readonly inspected: Observed | undefined
 }
 
-/** Context supplied to a custom runtime inspection effect. */
+/**
+ * Context supplied to a custom runtime inspection effect.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface RuntimeInspectionContext<State, Event, Error, Output> {
   readonly index: number
   readonly command: RuntimeCommand<Event>
@@ -121,7 +172,12 @@ export interface RuntimeInspectionContext<State, Event, Error, Output> {
   readonly published: ReadonlyArray<Machine.RuntimeSnapshot<State, Error, Output>>
 }
 
-/** Context supplied to the reference-model assertion. */
+/**
+ * Context supplied to the reference-model assertion.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface RuntimeAssertionContext<Model, Expected, State, Event, Error, Output, Observed>
   extends RuntimeInspectionContext<State, Event, Error, Output>
 {
@@ -130,7 +186,12 @@ export interface RuntimeAssertionContext<Model, Expected, State, Event, Error, O
   readonly actual: RuntimeCommandActual<State, Error, Output, Observed>
 }
 
-/** Configuration for an Effect-native runtime command-model run. */
+/**
+ * Configuration for an Effect-native runtime command-model run.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface RuntimeModelOptions<
   Model,
   Expected,
@@ -169,7 +230,12 @@ export interface RuntimeModelOptions<
   ) => Effect.Effect<void, AssertionError, AssertionServices>
 }
 
-/** One successfully checked command in a replayable runtime transcript. */
+/**
+ * One successfully checked command in a replayable runtime transcript.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface RuntimeCommandRecord<Model, Expected, State, Event, Error, Output, Observed> {
   readonly index: number
   readonly command: RuntimeCommand<Event>
@@ -178,7 +244,12 @@ export interface RuntimeCommandRecord<Model, Expected, State, Event, Error, Outp
   readonly actual: RuntimeCommandActual<State, Error, Output, Observed>
 }
 
-/** A complete command-model execution transcript. */
+/**
+ * A complete command-model execution transcript.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface RuntimeTranscript<Model, Expected, State, Event, Error, Output, Observed> {
   readonly commands: ReadonlyArray<RuntimeCommand<Event>>
   readonly initial: Machine.RuntimeSnapshot<State, Error, Output>
@@ -193,7 +264,12 @@ export interface RuntimeTranscript<Model, Expected, State, Event, Error, Output,
   readonly synchronized: boolean
 }
 
-/** Failure raised when an expected public change stream observation is absent. */
+/**
+ * Failure raised when an expected public change stream observation is absent.
+ *
+ * @category errors
+ * @since 4.0.0
+ */
 export class RuntimeObservationError extends Data.TaggedError("MachineTestRuntimeObservationError")<{
   readonly index: number
   readonly synchronization: "Next" | "Until"
@@ -201,7 +277,12 @@ export class RuntimeObservationError extends Data.TaggedError("MachineTestRuntim
   readonly message: string
 }> {}
 
-/** A typed command-model failure retaining the successfully checked prefix. */
+/**
+ * A typed command-model failure retaining the successfully checked prefix.
+ *
+ * @category errors
+ * @since 4.0.0
+ */
 export class RuntimeCommandFailure<
   Failure = unknown,
   Model = unknown,
@@ -350,6 +431,9 @@ const synchronize = <State, Event, Error, Output>(
  * inspection, and assertions are retained as full `Cause` values. A cause
  * containing only interruption is propagated as interruption so cancelling a
  * property run cannot be mistaken for a machine counterexample.
+ *
+ * @category constructors
+ * @since 4.0.0
  */
 export const runRuntimeCommands = <
   Model,
@@ -598,7 +682,12 @@ export const runRuntimeCommands = <
     })
   )
 
-/** Options controlling schema-derived runtime command generation. */
+/**
+ * Options controlling schema-derived runtime command generation.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface RuntimeCommandsOptions<M extends AnyMachine> {
   readonly minCommands?: number
   readonly maxCommands?: number
@@ -610,7 +699,12 @@ export interface RuntimeCommandsOptions<M extends AnyMachine> {
   readonly additionalCommands?: ReadonlyArray<FastCheck.Arbitrary<RuntimeCommand<Machine.Machine.InputEvent<M>>>>
 }
 
-/** Diagnostics describing a schema-derived runtime command arbitrary. */
+/**
+ * Diagnostics describing a schema-derived runtime command arbitrary.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface RuntimeCommandsDiagnostics {
   readonly events: "none" | "schema" | "override"
   readonly schemaReports: ReadonlyArray<Schema.Annotations.ToArbitrary.Report>
@@ -619,7 +713,12 @@ export interface RuntimeCommandsDiagnostics {
   readonly includesCheckpoint: boolean
 }
 
-/** A shrinkable runtime command arbitrary and its derivation diagnostics. */
+/**
+ * A shrinkable runtime command arbitrary and its derivation diagnostics.
+ *
+ * @category models
+ * @since 4.0.0
+ */
 export interface RuntimeCommands<M extends AnyMachine> {
   readonly arbitrary: FastCheck.Arbitrary<ReadonlyArray<RuntimeCommand<Machine.Machine.InputEvent<M>>>>
   readonly diagnostics: RuntimeCommandsDiagnostics
@@ -638,6 +737,9 @@ const validateCommandLength = (name: "minCommands" | "maxCommands", value: numbe
  * This deliberately returns ordinary Effect FastCheck arbitraries instead of
  * adapting the runner through `asyncModelRun`: the latter requires Promise
  * callbacks and would erase Effect error and service channels.
+ *
+ * @category constructors
+ * @since 4.0.0
  */
 export const runtimeCommands = <M extends AnyMachine>(
   machine: M,
@@ -708,7 +810,12 @@ export const runtimeCommands = <M extends AnyMachine>(
   }
 }
 
-/** Formats a runtime transcript or failure as replayable line-oriented evidence. */
+/**
+ * Formats a runtime transcript or failure as replayable line-oriented evidence.
+ *
+ * @category formatting
+ * @since 4.0.0
+ */
 export const formatRuntimeTranscript = (
   value:
     | RuntimeTranscript<any, any, any, any, any, any, any>

--- a/src/internal/machineTestRuntime.ts
+++ b/src/internal/machineTestRuntime.ts
@@ -1,0 +1,765 @@
+/**
+ * Effect-native command-model testing for live machine references.
+ *
+ * @since 4.0.0
+ */
+
+import * as Cause from "effect/Cause"
+import * as Data from "effect/Data"
+import * as Deferred from "effect/Deferred"
+import * as Duration from "effect/Duration"
+import * as Effect from "effect/Effect"
+import * as Inspectable from "effect/Inspectable"
+import * as Queue from "effect/Queue"
+import * as Schema from "effect/Schema"
+import * as Stream from "effect/Stream"
+import { FastCheck, TestClock } from "effect/testing"
+import * as Machine from "../Machine.js"
+
+type AnyMachine = Machine.Machine.Any
+
+/** A command applied to a running machine during model-based testing. */
+export type RuntimeCommand<Event> =
+  | {
+    readonly _tag: "Send"
+    readonly event: Event
+  }
+  | {
+    readonly _tag: "Advance"
+    readonly duration: Duration.Input
+  }
+  | {
+    readonly _tag: "Stop"
+  }
+  | {
+    readonly _tag: "Checkpoint"
+    readonly label: string | undefined
+  }
+
+/** Constructs a command that sends one public event. */
+export const sendCommand = <Event>(event: Event): RuntimeCommand<Event> => ({
+  _tag: "Send",
+  event
+})
+
+/** Constructs a command that advances Effect's `TestClock`. */
+export const advanceCommand = <Event = never>(duration: Duration.Input): RuntimeCommand<Event> => ({
+  _tag: "Advance",
+  duration
+})
+
+/** Constructs an idempotent command that stops the machine. */
+export const stopCommand = <Event = never>(): RuntimeCommand<Event> => ({ _tag: "Stop" })
+
+/**
+ * Constructs a no-op command used to synchronize with work enqueued by earlier
+ * commands. Its behavior is selected by the reference-model step.
+ */
+export const checkpointCommand = <Event = never>(label?: string): RuntimeCommand<Event> => ({
+  _tag: "Checkpoint",
+  label
+})
+
+/** The result of executing one runtime command. */
+export type RuntimeCommandResult =
+  | { readonly _tag: "SendAccepted" }
+  | { readonly _tag: "SendRejected"; readonly error: Machine.StoppedError }
+  | { readonly _tag: "ClockAdvanced" }
+  | { readonly _tag: "Stopped" }
+  | { readonly _tag: "Checkpoint" }
+
+/**
+ * Defines how a model step synchronizes with public machine observations.
+ *
+ * `None` is appropriate when a send is intentionally only enqueued. `Next`
+ * consumes the next snapshot published after the previously consumed one.
+ * `Until` also consumes intermediate snapshots and is useful for a checkpoint
+ * after several queued sends. `Current` is only a sample; it should be used
+ * when the model already knows there is no outstanding asynchronous work.
+ */
+export type RuntimeSynchronization<State, Error, Output> =
+  | { readonly _tag: "None" }
+  | { readonly _tag: "Current" }
+  | { readonly _tag: "Next" }
+  | {
+    readonly _tag: "Until"
+    readonly predicate: (snapshot: Machine.RuntimeSnapshot<State, Error, Output>) => boolean
+  }
+
+/** Constructors for runtime synchronization policies. */
+export const RuntimeSynchronization = {
+  none: { _tag: "None" } as const,
+  current: { _tag: "Current" } as const,
+  next: { _tag: "Next" } as const,
+  until: <State, Error = never, Output = never>(
+    predicate: (snapshot: Machine.RuntimeSnapshot<State, Error, Output>) => boolean
+  ): RuntimeSynchronization<State, Error, Output> => ({ _tag: "Until", predicate })
+} as const
+
+/** The pure/reference-model result for one runtime command. */
+export interface RuntimeModelStep<Model, Expected, State, Error, Output> {
+  readonly model: Model
+  readonly expected: Expected
+  readonly synchronize: RuntimeSynchronization<State, Error, Output>
+}
+
+/** Actual evidence made available to a runtime command assertion. */
+export interface RuntimeCommandActual<State, Error, Output, Observed> {
+  readonly result: RuntimeCommandResult
+  readonly snapshot: Machine.RuntimeSnapshot<State, Error, Output> | undefined
+  readonly published: ReadonlyArray<Machine.RuntimeSnapshot<State, Error, Output>>
+  readonly inspected: Observed | undefined
+}
+
+/** Context supplied to a custom runtime inspection effect. */
+export interface RuntimeInspectionContext<State, Event, Error, Output> {
+  readonly index: number
+  readonly command: RuntimeCommand<Event>
+  readonly result: RuntimeCommandResult
+  readonly ref: Machine.MachineRef<State, Event, Error, Output>
+  readonly snapshot: Machine.RuntimeSnapshot<State, Error, Output> | undefined
+  readonly published: ReadonlyArray<Machine.RuntimeSnapshot<State, Error, Output>>
+}
+
+/** Context supplied to the reference-model assertion. */
+export interface RuntimeAssertionContext<Model, Expected, State, Event, Error, Output, Observed>
+  extends RuntimeInspectionContext<State, Event, Error, Output>
+{
+  readonly model: Model
+  readonly expected: Expected
+  readonly actual: RuntimeCommandActual<State, Error, Output, Observed>
+}
+
+/** Configuration for an Effect-native runtime command-model run. */
+export interface RuntimeModelOptions<
+  Model,
+  Expected,
+  State,
+  Event,
+  Error,
+  Output,
+  Observed = never,
+  ModelError = never,
+  ModelServices = never,
+  InspectionError = never,
+  InspectionServices = never,
+  AssertionError = never,
+  AssertionServices = never
+> {
+  readonly initialModel: Model
+  /**
+   * Live-clock bound for `Next` and `Until` synchronization. Defaults to one
+   * second and never advances the machine's virtual `TestClock`.
+   */
+  readonly observationTimeout?: Duration.Input
+  readonly transition: (
+    model: Model,
+    command: RuntimeCommand<Event>,
+    index: number
+  ) => Effect.Effect<
+    RuntimeModelStep<Model, Expected, State, Error, Output>,
+    ModelError,
+    ModelServices
+  >
+  readonly inspect?: (
+    context: RuntimeInspectionContext<State, Event, Error, Output>
+  ) => Effect.Effect<Observed, InspectionError, InspectionServices>
+  readonly assert: (
+    context: RuntimeAssertionContext<Model, Expected, State, Event, Error, Output, Observed>
+  ) => Effect.Effect<void, AssertionError, AssertionServices>
+}
+
+/** One successfully checked command in a replayable runtime transcript. */
+export interface RuntimeCommandRecord<Model, Expected, State, Event, Error, Output, Observed> {
+  readonly index: number
+  readonly command: RuntimeCommand<Event>
+  readonly model: Model
+  readonly expected: Expected
+  readonly actual: RuntimeCommandActual<State, Error, Output, Observed>
+}
+
+/** A complete command-model execution transcript. */
+export interface RuntimeTranscript<Model, Expected, State, Event, Error, Output, Observed> {
+  readonly commands: ReadonlyArray<RuntimeCommand<Event>>
+  readonly initial: Machine.RuntimeSnapshot<State, Error, Output>
+  readonly records: ReadonlyArray<RuntimeCommandRecord<Model, Expected, State, Event, Error, Output, Observed>>
+  readonly finalModel: Model
+  /** The last explicitly synchronized snapshot, never a racy trailing sample. */
+  readonly final: Machine.RuntimeSnapshot<State, Error, Output>
+  /**
+   * `false` when potentially outstanding work has not been bounded by an
+   * `Until` predicate or a terminal snapshot.
+   */
+  readonly synchronized: boolean
+}
+
+/** Failure raised when an expected public change stream observation is absent. */
+export class RuntimeObservationError extends Data.TaggedError("MachineTestRuntimeObservationError")<{
+  readonly index: number
+  readonly synchronization: "Next" | "Until"
+  readonly reason: "ended" | "timeout"
+  readonly message: string
+}> {}
+
+/** A typed command-model failure retaining the successfully checked prefix. */
+export class RuntimeCommandFailure<
+  Failure = unknown,
+  Model = unknown,
+  Expected = unknown,
+  State = unknown,
+  Event = unknown,
+  Error = unknown,
+  Output = unknown,
+  Observed = unknown
+> extends Data.TaggedError("MachineTestRuntimeCommandFailure")<{
+  readonly phase: "model" | "execution" | "observation" | "inspection" | "assertion"
+  readonly index: number
+  readonly command: RuntimeCommand<Event>
+  readonly cause: Cause.Cause<Failure>
+  readonly prefix: ReadonlyArray<RuntimeCommandRecord<Model, Expected, State, Event, Error, Output, Observed>>
+  readonly attempted: RuntimeCommandRecord<Model, Expected, State, Event, Error, Output, Observed> | undefined
+}> {}
+
+type ChangeEntry<State, Error, Output> =
+  | { readonly _tag: "Snapshot"; readonly snapshot: Machine.RuntimeSnapshot<State, Error, Output> }
+  | { readonly _tag: "End" }
+
+const makeFailure = <Failure, Model, Expected, State, Event, Error, Output, Observed>(options: {
+  readonly phase: "model" | "execution" | "observation" | "inspection" | "assertion"
+  readonly index: number
+  readonly command: RuntimeCommand<Event>
+  readonly cause: Cause.Cause<Failure>
+  readonly prefix: ReadonlyArray<RuntimeCommandRecord<Model, Expected, State, Event, Error, Output, Observed>>
+  readonly attempted?: RuntimeCommandRecord<Model, Expected, State, Event, Error, Output, Observed>
+}): RuntimeCommandFailure<Failure, Model, Expected, State, Event, Error, Output, Observed> =>
+  new RuntimeCommandFailure({
+    ...options,
+    prefix: options.prefix.slice(),
+    attempted: options.attempted
+  })
+
+const executeCommand = <State, Event, Error, Output>(
+  ref: Machine.MachineRef<State, Event, Error, Output>,
+  command: RuntimeCommand<Event>
+): Effect.Effect<RuntimeCommandResult> => {
+  switch (command._tag) {
+    case "Send":
+      return ref.send(command.event).pipe(
+        Effect.match({
+          onFailure: (error): RuntimeCommandResult => ({ _tag: "SendRejected", error }),
+          onSuccess: (): RuntimeCommandResult => ({ _tag: "SendAccepted" })
+        })
+      )
+    case "Advance":
+      return TestClock.adjust(command.duration).pipe(Effect.as({ _tag: "ClockAdvanced" } as const))
+    case "Stop":
+      return ref.stop.pipe(Effect.as({ _tag: "Stopped" } as const))
+    case "Checkpoint":
+      return Effect.succeed({ _tag: "Checkpoint" } as const)
+  }
+}
+
+const synchronize = <State, Event, Error, Output>(
+  ref: Machine.MachineRef<State, Event, Error, Output>,
+  queue: Queue.Dequeue<ChangeEntry<State, Error, Output>>,
+  policy: RuntimeSynchronization<State, Error, Output>,
+  index: number,
+  timeout: Duration.Input
+): Effect.Effect<{
+  readonly snapshot: Machine.RuntimeSnapshot<State, Error, Output> | undefined
+  readonly published: ReadonlyArray<Machine.RuntimeSnapshot<State, Error, Output>>
+}, RuntimeObservationError> => {
+  const wait = <A>(
+    synchronization: "Next" | "Until",
+    effect: Effect.Effect<A, RuntimeObservationError>
+  ): Effect.Effect<A, RuntimeObservationError> =>
+    TestClock.withLive(effect.pipe(Effect.timeout(timeout))).pipe(
+      Effect.mapError((cause) =>
+        cause instanceof RuntimeObservationError
+          ? cause
+          : new RuntimeObservationError({
+            index,
+            synchronization,
+            reason: "timeout",
+            message: `timed out after ${Duration.toMillis(timeout)}ms waiting for the expected published snapshot`
+          })
+      )
+    )
+  switch (policy._tag) {
+    case "None":
+      return Effect.succeed({ snapshot: undefined, published: [] })
+    case "Current":
+      return ref.snapshot.pipe(Effect.map((snapshot) => ({ snapshot, published: [] })))
+    case "Next":
+      return wait(
+        "Next",
+        Queue.take(queue).pipe(
+          Effect.flatMap((entry) =>
+            entry._tag === "Snapshot"
+              ? Effect.succeed({ snapshot: entry.snapshot, published: [entry.snapshot] })
+              : Effect.fail(
+                new RuntimeObservationError({
+                  index,
+                  synchronization: "Next",
+                  reason: "ended",
+                  message: "the machine changes stream ended before publishing the expected snapshot"
+                })
+              )
+          )
+        )
+      )
+    case "Until":
+      return wait(
+        "Until",
+        Effect.gen(function*() {
+          const published: Array<Machine.RuntimeSnapshot<State, Error, Output>> = []
+          while (true) {
+            const entry = yield* Queue.take(queue)
+            if (entry._tag === "End") {
+              return yield* Effect.fail(
+                new RuntimeObservationError({
+                  index,
+                  synchronization: "Until",
+                  reason: "ended",
+                  message: "the machine changes stream ended before a published snapshot matched the predicate"
+                })
+              )
+            }
+            published.push(entry.snapshot)
+            if (policy.predicate(entry.snapshot)) {
+              return { snapshot: entry.snapshot, published }
+            }
+          }
+        })
+      )
+  }
+}
+
+/**
+ * Runs typed commands against a live `MachineRef` and checks them against a
+ * supplied Effect-native reference model.
+ *
+ * The runner observes only public `MachineRef` behavior. In particular, a
+ * successful send means enqueue acceptance, not completed processing. A model
+ * must request `Next`/`Until` only when it predicts a publication, or use an
+ * explicit checkpoint to drain previously enqueued work. Machine emissions can
+ * be captured by the runtime service used by the machine and returned from the
+ * optional `inspect` effect.
+ *
+ * Typed failures and defects from model transitions, command execution,
+ * inspection, and assertions are retained as full `Cause` values. A cause
+ * containing only interruption is propagated as interruption so cancelling a
+ * property run cannot be mistaken for a machine counterexample.
+ */
+export const runRuntimeCommands = <
+  Model,
+  Expected,
+  State,
+  Event,
+  Error,
+  Output,
+  Observed = never,
+  ModelError = never,
+  ModelServices = never,
+  InspectionError = never,
+  InspectionServices = never,
+  AssertionError = never,
+  AssertionServices = never
+>(
+  ref: Machine.MachineRef<State, Event, Error, Output>,
+  commands: Iterable<RuntimeCommand<Event>>,
+  options: RuntimeModelOptions<
+    Model,
+    Expected,
+    State,
+    Event,
+    Error,
+    Output,
+    Observed,
+    ModelError,
+    ModelServices,
+    InspectionError,
+    InspectionServices,
+    AssertionError,
+    AssertionServices
+  >
+): Effect.Effect<
+  RuntimeTranscript<Model, Expected, State, Event, Error, Output, Observed>,
+  RuntimeCommandFailure<
+    ModelError | InspectionError | AssertionError | RuntimeObservationError,
+    Model,
+    Expected,
+    State,
+    Event,
+    Error,
+    Output,
+    Observed
+  >,
+  ModelServices | InspectionServices | AssertionServices
+> =>
+  Effect.scoped(
+    Effect.gen(function*() {
+      const sequence = Array.from(commands)
+      const observationTimeout = options.observationTimeout ?? "1 second"
+      const observationTimeoutMillis = Duration.toMillis(observationTimeout)
+      if (!Number.isFinite(observationTimeoutMillis) || observationTimeoutMillis < 0) {
+        return yield* Effect.die(
+          new Error("MachineTest.runRuntimeCommands expected observationTimeout to be a finite non-negative duration")
+        )
+      }
+      const changes = yield* Queue.unbounded<ChangeEntry<State, Error, Output>>()
+      const ready = yield* Deferred.make<void>()
+      yield* ref.changes.pipe(
+        Stream.runForEach((snapshot) =>
+          Queue.offer(changes, { _tag: "Snapshot", snapshot }).pipe(
+            Effect.andThen(Deferred.succeed(ready, undefined)),
+            Effect.asVoid
+          )
+        ),
+        Effect.ensuring(
+          Deferred.succeed(ready, undefined).pipe(
+            Effect.andThen(Queue.offer(changes, { _tag: "End" })),
+            Effect.asVoid
+          )
+        ),
+        Effect.forkScoped({ startImmediately: true })
+      )
+      yield* Deferred.await(ready)
+      const initialEntry = yield* Queue.take(changes)
+      const initial = initialEntry._tag === "Snapshot" ? initialEntry.snapshot : yield* ref.snapshot
+      const records: Array<RuntimeCommandRecord<Model, Expected, State, Event, Error, Output, Observed>> = []
+      let model = options.initialModel
+      let lastSynchronized = initial
+      let outstandingWorkUnknown = false
+
+      const capture = <A, Failure, R>(options: {
+        readonly phase: "model" | "observation" | "inspection" | "assertion" | "execution"
+        readonly index: number
+        readonly command: RuntimeCommand<Event>
+        readonly effect: () => Effect.Effect<A, Failure, R>
+        readonly attempted?: RuntimeCommandRecord<Model, Expected, State, Event, Error, Output, Observed>
+      }): Effect.Effect<
+        A,
+        RuntimeCommandFailure<Failure, Model, Expected, State, Event, Error, Output, Observed>,
+        R
+      > =>
+        Effect.catchCause(Effect.suspend(options.effect), (cause) =>
+          Cause.hasInterruptsOnly(cause)
+            ? Effect.failCause(cause as Cause.Cause<never>)
+            : Effect.fail(
+              makeFailure<Failure, Model, Expected, State, Event, Error, Output, Observed>({
+                phase: options.phase,
+                index: options.index,
+                command: options.command,
+                cause,
+                prefix: records,
+                ...(options.attempted === undefined ? {} : { attempted: options.attempted })
+              })
+            ))
+
+      for (let index = 0; index < sequence.length; index++) {
+        const command = sequence[index]!
+        const step = yield* capture({
+          phase: "model",
+          index,
+          command,
+          effect: () => options.transition(model, command, index)
+        })
+        model = step.model
+        const result = yield* capture({
+          phase: "execution",
+          index,
+          command,
+          effect: () => executeCommand(ref, command)
+        })
+        const attemptedBeforeObservation: RuntimeCommandRecord<
+          Model,
+          Expected,
+          State,
+          Event,
+          Error,
+          Output,
+          Observed
+        > = {
+          index,
+          command,
+          model,
+          expected: step.expected,
+          actual: {
+            result,
+            snapshot: undefined,
+            published: [],
+            inspected: undefined
+          }
+        }
+        const synchronized = yield* capture({
+          phase: "observation",
+          index,
+          command,
+          effect: () => synchronize(ref, changes, step.synchronize, index, observationTimeout),
+          attempted: attemptedBeforeObservation
+        })
+        const terminal = synchronized.snapshot !== undefined && synchronized.snapshot.status !== "active"
+        const previouslyOutstanding: boolean = outstandingWorkUnknown
+        switch (step.synchronize._tag) {
+          case "None":
+            if (
+              command._tag === "Advance" || command._tag === "Stop" ||
+              (command._tag === "Send" && result._tag === "SendAccepted")
+            ) outstandingWorkUnknown = true
+            break
+          case "Next":
+            if (synchronized.snapshot !== undefined) lastSynchronized = synchronized.snapshot
+            outstandingWorkUnknown = terminal
+              ? false
+              : previouslyOutstanding || command._tag === "Advance" ||
+                (command._tag === "Send" && result._tag === "SendAccepted")
+            break
+          case "Until":
+            if (synchronized.snapshot !== undefined) lastSynchronized = synchronized.snapshot
+            outstandingWorkUnknown = false
+            break
+          case "Current":
+            if (terminal) outstandingWorkUnknown = false
+            if (!outstandingWorkUnknown && synchronized.snapshot !== undefined) lastSynchronized = synchronized.snapshot
+            break
+        }
+        const inspectionContext: RuntimeInspectionContext<State, Event, Error, Output> = {
+          index,
+          command,
+          result,
+          ref,
+          snapshot: synchronized.snapshot,
+          published: synchronized.published
+        }
+        const attemptedBeforeInspection: RuntimeCommandRecord<
+          Model,
+          Expected,
+          State,
+          Event,
+          Error,
+          Output,
+          Observed
+        > = {
+          ...attemptedBeforeObservation,
+          actual: {
+            result,
+            snapshot: synchronized.snapshot,
+            published: synchronized.published,
+            inspected: undefined
+          }
+        }
+        const inspected = options.inspect === undefined
+          ? undefined
+          : yield* capture({
+            phase: "inspection",
+            index,
+            command,
+            effect: () => options.inspect!(inspectionContext),
+            attempted: attemptedBeforeInspection
+          })
+        const actual: RuntimeCommandActual<State, Error, Output, Observed> = {
+          result,
+          snapshot: synchronized.snapshot,
+          published: synchronized.published,
+          inspected
+        }
+        const record: RuntimeCommandRecord<Model, Expected, State, Event, Error, Output, Observed> = {
+          index,
+          command,
+          model,
+          expected: step.expected,
+          actual
+        }
+        yield* capture({
+          phase: "assertion",
+          index,
+          command,
+          effect: () =>
+            options.assert({
+              ...inspectionContext,
+              model,
+              expected: step.expected,
+              actual
+            }),
+          attempted: record
+        })
+        records.push(record)
+      }
+
+      return {
+        commands: sequence,
+        initial,
+        records,
+        finalModel: model,
+        final: lastSynchronized,
+        synchronized: !outstandingWorkUnknown
+      }
+    })
+  )
+
+/** Options controlling schema-derived runtime command generation. */
+export interface RuntimeCommandsOptions<M extends AnyMachine> {
+  readonly minCommands?: number
+  readonly maxCommands?: number
+  readonly eventArbitrary?: FastCheck.Arbitrary<Machine.Machine.InputEvent<M>>
+  readonly advanceArbitrary?: FastCheck.Arbitrary<Duration.Input>
+  readonly includeAdvance?: boolean
+  readonly includeStop?: boolean
+  readonly includeCheckpoint?: boolean
+  readonly additionalCommands?: ReadonlyArray<FastCheck.Arbitrary<RuntimeCommand<Machine.Machine.InputEvent<M>>>>
+}
+
+/** Diagnostics describing a schema-derived runtime command arbitrary. */
+export interface RuntimeCommandsDiagnostics {
+  readonly events: "none" | "schema" | "override"
+  readonly schemaReports: ReadonlyArray<Schema.Annotations.ToArbitrary.Report>
+  readonly includesAdvance: boolean
+  readonly includesStop: boolean
+  readonly includesCheckpoint: boolean
+}
+
+/** A shrinkable runtime command arbitrary and its derivation diagnostics. */
+export interface RuntimeCommands<M extends AnyMachine> {
+  readonly arbitrary: FastCheck.Arbitrary<ReadonlyArray<RuntimeCommand<Machine.Machine.InputEvent<M>>>>
+  readonly diagnostics: RuntimeCommandsDiagnostics
+}
+
+const validateCommandLength = (name: "minCommands" | "maxCommands", value: number): void => {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`MachineTest.runtimeCommands expected ${name} to be a non-negative safe integer`)
+  }
+}
+
+/**
+ * Derives a shrinkable command sequence from public event schemas and explicit
+ * clock/stop/checkpoint command choices.
+ *
+ * This deliberately returns ordinary Effect FastCheck arbitraries instead of
+ * adapting the runner through `asyncModelRun`: the latter requires Promise
+ * callbacks and would erase Effect error and service channels.
+ */
+export const runtimeCommands = <M extends AnyMachine>(
+  machine: M,
+  options: RuntimeCommandsOptions<M> = {}
+): RuntimeCommands<M> => {
+  const minCommands = options.minCommands ?? 0
+  const maxCommands = options.maxCommands ?? 50
+  validateCommandLength("minCommands", minCommands)
+  validateCommandLength("maxCommands", maxCommands)
+  if (minCommands > maxCommands) {
+    throw new Error("MachineTest.runtimeCommands expected minCommands to be less than or equal to maxCommands")
+  }
+
+  const reports: Array<Schema.Annotations.ToArbitrary.Report> = []
+  const eventArbitraries = options.eventArbitrary === undefined
+    ? machine.events.map((schema) => {
+      const derived = Schema.toArbitrary(schema, { report: true })
+      reports.push(derived.report)
+      return derived.value as FastCheck.Arbitrary<Machine.Machine.InputEvent<M>>
+    })
+    : []
+  const eventArbitrary = options.eventArbitrary ?? (eventArbitraries.length === 0
+    ? undefined
+    : FastCheck.oneof(
+      ...eventArbitraries as [
+        FastCheck.Arbitrary<Machine.Machine.InputEvent<M>>,
+        ...Array<FastCheck.Arbitrary<Machine.Machine.InputEvent<M>>>
+      ]
+    ))
+  const commandArbitraries: Array<FastCheck.Arbitrary<RuntimeCommand<Machine.Machine.InputEvent<M>>>> = []
+  if (eventArbitrary !== undefined) commandArbitraries.push(eventArbitrary.map(sendCommand))
+
+  if (options.includeAdvance !== false) {
+    const advanceArbitrary = options.advanceArbitrary ?? FastCheck.nat({ max: 60_000 })
+    commandArbitraries.push(advanceArbitrary.map(advanceCommand))
+  }
+  if (options.includeStop !== false) commandArbitraries.push(FastCheck.constant(stopCommand()))
+  if (options.includeCheckpoint !== false) commandArbitraries.push(FastCheck.constant(checkpointCommand()))
+  commandArbitraries.push(...options.additionalCommands ?? [])
+  if (commandArbitraries.length === 0) {
+    if (minCommands > 0) {
+      throw new Error("MachineTest.runtimeCommands cannot generate a non-empty command sequence without commands")
+    }
+    return {
+      arbitrary: FastCheck.constant([]),
+      diagnostics: {
+        events: options.eventArbitrary !== undefined ? "override" : eventArbitraries.length === 0 ? "none" : "schema",
+        schemaReports: reports,
+        includesAdvance: false,
+        includesStop: false,
+        includesCheckpoint: false
+      }
+    }
+  }
+
+  return {
+    arbitrary: FastCheck.array(FastCheck.oneof(...commandArbitraries), {
+      minLength: minCommands,
+      maxLength: maxCommands
+    }),
+    diagnostics: {
+      events: options.eventArbitrary !== undefined ? "override" : eventArbitraries.length === 0 ? "none" : "schema",
+      schemaReports: reports,
+      includesAdvance: options.includeAdvance !== false,
+      includesStop: options.includeStop !== false,
+      includesCheckpoint: options.includeCheckpoint !== false
+    }
+  }
+}
+
+/** Formats a runtime transcript or failure as replayable line-oriented evidence. */
+export const formatRuntimeTranscript = (
+  value:
+    | RuntimeTranscript<any, any, any, any, any, any, any>
+    | RuntimeCommandFailure<any, any, any, any, any, any, any, any>
+): string => {
+  const failure = value instanceof RuntimeCommandFailure
+  const records = failure ? value.prefix : value.records
+  const lines = [
+    `commands: ${
+      Inspectable.toStringUnknown(
+        failure ?
+          [
+            ...value.prefix.map((record) => record.command),
+            value.command
+          ] :
+          value.commands,
+        0
+      )
+    }`
+  ]
+  for (const record of records) {
+    lines.push(
+      `command ${record.index}: command=${Inspectable.toStringUnknown(record.command, 0)} ` +
+        `model=${Inspectable.toStringUnknown(record.model, 0)} ` +
+        `expected=${Inspectable.toStringUnknown(record.expected, 0)} ` +
+        `result=${Inspectable.toStringUnknown(record.actual.result, 0)} ` +
+        `snapshot=${Inspectable.toStringUnknown(record.actual.snapshot, 0)} ` +
+        `published=${Inspectable.toStringUnknown(record.actual.published, 0)} ` +
+        `inspected=${Inspectable.toStringUnknown(record.actual.inspected, 0)}`
+    )
+  }
+  if (failure) {
+    if (value.attempted !== undefined) {
+      lines.push(
+        `attempted ${value.attempted.index}: command=${Inspectable.toStringUnknown(value.attempted.command, 0)} ` +
+          `model=${Inspectable.toStringUnknown(value.attempted.model, 0)} ` +
+          `expected=${Inspectable.toStringUnknown(value.attempted.expected, 0)} ` +
+          `result=${Inspectable.toStringUnknown(value.attempted.actual.result, 0)} ` +
+          `snapshot=${Inspectable.toStringUnknown(value.attempted.actual.snapshot, 0)} ` +
+          `published=${Inspectable.toStringUnknown(value.attempted.actual.published, 0)} ` +
+          `inspected=${Inspectable.toStringUnknown(value.attempted.actual.inspected, 0)}`
+      )
+    }
+    lines.push(
+      `failure: phase=${value.phase} index=${value.index} command=${Inspectable.toStringUnknown(value.command, 0)} ` +
+        `cause=${Inspectable.toStringUnknown(value.cause, 0)}`
+    )
+  } else {
+    lines.push(
+      `final: synchronized=${String(value.synchronized)} snapshot=${Inspectable.toStringUnknown(value.final, 0)}`
+    )
+  }
+  return lines.join("\n")
+}

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,0 +1,7 @@
+/**
+ * Property-based testing and planner trace utilities.
+ *
+ * @since 4.0.0
+ */
+
+export * as MachineTest from "./MachineTest.js"

--- a/test/Machine.test.ts
+++ b/test/Machine.test.ts
@@ -3992,6 +3992,335 @@ describe("Machine", () => {
       })
     }))
 
+  it.effect("preserves simultaneous value-only updates in separate parallel regions", () =>
+    Effect.gen(function*() {
+      const deferredLog = yield* makeDeferredLog
+      const fulfillment = new Fulfillment({ id: "fulfillment-1" })
+      const inventory = new Inventory({ warehouse: "warehouse-1" })
+      const shipping = new Shipping({ address: "Main Street" })
+      const states = Machine.defineStates({
+        fulfillment: {
+          schema: Fulfillment,
+          type: "parallel",
+          states: {
+            inventory: {
+              schema: Inventory,
+              initial: "checking",
+              states: { checking: CheckingInventory }
+            },
+            shipping: {
+              schema: Shipping,
+              initial: "quoting",
+              states: { quoting: QuotingShipping }
+            }
+          }
+        }
+      })
+      const machine = Machine.make({
+        states: states.states,
+        events: [ReserveInventory],
+        initial: () =>
+          states.initial.fulfillment(fulfillment, (regions) =>
+            regions
+              .inventory(inventory, (region) => region.checking(new CheckingInventory({ sku: "sku-1" })))
+              .shipping(shipping, (region) => region.quoting(new QuotingShipping({ postalCode: "10000" }))))
+      }).handle({
+        fulfillment: {
+          states: {
+            inventory: {
+              states: {
+                checking: {
+                  on: {
+                    ReserveInventory: Effect.fn(function*({ event, target }) {
+                      const deferredLog = yield* DeferredLog
+                      yield* Machine.action(deferredLog.push("transition:inventory:value"))
+                      return target.local.checking(
+                        new CheckingInventory({ sku: `${event.reservationId}:inventory` })
+                      )
+                    })
+                  }
+                }
+              }
+            },
+            shipping: {
+              states: {
+                quoting: {
+                  on: {
+                    ReserveInventory: Effect.fn(function*({ event, target }) {
+                      const deferredLog = yield* DeferredLog
+                      yield* Machine.action(deferredLog.push("transition:shipping:value"))
+                      return target.local.quoting(
+                        new QuotingShipping({ postalCode: `${event.reservationId}:shipping` })
+                      )
+                    })
+                  }
+                }
+              }
+            }
+          }
+        }
+      })
+
+      const initial = yield* Machine.planInitial(machine).pipe(Effect.provideService(DeferredLog, deferredLog))
+      const planned = yield* Machine.plan(
+        machine,
+        initial.state,
+        new ReserveInventory({ reservationId: "request-42" })
+      ).pipe(Effect.provideService(DeferredLog, deferredLog))
+
+      assertParallelStateSnapshot(planned.next as any, "fulfillment", fulfillment, {
+        inventory: {
+          path: "fulfillment.inventory",
+          value: inventory,
+          state: {
+            path: "fulfillment.inventory.checking",
+            value: new CheckingInventory({ sku: "request-42:inventory" })
+          }
+        },
+        shipping: {
+          path: "fulfillment.shipping",
+          value: shipping,
+          state: {
+            path: "fulfillment.shipping.quoting",
+            value: new QuotingShipping({ postalCode: "request-42:shipping" })
+          }
+        }
+      })
+      assert.strictEqual(planned.microsteps[0]!.changed, false)
+      assert.deepStrictEqual(
+        planned.microsteps[0]!.transitions.map(({ resolvedTarget, source, target }) => ({
+          source,
+          target,
+          resolvedTarget
+        })),
+        [
+          {
+            source: "fulfillment.inventory.checking",
+            target: "fulfillment.inventory.checking",
+            resolvedTarget: "fulfillment.inventory.checking"
+          },
+          {
+            source: "fulfillment.shipping.quoting",
+            target: "fulfillment.shipping.quoting",
+            resolvedTarget: "fulfillment.shipping.quoting"
+          }
+        ]
+      )
+      assert.strictEqual(planned.microsteps[0]!.actions.length, 2)
+      assert.deepStrictEqual(yield* deferredLog.read, [])
+
+      const actor = yield* Machine.start(machine).pipe(Effect.provideService(DeferredLog, deferredLog))
+      yield* sendAndWaitForSnapshot(
+        actor,
+        new ReserveInventory({ reservationId: "request-42" }),
+        (snapshot) =>
+          snapshot.state.path === "fulfillment" &&
+          (snapshot.state as any).states.inventory.state.value.sku === "request-42:inventory" &&
+          (snapshot.state as any).states.shipping.state.value.postalCode === "request-42:shipping"
+      )
+      yield* Effect.yieldNow
+
+      assert.deepStrictEqual(yield* deferredLog.read, [
+        "transition:inventory:value",
+        "transition:shipping:value"
+      ])
+    }))
+
+  it.effect("keeps transition metadata and staged actions in document order across target application phases", () =>
+    Effect.gen(function*() {
+      const deferredLog = yield* makeDeferredLog
+      const fulfillment = new Fulfillment({ id: "fulfillment-1" })
+      const inventory = new Inventory({ warehouse: "warehouse-1" })
+      const checking = new CheckingInventory({ sku: "sku-1" })
+      const shipping = new Shipping({ address: "Main Street" })
+      const quoting = new QuotingShipping({ postalCode: "10000" })
+      const states = Machine.defineStates({
+        fulfillment: {
+          schema: Fulfillment,
+          type: "parallel",
+          states: {
+            inventory: {
+              schema: Inventory,
+              initial: "checking",
+              states: { checking: CheckingInventory, reserved: InventoryReserved }
+            },
+            shipping: {
+              schema: Shipping,
+              initial: "quoting",
+              states: { quoting: QuotingShipping, quoted: ShippingQuoted }
+            }
+          }
+        }
+      })
+      const machine = Machine.make({
+        states: states.states,
+        events: [Resolve, Reset],
+        initial: () =>
+          states.initial.fulfillment(fulfillment, (regions) =>
+            regions
+              .inventory(inventory, (region) => region.checking(checking))
+              .shipping(shipping, (region) => region.quoting(quoting)))
+      }).handle({
+        fulfillment: {
+          states: {
+            inventory: {
+              states: {
+                checking: {
+                  on: {
+                    Resolve: Effect.fn(function*({ target }) {
+                      const deferredLog = yield* DeferredLog
+                      yield* Machine.action(deferredLog.push("resolve:inventory:changed"))
+                      return target.local.reserved(new InventoryReserved({ reservationId: "resolved" }))
+                    }),
+                    Reset: Effect.fn(function*({ target }) {
+                      const deferredLog = yield* DeferredLog
+                      yield* Machine.action(deferredLog.push("reset:inventory:value"))
+                      return target.local.checking(new CheckingInventory({ sku: "reset" }))
+                    })
+                  }
+                }
+              }
+            },
+            shipping: {
+              states: {
+                quoting: {
+                  on: {
+                    Resolve: Effect.fn(function*({ target }) {
+                      const deferredLog = yield* DeferredLog
+                      yield* Machine.action(deferredLog.push("resolve:shipping:value"))
+                      return target.local.quoting(new QuotingShipping({ postalCode: "resolved" }))
+                    }),
+                    Reset: Effect.fn(function*({ target }) {
+                      const deferredLog = yield* DeferredLog
+                      yield* Machine.action(deferredLog.push("reset:shipping:changed"))
+                      return target.local.quoted(new ShippingQuoted({ quoteId: "reset" }))
+                    })
+                  }
+                }
+              }
+            }
+          }
+        }
+      })
+
+      const initial = yield* Machine.planInitial(machine).pipe(Effect.provideService(DeferredLog, deferredLog))
+      const changedThenValue = yield* Machine.plan(machine, initial.state, new Resolve({})).pipe(
+        Effect.provideService(DeferredLog, deferredLog)
+      )
+      assertParallelStateSnapshot(changedThenValue.next as any, "fulfillment", fulfillment, {
+        inventory: {
+          path: "fulfillment.inventory",
+          value: inventory,
+          state: {
+            path: "fulfillment.inventory.reserved",
+            value: new InventoryReserved({ reservationId: "resolved" })
+          }
+        },
+        shipping: {
+          path: "fulfillment.shipping",
+          value: shipping,
+          state: {
+            path: "fulfillment.shipping.quoting",
+            value: new QuotingShipping({ postalCode: "resolved" })
+          }
+        }
+      })
+      assert.deepStrictEqual(
+        changedThenValue.microsteps[0]!.transitions.map(({ resolvedTarget, source, target }) => ({
+          source,
+          target,
+          resolvedTarget
+        })),
+        [
+          {
+            source: "fulfillment.inventory.checking",
+            target: "fulfillment.inventory.reserved",
+            resolvedTarget: "fulfillment.inventory.reserved"
+          },
+          {
+            source: "fulfillment.shipping.quoting",
+            target: "fulfillment.shipping.quoting",
+            resolvedTarget: "fulfillment.shipping.quoting"
+          }
+        ]
+      )
+      assert.strictEqual(changedThenValue.microsteps[0]!.actions.length, 2)
+
+      const valueThenChanged = yield* Machine.plan(machine, initial.state, new Reset({})).pipe(
+        Effect.provideService(DeferredLog, deferredLog)
+      )
+      assertParallelStateSnapshot(valueThenChanged.next as any, "fulfillment", fulfillment, {
+        inventory: {
+          path: "fulfillment.inventory",
+          value: inventory,
+          state: {
+            path: "fulfillment.inventory.checking",
+            value: new CheckingInventory({ sku: "reset" })
+          }
+        },
+        shipping: {
+          path: "fulfillment.shipping",
+          value: shipping,
+          state: {
+            path: "fulfillment.shipping.quoted",
+            value: new ShippingQuoted({ quoteId: "reset" })
+          }
+        }
+      })
+      assert.deepStrictEqual(
+        valueThenChanged.microsteps[0]!.transitions.map(({ resolvedTarget, source, target }) => ({
+          source,
+          target,
+          resolvedTarget
+        })),
+        [
+          {
+            source: "fulfillment.inventory.checking",
+            target: "fulfillment.inventory.checking",
+            resolvedTarget: "fulfillment.inventory.checking"
+          },
+          {
+            source: "fulfillment.shipping.quoting",
+            target: "fulfillment.shipping.quoted",
+            resolvedTarget: "fulfillment.shipping.quoted"
+          }
+        ]
+      )
+      assert.strictEqual(valueThenChanged.microsteps[0]!.actions.length, 2)
+      assert.deepStrictEqual(yield* deferredLog.read, [])
+
+      const changedThenValueActor = yield* Machine.start(machine).pipe(
+        Effect.provideService(DeferredLog, deferredLog)
+      )
+      yield* sendAndWaitForSnapshot(
+        changedThenValueActor,
+        new Resolve({}),
+        (snapshot) =>
+          snapshot.state.path === "fulfillment" &&
+          (snapshot.state as any).states.inventory.state.path === "fulfillment.inventory.reserved" &&
+          (snapshot.state as any).states.shipping.state.value.postalCode === "resolved"
+      )
+      const valueThenChangedActor = yield* Machine.start(machine).pipe(
+        Effect.provideService(DeferredLog, deferredLog)
+      )
+      yield* sendAndWaitForSnapshot(
+        valueThenChangedActor,
+        new Reset({}),
+        (snapshot) =>
+          snapshot.state.path === "fulfillment" &&
+          (snapshot.state as any).states.inventory.state.value.sku === "reset" &&
+          (snapshot.state as any).states.shipping.state.path === "fulfillment.shipping.quoted"
+      )
+      yield* Effect.yieldNow
+
+      assert.deepStrictEqual(yield* deferredLog.read, [
+        "resolve:inventory:changed",
+        "resolve:shipping:value",
+        "reset:inventory:value",
+        "reset:shipping:changed"
+      ])
+    }))
+
   it.effect("prefers child transitions over conflicting ancestor transitions", () =>
     Effect.gen(function*() {
       const deferredLog = yield* makeDeferredLog

--- a/test/MachineHistory.test.ts
+++ b/test/MachineHistory.test.ts
@@ -483,6 +483,8 @@ describe("Machine history states", () => {
       const resumed = yield* Machine.plan(machine, initial.state, new ResumeDeep({}))
 
       assert.deepStrictEqual(resumed.next, checkoutShipping("fallback-order", "fallback-address"))
+      assert.strictEqual(resumed.microsteps[0]?.transitions[0]?.target, "checkout.exact")
+      assert.strictEqual(resumed.microsteps[0]?.transitions[0]?.resolvedTarget, "checkout")
       assert.strictEqual(initialized, 0)
     }))
 
@@ -498,6 +500,8 @@ describe("Machine history states", () => {
       ])
 
       const exact = yield* Machine.plan(machine, firstLeave.next, new ResumeDeep({}))
+      assert.strictEqual(exact.microsteps[0]?.transitions[0]?.target, "checkout.exact")
+      assert.strictEqual(exact.microsteps[0]?.transitions[0]?.resolvedTarget, "checkout")
       assert.strictEqual(exact.next.path, original.path)
       assert.deepStrictEqual(exact.next.value, original.value)
       assert.deepStrictEqual((exact.next as any).state, (original as any).state)
@@ -526,6 +530,8 @@ describe("Machine history states", () => {
       const left = yield* Machine.plan(machine, original, new Leave({}))
       const resumed = yield* Machine.plan(machine, left.next, new ResumeShallow({}))
 
+      assert.strictEqual(resumed.microsteps[0]?.transitions[0]?.target, "checkout.recent")
+      assert.strictEqual(resumed.microsteps[0]?.transitions[0]?.resolvedTarget, "checkout")
       assert.strictEqual(initialized, 1)
       assert.deepStrictEqual(resumed.next.value, new Checkout({ orderId: "order-1" }))
       assert.deepStrictEqual((resumed.next as any).state.value, new Payment({ attempt: 3 }))
@@ -575,6 +581,8 @@ describe("Machine history states", () => {
 
       const reentered = yield* Machine.plan(machine, original, new ReenterHistory({}))
 
+      assert.strictEqual(reentered.microsteps[0]?.transitions[0]?.target, "checkout.exact")
+      assert.strictEqual(reentered.microsteps[0]?.transitions[0]?.resolvedTarget, "checkout")
       assert.strictEqual(defaults, 0)
       assert.strictEqual(reentered.next.path, "checkout")
       assert.deepStrictEqual(reentered.next.value, original.value)

--- a/test/MachineTest.test.ts
+++ b/test/MachineTest.test.ts
@@ -1,0 +1,324 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Data, Effect, Schema } from "effect"
+import { FastCheck } from "effect/testing"
+import { Machine } from "../src/index.js"
+import { MachineTest } from "../src/testing.js"
+
+class TestInput extends Schema.Class<TestInput>("TestInput")({
+  userId: Schema.String
+}) {}
+
+class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", {
+  userId: Schema.String
+}) {}
+
+class Ready extends Schema.TaggedClass<Ready>("Ready")("Ready", {
+  count: Schema.Int
+}) {}
+
+class Start extends Schema.TaggedClass<Start>("Start")("Start", {}) {}
+
+class Add extends Schema.TaggedClass<Add>("Add")("Add", {
+  amount: Schema.Int
+}) {}
+
+class InitialPlanFailure extends Data.TaggedError("InitialPlanFailure")<{
+  readonly reason: string
+}> {}
+
+class EventPlanFailure extends Data.TaggedError("EventPlanFailure")<{
+  readonly amount: number
+}> {}
+
+const States = Machine.defineStates({ Idle, Ready })
+
+const makeTraceMachine = (onAction: () => void) =>
+  Machine.make({
+    states: States.states,
+    events: [Start, Add],
+    input: TestInput,
+    initial: Effect.fn(function*({ userId }) {
+      const runtime = yield* Machine.runtime<{ readonly events: Start | Add }>()
+      yield* runtime.raise(new Start({}))
+      return States.initial.Idle(new Idle({ userId }))
+    })
+  }).handle({
+    Idle: {
+      on: {
+        Start: Effect.fn(function*({ target }) {
+          yield* Machine.action(Effect.sync(onAction))
+          return target.full.Ready(new Ready({ count: 0 }))
+        })
+      }
+    },
+    Ready: {
+      on: {
+        Add: ({ event, state, target }) =>
+          Machine.action(
+            Effect.sync(onAction),
+            target.full.Ready(new Ready({ count: state.count + event.amount }))
+          )
+      }
+    }
+  })
+
+describe("MachineTest", () => {
+  it("derives complete scenarios from machine schemas and reports diagnostics", () => {
+    const machine = makeTraceMachine(() => undefined)
+    const generated = MachineTest.scenarios(machine, { minEvents: 2, maxEvents: 2 })
+    const samples = FastCheck.sample(generated.arbitrary, 10)
+
+    assert.strictEqual(generated.diagnostics.input, "schema")
+    assert.strictEqual(generated.diagnostics.events, "schema")
+    assert.strictEqual(generated.diagnostics.schemas.length, 3)
+    assert.deepStrictEqual(generated.diagnostics.schemas.map(({ boundary, index }) => ({ boundary, index })), [
+      { boundary: "input", index: undefined },
+      { boundary: "event", index: 0 },
+      { boundary: "event", index: 1 }
+    ])
+    for (const sample of samples) {
+      assert.strictEqual(typeof sample.input.userId, "string")
+      assert.strictEqual(sample.events.length, 2)
+      for (const event of sample.events) {
+        assert.ok(event._tag === "Start" || event._tag === "Add")
+      }
+    }
+  })
+
+  it("accepts whole-input and whole-events arbitrary overrides", () => {
+    const machine = makeTraceMachine(() => undefined)
+    const input = new TestInput({ userId: "fixed" })
+    const events = [new Add({ amount: 2 })] as const
+    const generated = MachineTest.scenarios(machine, {
+      minEvents: 10,
+      maxEvents: 10,
+      inputArbitrary: FastCheck.constant(input),
+      eventsArbitrary: FastCheck.constant(events)
+    })
+
+    assert.deepStrictEqual(FastCheck.sample(generated.arbitrary, 1), [{ input, events }])
+    assert.strictEqual(generated.diagnostics.input, "override")
+    assert.strictEqual(generated.diagnostics.events, "override")
+  })
+
+  it("rejects a non-empty minimum for machines without public events", () => {
+    const machine = Machine.make({
+      states: States.states,
+      events: [],
+      initial: () => States.initial.Idle(new Idle({ userId: "user-1" }))
+    })
+
+    assert.throws(
+      () => MachineTest.scenarios(machine, { minEvents: 1 }),
+      /cannot generate a non-empty event sequence for a machine without public events/
+    )
+  })
+
+  it.effect("runs startup and event plans without executing staged actions", () =>
+    Effect.gen(function*() {
+      let actionsExecuted = 0
+      const machine = makeTraceMachine(() => {
+        actionsExecuted += 1
+      })
+      const scenario: MachineTest.Scenario<typeof machine> = {
+        input: new TestInput({ userId: "user-1" }),
+        events: [new Add({ amount: 2 }), new Add({ amount: 3 })]
+      }
+
+      const trace = yield* MachineTest.run(machine, scenario)
+
+      assert.strictEqual(actionsExecuted, 0)
+      assert.deepStrictEqual(trace.initial.startingConfiguration, ["Idle"])
+      assert.deepStrictEqual(trace.initial.initialEntryPaths, ["Idle"])
+      assert.deepStrictEqual(trace.initial.startingState.value, new Idle({ userId: "user-1" }))
+      assert.deepStrictEqual(trace.initial.configuration, ["Ready"])
+      assert.strictEqual(trace.initial.plan.microsteps.length, 1)
+      assert.deepStrictEqual(trace.initial.plan.microsteps[0]?.transitions, [{
+        source: "Idle",
+        trigger: { type: "event", event: "Start" },
+        reenter: false,
+        target: "Ready",
+        resolvedTarget: "Ready"
+      }])
+      assert.deepStrictEqual(trace.steps.map((step) => (step.after.value as Ready).count), [2, 5])
+      assert.deepStrictEqual(trace.finalConfiguration, ["Ready"])
+      const formatted = MachineTest.formatTrace(trace)
+      assert.strictEqual(
+        formatted.split("\n")[0],
+        "scenario: {\"events\":[{\"_tag\":\"Add\",\"amount\":2},{\"_tag\":\"Add\",\"amount\":3}],\"input\":{\"userId\":\"user-1\"}}"
+      )
+      assert.match(formatted, /microstep 0: event=/)
+      assert.match(formatted, / next=/)
+      assert.match(formatted, /final: configuration=\[Ready\]/)
+    }))
+
+  it.effect("retains structured startup failures for formatting", () =>
+    Effect.gen(function*() {
+      const machine = Machine.make({
+        states: States.states,
+        events: [],
+        input: TestInput,
+        initial: ({ userId }) =>
+          Effect.fail(new InitialPlanFailure({ reason: userId })).pipe(
+            Effect.as(States.initial.Idle(new Idle({ userId })))
+          )
+      })
+      const scenario: MachineTest.Scenario<typeof machine> = {
+        input: new TestInput({ userId: "startup" }),
+        events: []
+      }
+
+      const failure = yield* MachineTest.run(machine, scenario).pipe(Effect.flip)
+
+      assert.strictEqual(failure.phase, "initial")
+      assert.strictEqual(failure.initial, undefined)
+      assert.deepStrictEqual(failure.steps, [])
+      assert.deepStrictEqual(failure.cause, new InitialPlanFailure({ reason: "startup" }))
+      const formatted = MachineTest.formatTrace(failure)
+      assert.notMatch(formatted, /\ninitial:/)
+      assert.match(formatted, /failure: phase=initial/)
+      assert.match(formatted, /InitialPlanFailure/)
+    }))
+
+  it.effect("retains the successful trace prefix when an event plan fails", () =>
+    Effect.gen(function*() {
+      const machine = Machine.make({
+        states: States.states,
+        events: [Add],
+        initial: () => States.initial.Ready(new Ready({ count: 0 }))
+      }).handle({
+        Ready: {
+          on: {
+            Add: ({ event, state, target }) =>
+              event.amount < 0
+                ? Effect.fail(new EventPlanFailure({ amount: event.amount }))
+                : Effect.succeed(target.full.Ready(new Ready({ count: state.count + event.amount })))
+          }
+        }
+      })
+      const scenario: MachineTest.Scenario<typeof machine> = {
+        events: [new Add({ amount: 2 }), new Add({ amount: -1 })]
+      }
+
+      const failure = yield* MachineTest.run(machine, scenario).pipe(Effect.flip)
+
+      assert.strictEqual(failure.phase, "event")
+      if (failure.phase === "event") {
+        assert.strictEqual(failure.eventIndex, 1)
+        assert.deepStrictEqual(failure.event, new Add({ amount: -1 }))
+        assert.strictEqual(failure.steps.length, 1)
+        assert.deepStrictEqual(failure.steps[0]?.after.value, new Ready({ count: 2 }))
+        assert.deepStrictEqual(failure.cause, new EventPlanFailure({ amount: -1 }))
+      }
+      const formatted = MachineTest.formatTrace(failure)
+      assert.match(formatted, /\ninitial:/)
+      assert.match(formatted, /\nstep 0:/)
+      assert.match(formatted, /failure: phase=event eventIndex=1/)
+      assert.match(formatted, /EventPlanFailure/)
+      assert.notMatch(formatted, /\nfinal:/)
+    }))
+
+  it.effect("retains only transitions that survive parallel conflict resolution", () =>
+    Effect.gen(function*() {
+      class App extends Schema.TaggedClass<App>("App")("App", {}) {}
+      class Left extends Schema.TaggedClass<Left>("Left")("Left", {}) {}
+      class LeftIdle extends Schema.TaggedClass<LeftIdle>("LeftIdle")("LeftIdle", {}) {}
+      class Right extends Schema.TaggedClass<Right>("Right")("Right", {}) {}
+      class RightIdle extends Schema.TaggedClass<RightIdle>("RightIdle")("RightIdle", {}) {}
+      class Disabled extends Schema.TaggedClass<Disabled>("Disabled")("Disabled", {}) {}
+      class Stop extends Schema.TaggedClass<Stop>("Stop")("Stop", {}) {}
+
+      const ParallelStates = Machine.defineStates({
+        app: {
+          schema: App,
+          type: "parallel",
+          states: {
+            left: {
+              schema: Left,
+              initial: "idle",
+              states: { idle: LeftIdle }
+            },
+            right: {
+              schema: Right,
+              initial: "idle",
+              states: { idle: RightIdle }
+            }
+          }
+        },
+        disabled: Disabled
+      })
+      const machine = Machine.make({
+        states: ParallelStates.states,
+        events: [Stop],
+        initial: () =>
+          ParallelStates.initial.app(
+            new App({}),
+            (app) =>
+              app
+                .left(new Left({}), (left) => left.idle(new LeftIdle({})))
+                .right(new Right({}), (right) => right.idle(new RightIdle({})))
+          )
+      }).handle({
+        app: {
+          states: {
+            left: {
+              states: {
+                idle: {
+                  on: {
+                    Stop: ({ target }) => target.full.disabled(new Disabled({}))
+                  }
+                }
+              }
+            },
+            right: {
+              states: {
+                idle: {
+                  on: {
+                    Stop: ({ target }) => target.full.disabled(new Disabled({}))
+                  }
+                }
+              }
+            }
+          }
+        }
+      })
+
+      const initial = yield* Machine.planInitial(machine)
+      assert.deepStrictEqual(initial.initialEntryPaths, [
+        "app",
+        "app.left",
+        "app.left.idle",
+        "app.right",
+        "app.right.idle"
+      ])
+      const planned = yield* Machine.plan(machine, initial.state, new Stop({}))
+
+      assert.deepStrictEqual(planned.microsteps[0]?.transitions, [{
+        source: "app.left.idle",
+        trigger: { type: "event", event: "Stop" },
+        reenter: false,
+        target: "disabled",
+        resolvedTarget: "disabled"
+      }])
+    }))
+
+  it.effect("reports both targets as undefined for a targetless transition", () =>
+    Effect.gen(function*() {
+      const machine = Machine.make({
+        states: { Idle },
+        events: [Start],
+        initial: () => ({ path: "Idle", value: new Idle({ userId: "user-1" }) })
+      }).handle({
+        Idle: {
+          on: {
+            Start: () => undefined
+          }
+        }
+      })
+      const initial = yield* Machine.planInitial(machine)
+      const planned = yield* Machine.plan(machine, initial.state, new Start({}))
+
+      assert.strictEqual(planned.microsteps[0]?.transitions[0]?.target, undefined)
+      assert.strictEqual(planned.microsteps[0]?.transitions[0]?.resolvedTarget, undefined)
+    }))
+})

--- a/test/MachineTestCoverage.test.ts
+++ b/test/MachineTestCoverage.test.ts
@@ -1,0 +1,357 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Graph from "effect/Graph"
+import * as Option from "effect/Option"
+import * as Schema from "effect/Schema"
+import { Machine } from "../src/index.js"
+import { MachineTest } from "../src/testing.js"
+
+class Count extends Schema.TaggedClass<Count>("Count")("Count", {
+  value: Schema.Int
+}) {}
+class Done extends Schema.TaggedClass<Done>("Done")("Done", {}) {}
+class Add extends Schema.TaggedClass<Add>("Add")("Add", {
+  amount: Schema.Int
+}) {}
+class Finish extends Schema.TaggedClass<Finish>("Finish")("Finish", {}) {}
+
+const CounterStates = Machine.defineStates({ count: Count, done: Done })
+
+const counterMachine = Machine.make({
+  states: CounterStates.states,
+  events: [Add, Finish],
+  initial: () => CounterStates.initial.count(new Count({ value: 0 }))
+}).handle({
+  count: {
+    on: {
+      Add: {
+        reenter: true,
+        targets: ["count"],
+        transition: ({ event, state, target }) => target.full.count(new Count({ value: state.value + event.amount }))
+      },
+      Finish: {
+        targets: ["done"],
+        transition: ({ target }) => target.full.done(new Done({}))
+      }
+    }
+  },
+  done: {}
+})
+
+class Opaque extends Schema.TaggedClass<Opaque>("Opaque")("Opaque", {
+  payload: Schema.Any
+}) {}
+
+const OpaqueStates = Machine.defineStates({ opaque: Opaque })
+const opaqueMachine = Machine.make({
+  states: OpaqueStates.states,
+  events: [],
+  input: Schema.Any,
+  initial: (payload) => OpaqueStates.initial.opaque(new Opaque({ payload }))
+})
+
+const StartupStates = Machine.defineStates({ count: Count })
+const startupMachine = Machine.make({
+  states: StartupStates.states,
+  events: [Add],
+  initial: Effect.fn(function*() {
+    const runtime = yield* Machine.runtime<{ readonly events: Add }>()
+    yield* runtime.raise(new Add({ amount: 1 }))
+    return StartupStates.initial.count(new Count({ value: 0 }))
+  })
+}).handle({
+  count: {
+    on: {
+      Add: ({ event, state, target }) => target.full.count(new Count({ value: state.value + event.amount }))
+    }
+  }
+})
+
+const Tick = Symbol.for("MachineTestCoverage/Tick")
+const TickEvent = Schema.Struct({ _tag: Schema.UniqueSymbol(Tick) })
+const ChoiceEvent = Schema.Struct({
+  _tag: Schema.Union([Schema.Literal("Alpha"), Schema.Literal("Beta")])
+})
+const OpenEvent = Schema.Struct({ _tag: Schema.String })
+const EventStates = Machine.defineStates({ count: Count })
+const finiteEventMachine = Machine.make({
+  states: EventStates.states,
+  events: [TickEvent, ChoiceEvent],
+  initial: () => EventStates.initial.count(new Count({ value: 0 }))
+}).handle({
+  count: {
+    on: {
+      [Tick]: () => undefined,
+      Alpha: () => undefined,
+      Beta: () => undefined
+    }
+  }
+})
+const openEventMachine = Machine.make({
+  states: EventStates.states,
+  events: [OpenEvent],
+  initial: () => EventStates.initial.count(new Count({ value: 0 }))
+}).handle({ count: {} })
+
+const event = (_tag: string): { readonly _tag: string } => ({ _tag })
+
+const parallelModel: MachineTest.FiniteModel = {
+  roots: [{
+    _tag: "Parallel",
+    key: "workflow",
+    value: 0,
+    output: "workflow:done",
+    states: [
+      {
+        _tag: "Compound",
+        key: "left",
+        value: 1,
+        initial: "idle",
+        states: [
+          { _tag: "Atomic", key: "idle", value: 2 },
+          { _tag: "Final", key: "done", value: 3, output: "left:done" }
+        ]
+      },
+      {
+        _tag: "Compound",
+        key: "right",
+        value: 4,
+        initial: "idle",
+        states: [
+          { _tag: "Atomic", key: "idle", value: 5 },
+          { _tag: "Final", key: "done", value: 6, output: "right:done" }
+        ]
+      }
+    ]
+  }],
+  initial: "workflow",
+  events: ["Left", "Right"],
+  transitions: [
+    { source: "workflow.left.idle", event: "Left", target: "workflow.left.done", reenter: false },
+    { source: "workflow.right.idle", event: "Right", target: "workflow.right.done", reenter: false }
+  ]
+}
+
+const historyModel: MachineTest.FiniteModel = {
+  roots: [
+    {
+      _tag: "Compound",
+      key: "owner",
+      value: 0,
+      initial: "a",
+      states: [
+        { _tag: "Atomic", key: "a", value: 1 },
+        { _tag: "Atomic", key: "b", value: 2 },
+        { _tag: "History", key: "exact", history: "deep", fallback: "owner.a" }
+      ]
+    },
+    { _tag: "Atomic", key: "outside", value: 3 }
+  ],
+  initial: "owner",
+  events: ["Next", "Leave", "Resume"],
+  transitions: [
+    { source: "owner.a", event: "Next", target: "owner.b", reenter: false },
+    { source: "owner.a", event: "Leave", target: "outside", reenter: false },
+    { source: "owner.b", event: "Leave", target: "outside", reenter: false },
+    { source: "outside", event: "Resume", target: "owner.exact", reenter: false }
+  ]
+}
+
+describe("MachineTest trace coverage", () => {
+  it.effect("turns definition-aware state, transition, and event misses into hits", () =>
+    Effect.gen(function*() {
+      const addTrace = yield* MachineTest.run(counterMachine, {
+        events: [new Add({ amount: 1 })]
+      })
+      const finishTrace = yield* MachineTest.run(counterMachine, {
+        events: [new Finish({})]
+      })
+
+      const partial = MachineTest.coverage(counterMachine, addTrace)
+      assert.strictEqual(partial.events.available, true)
+      if (!partial.events.available) return
+      assert.deepStrictEqual(partial.states.activation.misses.map(({ path }) => path), ["done"])
+      assert.deepStrictEqual(partial.transitions.misses.map(({ source, trigger }) => ({ source, trigger })), [{
+        source: "count",
+        trigger: { type: "event", event: "Finish" }
+      }])
+      assert.deepStrictEqual(partial.events.misses, [{ tag: "Finish", count: 0 }])
+      assert.strictEqual(partial.logicalConfigurations.hit, 2)
+
+      const combined = MachineTest.coverage(counterMachine, [addTrace, finishTrace])
+      assert.strictEqual(combined.events.available, true)
+      if (!combined.events.available) return
+      assert.strictEqual(combined.states.activation.missing, 0)
+      assert.strictEqual(combined.transitions.missing, 0)
+      assert.strictEqual(combined.events.missing, 0)
+      assert.ok(combined.states.exit.hits.some(({ path }) => path === "count"))
+      assert.ok(combined.states.entry.hits.some(({ path }) => path === "done"))
+      assert.strictEqual(combined.scenarios.traces, 2)
+      assert.strictEqual(combined.scenarios.events, 2)
+    }))
+
+  it.effect("covers finite decoded symbol and union tags and diagnoses open tag spaces", () =>
+    Effect.gen(function*() {
+      const finiteTrace = yield* MachineTest.run(finiteEventMachine, {
+        events: [{ _tag: Tick }, { _tag: "Alpha" }]
+      })
+      const finite = MachineTest.coverage(finiteEventMachine, finiteTrace)
+      assert.strictEqual(finite.events.available, true)
+      if (finite.events.available) {
+        assert.strictEqual(finite.events.total, 3)
+        assert.deepStrictEqual(finite.events.hits.map(({ tag }) => tag), [Tick, "Alpha"])
+        assert.deepStrictEqual(finite.events.misses, [{ tag: "Beta", count: 0 }])
+      }
+
+      const openTrace = yield* MachineTest.run(openEventMachine, { events: [{ _tag: "Dynamic" }] })
+      const open = MachineTest.coverage(openEventMachine, openTrace)
+      assert.strictEqual(open.events.available, false)
+      if (!open.events.available) {
+        assert.strictEqual(open.events.total, undefined)
+        assert.deepStrictEqual(open.events.observed, [{ tag: "Dynamic", count: 1 }])
+        assert.strictEqual(open.events.diagnostics.length, 1)
+      }
+    }))
+
+  it.effect("reports parallel completion and history evidence without inferring unobserved behavior", () =>
+    Effect.gen(function*() {
+      const parallelMachine = MachineTest.compileModel(parallelModel)
+      const parallel = yield* MachineTest.run(parallelMachine, {
+        events: [event("Left"), event("Right")]
+      })
+      const parallelCoverage = MachineTest.coverage(parallelMachine, parallel)
+      assert.ok(parallelCoverage.completion.donePlans > 0)
+      assert.ok(parallelCoverage.completion.paths.includes("workflow"))
+      assert.ok(parallelCoverage.completion.paths.includes("workflow.left"))
+      assert.strictEqual(parallelCoverage.microsteps.eventTriggered, 2)
+
+      const historyMachine = MachineTest.compileModel(historyModel)
+      const history = yield* MachineTest.run(historyMachine, {
+        events: [event("Next"), event("Leave"), event("Resume")]
+      })
+      const historyCoverage = MachineTest.coverage(historyMachine, history)
+      assert.ok(historyCoverage.history.recordObservations > 0)
+      assert.deepStrictEqual(historyCoverage.history.recorded, [{ path: "owner.exact", modes: ["deep"] }])
+      assert.strictEqual(historyCoverage.history.targets, 1)
+      assert.strictEqual(historyCoverage.history.resolvedTargets, 1)
+    }))
+})
+
+describe("MachineTest observed graph", () => {
+  it.effect("deduplicates encoded snapshots while preserving concrete startup and event edges", () =>
+    Effect.gen(function*() {
+      const first = yield* MachineTest.run(counterMachine, {
+        events: [new Add({ amount: 1 })]
+      })
+      const second = yield* MachineTest.run(counterMachine, {
+        events: [new Add({ amount: 1 })]
+      })
+      const observed = yield* MachineTest.observedGraph(counterMachine, [first, second])
+
+      assert.strictEqual(Graph.nodeCount(observed.graph), 2)
+      assert.strictEqual(Graph.edgeCount(observed.graph), 4)
+      const edges = Array.from(Graph.edges(observed.graph), ([, edge]) => edge.data)
+      assert.strictEqual(edges.filter(({ _tag }) => _tag === "Startup").length, 2)
+      assert.strictEqual(edges.filter(({ _tag }) => _tag === "Event").length, 2)
+      assert.ok(edges.filter(({ _tag }) => _tag === "Event").every((edge) => edge.microsteps.length === 1))
+      assert.ok(
+        edges.flatMap(({ microsteps }) => microsteps).every(({ next }) => observed.nodesById.has(next))
+      )
+
+      const nodes = Array.from(observed.graph)
+      const zero = nodes.find(([, node]) =>
+        node.encoded.active.some(({ value }) => (value as { readonly value?: number }).value === 0)
+      )!
+      const one = nodes.find(([, node]) =>
+        node.encoded.active.some(({ value }) => (value as { readonly value?: number }).value === 1)
+      )!
+      assert.notStrictEqual(zero[1].id, one[1].id)
+      const shortest = Graph.dijkstra(observed.graph, {
+        source: zero[0],
+        target: one[0],
+        cost: () => 1
+      })
+      assert.ok(Option.isSome(shortest))
+      if (Option.isSome(shortest)) assert.strictEqual(shortest.value.distance, 1)
+    }))
+
+  it.effect("separates pre-settled startup sources from post-startup path starts", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(startupMachine, { events: [] })
+      const observed = yield* MachineTest.observedGraph(startupMachine, trace)
+
+      assert.strictEqual(observed.startupSources.length, 1)
+      assert.strictEqual(observed.starts.length, 1)
+      assert.notStrictEqual(observed.startupSources[0], observed.starts[0])
+      const startup = Array.from(Graph.edges(observed.graph), ([, edge]) => edge.data)[0]!
+      assert.strictEqual(startup._tag, "Startup")
+      assert.strictEqual(startup.microsteps.length, 1)
+    }))
+
+  it.effect("retains complete parallel configurations and completion on macrostep edges", () =>
+    Effect.gen(function*() {
+      const machine = MachineTest.compileModel(parallelModel)
+      const trace = yield* MachineTest.run(machine, {
+        events: [event("Left"), event("Right")]
+      })
+      const observed = yield* MachineTest.observedGraph(machine, trace)
+      const nodes = Array.from(observed.graph, ([, node]) => node)
+
+      assert.ok(nodes.some(({ configuration }) =>
+        configuration.includes("workflow.left.done") && configuration.includes("workflow.right.idle")
+      ))
+      const eventEdges = Array.from(Graph.edges(observed.graph), ([, edge]) =>
+        edge.data).filter(
+          (edge): edge is Extract<typeof edge, { readonly _tag: "Event" }> => edge._tag === "Event"
+        )
+      assert.strictEqual(eventEdges.length, 2)
+      assert.strictEqual(eventEdges[0]!.completion.done, false)
+      assert.strictEqual(eventEdges[1]!.completion.done, true)
+    }))
+
+  it.effect("keeps equal active paths with different history records as distinct logical nodes", () =>
+    Effect.gen(function*() {
+      const machine = MachineTest.compileModel(historyModel)
+      const rememberedA = yield* MachineTest.run(machine, { events: [event("Leave")] })
+      const rememberedB = yield* MachineTest.run(machine, {
+        events: [event("Next"), event("Leave")]
+      })
+      const observed = yield* MachineTest.observedGraph(machine, [rememberedA, rememberedB])
+      const outside = Array.from(observed.graph, ([, node]) => node).filter(
+        ({ configuration }) => configuration.length === 1 && configuration[0] === "outside"
+      )
+
+      assert.strictEqual(outside.length, 2)
+      assert.notStrictEqual(
+        JSON.stringify(outside[0]!.encoded.history),
+        JSON.stringify(outside[1]!.encoded.history)
+      )
+      assert.notStrictEqual(outside[0]!.id, outside[1]!.id)
+    }))
+
+  it.effect("does not merge colliding non-JSON encoded values", () =>
+    Effect.gen(function*() {
+      const makePayload = () => function collision() {}
+      const first = yield* MachineTest.run(opaqueMachine, { input: makePayload(), events: [] })
+      const second = yield* MachineTest.run(opaqueMachine, { input: makePayload(), events: [] })
+      const observed = yield* MachineTest.observedGraph(opaqueMachine, [first, second])
+
+      assert.strictEqual(Graph.nodeCount(observed.graph), 2)
+      assert.strictEqual(MachineTest.coverage(opaqueMachine, [first, second]).logicalConfigurations.hit, 2)
+
+      const firstBuffer = yield* MachineTest.run(opaqueMachine, {
+        input: new Uint8Array([1]).buffer,
+        events: []
+      })
+      const secondBuffer = yield* MachineTest.run(opaqueMachine, {
+        input: new Uint8Array([2]).buffer,
+        events: []
+      })
+      const buffers = yield* MachineTest.observedGraph(opaqueMachine, [firstBuffer, secondBuffer])
+      assert.strictEqual(Graph.nodeCount(buffers.graph), 2)
+      assert.strictEqual(
+        MachineTest.coverage(opaqueMachine, [firstBuffer, secondBuffer]).logicalConfigurations.hit,
+        2
+      )
+    }))
+})

--- a/test/MachineTestFiniteModel.test.ts
+++ b/test/MachineTestFiniteModel.test.ts
@@ -1,0 +1,499 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { FastCheck } from "effect/testing"
+import { Machine } from "../src/index.js"
+import { MachineTest } from "../src/testing.js"
+
+type FlatState = {
+  readonly node: MachineTest.FiniteState
+  readonly path: string
+  readonly parent: string | undefined
+  readonly root: string
+  readonly depth: number
+}
+
+const flatten = (model: MachineTest.FiniteModel): ReadonlyArray<FlatState> => {
+  const result: Array<FlatState> = []
+  const visit = (
+    states: ReadonlyArray<MachineTest.FiniteState>,
+    parent: string | undefined,
+    root: string | undefined,
+    depth: number
+  ): void => {
+    for (const node of states) {
+      const path = parent === undefined ? node.key : `${parent}.${node.key}`
+      const nodeRoot = root ?? path
+      result.push({ node, path, parent, root: nodeRoot, depth })
+      if (node._tag === "Compound" || node._tag === "Parallel") {
+        visit(node.states, path, nodeRoot, depth + 1)
+      }
+    }
+  }
+  visit(model.roots, undefined, undefined, 1)
+  return result
+}
+
+const snapshotAtPath = (snapshot: unknown, path: string): unknown => {
+  if (typeof snapshot !== "object" || snapshot === null) return undefined
+  const current = snapshot as Record<string, unknown>
+  if (current.path === path) return snapshot
+  if (current.state !== undefined) {
+    const found = snapshotAtPath(current.state, path)
+    if (found !== undefined) return found
+  }
+  if (typeof current.states === "object" && current.states !== null) {
+    for (const child of Object.values(current.states)) {
+      const found = snapshotAtPath(child, path)
+      if (found !== undefined) return found
+    }
+  }
+  return undefined
+}
+
+const assertValid = (
+  model: MachineTest.FiniteModel,
+  limits: MachineTest.FiniteModelDiagnostics["limits"]
+): void => {
+  assert.ok(Object.isFrozen(model))
+  assert.ok(Object.isFrozen(model.roots))
+  assert.ok(Object.isFrozen(model.events))
+  assert.ok(Object.isFrozen(model.transitions))
+  assert.ok(Object.isFrozen(model.historyScenarios))
+  assert.ok(model.roots.length >= 1 && model.roots.length <= limits.maxRoots)
+  assert.ok(model.roots.some(({ key }) => key === model.initial))
+  assert.ok(model.events.length >= 1 && model.events.length <= limits.maxEvents)
+  assert.strictEqual(new Set(model.events).size, model.events.length)
+
+  const states = flatten(model)
+  const byPath = new Map(states.map((state) => [state.path, state]))
+  assert.strictEqual(byPath.size, states.length)
+  for (const state of states) {
+    assert.ok(Object.isFrozen(state.node))
+    assert.ok(state.depth <= limits.maxDepth)
+    if (state.node._tag !== "History") assert.ok(Number.isSafeInteger(state.node.value))
+    if (state.node._tag === "History") {
+      assert.ok(state.parent !== undefined)
+      const fallback = byPath.get(state.node.fallback)
+      assert.ok(fallback !== undefined && fallback.node._tag !== "History")
+      assert.ok(fallback.path.startsWith(`${state.parent}.`))
+    } else if (state.node._tag === "Compound") {
+      const compound = state.node
+      assert.ok(Object.isFrozen(compound.states))
+      const children = compound.states.filter((child) => child._tag !== "History")
+      assert.ok(children.length >= 1 && children.length <= limits.maxChildren)
+      assert.ok(children.some(({ key }) => key === compound.initial))
+    } else if (state.node._tag === "Parallel") {
+      assert.ok(Object.isFrozen(state.node.states))
+      const regions = state.node.states.filter((child) => child._tag !== "History")
+      assert.ok(regions.length >= 2 && regions.length <= limits.maxParallelRegions)
+      assert.strictEqual(state.node.output, `output:${state.path}`)
+    } else if (state.node._tag === "Final") {
+      assert.strictEqual(state.node.output, `output:${state.path}`)
+    }
+  }
+
+  const registrations = new Set<string>()
+  assert.ok(model.transitions.length <= limits.maxTransitions)
+  for (const transition of model.transitions) {
+    assert.ok(Object.isFrozen(transition))
+    const source = byPath.get(transition.source)
+    assert.ok(source !== undefined && source.node._tag !== "Final" && source.node._tag !== "History")
+    assert.ok(model.events.includes(transition.event))
+    const registration = `${transition.source}\u0000${transition.event}`
+    assert.ok(!registrations.has(registration))
+    registrations.add(registration)
+    if (transition.target !== undefined) {
+      const target = byPath.get(transition.target)
+      assert.ok(target !== undefined)
+      assert.ok(target.node._tag === "History" || target.root === source.root || target.parent === undefined)
+      if (transition.targetValue !== undefined) {
+        assert.ok(target.node._tag !== "History")
+        assert.ok(Number.isSafeInteger(transition.targetValue))
+      }
+    } else {
+      assert.strictEqual(transition.targetValue, undefined)
+    }
+  }
+  for (const scenario of model.historyScenarios ?? []) {
+    assert.ok(Object.isFrozen(scenario))
+    assert.ok(Object.isFrozen(scenario.events))
+    assert.deepStrictEqual(scenario.events, [
+      scenario.mutation.event,
+      scenario.leave.event,
+      scenario.resume.event
+    ])
+    assert.strictEqual(scenario.leave.event, scenario.resume.event)
+    assert.strictEqual(scenario.resume.target, scenario.history)
+    assert.notStrictEqual(byPath.get(scenario.mutation.source)?.node._tag, "History")
+    assert.ok(scenario.mutation.source.startsWith(`${scenario.owner}.`))
+  }
+}
+
+const canonicalTransition = (transition: Machine.Machine.TransitionDefinition) => ({
+  source: transition.source,
+  event: transition.trigger.type === "event" ? transition.trigger.event : transition.trigger.type,
+  reenter: transition.reenter,
+  targets: transition.targets.type === "declared" ? transition.targets.paths : undefined
+})
+
+describe("MachineTest finite models", () => {
+  const generated = MachineTest.finiteModels({
+    maxRoots: 3,
+    maxDepth: 4,
+    maxChildren: 3,
+    maxEvents: 4,
+    maxTransitions: 20,
+    maxHistoryStates: 2
+  })
+
+  it("generates immutable bounded models whose references remain valid", () => {
+    assert.deepStrictEqual(generated.diagnostics.guarantees, {
+      compoundOnly: false,
+      parallelStates: true,
+      historyStates: true,
+      historyLeaveResumeSequences: true,
+      historyValueScenarios: true,
+      structurallyValid: true,
+      shrinkPreservesValidity: true,
+      eventlessTransitions: false
+    })
+    const samples = FastCheck.sample(generated.arbitrary, { numRuns: 250, seed: 10_241 })
+    for (const model of samples) {
+      assertValid(model, generated.diagnostics.limits)
+      assert.ok(
+        flatten(model).filter(({ node }) => node._tag === "History").length <=
+          generated.diagnostics.limits.maxHistoryStates
+      )
+      assert.strictEqual(
+        model.historyScenarios?.length,
+        flatten(model).filter(({ node }) => node._tag === "History").length
+      )
+    }
+    assert.ok(samples.some((model) => flatten(model).some(({ node }) => node._tag === "Parallel")))
+    assert.ok(samples.some((model) => flatten(model).some(({ node }) => node._tag === "History")))
+    assert.ok(samples.some((model) => flatten(model).filter(({ node }) => node._tag === "History").length > 1))
+    assert.ok(
+      samples.some((model) =>
+        flatten(model).some(({ node, parent }) => node._tag === "History" && parent?.includes(".") === true)
+      )
+    )
+  })
+
+  it.effect("replays exact generated root and nested value-mutation/capture/restore scenarios", () =>
+    Effect.gen(function*() {
+      const samples = FastCheck.sample(generated.arbitrary, { numRuns: 1_000, seed: 15_361 })
+      const candidates = samples.flatMap((model) =>
+        (model.historyScenarios ?? []).map((scenario) => ({ model, scenario }))
+      )
+      const root = candidates.find(({ scenario }) => !scenario.owner.includes("."))
+      const nested = candidates.find(({ scenario }) => scenario.owner.includes("."))
+      assert.ok(root !== undefined)
+      assert.ok(nested !== undefined)
+
+      for (const { model, scenario } of [root, nested]) {
+        const machine = MachineTest.compileModel(model)
+        const trace = yield* MachineTest.run(machine, {
+          events: scenario.events.map((_tag) => ({ _tag }))
+        })
+        const mutated = snapshotAtPath(trace.steps[0]!.after, scenario.mutation.source) as any
+        const restored = snapshotAtPath(trace.final, scenario.mutation.source) as any
+        assert.strictEqual(mutated.value.value, scenario.mutation.value)
+        assert.strictEqual(restored.value.value, scenario.mutation.value)
+        assert.strictEqual(
+          (trace.final as any).history[scenario.history].values[scenario.mutation.source].value,
+          scenario.mutation.value
+        )
+        yield* MachineTest.verifyModel(model, trace)
+      }
+    }))
+
+  it("compiles state nodes and transition definitions through the public Machine API", () => {
+    for (const model of FastCheck.sample(generated.arbitrary, { numRuns: 100, seed: 20_482 })) {
+      const machine = MachineTest.compileModel(model)
+      const expectedStates = flatten(model)
+      const actualStates = Machine.stateNodes(machine)
+      const expected = expectedStates.map(({ node, parent, path }): {
+        readonly path: string
+        readonly parent: string | undefined
+        readonly type: "atomic" | "compound" | "parallel" | "final" | "history"
+        readonly children: ReadonlyArray<string>
+        readonly initial: string | undefined
+      } => ({
+        path,
+        parent,
+        type: node._tag === "Atomic"
+          ? "atomic"
+          : node._tag === "Final"
+          ? "final"
+          : node._tag === "Parallel"
+          ? "parallel"
+          : node._tag === "History"
+          ? "history"
+          : "compound",
+        children: node._tag === "Compound" || node._tag === "Parallel"
+          ? node.states.filter((child) => child._tag !== "History").map(({ key }) => `${path}.${key}`)
+          : [],
+        initial: node._tag === "Compound" ? `${path}.${node.initial}` : undefined
+      }))
+      assert.deepStrictEqual(
+        actualStates.map(({ children, initial, parent, path, type }) => ({ children, initial, parent, path, type })),
+        expected
+      )
+
+      const actualTransitions = Machine.transitionDefinitions(machine).map(canonicalTransition)
+      assert.strictEqual(actualTransitions.length, model.transitions.length)
+      for (let index = 0; index < model.transitions.length; index++) {
+        const expected = model.transitions[index]!
+        const actual = actualTransitions[index]!
+        assert.strictEqual(actual.source, expected.source)
+        assert.strictEqual(actual.event, expected.event)
+        assert.strictEqual(actual.reenter, expected.reenter)
+        if (expected.target === undefined) {
+          assert.strictEqual(actual.targets, undefined)
+        } else {
+          assert.strictEqual(actual.targets?.length, 1)
+          const bound = actual.targets![0]!
+          assert.ok(
+            expected.target === bound || expected.target.startsWith(`${bound}.`) ||
+              bound.startsWith(`${expected.target}.`)
+          )
+        }
+      }
+    }
+  })
+
+  const executable = generated.arbitrary.chain((model) => {
+    const machine = MachineTest.compileModel(model)
+    return MachineTest.scenarios(machine, { minEvents: 0, maxEvents: 20 }).arbitrary.map((scenario) => ({
+      model,
+      machine,
+      scenario
+    }))
+  })
+
+  it.effect.prop(
+    "runs and independently verifies schema-valid scenarios for generated machines",
+    { generated: executable },
+    ({ generated }) =>
+      MachineTest.run(generated.machine, generated.scenario).pipe(
+        Effect.flatMap((trace) => MachineTest.verify(generated.machine, trace))
+      ),
+    { fastCheck: { numRuns: 250, seed: 30_723 } }
+  )
+
+  it.effect("keeps the natural cross-root lifecycle boundary for reentering transitions", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [
+          {
+            _tag: "Compound",
+            key: "left",
+            value: 0,
+            initial: "idle",
+            states: [{ _tag: "Atomic", key: "idle", value: 1 }]
+          },
+          {
+            _tag: "Compound",
+            key: "right",
+            value: 2,
+            initial: "idle",
+            states: [{ _tag: "Atomic", key: "idle", value: 3 }]
+          }
+        ],
+        initial: "right",
+        events: ["Switch"],
+        transitions: [{ source: "right.idle", event: "Switch", target: "left", reenter: true }]
+      }
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [{ _tag: "Switch" }] })
+      const step = trace.steps[0]!.plan.microsteps[0]!
+
+      assert.deepStrictEqual(step.exitPaths, ["right.idle", "right"])
+      assert.deepStrictEqual(step.entryPaths, ["left", "left.idle"])
+      yield* MachineTest.verify(machine, trace)
+    }))
+
+  it.effect("uses deterministic schema-valid state values and final outputs", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [{ _tag: "Final", key: "done", value: 42, output: "completed" }],
+        initial: "done",
+        events: ["Unused"],
+        transitions: []
+      }
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [] })
+
+      assert.deepStrictEqual(trace.initial.startingState.value, { _tag: "State_done", value: 42 })
+      assert.strictEqual(trace.initial.plan.done, true)
+      assert.strictEqual(trace.initial.plan.output, "completed")
+      yield* MachineTest.verify(machine, trace)
+    }))
+
+  it("keeps every visited shrink valid and replays the minimal counterexample", () => {
+    const visited: Array<MachineTest.FiniteModel> = []
+    const property = FastCheck.property(generated.arbitrary, (model) => {
+      assertValid(model, generated.diagnostics.limits)
+      MachineTest.compileModel(model)
+      visited.push(model)
+      return false
+    })
+    const result = FastCheck.check(property, { numRuns: 20, seed: 40_964 })
+
+    assert.strictEqual(result.failed, true)
+    assert.ok(visited.length > 1, "the failing input should have been shrunk")
+    assert.ok(result.counterexample !== null)
+    const smallest = result.counterexample![0]
+    assertValid(smallest, generated.diagnostics.limits)
+
+    const replay = FastCheck.check(property, {
+      numRuns: 1,
+      seed: result.seed,
+      path: result.counterexamplePath
+    })
+    assert.strictEqual(replay.failed, true)
+    assert.deepStrictEqual(replay.counterexample?.[0], smallest)
+  })
+
+  it("rejects hand-authored dangling and duplicate transition registrations", () => {
+    const base: MachineTest.FiniteModel = {
+      roots: [{ _tag: "Atomic", key: "idle", value: 0 }],
+      initial: "idle",
+      events: ["Go"],
+      transitions: []
+    }
+    assert.throws(
+      () => MachineTest.compileModel({ ...base, transitions: [{ source: "missing", event: "Go", reenter: false }] }),
+      /invalid transition source/
+    )
+    assert.throws(
+      () =>
+        MachineTest.compileModel({
+          ...base,
+          transitions: [
+            { source: "idle", event: "Go", reenter: false },
+            { source: "idle", event: "Go", target: "idle", reenter: true }
+          ]
+        }),
+      /duplicate transition/
+    )
+    assert.throws(
+      () =>
+        MachineTest.compileModel({
+          ...base,
+          roots: [{ _tag: "History", key: "recent", history: "shallow", fallback: "idle" }],
+          initial: "recent"
+        }),
+      /root history state/
+    )
+    assert.throws(
+      () =>
+        MachineTest.compileModel({
+          roots: [{
+            _tag: "Compound",
+            key: "root",
+            value: 0,
+            initial: "recent",
+            states: [
+              { _tag: "Atomic", key: "idle", value: 1 },
+              { _tag: "History", key: "recent", history: "deep", fallback: "root.idle" }
+            ]
+          }],
+          initial: "root",
+          events: ["Go"],
+          transitions: []
+        }),
+      /unknown initial child/
+    )
+  })
+
+  it("rejects forged history scenarios that cannot replay their promised witness", () => {
+    const witnessModel = (
+      historyType: "shallow" | "deep",
+      mutationSource: "root.work.phase.idle" | "root.work.other"
+    ): MachineTest.FiniteModel => {
+      const history = "root.work.recent"
+      const scenario: MachineTest.FiniteHistoryScenario = {
+        history,
+        owner: "root.work",
+        historyType,
+        mutation: { source: mutationSource, event: "Mutate", target: mutationSource, value: 100 },
+        leave: { source: "root.work.phase.idle", event: "Leave", target: "outside" },
+        resume: { source: "outside", event: "Leave", target: history },
+        events: ["Mutate", "Leave", "Leave"]
+      }
+      return {
+        roots: [
+          {
+            _tag: "Compound",
+            key: "root",
+            value: 0,
+            initial: "work",
+            states: [{
+              _tag: "Compound",
+              key: "work",
+              value: 1,
+              initial: "phase",
+              states: [
+                {
+                  _tag: "Compound",
+                  key: "phase",
+                  value: 2,
+                  initial: "idle",
+                  states: [{ _tag: "Atomic", key: "idle", value: 3 }]
+                },
+                { _tag: "Atomic", key: "other", value: 4 },
+                { _tag: "History", key: "recent", history: historyType, fallback: "root.work.phase" }
+              ]
+            }]
+          },
+          { _tag: "Atomic", key: "outside", value: 5 }
+        ],
+        initial: "root",
+        events: ["Mutate", "Leave"],
+        transitions: [
+          {
+            source: mutationSource,
+            event: "Mutate",
+            target: mutationSource,
+            targetValue: 100,
+            reenter: false
+          },
+          { source: "root.work.phase.idle", event: "Leave", target: "outside", reenter: false },
+          { source: "outside", event: "Leave", target: history, reenter: false }
+        ],
+        historyScenarios: [scenario]
+      }
+    }
+
+    const valid = witnessModel("deep", "root.work.phase.idle")
+    assert.doesNotThrow(() => MachineTest.compileModel(valid))
+    assert.throws(
+      () => MachineTest.compileModel(witnessModel("shallow", "root.work.phase.idle")),
+      /invalid history mutation/
+    )
+    assert.throws(
+      () => MachineTest.compileModel(witnessModel("deep", "root.work.other")),
+      /invalid history mutation/
+    )
+    assert.throws(
+      () =>
+        MachineTest.compileModel({
+          ...valid,
+          historyScenarios: [{
+            ...valid.historyScenarios![0]!,
+            events: ["Mutate", "Leave"] as any
+          }]
+        }),
+      /inconsistent history events/
+    )
+    assert.throws(
+      () =>
+        MachineTest.compileModel({
+          ...valid,
+          historyScenarios: [valid.historyScenarios![0]!, valid.historyScenarios![0]!]
+        }),
+      /duplicate history scenario/
+    )
+  })
+})

--- a/test/MachineTestReferenceModel.test.ts
+++ b/test/MachineTestReferenceModel.test.ts
@@ -1469,6 +1469,6 @@ describe("MachineTest finite-model reference interpreter", () => {
         Effect.flatMap((trace) => MachineTest.verifyModel(generated.model, trace))
       )
     },
-    { fastCheck: { numRuns: 1_500, seed: 51_205 } }
+    { timeout: 30_000, fastCheck: { numRuns: 1_500, seed: 51_205 } }
   )
 })

--- a/test/MachineTestReferenceModel.test.ts
+++ b/test/MachineTestReferenceModel.test.ts
@@ -1,0 +1,1474 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as Cause from "effect/Cause"
+import * as Effect from "effect/Effect"
+import * as Schema from "effect/Schema"
+import { FastCheck } from "effect/testing"
+import { Machine } from "../src/index.js"
+import { MachineTest } from "../src/testing.js"
+
+const event = (_tag: string): { readonly _tag: string } => ({ _tag })
+
+const fields = (error: MachineTest.ModelVerificationError): ReadonlyArray<string> =>
+  error.mismatches.map((mismatch) => mismatch.field)
+
+const snapshotAtPath = (snapshot: unknown, path: string): unknown => {
+  if (typeof snapshot !== "object" || snapshot === null) return undefined
+  const current = snapshot as Record<string, unknown>
+  if (current.path === path) return snapshot
+  if (current.state !== undefined) {
+    const found = snapshotAtPath(current.state, path)
+    if (found !== undefined) return found
+  }
+  if (typeof current.states === "object" && current.states !== null) {
+    for (const child of Object.values(current.states)) {
+      const found = snapshotAtPath(child, path)
+      if (found !== undefined) return found
+    }
+  }
+  return undefined
+}
+
+describe("MachineTest finite-model reference interpreter", () => {
+  const parallelWorkflow = (
+    transitions: ReadonlyArray<MachineTest.FiniteTransition>
+  ): MachineTest.FiniteModel => ({
+    roots: [
+      {
+        _tag: "Parallel",
+        key: "workflow",
+        value: 0,
+        output: "workflow:complete",
+        states: [
+          {
+            _tag: "Compound",
+            key: "left",
+            value: 1,
+            initial: "idle",
+            states: [
+              { _tag: "Atomic", key: "idle", value: 2 },
+              { _tag: "Final", key: "done", value: 3, output: "left:done" }
+            ]
+          },
+          {
+            _tag: "Compound",
+            key: "right",
+            value: 4,
+            initial: "idle",
+            states: [
+              { _tag: "Atomic", key: "idle", value: 5 },
+              { _tag: "Final", key: "done", value: 6, output: "right:done" }
+            ]
+          }
+        ]
+      },
+      { _tag: "Atomic", key: "failed", value: 7 },
+      { _tag: "Atomic", key: "cancelled", value: 8 }
+    ],
+    initial: "workflow",
+    events: ["Both", "Left", "Right", "Abort"],
+    transitions
+  })
+
+  const completionTransitions: ReadonlyArray<MachineTest.FiniteTransition> = [
+    { source: "workflow.left.idle", event: "Both", target: "workflow.left.done", reenter: false },
+    { source: "workflow.right.idle", event: "Both", target: "workflow.right.done", reenter: false },
+    { source: "workflow.left.idle", event: "Left", target: "workflow.left.done", reenter: false },
+    { source: "workflow.right.idle", event: "Right", target: "workflow.right.done", reenter: false }
+  ]
+
+  const idleParallelRegions = (offset: number): ReadonlyArray<MachineTest.FiniteState> => [
+    {
+      _tag: "Compound",
+      key: "left",
+      value: offset,
+      initial: "idle",
+      states: [{ _tag: "Atomic", key: "idle", value: offset + 1 }]
+    },
+    {
+      _tag: "Compound",
+      key: "right",
+      value: offset + 2,
+      initial: "idle",
+      states: [{ _tag: "Atomic", key: "idle", value: offset + 3 }]
+    }
+  ]
+
+  it.effect("retains simultaneous transitions in two orthogonal regions", () =>
+    Effect.gen(function*() {
+      const model = parallelWorkflow(completionTransitions)
+      const reference = MachineTest.interpretModel(model, ["Both"])
+      const microstep = reference.steps[0]!.microsteps[0]!
+
+      assert.deepStrictEqual(microstep.transitions.map(({ source }) => source), [
+        "workflow.left.idle",
+        "workflow.right.idle"
+      ])
+      assert.deepStrictEqual(microstep.exitPaths, ["workflow.right.idle", "workflow.left.idle"])
+      assert.deepStrictEqual(microstep.entryPaths, ["workflow.left.done", "workflow.right.done"])
+      assert.strictEqual(reference.steps[0]!.done, true)
+      assert.strictEqual(reference.steps[0]!.output, "workflow:complete")
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Both")] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("lets a child transition preempt an enabled parallel ancestor", () =>
+    Effect.gen(function*() {
+      const model = parallelWorkflow([
+        { source: "workflow", event: "Abort", target: "failed", reenter: false },
+        { source: "workflow.left.idle", event: "Abort", target: "workflow.left.done", reenter: false }
+      ])
+      const reference = MachineTest.interpretModel(model, ["Abort"])
+      assert.deepStrictEqual(reference.steps[0]!.microsteps[0]!.transitions.map(({ source }) => source), [
+        "workflow.left.idle"
+      ])
+      assert.deepStrictEqual(reference.steps[0]!.after.activePaths, [
+        "workflow",
+        "workflow.left",
+        "workflow.left.done",
+        "workflow.right",
+        "workflow.right.idle"
+      ])
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Abort")] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("uses source document order for conflicting cross-root targets", () =>
+    Effect.gen(function*() {
+      const model = parallelWorkflow([
+        { source: "workflow.left.idle", event: "Abort", target: "failed", reenter: false },
+        { source: "workflow.right.idle", event: "Abort", target: "cancelled", reenter: false }
+      ])
+      const reference = MachineTest.interpretModel(model, ["Abort"])
+      assert.deepStrictEqual(reference.steps[0]!.microsteps[0]!.transitions.map(({ source }) => source), [
+        "workflow.left.idle"
+      ])
+      assert.deepStrictEqual(reference.steps[0]!.after.activePaths, ["failed"])
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Abort")] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("preserves an unaffected sibling and completes parallel state only after every region", () =>
+    Effect.gen(function*() {
+      const model = parallelWorkflow(completionTransitions)
+      const reference = MachineTest.interpretModel(model, ["Left", "Right"])
+      const afterLeft = reference.steps[0]!.after
+
+      assert.deepStrictEqual(afterLeft.activePaths, [
+        "workflow",
+        "workflow.left",
+        "workflow.left.done",
+        "workflow.right",
+        "workflow.right.idle"
+      ])
+      assert.strictEqual(reference.steps[0]!.done, false)
+      assert.deepStrictEqual(afterLeft.completions, [
+        { path: "workflow.left.done", output: "left:done" },
+        { path: "workflow.left", output: "left:done" }
+      ])
+
+      const afterRight = reference.steps[1]!.after
+      assert.strictEqual(reference.steps[1]!.done, true)
+      assert.strictEqual(reference.steps[1]!.output, "workflow:complete")
+      assert.ok(afterRight.completions.some(({ path, output }) => path === "workflow.left" && output === "left:done"))
+      assert.ok(
+        afterRight.completions.some(({ path, output }) => path === "workflow" && output === "workflow:complete")
+      )
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Left"), event("Right")] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("initializes every region when a same-root transition directly targets a parallel state", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [{
+          _tag: "Compound",
+          key: "app",
+          value: 0,
+          initial: "idle",
+          states: [
+            { _tag: "Atomic", key: "idle", value: 1 },
+            {
+              _tag: "Parallel",
+              key: "work",
+              value: 2,
+              output: "work:complete",
+              states: idleParallelRegions(3)
+            }
+          ]
+        }],
+        initial: "app",
+        events: ["Enter"],
+        transitions: [{ source: "app.idle", event: "Enter", target: "app.work", reenter: false }]
+      }
+
+      const reference = MachineTest.interpretModel(model, ["Enter"])
+      assert.deepStrictEqual(reference.steps[0]!.after.activePaths, [
+        "app",
+        "app.work",
+        "app.work.left",
+        "app.work.left.idle",
+        "app.work.right",
+        "app.work.right.idle"
+      ])
+      assert.strictEqual(reference.steps[0]!.microsteps[0]!.transitions[0]!.resolvedTarget, "app.work")
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Enter")] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("follows a same-root compound target through its initial parallel state", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [{
+          _tag: "Compound",
+          key: "app",
+          value: 0,
+          initial: "idle",
+          states: [
+            { _tag: "Atomic", key: "idle", value: 1 },
+            {
+              _tag: "Compound",
+              key: "running",
+              value: 2,
+              initial: "work",
+              states: [{
+                _tag: "Parallel",
+                key: "work",
+                value: 3,
+                output: "work:complete",
+                states: idleParallelRegions(4)
+              }]
+            }
+          ]
+        }],
+        initial: "app",
+        events: ["Enter"],
+        transitions: [{ source: "app.idle", event: "Enter", target: "app.running", reenter: false }]
+      }
+
+      const reference = MachineTest.interpretModel(model, ["Enter"])
+      assert.deepStrictEqual(reference.steps[0]!.after.activePaths, [
+        "app",
+        "app.running",
+        "app.running.work",
+        "app.running.work.left",
+        "app.running.work.left.idle",
+        "app.running.work.right",
+        "app.running.work.right.idle"
+      ])
+      assert.strictEqual(
+        reference.steps[0]!.microsteps[0]!.transitions[0]!.resolvedTarget,
+        "app.running.work"
+      )
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Enter")] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("preserves sibling regions when targeting a nested state from within an active parallel region", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [{
+          _tag: "Compound",
+          key: "app",
+          value: 0,
+          initial: "work",
+          states: [{
+            _tag: "Parallel",
+            key: "work",
+            value: 1,
+            output: "work:complete",
+            states: [
+              {
+                _tag: "Compound",
+                key: "left",
+                value: 2,
+                initial: "idle",
+                states: [
+                  { _tag: "Atomic", key: "idle", value: 3 },
+                  {
+                    _tag: "Compound",
+                    key: "running",
+                    value: 4,
+                    initial: "first",
+                    states: [
+                      { _tag: "Atomic", key: "first", value: 5 },
+                      { _tag: "Atomic", key: "second", value: 6 }
+                    ]
+                  }
+                ]
+              },
+              {
+                _tag: "Compound",
+                key: "right",
+                value: 7,
+                initial: "idle",
+                states: [{ _tag: "Atomic", key: "idle", value: 8 }]
+              }
+            ]
+          }]
+        }],
+        initial: "app",
+        events: ["Advance"],
+        transitions: [{
+          source: "app.work.left.idle",
+          event: "Advance",
+          target: "app.work.left.running",
+          reenter: false
+        }]
+      }
+
+      const reference = MachineTest.interpretModel(model, ["Advance"])
+      assert.deepStrictEqual(reference.steps[0]!.after.activePaths, [
+        "app",
+        "app.work",
+        "app.work.left",
+        "app.work.left.running",
+        "app.work.left.running.first",
+        "app.work.right",
+        "app.work.right.idle"
+      ])
+      assert.deepStrictEqual(reference.steps[0]!.microsteps[0]!.exitPaths, ["app.work.left.idle"])
+      assert.deepStrictEqual(reference.steps[0]!.microsteps[0]!.entryPaths, [
+        "app.work.left.running",
+        "app.work.left.running.first"
+      ])
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Advance")] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("reinitializes only the source region when targeting an active parallel ancestor", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [{
+          _tag: "Compound",
+          key: "app",
+          value: 0,
+          initial: "work",
+          states: [{
+            _tag: "Parallel",
+            key: "work",
+            value: 1,
+            output: "work:complete",
+            states: [
+              {
+                _tag: "Compound",
+                key: "left",
+                value: 2,
+                initial: "idle",
+                states: [
+                  { _tag: "Atomic", key: "idle", value: 3 },
+                  { _tag: "Atomic", key: "alternate", value: 4 }
+                ]
+              },
+              {
+                _tag: "Compound",
+                key: "right",
+                value: 5,
+                initial: "idle",
+                states: [
+                  { _tag: "Atomic", key: "idle", value: 6 },
+                  { _tag: "Atomic", key: "alternate", value: 7 }
+                ]
+              }
+            ]
+          }]
+        }],
+        initial: "app",
+        events: ["Move", "ResetParallel", "ResetCompound"],
+        transitions: [
+          {
+            source: "app.work.left.idle",
+            event: "Move",
+            target: "app.work.left.alternate",
+            reenter: false
+          },
+          {
+            source: "app.work.right.idle",
+            event: "Move",
+            target: "app.work.right.alternate",
+            reenter: false
+          },
+          {
+            source: "app.work.left.alternate",
+            event: "ResetParallel",
+            target: "app.work",
+            reenter: false
+          },
+          {
+            source: "app.work.left.alternate",
+            event: "ResetCompound",
+            target: "app",
+            reenter: false
+          }
+        ]
+      }
+      const expected = [
+        "app",
+        "app.work",
+        "app.work.left",
+        "app.work.left.idle",
+        "app.work.right",
+        "app.work.right.alternate"
+      ]
+
+      for (const reset of ["ResetParallel", "ResetCompound"]) {
+        const reference = MachineTest.interpretModel(model, ["Move", reset])
+        assert.deepStrictEqual(reference.steps[1]!.after.activePaths, expected)
+        assert.strictEqual(
+          reference.steps[1]!.microsteps[0]!.transitions[0]!.resolvedTarget,
+          "app.work.left.idle"
+        )
+
+        const machine = MachineTest.compileModel(model)
+        const trace = yield* MachineTest.run(machine, { events: [event("Move"), event(reset)] })
+        yield* MachineTest.verifyModel(model, trace)
+      }
+    }))
+
+  it.effect("initializes every region when a cross-root transition fully targets a parallel root", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [
+          { _tag: "Atomic", key: "idle", value: 0 },
+          {
+            _tag: "Parallel",
+            key: "work",
+            value: 1,
+            output: "work:complete",
+            states: idleParallelRegions(2)
+          }
+        ],
+        initial: "idle",
+        events: ["Enter"],
+        transitions: [{ source: "idle", event: "Enter", target: "work", reenter: false }]
+      }
+
+      const reference = MachineTest.interpretModel(model, ["Enter"])
+      assert.deepStrictEqual(reference.steps[0]!.after.activePaths, [
+        "work",
+        "work.left",
+        "work.left.idle",
+        "work.right",
+        "work.right.idle"
+      ])
+      assert.strictEqual(reference.steps[0]!.microsteps[0]!.transitions[0]!.resolvedTarget, "work")
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Enter")] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("rejects parallel selection, conflict, retention, and configuration mutations", () =>
+    Effect.gen(function*() {
+      const simultaneousModel = parallelWorkflow(completionTransitions)
+      const simultaneousMachine = MachineTest.compileModel(simultaneousModel)
+      const simultaneous = yield* MachineTest.run(simultaneousMachine, { events: [event("Both")] })
+      const simultaneousStep = simultaneous.steps[0]!
+      const simultaneousMicrostep = simultaneousStep.plan.microsteps[0]!
+      const dropped = {
+        ...simultaneous,
+        steps: [{
+          ...simultaneousStep,
+          plan: {
+            ...simultaneousStep.plan,
+            microsteps: [{
+              ...simultaneousMicrostep,
+              transitions: simultaneousMicrostep.transitions.slice(0, 1)
+            }]
+          }
+        }]
+      } as typeof simultaneous
+      const droppedError = yield* MachineTest.verifyModel(simultaneousModel, dropped).pipe(Effect.flip)
+      assert.include(fields(droppedError), "microstep.transitions")
+
+      const ancestorModel = parallelWorkflow([
+        { source: "workflow", event: "Abort", target: "failed", reenter: false },
+        { source: "workflow.left.idle", event: "Abort", target: "workflow.left.done", reenter: false }
+      ])
+      const ancestorMachine = MachineTest.compileModel(ancestorModel)
+      const ancestor = yield* MachineTest.run(ancestorMachine, { events: [event("Abort")] })
+      const ancestorStep = ancestor.steps[0]!
+      const ancestorMicrostep = ancestorStep.plan.microsteps[0]!
+      const choseAncestor = {
+        ...ancestor,
+        steps: [{
+          ...ancestorStep,
+          plan: {
+            ...ancestorStep.plan,
+            microsteps: [{
+              ...ancestorMicrostep,
+              transitions: [{ ...ancestorMicrostep.transitions[0]!, source: "workflow" }]
+            }]
+          }
+        }]
+      } as typeof ancestor
+      const ancestorError = yield* MachineTest.verifyModel(ancestorModel, choseAncestor).pipe(Effect.flip)
+      assert.include(fields(ancestorError), "microstep.transitions")
+
+      const conflictModel = parallelWorkflow([
+        { source: "workflow.left.idle", event: "Abort", target: "failed", reenter: false },
+        { source: "workflow.right.idle", event: "Abort", target: "cancelled", reenter: false }
+      ])
+      const reversedModel = parallelWorkflow([
+        { source: "workflow.left.idle", event: "Abort", target: "cancelled", reenter: false },
+        { source: "workflow.right.idle", event: "Abort", target: "failed", reenter: false }
+      ])
+      const reversedMachine = MachineTest.compileModel(reversedModel)
+      const reversed = yield* MachineTest.run(reversedMachine, { events: [event("Abort")] })
+      const conflictError = yield* MachineTest.verifyModel(conflictModel, reversed).pipe(Effect.flip)
+      assert.include(fields(conflictError), "microstep.transitions")
+      assert.include(fields(conflictError), "step.plan.next.activePaths")
+
+      const initial = simultaneous.initial.startingState as any
+      const omitted = { ...initial, states: { left: initial.states.left } }
+      const omittedPaths = ["workflow", "workflow.left", "workflow.left.idle"]
+      const omittedTrace = {
+        ...simultaneous,
+        scenario: { events: [] },
+        initial: {
+          ...simultaneous.initial,
+          startingState: omitted,
+          startingConfiguration: omittedPaths,
+          initialEntryPaths: omittedPaths,
+          configuration: omittedPaths,
+          plan: {
+            ...simultaneous.initial.plan,
+            startingState: omitted,
+            initialEntryPaths: omittedPaths,
+            state: omitted,
+            microsteps: [],
+            done: false,
+            output: undefined
+          }
+        },
+        steps: [],
+        final: omitted,
+        finalConfiguration: omittedPaths
+      } as unknown as typeof simultaneous
+      const omittedError = yield* MachineTest.verifyModel(simultaneousModel, omittedTrace).pipe(Effect.flip)
+      assert.include(fields(omittedError), "initial.startingState.activePaths")
+    }))
+
+  it.effect("applies value-only targets before control changes without resurrecting exited branches", () =>
+    Effect.gen(function*() {
+      const Root = Schema.TaggedStruct("Root", { version: Schema.Number })
+      const Left = Schema.TaggedStruct("Left", { version: Schema.Number })
+      const LeftIdle = Schema.TaggedStruct("LeftIdle", { version: Schema.Number })
+      const LeftDone = Schema.TaggedStruct("LeftDone", { version: Schema.Number })
+      const Right = Schema.TaggedStruct("Right", { version: Schema.Number })
+      const RightIdle = Schema.TaggedStruct("RightIdle", { version: Schema.Number })
+      const Outside = Schema.TaggedStruct("Outside", { version: Schema.Number })
+      const Local = Schema.TaggedStruct("Local", {})
+      const Exit = Schema.TaggedStruct("Exit", {})
+      const states = Machine.defineStates({
+        root: {
+          schema: Root,
+          type: "parallel",
+          states: {
+            left: {
+              schema: Left,
+              initial: "idle",
+              states: { idle: LeftIdle, done: LeftDone }
+            },
+            right: {
+              schema: Right,
+              initial: "idle",
+              states: { idle: RightIdle }
+            }
+          }
+        },
+        outside: Outside
+      })
+      const machine = Machine.make({
+        states: states.states,
+        events: [Local, Exit],
+        initial: () =>
+          states.initial.root({ _tag: "Root", version: 0 }, (regions) =>
+            regions
+              .left({ _tag: "Left", version: 0 }, (left) => left.idle({ _tag: "LeftIdle", version: 0 }))
+              .right({ _tag: "Right", version: 0 }, (right) => right.idle({ _tag: "RightIdle", version: 0 })))
+      }).handle({
+        root: {
+          states: {
+            left: {
+              states: {
+                idle: {
+                  on: {
+                    Local: ({ target }) => target.local.done({ _tag: "LeftDone", version: 1 }),
+                    Exit: ({ target }) => target.full.outside({ _tag: "Outside", version: 1 })
+                  }
+                }
+              }
+            },
+            right: {
+              states: {
+                idle: {
+                  on: {
+                    Local: ({ target }) => target.local.idle({ _tag: "RightIdle", version: 1 }),
+                    Exit: ({ target }) => target.local.idle({ _tag: "RightIdle", version: 2 })
+                  }
+                }
+              }
+            }
+          }
+        }
+      })
+
+      const initial = yield* Machine.planInitial(machine)
+      const local = yield* Machine.plan(machine, initial.state, { _tag: "Local" })
+      assert.strictEqual((local.next as any).states.left.state.path, "root.left.done")
+      assert.strictEqual((local.next as any).states.right.state.value.version, 1)
+
+      const exited = yield* Machine.plan(machine, initial.state, { _tag: "Exit" })
+      assert.strictEqual(exited.next.path, "outside")
+      assert.deepStrictEqual(exited.microsteps[0]!.transitions.map(({ source }) => source), [
+        "root.left.idle",
+        "root.right.idle"
+      ])
+    }))
+
+  it.effect("initializes the default descendants of a same-root compound target", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [{
+          _tag: "Compound",
+          key: "workflow",
+          value: 0,
+          initial: "idle",
+          states: [
+            { _tag: "Atomic", key: "idle", value: 1 },
+            {
+              _tag: "Compound",
+              key: "running",
+              value: 2,
+              initial: "first",
+              states: [
+                { _tag: "Atomic", key: "first", value: 3 },
+                { _tag: "Atomic", key: "second", value: 4 }
+              ]
+            }
+          ]
+        }],
+        initial: "workflow",
+        events: ["Start"],
+        transitions: [{
+          source: "workflow.idle",
+          event: "Start",
+          target: "workflow.running",
+          reenter: false
+        }]
+      }
+
+      const reference = MachineTest.interpretModel(model, ["Start"])
+      assert.deepStrictEqual(reference.initial.startingState.activePaths, ["workflow", "workflow.idle"])
+      assert.deepStrictEqual(reference.steps[0]?.after.activePaths, [
+        "workflow",
+        "workflow.running",
+        "workflow.running.first"
+      ])
+      assert.deepStrictEqual(reference.steps[0]?.microsteps[0]?.exitPaths, ["workflow.idle"])
+      assert.deepStrictEqual(reference.steps[0]?.microsteps[0]?.entryPaths, [
+        "workflow.running",
+        "workflow.running.first"
+      ])
+      assert.deepStrictEqual(reference.steps[0]?.after.values["workflow.running.first"], {
+        _tag: "State_workflow_running_first",
+        value: 3
+      })
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Start")] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("retains a direct final root output and ignores later events", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [{ _tag: "Final", key: "finished", value: 42, output: "complete" }],
+        initial: "finished",
+        events: ["After"],
+        transitions: []
+      }
+
+      const reference = MachineTest.interpretModel(model, ["After"])
+      assert.deepStrictEqual(reference.initial.startingState.completions, [])
+      assert.deepStrictEqual(reference.initial.state.completions, [{ path: "finished", output: "complete" }])
+      assert.strictEqual(reference.initial.done, true)
+      assert.strictEqual(reference.initial.output, "complete")
+      assert.strictEqual(reference.steps[0]?.done, true)
+      assert.strictEqual(reference.steps[0]?.output, "complete")
+      assert.deepStrictEqual(reference.steps[0]?.microsteps, [])
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("After")] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("propagates a direct final child through compound completion", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [{
+          _tag: "Compound",
+          key: "job",
+          value: 0,
+          initial: "done",
+          states: [{ _tag: "Final", key: "done", value: 1, output: "result" }]
+        }],
+        initial: "job",
+        events: ["Unused"],
+        transitions: []
+      }
+
+      const reference = MachineTest.interpretModel(model, [])
+      assert.deepStrictEqual(reference.initial.state.completions, [
+        { path: "job.done", output: "result" },
+        { path: "job", output: "result" }
+      ])
+      assert.strictEqual(reference.initial.state.status, "done")
+      assert.strictEqual(reference.initial.output, "result")
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("models targetless steps, broadened reentry, and cross-root lifecycle order", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [
+          {
+            _tag: "Compound",
+            key: "left",
+            value: 0,
+            initial: "branch",
+            states: [{
+              _tag: "Compound",
+              key: "branch",
+              value: 1,
+              initial: "leaf",
+              states: [{ _tag: "Atomic", key: "leaf", value: 2 }]
+            }]
+          },
+          {
+            _tag: "Compound",
+            key: "right",
+            value: 3,
+            initial: "idle",
+            states: [{ _tag: "Atomic", key: "idle", value: 4 }]
+          }
+        ],
+        initial: "left",
+        events: ["Noop", "Reenter", "Switch"],
+        transitions: [
+          { source: "left.branch.leaf", event: "Noop", reenter: false },
+          { source: "left.branch", event: "Reenter", target: "left.branch", reenter: true },
+          { source: "left.branch.leaf", event: "Switch", target: "right", reenter: false }
+        ]
+      }
+
+      const reference = MachineTest.interpretModel(model, ["Noop", "Reenter", "Switch"])
+      assert.deepStrictEqual(reference.steps[0]?.microsteps[0], {
+        next: reference.steps[0]?.before,
+        event: "Noop",
+        transitions: [{
+          source: "left.branch.leaf",
+          trigger: { type: "event", event: "Noop" },
+          reenter: false,
+          target: undefined,
+          resolvedTarget: undefined
+        }],
+        exitPaths: [],
+        entryPaths: [],
+        changed: false
+      })
+      assert.deepStrictEqual(reference.steps[1]?.microsteps[0]?.exitPaths, [
+        "left.branch.leaf",
+        "left.branch"
+      ])
+      assert.deepStrictEqual(reference.steps[1]?.microsteps[0]?.entryPaths, [
+        "left.branch",
+        "left.branch.leaf"
+      ])
+      assert.deepStrictEqual(reference.steps[2]?.microsteps[0]?.exitPaths, [
+        "left.branch.leaf",
+        "left.branch",
+        "left"
+      ])
+      assert.deepStrictEqual(reference.steps[2]?.microsteps[0]?.entryPaths, ["right", "right.idle"])
+      assert.deepStrictEqual(reference.steps[2]?.microsteps[0]?.transitions[0]?.target, "right")
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, {
+        events: [event("Noop"), event("Reenter"), event("Switch")]
+      })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("rejects an ancestor source when the active leaf transition has priority", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [{
+          _tag: "Compound",
+          key: "root",
+          value: 0,
+          initial: "branch",
+          states: [
+            {
+              _tag: "Compound",
+              key: "branch",
+              value: 1,
+              initial: "leaf",
+              states: [{ _tag: "Atomic", key: "leaf", value: 2 }]
+            },
+            { _tag: "Atomic", key: "other", value: 3 }
+          ]
+        }],
+        initial: "root",
+        events: ["Go"],
+        transitions: [
+          { source: "root.branch", event: "Go", target: "root.other", reenter: false },
+          { source: "root.branch.leaf", event: "Go", target: "root.other", reenter: false }
+        ]
+      }
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Go")] })
+      const step = trace.steps[0]!
+      const microstep = step.plan.microsteps[0]!
+      const retained = microstep.transitions[0]!
+      const corrupted = {
+        ...trace,
+        steps: [{
+          ...step,
+          plan: {
+            ...step.plan,
+            microsteps: [{
+              ...microstep,
+              transitions: [{ ...retained, source: "root.branch" }]
+            }]
+          }
+        }]
+      } as typeof trace
+
+      // The mutated transition is declared and produces the same structurally
+      // valid configuration, so only selection semantics distinguish it.
+      yield* MachineTest.verify(machine, corrupted)
+      const error = yield* MachineTest.verifyModel(model, corrupted).pipe(Effect.flip)
+      assert.include(fields(error), "microstep.transitions")
+    }))
+
+  it.effect("rejects a valid sibling configuration in place of the declared initial branch", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [{
+          _tag: "Compound",
+          key: "root",
+          value: 0,
+          initial: "left",
+          states: [
+            { _tag: "Atomic", key: "left", value: 1 },
+            { _tag: "Atomic", key: "right", value: 2 }
+          ]
+        }],
+        initial: "root",
+        events: ["Unused"],
+        transitions: []
+      }
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [] })
+      const right = {
+        path: "root",
+        value: { _tag: "State_root", value: 0 },
+        state: {
+          path: "root.right",
+          value: { _tag: "State_root_right", value: 2 }
+        }
+      }
+      const rightPaths = ["root", "root.right"]
+      const corrupted = {
+        ...trace,
+        initial: {
+          ...trace.initial,
+          startingState: right,
+          startingConfiguration: rightPaths,
+          initialEntryPaths: rightPaths,
+          configuration: rightPaths,
+          plan: {
+            ...trace.initial.plan,
+            startingState: right,
+            initialEntryPaths: rightPaths,
+            state: right
+          }
+        },
+        final: right,
+        finalConfiguration: rightPaths
+      } as typeof trace
+
+      // The trace is self-consistent and every state/value is schema-valid,
+      // but it does not represent the model's declared initial state.
+      yield* MachineTest.verify(machine, corrupted)
+      const error = yield* MachineTest.verifyModel(model, corrupted).pipe(Effect.flip)
+      assert.include(fields(error), "initial.startingState.activePaths")
+      assert.include(fields(error), "trace.final.activePaths")
+    }))
+
+  it.effect("rejects a self-consistent trace that drops an enabled transition", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [
+          { _tag: "Atomic", key: "idle", value: 0 },
+          { _tag: "Atomic", key: "ready", value: 1 }
+        ],
+        initial: "idle",
+        events: ["Start"],
+        transitions: [{ source: "idle", event: "Start", target: "ready", reenter: false }]
+      }
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Start")] })
+      const step = trace.steps[0]!
+      const corrupted = {
+        ...trace,
+        steps: [{
+          ...step,
+          plan: {
+            ...step.plan,
+            next: step.before,
+            microsteps: [],
+            done: false,
+            output: undefined
+          },
+          after: step.before,
+          afterConfiguration: step.beforeConfiguration
+        }],
+        final: step.before,
+        finalConfiguration: step.beforeConfiguration
+      } as typeof trace
+
+      yield* MachineTest.verify(machine, corrupted)
+      const error = yield* MachineTest.verifyModel(model, corrupted).pipe(Effect.flip)
+      assert.include(fields(error), "step.plan.microsteps.length")
+      assert.include(fields(error), "step.plan.next.activePaths")
+    }))
+
+  const compoundHistoryModel = (
+    history: "shallow" | "deep",
+    initial: "workspace" | "outside" = "workspace"
+  ): MachineTest.FiniteModel => ({
+    roots: [
+      {
+        _tag: "Compound",
+        key: "workspace",
+        value: 0,
+        initial: "editor",
+        states: [
+          {
+            _tag: "Compound",
+            key: "editor",
+            value: 1,
+            initial: "writing",
+            states: [
+              { _tag: "Atomic", key: "writing", value: 2 },
+              { _tag: "Atomic", key: "preview", value: 3 }
+            ]
+          },
+          { _tag: "History", key: "recent", history, fallback: "workspace.editor" }
+        ]
+      },
+      { _tag: "Atomic", key: "outside", value: 4 }
+    ],
+    initial,
+    events: ["Advance", "Reset", "Leave", "Resume"],
+    transitions: [
+      { source: "workspace.editor.writing", event: "Advance", target: "workspace.editor.preview", reenter: false },
+      { source: "workspace.editor.writing", event: "Leave", target: "outside", reenter: false },
+      { source: "workspace.editor.preview", event: "Reset", target: "workspace.editor.writing", reenter: false },
+      { source: "workspace.editor.preview", event: "Leave", target: "outside", reenter: false },
+      { source: "outside", event: "Resume", target: "workspace.recent", reenter: false }
+    ]
+  })
+
+  it.effect("uses fallback only before capture, then deep history overwrites and reuses its register", () =>
+    Effect.gen(function*() {
+      const fallbackModel = compoundHistoryModel("deep", "outside")
+      const fallbackReference = MachineTest.interpretModel(fallbackModel, ["Resume"])
+      assert.deepStrictEqual(fallbackReference.final.activePaths, [
+        "workspace",
+        "workspace.editor",
+        "workspace.editor.writing"
+      ])
+      assert.deepStrictEqual(fallbackReference.final.history, {})
+      const fallbackMachine = MachineTest.compileModel(fallbackModel)
+      const fallbackTrace = yield* MachineTest.run(fallbackMachine, { events: [event("Resume")] })
+      yield* MachineTest.verifyModel(fallbackModel, fallbackTrace)
+
+      const model = compoundHistoryModel("deep")
+      const events = ["Advance", "Leave", "Resume", "Reset", "Leave", "Resume", "Leave", "Resume"]
+      const reference = MachineTest.interpretModel(model, events)
+      assert.deepStrictEqual(reference.steps[2]!.after.activePaths, [
+        "workspace",
+        "workspace.editor",
+        "workspace.editor.preview"
+      ])
+      assert.deepStrictEqual(reference.steps[5]!.after.activePaths, [
+        "workspace",
+        "workspace.editor",
+        "workspace.editor.writing"
+      ])
+      assert.deepStrictEqual(reference.final.activePaths, reference.steps[5]!.after.activePaths)
+      assert.ok(reference.final.history["workspace.recent"]?.active.includes("workspace.editor.writing"))
+      assert.ok(!reference.final.history["workspace.recent"]?.active.includes("workspace.editor.preview"))
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: events.map(event) })
+      yield* MachineTest.verify(machine, trace)
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("reinitializes descendants for shallow history instead of restoring the deep branch", () =>
+    Effect.gen(function*() {
+      const model = compoundHistoryModel("shallow")
+      const events = ["Advance", "Leave", "Resume"]
+      const reference = MachineTest.interpretModel(model, events)
+      assert.deepStrictEqual(reference.final.activePaths, [
+        "workspace",
+        "workspace.editor",
+        "workspace.editor.writing"
+      ])
+      assert.deepStrictEqual(reference.final.history["workspace.recent"]?.active, [
+        "workspace",
+        "workspace.editor"
+      ])
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: events.map(event) })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  const parallelHistoryModel = (): MachineTest.FiniteModel => ({
+    roots: [
+      {
+        _tag: "Parallel",
+        key: "workspace",
+        value: 0,
+        output: "workspace:done",
+        states: [
+          {
+            _tag: "Compound",
+            key: "editor",
+            value: 1,
+            initial: "idle",
+            states: [
+              { _tag: "Atomic", key: "idle", value: 2 },
+              { _tag: "Atomic", key: "active", value: 3 }
+            ]
+          },
+          {
+            _tag: "Compound",
+            key: "sidebar",
+            value: 4,
+            initial: "closed",
+            states: [
+              { _tag: "Atomic", key: "closed", value: 5 },
+              { _tag: "Atomic", key: "open", value: 6 }
+            ]
+          },
+          { _tag: "History", key: "recent", history: "shallow", fallback: "workspace.editor" },
+          { _tag: "History", key: "exact", history: "deep", fallback: "workspace.editor" }
+        ]
+      },
+      { _tag: "Atomic", key: "outside", value: 7 }
+    ],
+    initial: "workspace",
+    events: ["Advance", "Leave", "ResumeShallow", "ResumeDeep"],
+    transitions: [
+      { source: "workspace", event: "Leave", target: "outside", reenter: false },
+      { source: "workspace.editor.idle", event: "Advance", target: "workspace.editor.active", reenter: false },
+      { source: "workspace.sidebar.closed", event: "Advance", target: "workspace.sidebar.open", reenter: false },
+      { source: "outside", event: "ResumeShallow", target: "workspace.recent", reenter: false },
+      { source: "outside", event: "ResumeDeep", target: "workspace.exact", reenter: false }
+    ]
+  })
+
+  it.effect("captures and restores every parallel region in shallow and deep modes", () =>
+    Effect.gen(function*() {
+      const model = parallelHistoryModel()
+      const shallowEvents = ["Advance", "Leave", "ResumeShallow"]
+      const shallow = MachineTest.interpretModel(model, shallowEvents)
+      assert.deepStrictEqual(shallow.final.activePaths, [
+        "workspace",
+        "workspace.editor",
+        "workspace.editor.idle",
+        "workspace.sidebar",
+        "workspace.sidebar.closed"
+      ])
+      assert.deepStrictEqual(shallow.final.history["workspace.recent"]?.active, [
+        "workspace",
+        "workspace.editor",
+        "workspace.sidebar"
+      ])
+
+      const deepEvents = ["Advance", "Leave", "ResumeDeep"]
+      const deep = MachineTest.interpretModel(model, deepEvents)
+      assert.deepStrictEqual(deep.final.activePaths, [
+        "workspace",
+        "workspace.editor",
+        "workspace.editor.active",
+        "workspace.sidebar",
+        "workspace.sidebar.open"
+      ])
+      assert.ok(deep.final.history["workspace.exact"]?.active.includes("workspace.editor.active"))
+      assert.ok(deep.final.history["workspace.exact"]?.active.includes("workspace.sidebar.open"))
+
+      for (const events of [shallowEvents, deepEvents]) {
+        const machine = MachineTest.compileModel(model)
+        const trace = yield* MachineTest.run(machine, { events: events.map(event) })
+        yield* MachineTest.verifyModel(model, trace)
+      }
+    }))
+
+  it.effect("restores nested history without disturbing a parallel sibling and self-reentry captures current state", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [{
+          _tag: "Parallel",
+          key: "workspace",
+          value: 0,
+          output: "workspace:done",
+          states: [
+            {
+              _tag: "Compound",
+              key: "editor",
+              value: 1,
+              initial: "writing",
+              states: [
+                { _tag: "Atomic", key: "writing", value: 2 },
+                { _tag: "Atomic", key: "preview", value: 3 },
+                {
+                  _tag: "History",
+                  key: "exact",
+                  history: "deep",
+                  fallback: "workspace.editor.writing"
+                }
+              ]
+            },
+            {
+              _tag: "Compound",
+              key: "sidebar",
+              value: 4,
+              initial: "closed",
+              states: [
+                { _tag: "Atomic", key: "closed", value: 5 },
+                { _tag: "Atomic", key: "open", value: 6 }
+              ]
+            }
+          ]
+        }],
+        initial: "workspace",
+        events: ["Advance", "Restore"],
+        transitions: [
+          { source: "workspace.editor.writing", event: "Advance", target: "workspace.editor.preview", reenter: false },
+          {
+            source: "workspace.sidebar.open",
+            event: "Restore",
+            target: "workspace.editor.exact",
+            reenter: true
+          },
+          { source: "workspace.sidebar.closed", event: "Advance", target: "workspace.sidebar.open", reenter: false }
+        ]
+      }
+      const events = ["Advance", "Restore"]
+      const reference = MachineTest.interpretModel(model, events)
+      assert.deepStrictEqual(reference.final.activePaths, [
+        "workspace",
+        "workspace.editor",
+        "workspace.editor.preview",
+        "workspace.sidebar",
+        "workspace.sidebar.open"
+      ])
+      assert.ok(reference.final.history["workspace.editor.exact"]?.active.includes("workspace.editor.preview"))
+      assert.deepStrictEqual(reference.steps[1]!.microsteps[0]!.exitPaths, [
+        "workspace.editor.preview",
+        "workspace.editor"
+      ])
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: events.map(event) })
+      yield* MachineTest.verify(machine, trace)
+      yield* MachineTest.verifyModel(model, trace)
+
+      const restoreStep = trace.steps[1]!
+      const restoreMicrostep = restoreStep.plan.microsteps[0]!
+      const injectedSiblingLifecycle = {
+        ...trace,
+        steps: [trace.steps[0]!, {
+          ...restoreStep,
+          plan: {
+            ...restoreStep.plan,
+            microsteps: [{
+              ...restoreMicrostep,
+              exitPaths: ["workspace.sidebar.open", ...restoreMicrostep.exitPaths],
+              entryPaths: [...restoreMicrostep.entryPaths, "workspace.sidebar.open"]
+            }]
+          }
+        }]
+      } as typeof trace
+      const lifecycleError = yield* MachineTest.verify(machine, injectedSiblingLifecycle).pipe(Effect.flip)
+      assert.ok(
+        lifecycleError.violations.some(({ law, path }) =>
+          law === "microsteps.reentry" && path === "workspace.sidebar.open"
+        )
+      )
+    }))
+
+  const inactiveOuterHistoryModel = (
+    initial: "workspace" | "outside"
+  ): MachineTest.FiniteModel => ({
+    roots: [
+      {
+        _tag: "Parallel",
+        key: "workspace",
+        value: 0,
+        output: "workspace:done",
+        states: [
+          {
+            _tag: "Compound",
+            key: "editor",
+            value: 1,
+            initial: "writing",
+            states: [
+              { _tag: "Atomic", key: "writing", value: 2 },
+              { _tag: "Atomic", key: "preview", value: 3 },
+              {
+                _tag: "History",
+                key: "exact",
+                history: "deep",
+                fallback: "workspace.editor.writing"
+              }
+            ]
+          },
+          {
+            _tag: "Compound",
+            key: "sidebar",
+            value: 4,
+            initial: "closed",
+            states: [
+              { _tag: "Atomic", key: "closed", value: 5 },
+              { _tag: "Atomic", key: "open", value: 6 }
+            ]
+          }
+        ]
+      },
+      { _tag: "Atomic", key: "outside", value: 7 }
+    ],
+    initial,
+    events: ["Advance", "Mutate", "Leave", "Resume"],
+    transitions: [
+      { source: "workspace", event: "Leave", target: "outside", reenter: false },
+      {
+        source: "workspace.editor.writing",
+        event: "Mutate",
+        target: "workspace.editor.writing",
+        targetValue: 42,
+        reenter: false
+      },
+      { source: "workspace.editor.writing", event: "Advance", target: "workspace.editor.preview", reenter: false },
+      { source: "workspace.sidebar.closed", event: "Advance", target: "workspace.sidebar.open", reenter: false },
+      { source: "outside", event: "Resume", target: "workspace.editor.exact", reenter: false }
+    ]
+  })
+
+  it.effect("rebuilds inactive ancestors and initializes outer parallel siblings for recorded nested history", () =>
+    Effect.gen(function*() {
+      const model = inactiveOuterHistoryModel("workspace")
+      const events = ["Advance", "Leave", "Resume"]
+      const reference = MachineTest.interpretModel(model, events)
+      assert.deepStrictEqual(reference.final.activePaths, [
+        "workspace",
+        "workspace.editor",
+        "workspace.editor.preview",
+        "workspace.sidebar",
+        "workspace.sidebar.closed"
+      ])
+      assert.deepStrictEqual(reference.final.values.workspace, { _tag: "State_workspace", value: 0 })
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: events.map(event) })
+      yield* MachineTest.verify(machine, trace)
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("restores a non-default nested value after its outer root becomes inactive", () =>
+    Effect.gen(function*() {
+      const model = inactiveOuterHistoryModel("workspace")
+      const events = ["Mutate", "Leave", "Resume"]
+      const reference = MachineTest.interpretModel(model, events)
+      assert.deepStrictEqual(reference.steps[0]!.after.values["workspace.editor.writing"], {
+        _tag: "State_workspace_editor_writing",
+        value: 42
+      })
+      assert.deepStrictEqual(reference.final.values["workspace.editor.writing"], {
+        _tag: "State_workspace_editor_writing",
+        value: 42
+      })
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: events.map(event) })
+      const mutated = snapshotAtPath(trace.steps[0]!.after, "workspace.editor.writing") as any
+      const restored = snapshotAtPath(trace.final, "workspace.editor.writing") as any
+      assert.strictEqual(mutated.value.value, 42)
+      assert.strictEqual(restored.value.value, 42)
+      assert.strictEqual(
+        (trace.final as any).history["workspace.editor.exact"].values["workspace.editor.writing"].value,
+        42
+      )
+      yield* MachineTest.verify(machine, trace)
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("documents that nested fallback cannot reconstruct an inactive outer ancestor yet", () =>
+    Effect.gen(function*() {
+      const model = inactiveOuterHistoryModel("outside")
+      const machine = MachineTest.compileModel(model)
+      const exit = yield* Effect.exit(MachineTest.run(machine, { events: [event("Resume")] }))
+
+      assert.strictEqual(exit._tag, "Failure")
+      if (exit._tag === "Failure") {
+        assert.include(Cause.pretty(exit.cause), "requires a value for ancestor state")
+      }
+    }))
+
+  it.effect("rejects consumed, shallow-as-deep, missing-region, and fallback-after-record mutations", () =>
+    Effect.gen(function*() {
+      const deepModel = compoundHistoryModel("deep")
+      const deepMachine = MachineTest.compileModel(deepModel)
+      const deepTrace = yield* MachineTest.run(deepMachine, {
+        events: ["Advance", "Leave", "Resume", "Leave", "Resume"].map(event)
+      })
+      const consumed = { ...deepTrace, final: { ...(deepTrace.final as any), history: {} } } as typeof deepTrace
+      const consumedError = yield* MachineTest.verifyModel(deepModel, consumed).pipe(Effect.flip)
+      assert.include(fields(consumedError), "trace.final.history")
+
+      const shallowModel = compoundHistoryModel("shallow")
+      const shallowMachine = MachineTest.compileModel(shallowModel)
+      const shallowTrace = yield* MachineTest.run(shallowMachine, {
+        events: ["Advance", "Leave"].map(event)
+      })
+      const shallowFinal = shallowTrace.final as any
+      const shallowRecord = shallowFinal.history["workspace.recent"]
+      const shallowAsDeep = {
+        ...shallowTrace,
+        final: {
+          ...shallowFinal,
+          history: {
+            ...shallowFinal.history,
+            "workspace.recent": {
+              ...shallowRecord,
+              active: [...shallowRecord.active, "workspace.editor.preview"],
+              values: {
+                ...shallowRecord.values,
+                "workspace.editor.preview": { _tag: "State_workspace_editor_preview", value: 3 }
+              }
+            }
+          }
+        }
+      } as typeof shallowTrace
+      const shallowError = yield* MachineTest.verifyModel(shallowModel, shallowAsDeep).pipe(Effect.flip)
+      assert.include(fields(shallowError), "trace.final.history")
+
+      const parallelModel = parallelHistoryModel()
+      const parallelMachine = MachineTest.compileModel(parallelModel)
+      const parallelTrace = yield* MachineTest.run(parallelMachine, { events: ["Advance", "Leave"].map(event) })
+      const parallelFinal = parallelTrace.final as any
+      const deepRecord = parallelFinal.history["workspace.exact"]
+      const missingRegion = {
+        ...parallelTrace,
+        final: {
+          ...parallelFinal,
+          history: {
+            ...parallelFinal.history,
+            "workspace.exact": {
+              ...deepRecord,
+              active: deepRecord.active.filter((path: string) => !path.startsWith("workspace.sidebar")),
+              values: Object.fromEntries(
+                Object.entries(deepRecord.values).filter(([path]) => !path.startsWith("workspace.sidebar"))
+              )
+            }
+          }
+        }
+      } as typeof parallelTrace
+      const regionError = yield* MachineTest.verifyModel(parallelModel, missingRegion).pipe(Effect.flip)
+      assert.include(fields(regionError), "trace.final.history")
+
+      const restoredTrace = yield* MachineTest.run(deepMachine, {
+        events: ["Advance", "Leave", "Resume"].map(event)
+      })
+      const fallback = restoredTrace.initial.startingState as any
+      const fallbackAfterRecord = {
+        ...restoredTrace,
+        final: { ...fallback, history: (restoredTrace.final as any).history },
+        finalConfiguration: ["workspace", "workspace.editor", "workspace.editor.writing"]
+      } as typeof restoredTrace
+      const fallbackError = yield* MachineTest.verifyModel(deepModel, fallbackAfterRecord).pipe(Effect.flip)
+      assert.include(fields(fallbackError), "trace.final.activePaths")
+    }))
+
+  const generated = MachineTest.finiteModels({
+    maxRoots: 3,
+    maxDepth: 4,
+    maxChildren: 3,
+    maxEvents: 4,
+    maxTransitions: 20
+  }).arbitrary.chain((model) => {
+    const randomEvents = FastCheck.array(FastCheck.constantFrom(...model.events), { maxLength: 20 })
+    const historyScenarios = model.historyScenarios ?? []
+    // Execute the generator-authored witness itself. This prevents an
+    // unrelated value-bearing transition under the same owner from silently
+    // standing in for the mutation that must be captured and restored.
+    return FastCheck.oneof(
+      ...(historyScenarios.length === 0
+        ? [FastCheck.constant({ events: [] as ReadonlyArray<string>, scenario: undefined })]
+        : historyScenarios.map((scenario) => FastCheck.constant({ events: scenario.events, scenario }))),
+      ...(historyScenarios.length === 0
+        ? []
+        : historyScenarios.map((scenario) => FastCheck.constant({ events: scenario.events, scenario }))),
+      randomEvents.map((events) => ({ events, scenario: undefined }))
+    ).map(({ events, scenario }) => ({ model, events, scenario }))
+  })
+
+  it.effect.prop(
+    "stress-checks planner traces across shrinkable generated parallel/history models and scenarios",
+    { generated },
+    ({ generated }) => {
+      const machine = MachineTest.compileModel(generated.model)
+      return MachineTest.run(machine, { events: generated.events.map(event) }).pipe(
+        Effect.tap((trace) => {
+          if (generated.scenario === undefined) return Effect.void
+          const scenario = generated.scenario
+          const mutated = snapshotAtPath(trace.steps[0]!.after, scenario.mutation.source) as any
+          const restored = snapshotAtPath(trace.final, scenario.mutation.source) as any
+          assert.strictEqual(mutated.value.value, scenario.mutation.value)
+          assert.strictEqual(restored.value.value, scenario.mutation.value)
+          assert.strictEqual(
+            (trace.final as any).history[scenario.history].values[scenario.mutation.source].value,
+            scenario.mutation.value
+          )
+          return Effect.void
+        }),
+        Effect.flatMap((trace) => MachineTest.verifyModel(generated.model, trace))
+      )
+    },
+    { fastCheck: { numRuns: 1_500, seed: 51_205 } }
+  )
+})

--- a/test/MachineTestRuntime.test.ts
+++ b/test/MachineTestRuntime.test.ts
@@ -1,0 +1,568 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Cause, Clock, Effect, Exit, Option, Ref, Schema, Stream } from "effect"
+import { FastCheck } from "effect/testing"
+import { Machine } from "../src/index.js"
+import { MachineTest } from "../src/testing.js"
+
+class Counter extends Schema.TaggedClass<Counter>("Counter")("Counter", {
+  count: Schema.Int
+}) {}
+
+class Add extends Schema.TaggedClass<Add>("Add")("Add", {
+  amount: Schema.Int
+}) {}
+
+class InternalAdd extends Schema.TaggedClass<InternalAdd>("InternalAdd")("InternalAdd", {
+  amount: Schema.Int
+}) {}
+
+const CounterStates = Machine.defineStates({ Counter })
+
+const makeCounterMachine = () =>
+  Machine.make({
+    states: CounterStates.states,
+    events: [Add],
+    internalEvents: [InternalAdd],
+    initial: () => CounterStates.initial.Counter(new Counter({ count: 0 }))
+  }).handle({
+    Counter: {
+      on: {
+        Add: ({ event, state, target }) => target.full.Counter(new Counter({ count: state.count + event.amount })),
+        InternalAdd: ({ event, state, target }) =>
+          target.full.Counter(new Counter({ count: state.count + event.amount }))
+      }
+    }
+  })
+
+type CounterMachine = ReturnType<typeof makeCounterMachine>
+type CounterSnapshot = Machine.Machine.Snapshot<Machine.Machine.States<CounterMachine>>
+type CounterRuntimeSnapshot = Machine.RuntimeSnapshot<CounterSnapshot, any, any>
+
+const snapshotCount = (snapshot: CounterRuntimeSnapshot | undefined): number | undefined => snapshot?.state.value.count
+
+const propertyMachine = makeCounterMachine()
+const generatedRuntimeCommands = MachineTest.runtimeCommands(propertyMachine, {
+  minCommands: 0,
+  maxCommands: 20,
+  includeCheckpoint: true
+})
+
+describe("MachineTest runtime commands", () => {
+  it("derives only public send commands and shrinkable clock/lifecycle commands", () => {
+    const machine = makeCounterMachine()
+    const generated = MachineTest.runtimeCommands(machine, {
+      minCommands: 4,
+      maxCommands: 4,
+      eventArbitrary: FastCheck.constant(new Add({ amount: 1 })),
+      advanceArbitrary: FastCheck.constant(10)
+    })
+    const samples = FastCheck.sample(generated.arbitrary, 20)
+
+    assert.strictEqual(generated.diagnostics.events, "override")
+    assert.strictEqual(generated.diagnostics.includesAdvance, true)
+    assert.strictEqual(generated.diagnostics.includesStop, true)
+    assert.strictEqual(generated.diagnostics.includesCheckpoint, true)
+    assert.strictEqual(samples.every((commands) => commands.length === 4), true)
+    for (const commands of samples) {
+      for (const command of commands) {
+        if (command._tag === "Send") assert.instanceOf(command.event, Add)
+      }
+    }
+
+    const onlySends = MachineTest.runtimeCommands(machine, {
+      maxCommands: 10,
+      eventArbitrary: FastCheck.constant(new Add({ amount: 1 })),
+      includeAdvance: false,
+      includeStop: false,
+      includeCheckpoint: false
+    })
+    const shrunk = FastCheck.check(
+      FastCheck.property(onlySends.arbitrary, (commands) => commands.length === 0),
+      { numRuns: 20 }
+    )
+    assert.strictEqual(shrunk.failed, true)
+    if (shrunk.failed) assert.strictEqual((shrunk.counterexample?.[0] as ReadonlyArray<unknown>).length, 1)
+  })
+
+  it.effect.prop(
+    "checks schema-generated commands against a pure model after every shrink",
+    { commands: generatedRuntimeCommands.arbitrary },
+    ({ commands }) =>
+      Effect.gen(function*() {
+        const ref = yield* Machine.start(propertyMachine)
+        const transcript = yield* MachineTest.runRuntimeCommands(ref, commands, {
+          initialModel: { count: 0, stopped: false },
+          transition: (model, command) => {
+            switch (command._tag) {
+              case "Send": {
+                const next = model.stopped ? model : { ...model, count: model.count + command.event.amount }
+                return Effect.succeed({
+                  model: next,
+                  expected: {
+                    result: model.stopped ? "SendRejected" : "SendAccepted" as string,
+                    count: next.count,
+                    status: model.stopped ? "stopped" as const : "active" as const
+                  },
+                  synchronize: model.stopped
+                    ? MachineTest.RuntimeSynchronization.none
+                    : MachineTest.RuntimeSynchronization.next
+                })
+              }
+              case "Stop":
+                return Effect.succeed({
+                  model: { ...model, stopped: true },
+                  expected: { result: "Stopped" as string, count: model.count, status: "stopped" as const },
+                  synchronize: model.stopped
+                    ? MachineTest.RuntimeSynchronization.current
+                    : MachineTest.RuntimeSynchronization.next
+                })
+              case "Advance":
+                return Effect.succeed({
+                  model,
+                  expected: {
+                    result: "ClockAdvanced" as string,
+                    count: model.count,
+                    status: model.stopped ? "stopped" as const : "active" as const
+                  },
+                  synchronize: MachineTest.RuntimeSynchronization.current
+                })
+              case "Checkpoint":
+                return Effect.succeed({
+                  model,
+                  expected: {
+                    result: "Checkpoint" as string,
+                    count: model.count,
+                    status: model.stopped ? "stopped" as const : "active" as const
+                  },
+                  synchronize: MachineTest.RuntimeSynchronization.current
+                })
+            }
+          },
+          assert: ({ actual, expected }) =>
+            Effect.sync(() => {
+              assert.strictEqual(actual.result._tag, expected.result)
+              if (actual.snapshot !== undefined) {
+                assert.strictEqual(actual.snapshot.status, expected.status)
+                assert.strictEqual(snapshotCount(actual.snapshot), expected.count)
+              }
+            })
+        })
+        assert.strictEqual(transcript.records.length, commands.length)
+        yield* ref.stop
+      }),
+    { fastCheck: { numRuns: 100, seed: 18_241 } }
+  )
+
+  it.effect("buffers public changes so a checkpoint can verify multiple queued sends in order", () =>
+    Effect.gen(function*() {
+      const machine = makeCounterMachine()
+      const ref = yield* Machine.start(machine)
+      const commands = [
+        MachineTest.sendCommand(new Add({ amount: 2 })),
+        MachineTest.sendCommand(new Add({ amount: 5 })),
+        MachineTest.checkpointCommand("drain queued sends")
+      ]
+      const transcript = yield* MachineTest.runRuntimeCommands(ref, commands, {
+        initialModel: { count: 0, pending: 0 },
+        transition: (model, command) => {
+          if (command._tag === "Send") {
+            const next = { count: model.count + command.event.amount, pending: model.pending + 1 }
+            return Effect.succeed({
+              model: next,
+              expected: { count: next.count, result: "SendAccepted" as string },
+              synchronize: MachineTest.RuntimeSynchronization.none
+            })
+          }
+          const next = { ...model, pending: 0 }
+          return Effect.succeed({
+            model: next,
+            expected: { count: next.count, result: "Checkpoint" as string },
+            synchronize: MachineTest.RuntimeSynchronization.until<CounterSnapshot, any>(
+              (snapshot) => snapshotCount(snapshot) === next.count
+            )
+          })
+        },
+        assert: ({ actual, expected }) =>
+          Effect.sync(() => {
+            assert.strictEqual(actual.result._tag, expected.result)
+            if (actual.snapshot !== undefined) assert.strictEqual(snapshotCount(actual.snapshot), expected.count)
+          })
+      })
+
+      assert.deepStrictEqual(
+        transcript.records[2]?.actual.published.map((snapshot) => snapshotCount(snapshot)),
+        [2, 7]
+      )
+      assert.strictEqual(snapshotCount(transcript.final), 7)
+      yield* ref.stop
+    }))
+
+  it.effect("advances TestClock deterministically through Machine.after", () =>
+    Effect.gen(function*() {
+      class Waiting extends Schema.TaggedClass<Waiting>("Waiting")("Waiting", {}) {}
+      class TimedOut extends Schema.TaggedClass<TimedOut>("TimedOut")("TimedOut", {}) {}
+      class Timeout extends Schema.TaggedClass<Timeout>("Timeout")("Timeout", {}) {}
+      const states = Machine.defineStates({ Waiting, TimedOut })
+      const machine = Machine.make({
+        states: states.states,
+        events: [],
+        internalEvents: [Timeout],
+        initial: () => states.initial.Waiting(new Waiting({}))
+      }).handle({
+        Waiting: {
+          invoke: Machine.after("1 second", new Timeout({})),
+          on: { Timeout: ({ target }) => target.full.TimedOut(new TimedOut({})) }
+        },
+        TimedOut: {}
+      })
+      const ref = yield* Machine.start(machine)
+      const commands = [
+        MachineTest.advanceCommand(999),
+        MachineTest.checkpointCommand("before timeout"),
+        MachineTest.advanceCommand(1),
+        MachineTest.checkpointCommand("after timeout")
+      ]
+      const transcript = yield* MachineTest.runRuntimeCommands(ref, commands, {
+        initialModel: { elapsed: 0, path: "Waiting" as "Waiting" | "TimedOut" },
+        transition: (model, command) => {
+          if (command._tag === "Advance") {
+            const elapsed = model.elapsed + Number(command.duration)
+            return Effect.succeed({
+              model: { elapsed, path: elapsed >= 1_000 ? "TimedOut" as const : model.path },
+              expected: command._tag,
+              synchronize: MachineTest.RuntimeSynchronization.none
+            })
+          }
+          return Effect.succeed({
+            model,
+            expected: model.path,
+            synchronize: model.path === "TimedOut"
+              ? MachineTest.RuntimeSynchronization.until((snapshot) => snapshot.state.path === "TimedOut")
+              : MachineTest.RuntimeSynchronization.current
+          })
+        },
+        assert: ({ actual, command, model }) =>
+          Effect.sync(() => {
+            if (command._tag === "Checkpoint") {
+              assert.strictEqual(actual.snapshot?.state.path, model.path)
+            }
+          })
+      })
+
+      assert.strictEqual(transcript.records[3]?.actual.snapshot?.state.path, "TimedOut")
+      yield* ref.stop
+    }))
+
+  it.effect("models idempotent stop and rejected sends after stop explicitly", () =>
+    Effect.gen(function*() {
+      const ref = yield* Machine.start(makeCounterMachine())
+      const transcript = yield* MachineTest.runRuntimeCommands(ref, [
+        MachineTest.stopCommand(),
+        MachineTest.stopCommand(),
+        MachineTest.sendCommand(new Add({ amount: 1 })),
+        MachineTest.checkpointCommand("stopped")
+      ], {
+        initialModel: { stopped: false },
+        transition: (model, command) =>
+          Effect.succeed({
+            model: { stopped: model.stopped || command._tag === "Stop" },
+            expected: command._tag === "Send" ? "SendRejected" : command._tag === "Stop" ? "Stopped" : "Checkpoint",
+            synchronize: command._tag === "Stop" && !model.stopped
+              ? MachineTest.RuntimeSynchronization.next
+              : command._tag === "Send"
+              ? MachineTest.RuntimeSynchronization.none
+              : MachineTest.RuntimeSynchronization.current
+          }),
+        assert: ({ actual, expected }) =>
+          Effect.sync(() => {
+            assert.strictEqual(actual.result._tag, expected)
+            if (actual.result._tag === "SendRejected") {
+              assert.instanceOf(actual.result.error, Machine.StoppedError)
+            }
+          })
+      })
+
+      assert.deepStrictEqual(transcript.records.map(({ actual }) => actual.result._tag), [
+        "Stopped",
+        "Stopped",
+        "SendRejected",
+        "Checkpoint"
+      ])
+      assert.strictEqual(transcript.final.status, "stopped")
+    }))
+
+  it.effect("supports Effectful inspection of observable emission logs", () =>
+    Effect.gen(function*() {
+      const log = yield* Ref.make<ReadonlyArray<number>>([])
+      const machine = makeCounterMachine().handle({
+        Counter: {
+          on: {
+            Add: ({ event, state, target }) =>
+              Machine.action(
+                Ref.update(log, (values) => [...values, event.amount]),
+                target.full.Counter(new Counter({ count: state.count + event.amount }))
+              )
+          }
+        }
+      })
+      const ref = yield* Machine.start(machine)
+      const transcript = yield* MachineTest.runRuntimeCommands(ref, [MachineTest.sendCommand(new Add({ amount: 3 }))], {
+        initialModel: 0,
+        transition: (model) =>
+          Effect.succeed({
+            model: model + 3,
+            expected: [3],
+            synchronize: MachineTest.RuntimeSynchronization.next
+          }),
+        inspect: () => Ref.get(log),
+        assert: ({ actual, expected }) => Effect.sync(() => assert.deepStrictEqual(actual.inspected, expected))
+      })
+
+      assert.deepStrictEqual(transcript.records[0]?.actual.inspected, [3])
+      yield* ref.stop
+    }))
+
+  it.effect("retains a replayable prefix and attempted command in typed failures", () =>
+    Effect.gen(function*() {
+      const ref = yield* Machine.start(makeCounterMachine())
+      const commands = [
+        MachineTest.sendCommand(new Add({ amount: 1 })),
+        MachineTest.sendCommand(new Add({ amount: 2 }))
+      ]
+      const failure = yield* MachineTest.runRuntimeCommands(ref, commands, {
+        initialModel: 0,
+        transition: (count, command) => {
+          const next = count + (command._tag === "Send" ? command.event.amount : 0)
+          return Effect.succeed({
+            model: next,
+            expected: next,
+            synchronize: MachineTest.RuntimeSynchronization.next
+          })
+        },
+        assert: ({ expected }) => {
+          assert.isBelow(expected, 3, "expected count below three")
+          return Effect.void
+        }
+      }).pipe(Effect.flip)
+
+      assert.strictEqual(failure.phase, "assertion")
+      assert.strictEqual(failure.index, 1)
+      assert.strictEqual(failure.prefix.length, 1)
+      assert.strictEqual(failure.attempted?.index, 1)
+      assert.deepStrictEqual(failure.prefix[0]?.command, commands[0])
+      assert.deepStrictEqual(failure.command, commands[1])
+      assert.strictEqual(Cause.hasDies(failure.cause), true)
+      assert.instanceOf(Cause.squash(failure.cause), Error)
+      const formatted = MachineTest.formatRuntimeTranscript(failure)
+      assert.match(formatted, /commands:/)
+      assert.match(formatted, /command 0:/)
+      assert.match(formatted, /failure: phase=assertion index=1/)
+      assert.match(formatted, /expected count below three/)
+      yield* ref.stop
+    }))
+
+  it.effect("fails with structured evidence when an expected publication never arrives", () =>
+    Effect.gen(function*() {
+      const ref = yield* Machine.start(makeCounterMachine())
+      const virtualTimeBefore = yield* Clock.currentTimeMillis
+      const failure = yield* MachineTest.runRuntimeCommands(ref, [
+        MachineTest.checkpointCommand("incorrectly expect a publication")
+      ], {
+        initialModel: undefined,
+        observationTimeout: 10,
+        transition: (model) =>
+          Effect.succeed({
+            model,
+            expected: undefined,
+            synchronize: MachineTest.RuntimeSynchronization.next
+          }),
+        assert: () => Effect.void
+      }).pipe(Effect.flip)
+
+      assert.strictEqual(failure.phase, "observation")
+      assert.strictEqual(failure.index, 0)
+      assert.strictEqual(failure.prefix.length, 0)
+      assert.strictEqual(failure.attempted?.actual.result._tag, "Checkpoint")
+      assert.strictEqual(failure.attempted?.actual.snapshot, undefined)
+      const cause = Cause.squash(failure.cause)
+      assert.instanceOf(cause, MachineTest.RuntimeObservationError)
+      assert.strictEqual(cause.reason, "timeout")
+      assert.match(cause.message, /timed out after 10ms/)
+      assert.strictEqual(yield* Clock.currentTimeMillis, virtualTimeBefore)
+      yield* ref.stop
+    }))
+
+  it.effect("keeps trailing enqueue-only work explicit instead of sampling a racy final state", () =>
+    Effect.gen(function*() {
+      const ref = yield* Machine.start(makeCounterMachine())
+      const transcript = yield* MachineTest.runRuntimeCommands(ref, [
+        MachineTest.sendCommand(new Add({ amount: 5 })),
+        MachineTest.checkpointCommand("racy current sample")
+      ], {
+        initialModel: 5,
+        transition: (model, command) =>
+          Effect.succeed({
+            model,
+            expected: command._tag === "Send" ? "SendAccepted" : "Checkpoint",
+            synchronize: command._tag === "Send"
+              ? MachineTest.RuntimeSynchronization.none
+              : MachineTest.RuntimeSynchronization.current
+          }),
+        assert: ({ actual, expected }) => Effect.sync(() => assert.strictEqual(actual.result._tag, expected))
+      })
+
+      assert.strictEqual(transcript.synchronized, false)
+      assert.strictEqual(snapshotCount(transcript.final), 0)
+      yield* ref.stop
+    }))
+
+  it.effect("does not let one Next observation clear earlier unknown work", () =>
+    Effect.gen(function*() {
+      const initial = { status: "active" as const, state: 0 }
+      const first = { status: "active" as const, state: 1 }
+      const second = { status: "active" as const, state: 2 }
+      const ref: Machine.MachineRef<number, never> = {
+        id: "structural-review-ref",
+        sessionId: "structural-review-session",
+        state: Effect.succeed(2),
+        snapshot: Effect.succeed(second),
+        changes: Stream.make(initial, first, second),
+        join: Effect.never,
+        stop: Effect.void,
+        send: () => Effect.void,
+        child: () => Effect.succeed(Option.none()),
+        childChanges: () => Stream.empty
+      }
+      const transcript = yield* MachineTest.runRuntimeCommands(ref, [
+        MachineTest.advanceCommand(1),
+        MachineTest.checkpointCommand("only consume one")
+      ], {
+        initialModel: undefined,
+        transition: (model, command) =>
+          Effect.succeed({
+            model,
+            expected: undefined,
+            synchronize: command._tag === "Advance"
+              ? MachineTest.RuntimeSynchronization.none
+              : MachineTest.RuntimeSynchronization.next
+          }),
+        assert: () => Effect.void
+      })
+
+      assert.strictEqual(transcript.records[1]?.actual.snapshot?.state, 1)
+      assert.strictEqual(transcript.synchronized, false)
+    }))
+
+  it.effect("captures command execution defects without losing replay evidence", () =>
+    Effect.gen(function*() {
+      const ref = yield* Machine.start(makeCounterMachine())
+      const invalid = MachineTest.advanceCommand("not a duration" as any)
+      const failure = yield* MachineTest.runRuntimeCommands(ref, [invalid], {
+        initialModel: undefined,
+        transition: (model) =>
+          Effect.succeed({
+            model,
+            expected: undefined,
+            synchronize: MachineTest.RuntimeSynchronization.none
+          }),
+        assert: () => Effect.void
+      }).pipe(Effect.flip)
+
+      assert.strictEqual(failure.phase, "execution")
+      assert.strictEqual(failure.index, 0)
+      assert.deepStrictEqual(failure.command, invalid)
+      assert.strictEqual(failure.prefix.length, 0)
+      assert.strictEqual(Cause.hasDies(failure.cause), true)
+      yield* ref.stop
+    }))
+
+  it.effect("captures synchronous throws while constructing model and inspection effects", () =>
+    Effect.gen(function*() {
+      const ref = yield* Machine.start(makeCounterMachine())
+      const command = MachineTest.checkpointCommand<Add>("synchronous callback")
+      const modelFailure = yield* MachineTest.runRuntimeCommands(ref, [command], {
+        initialModel: undefined,
+        transition: () => {
+          throw new Error("model callback threw")
+        },
+        assert: () => Effect.void
+      }).pipe(Effect.flip)
+      assert.strictEqual(modelFailure.phase, "model")
+      assert.match(String(Cause.squash(modelFailure.cause)), /model callback threw/)
+
+      const inspectionFailure = yield* MachineTest.runRuntimeCommands(ref, [command], {
+        initialModel: undefined,
+        transition: (model) =>
+          Effect.succeed({
+            model,
+            expected: undefined,
+            synchronize: MachineTest.RuntimeSynchronization.current
+          }),
+        inspect: () => {
+          throw new Error("inspection callback threw")
+        },
+        assert: () => Effect.void
+      }).pipe(Effect.flip)
+      assert.strictEqual(inspectionFailure.phase, "inspection")
+      assert.strictEqual(inspectionFailure.attempted?.actual.result._tag, "Checkpoint")
+      assert.strictEqual(inspectionFailure.attempted?.actual.snapshot?.status, "active")
+      assert.match(String(Cause.squash(inspectionFailure.cause)), /inspection callback threw/)
+      yield* ref.stop
+    }))
+
+  it.effect("propagates pure interruption instead of reporting a counterexample", () =>
+    Effect.gen(function*() {
+      const ref = yield* Machine.start(makeCounterMachine())
+      const command = MachineTest.checkpointCommand<Add>("interrupt")
+      const exit = yield* MachineTest.runRuntimeCommands(ref, [command], {
+        initialModel: undefined,
+        transition: (model) =>
+          Effect.interrupt.pipe(
+            Effect.andThen(Effect.succeed({
+              model,
+              expected: undefined,
+              synchronize: MachineTest.RuntimeSynchronization.current
+            }))
+          ),
+        assert: () => Effect.void
+      }).pipe(Effect.exit)
+
+      assert.strictEqual(Exit.isFailure(exit), true)
+      if (Exit.isFailure(exit)) assert.strictEqual(Cause.hasInterruptsOnly(exit.cause), true)
+      yield* ref.stop
+    }))
+
+  it.effect("marks unobserved stop and one-of-possibly-many send publications as outstanding", () =>
+    Effect.gen(function*() {
+      const stoppedRef = yield* Machine.start(makeCounterMachine())
+      const stopped = yield* MachineTest.runRuntimeCommands(stoppedRef, [MachineTest.stopCommand()], {
+        initialModel: undefined,
+        transition: (model) =>
+          Effect.succeed({
+            model,
+            expected: undefined,
+            synchronize: MachineTest.RuntimeSynchronization.none
+          }),
+        assert: () => Effect.void
+      })
+      assert.strictEqual(stopped.final.status, "active")
+      assert.strictEqual(stopped.synchronized, false)
+
+      const sentRef = yield* Machine.start(makeCounterMachine())
+      const sent = yield* MachineTest.runRuntimeCommands(sentRef, [
+        MachineTest.sendCommand(new Add({ amount: 1 }))
+      ], {
+        initialModel: undefined,
+        transition: (model) =>
+          Effect.succeed({
+            model,
+            expected: undefined,
+            synchronize: MachineTest.RuntimeSynchronization.next
+          }),
+        assert: () => Effect.void
+      })
+      assert.strictEqual(snapshotCount(sent.final), 1)
+      assert.strictEqual(sent.synchronized, false)
+      yield* sentRef.stop
+    }))
+})

--- a/test/MachineTestVerification.test.ts
+++ b/test/MachineTestVerification.test.ts
@@ -1,0 +1,655 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Schema } from "effect"
+import { Machine } from "../src/index.js"
+import { MachineTest } from "../src/testing.js"
+
+class Off extends Schema.TaggedClass<Off>("Off")("Off", {}) {}
+class App extends Schema.TaggedClass<App>("App")("App", {}) {}
+class One extends Schema.TaggedClass<One>("One")("One", {}) {}
+class Two extends Schema.TaggedClass<Two>("Two")("Two", {}) {}
+class Go extends Schema.TaggedClass<Go>("Go")("Go", {}) {}
+class Counter extends Schema.TaggedClass<Counter>("Counter")("Counter", {
+  count: Schema.Int
+}) {}
+class Increment extends Schema.TaggedClass<Increment>("Increment")("Increment", {}) {}
+class Noop extends Schema.TaggedClass<Noop>("Noop")("Noop", {}) {}
+class Restart extends Schema.TaggedClass<Restart>("Restart")("Restart", {}) {}
+
+const NavigationStates = Machine.defineStates({
+  off: Off,
+  app: {
+    schema: App,
+    initial: "one",
+    states: {
+      one: One,
+      two: Two
+    }
+  }
+})
+
+const navigationMachine = Machine.make({
+  states: NavigationStates.states,
+  events: [Go],
+  initial: () => NavigationStates.initial.off(new Off({}))
+}).handle({
+  off: {
+    on: {
+      Go: {
+        targets: ["app"],
+        transition: ({ target }) => target.full.app(new App({}), (app) => app.two(new Two({})))
+      }
+    }
+  }
+})
+
+const raisedNavigationMachine = Machine.make({
+  states: NavigationStates.states,
+  events: [Go],
+  initial: Effect.fn(function*() {
+    const runtime = yield* Machine.runtime<{ readonly events: Go }>()
+    yield* runtime.raise(new Go({}))
+    return NavigationStates.initial.off(new Off({}))
+  })
+}).handle({
+  off: {
+    on: {
+      Go: ({ target }) => target.full.app(new App({}), (app) => app.one(new One({})))
+    }
+  }
+})
+
+const CounterStates = Machine.defineStates({ counter: Counter })
+
+const counterMachine = Machine.make({
+  states: CounterStates.states,
+  events: [Increment, Noop],
+  initial: () => CounterStates.initial.counter(new Counter({ count: 0 }))
+}).handle({
+  counter: {
+    on: {
+      Increment: ({ state, target }) => target.full.counter(new Counter({ count: state.count + 1 })),
+      Noop: () => undefined
+    }
+  }
+})
+
+const reentryMachine = Machine.make({
+  states: NavigationStates.states,
+  events: [Restart],
+  initial: () =>
+    NavigationStates.initial.app(
+      new App({}),
+      (app) => app.one(new One({}))
+    )
+}).handle({
+  app: {
+    on: {
+      Restart: {
+        reenter: true,
+        transition: ({ target }) => target.full.app(new App({}), (app) => app.one(new One({})))
+      }
+    }
+  }
+})
+
+class Dashboard extends Schema.TaggedClass<Dashboard>("Dashboard")("Dashboard", {}) {}
+class Left extends Schema.TaggedClass<Left>("Left")("Left", {}) {}
+class Right extends Schema.TaggedClass<Right>("Right")("Right", {}) {}
+
+const ParallelStates = Machine.defineStates({
+  dashboard: {
+    schema: Dashboard,
+    type: "parallel",
+    states: {
+      left: Left,
+      right: Right
+    }
+  }
+})
+
+const parallelMachine = Machine.make({
+  states: ParallelStates.states,
+  events: [],
+  initial: () =>
+    ParallelStates.initial.dashboard(
+      new Dashboard({}),
+      (dashboard) => dashboard.left(new Left({})).right(new Right({}))
+    )
+}).handle({ dashboard: {} })
+
+class Workspace extends Schema.TaggedClass<Workspace>("Workspace")("Workspace", {}) {}
+class Editor extends Schema.TaggedClass<Editor>("Editor")("Editor", {}) {}
+class Editing extends Schema.TaggedClass<Editing>("Editing")("Editing", {
+  revision: Schema.Int
+}) {}
+class Away extends Schema.TaggedClass<Away>("Away")("Away", {}) {}
+class Leave extends Schema.TaggedClass<Leave>("Leave")("Leave", {}) {}
+
+const HistoryStates = Machine.defineStates({
+  workspace: {
+    schema: Workspace,
+    initial: "editor",
+    states: {
+      editor: {
+        schema: Editor,
+        initial: "editing",
+        states: {
+          editing: Editing
+        }
+      },
+      recent: {
+        type: "history"
+      },
+      exact: {
+        type: "history",
+        history: "deep"
+      }
+    }
+  },
+  away: Away
+})
+
+const historyMachine = Machine.make({
+  states: HistoryStates.states,
+  events: [Leave],
+  initial: () =>
+    HistoryStates.initial.workspace(
+      new Workspace({}),
+      (workspace) =>
+        workspace.editor(
+          new Editor({}),
+          (editor) => editor.editing(new Editing({ revision: 1 }))
+        )
+    )
+}).handle({
+  workspace: {
+    history: {
+      recent: {
+        default: () =>
+          HistoryStates.initial.workspace(
+            new Workspace({}),
+            (workspace) =>
+              workspace.editor(
+                new Editor({}),
+                (editor) => editor.editing(new Editing({ revision: 0 }))
+              )
+          )
+      },
+      exact: {
+        default: () =>
+          HistoryStates.initial.workspace(
+            new Workspace({}),
+            (workspace) =>
+              workspace.editor(
+                new Editor({}),
+                (editor) => editor.editing(new Editing({ revision: 0 }))
+              )
+          )
+      }
+    },
+    on: {
+      Leave: ({ target }) => target.full.away(new Away({}))
+    },
+    states: {
+      editor: {
+        initial: () => new Editing({ revision: 0 })
+      }
+    }
+  }
+})
+
+class Finished extends Schema.TaggedClass<Finished>("Finished")("Finished", {}) {}
+
+const CompletionStates = Machine.defineStates({
+  finished: {
+    schema: Finished,
+    type: "final",
+    output: Schema.String
+  }
+})
+
+const completionMachine = Machine.make({
+  states: CompletionStates.states,
+  events: [],
+  initial: () => CompletionStates.initial.finished(new Finished({}))
+}).handle({
+  finished: {
+    output: () => "complete"
+  }
+})
+
+class Workflow extends Schema.TaggedClass<Workflow>("Workflow")("Workflow", {}) {}
+class Archived extends Schema.TaggedClass<Archived>("Archived")("Archived", {}) {}
+
+const DoneTransitionStates = Machine.defineStates({
+  workflow: {
+    schema: Workflow,
+    initial: "finished",
+    states: {
+      finished: {
+        schema: Finished,
+        type: "final",
+        output: Schema.String
+      }
+    }
+  },
+  archived: Archived
+})
+
+const doneTransitionMachine = Machine.make({
+  states: DoneTransitionStates.states,
+  events: [],
+  initial: () =>
+    DoneTransitionStates.initial.workflow(
+      new Workflow({}),
+      (workflow) => workflow.finished(new Finished({}))
+    )
+}).handle({
+  workflow: {
+    onDone: ({ target }) => target.full.archived(new Archived({})),
+    states: {
+      finished: {
+        output: () => "workflow-output"
+      }
+    }
+  }
+})
+
+const nestedCompletionMachine = Machine.make({
+  states: DoneTransitionStates.states,
+  events: [],
+  initial: () =>
+    DoneTransitionStates.initial.workflow(
+      new Workflow({}),
+      (workflow) => workflow.finished(new Finished({}))
+    )
+}).handle({
+  workflow: {
+    states: {
+      finished: {
+        output: () => "nested-output"
+      }
+    }
+  }
+})
+
+const laws = (error: MachineTest.VerificationError): ReadonlyArray<MachineTest.VerificationLaw> =>
+  error.violations.map((violation) => violation.law)
+
+describe("MachineTest.verify", () => {
+  it.effect("accepts valid compound, parallel, history, and completion traces", () =>
+    Effect.gen(function*() {
+      const navigation = yield* MachineTest.run(navigationMachine, { events: [new Go({})] })
+      const raisedNavigation = yield* MachineTest.run(raisedNavigationMachine, { events: [] })
+      const parallel = yield* MachineTest.run(parallelMachine, { events: [] })
+      const history = yield* MachineTest.run(historyMachine, { events: [new Leave({})] })
+      const completion = yield* MachineTest.run(completionMachine, { events: [] })
+      const doneTransition = yield* MachineTest.run(doneTransitionMachine, { events: [] })
+      const nestedCompletion = yield* MachineTest.run(nestedCompletionMachine, { events: [] })
+
+      yield* MachineTest.verify(navigationMachine, navigation)
+      yield* MachineTest.verify(raisedNavigationMachine, raisedNavigation)
+      yield* MachineTest.verify(parallelMachine, parallel)
+      yield* MachineTest.verify(historyMachine, history)
+      yield* MachineTest.verify(completionMachine, completion)
+      yield* MachineTest.verify(doneTransitionMachine, doneTransition)
+      yield* MachineTest.verify(nestedCompletionMachine, nestedCompletion)
+    }))
+
+  it.effect("allows same-path value updates while rejecting implausible changed no-ops", () =>
+    Effect.gen(function*() {
+      const updated = yield* MachineTest.run(counterMachine, { events: [new Increment({})] })
+      const updateMicrostep = updated.steps[0]!.plan.microsteps[0]!
+      assert.strictEqual(updateMicrostep.changed, false)
+      assert.deepStrictEqual(updateMicrostep.exitPaths, [])
+      assert.deepStrictEqual(updateMicrostep.entryPaths, [])
+      assert.strictEqual((updated.final.value as Counter).count, 1)
+      yield* MachineTest.verify(counterMachine, updated)
+
+      const noop = yield* MachineTest.run(counterMachine, { events: [new Noop({})] })
+      const step = noop.steps[0]!
+      const microstep = step.plan.microsteps[0]!
+      const corrupted = {
+        ...noop,
+        steps: [{
+          ...step,
+          plan: {
+            ...step.plan,
+            microsteps: [{ ...microstep, changed: true }]
+          }
+        }]
+      } as typeof noop
+      const error = yield* MachineTest.verify(counterMachine, corrupted, {
+        laws: ["microsteps"]
+      }).pipe(Effect.flip)
+      assert.include(laws(error), "microsteps.changed")
+    }))
+
+  it.effect("requires lifecycle boundaries to match retained reentry scopes", () =>
+    Effect.gen(function*() {
+      const reentry = yield* MachineTest.run(reentryMachine, { events: [new Restart({})] })
+      yield* MachineTest.verify(reentryMachine, reentry)
+      const step = reentry.steps[0]!
+      const microstep = step.plan.microsteps[0]!
+      const missingBoundary = {
+        ...reentry,
+        steps: [{
+          ...step,
+          plan: {
+            ...step.plan,
+            microsteps: [{
+              ...microstep,
+              exitPaths: microstep.exitPaths.filter((path) => path !== "app"),
+              entryPaths: microstep.entryPaths.filter((path) => path !== "app")
+            }]
+          }
+        }]
+      } as typeof reentry
+      const missingError = yield* MachineTest.verify(reentryMachine, missingBoundary, {
+        laws: ["microsteps"]
+      }).pipe(Effect.flip)
+      assert.ok(
+        missingError.violations.some((violation) => violation.law === "microsteps.reentry" && violation.path === "app")
+      )
+
+      const updated = yield* MachineTest.run(counterMachine, { events: [new Increment({})] })
+      const updateStep = updated.steps[0]!
+      const updateMicrostep = updateStep.plan.microsteps[0]!
+      const spuriousLifecycle = {
+        ...updated,
+        steps: [{
+          ...updateStep,
+          plan: {
+            ...updateStep.plan,
+            microsteps: [{
+              ...updateMicrostep,
+              changed: true,
+              exitPaths: ["counter"],
+              entryPaths: ["counter"]
+            }]
+          }
+        }]
+      } as typeof updated
+      const spuriousError = yield* MachineTest.verify(counterMachine, spuriousLifecycle, {
+        laws: ["microsteps"]
+      }).pipe(Effect.flip)
+      assert.ok(spuriousError.violations.some((violation) =>
+        violation.law === "microsteps.reentry" && violation.path === "counter"
+      ))
+    }))
+
+  it.effect("reports omitted parallel regions and duplicate active states", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(parallelMachine, { events: [] })
+      const final = trace.final as any
+      const omitted = {
+        ...trace,
+        final: {
+          ...final,
+          states: { left: final.states.left }
+        }
+      } as typeof trace
+      const omittedError = yield* MachineTest.verify(parallelMachine, omitted, {
+        laws: ["configuration"]
+      }).pipe(Effect.flip)
+      assert.include(laws(omittedError), "configuration.parallel")
+
+      const duplicate = {
+        ...trace,
+        final: {
+          ...final,
+          states: { left: final.states.left, right: final.states.left }
+        }
+      } as typeof trace
+      const duplicateError = yield* MachineTest.verify(parallelMachine, duplicate, {
+        laws: ["configuration"]
+      }).pipe(Effect.flip)
+      assert.include(laws(duplicateError), "configuration.duplicate")
+    }))
+
+  it.effect("reports reversed entry order with its event and microstep", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(navigationMachine, { events: [new Go({})] })
+      const step = trace.steps[0]!
+      const microstep = step.plan.microsteps[0]!
+      const reversed = {
+        ...trace,
+        steps: [{
+          ...step,
+          plan: {
+            ...step.plan,
+            microsteps: [{ ...microstep, entryPaths: [...microstep.entryPaths].reverse() }]
+          }
+        }]
+      } as typeof trace
+
+      const error = yield* MachineTest.verify(navigationMachine, reversed, {
+        laws: ["microsteps"]
+      }).pipe(Effect.flip)
+      const violation = error.violations.find(({ law }) => law === "microsteps.order")
+      assert.strictEqual(violation?.eventIndex, 0)
+      assert.strictEqual(violation?.microstepIndex, 0)
+    }))
+
+  it.effect("reports unknown and active history paths", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(historyMachine, { events: [] })
+      const workspace = trace.final as any
+
+      const unknown = {
+        ...trace,
+        final: {
+          ...workspace,
+          state: { path: "workspace.missing", value: new Editing({ revision: 1 }) }
+        }
+      } as typeof trace
+      const unknownError = yield* MachineTest.verify(historyMachine, unknown, {
+        laws: ["configuration"]
+      }).pipe(Effect.flip)
+      assert.include(laws(unknownError), "configuration.path")
+
+      const activeHistory = {
+        ...trace,
+        final: {
+          ...workspace,
+          state: { path: "workspace.recent", value: new Editing({ revision: 1 }) }
+        }
+      } as typeof trace
+      const historyError = yield* MachineTest.verify(historyMachine, activeHistory, {
+        laws: ["configuration"]
+      }).pipe(Effect.flip)
+      assert.ok(historyError.violations.some((violation) =>
+        violation.law === "configuration.path" && violation.path === "workspace.recent"
+      ))
+    }))
+
+  it.effect("reports invalid remembered values in public history metadata", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(historyMachine, { events: [new Leave({})] })
+      const final = trace.final as any
+      const record = final.history["workspace.recent"]
+      const corrupted = {
+        ...trace,
+        final: {
+          ...final,
+          history: {
+            ...final.history,
+            "workspace.recent": {
+              ...record,
+              values: {
+                ...record.values,
+                "workspace.editor": new Away({})
+              }
+            }
+          }
+        }
+      } as typeof trace
+
+      const error = yield* MachineTest.verify(historyMachine, corrupted, {
+        laws: ["history"]
+      }).pipe(Effect.flip)
+      assert.ok(
+        error.violations.some((violation) => violation.law === "history.value" && violation.path === "workspace.editor")
+      )
+    }))
+
+  it.effect("distinguishes shallow containment from complete deep history", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(historyMachine, { events: [new Leave({})] })
+      const final = trace.final as any
+      const shallow = final.history["workspace.recent"]
+      const deep = final.history["workspace.exact"]
+      const corrupted = {
+        ...trace,
+        final: {
+          ...final,
+          history: {
+            ...final.history,
+            "workspace.recent": {
+              ...shallow,
+              active: [...shallow.active, "workspace.editor.editing"],
+              values: {
+                ...shallow.values,
+                "workspace.editor.editing": new Editing({ revision: 1 })
+              }
+            },
+            "workspace.exact": {
+              ...deep,
+              active: deep.active.filter((path: string) => path !== "workspace.editor.editing"),
+              values: Object.fromEntries(
+                Object.entries(deep.values).filter(([path]) => path !== "workspace.editor.editing")
+              )
+            }
+          }
+        }
+      } as typeof trace
+
+      const error = yield* MachineTest.verify(historyMachine, corrupted, {
+        laws: ["history"]
+      }).pipe(Effect.flip)
+      assert.include(laws(error), "history.shallow")
+      assert.include(laws(error), "history.deep")
+    }))
+
+  it.effect("rejects orphan descendants in deep history", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(historyMachine, { events: [new Leave({})] })
+      const final = trace.final as any
+      const deep = final.history["workspace.exact"]
+      const corrupted = {
+        ...trace,
+        final: {
+          ...final,
+          history: {
+            ...final.history,
+            "workspace.exact": {
+              ...deep,
+              active: deep.active.filter((path: string) => path !== "workspace.editor"),
+              values: Object.fromEntries(
+                Object.entries(deep.values).filter(([path]) => path !== "workspace.editor")
+              )
+            }
+          }
+        }
+      } as typeof trace
+
+      const error = yield* MachineTest.verify(historyMachine, corrupted, {
+        laws: ["history"]
+      }).pipe(Effect.flip)
+      assert.ok(error.violations.some((violation) =>
+        violation.law === "history.deep" && violation.message.includes("without ancestor")
+      ))
+    }))
+
+  it.effect("reports inconsistent done and output data", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(completionMachine, { events: [] })
+      const corrupted = {
+        ...trace,
+        initial: {
+          ...trace.initial,
+          plan: {
+            ...trace.initial.plan,
+            done: false,
+            output: "not-allowed"
+          }
+        }
+      } as unknown as typeof trace
+
+      const error = yield* MachineTest.verify(completionMachine, corrupted, {
+        laws: ["completion"]
+      }).pipe(Effect.flip)
+      assert.include(laws(error), "completion.done")
+      assert.include(laws(error), "completion.output")
+    }))
+
+  it.effect("requires every nested completion in settled snapshots", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(nestedCompletionMachine, { events: [] })
+      const state = trace.initial.plan.state as any
+      const corrupted = {
+        ...trace,
+        initial: {
+          ...trace.initial,
+          plan: {
+            ...trace.initial.plan,
+            state: {
+              ...state,
+              completed: state.completed.filter(({ path }: { readonly path: string }) => path !== "workflow.finished")
+            }
+          }
+        }
+      } as typeof trace
+
+      const error = yield* MachineTest.verify(nestedCompletionMachine, corrupted, {
+        laws: ["completion"]
+      }).pipe(Effect.flip)
+      assert.ok(error.violations.some((violation) =>
+        violation.law === "completion.record" && violation.path === "workflow.finished"
+      ))
+    }))
+
+  it.effect("reports requested targets outside declared bounds", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(navigationMachine, { events: [new Go({})] })
+      const step = trace.steps[0]!
+      const microstep = step.plan.microsteps[0]!
+      const transition = microstep.transitions[0]!
+      const corrupted = {
+        ...trace,
+        steps: [{
+          ...step,
+          plan: {
+            ...step.plan,
+            microsteps: [{
+              ...microstep,
+              transitions: [{ ...transition, target: "off" }]
+            }]
+          }
+        }]
+      } as typeof trace
+
+      const error = yield* MachineTest.verify(navigationMachine, corrupted, {
+        laws: ["targetBounds"]
+      }).pipe(Effect.flip)
+      const violation = error.violations.find(({ law }) => law === "targetBounds.target")
+      assert.strictEqual(violation?.eventIndex, 0)
+      assert.strictEqual(violation?.microstepIndex, 0)
+      assert.strictEqual(violation?.path, "off")
+    }))
+
+  const generatedNavigation = MachineTest.scenarios(navigationMachine, {
+    minEvents: 0,
+    maxEvents: 20
+  })
+
+  it.effect.prop(
+    "verifies schema-derived scenarios after every shrink",
+    { scenario: generatedNavigation.arbitrary },
+    ({ scenario }) =>
+      MachineTest.run(navigationMachine, scenario).pipe(
+        Effect.flatMap((trace) => MachineTest.verify(navigationMachine, trace))
+      ),
+    { fastCheck: { numRuns: 50 } }
+  )
+})

--- a/typetest/MachineTest.tst.ts
+++ b/typetest/MachineTest.tst.ts
@@ -1,0 +1,183 @@
+import { Cause, Context, Data, Effect, Schema } from "effect"
+import { FastCheck } from "effect/testing"
+import { describe, expect, it } from "tstyche"
+import { Machine } from "../src/index.js"
+import { MachineTest } from "../src/testing.js"
+
+describe("MachineTest", () => {
+  class Input extends Schema.Class<Input>("Input")({ id: Schema.String }) {}
+  class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", {}) {}
+  class PublicEvent extends Schema.TaggedClass<PublicEvent>("PublicEvent")("PublicEvent", {
+    value: Schema.Number
+  }) {}
+  class InternalEvent extends Schema.TaggedClass<InternalEvent>("InternalEvent")("InternalEvent", {}) {}
+
+  const States = Machine.defineStates({ idle: Idle })
+  const machine = Machine.make({
+    states: States.states,
+    events: [PublicEvent],
+    internalEvents: [InternalEvent],
+    input: Input,
+    initial: () => States.initial.idle(new Idle({}))
+  }).handle({
+    idle: {
+      on: {
+        PublicEvent: () => undefined,
+        InternalEvent: () => undefined
+      }
+    }
+  })
+
+  it("preserves input and public event types in generated scenarios", () => {
+    const generated = MachineTest.scenarios(machine)
+    expect(generated.arbitrary).type.toBe<FastCheck.Arbitrary<MachineTest.Scenario<typeof machine>>>()
+
+    type Scenario = MachineTest.Scenario<typeof machine>
+    expect<Scenario["input"]>().type.toBe<Input>()
+    expect<Scenario["events"][number]>().type.toBe<PublicEvent>()
+    expect<InternalEvent>().type.not.toBeAssignableTo<Scenario["events"][number]>()
+  })
+
+  it("types whole-value arbitrary overrides", () => {
+    const options: MachineTest.ScenarioOptions<typeof machine> = {
+      inputArbitrary: FastCheck.constant(new Input({ id: "test" })),
+      eventsArbitrary: FastCheck.constant([new PublicEvent({ value: 1 })])
+    }
+    expect(options.inputArbitrary).type.toBe<FastCheck.Arbitrary<Input> | undefined>()
+    expect(options.eventsArbitrary).type.toBe<FastCheck.Arbitrary<ReadonlyArray<PublicEvent>> | undefined>()
+  })
+
+  it("omits input for machines without an input schema", () => {
+    const noInput = Machine.make({
+      states: States.states,
+      events: [PublicEvent],
+      initial: () => States.initial.idle(new Idle({}))
+    }).handle({ idle: {} })
+    type Scenario = MachineTest.Scenario<typeof noInput>
+    type Options = MachineTest.ScenarioOptions<typeof noInput>
+
+    expect<keyof Scenario>().type.toBe<"events">()
+    expect<Options["inputArbitrary"]>().type.toBe<undefined>()
+  })
+
+  it("retains typed trace plans and transition metadata", () => {
+    const scenario: MachineTest.Scenario<typeof machine> = {
+      input: new Input({ id: "test" }),
+      events: [new PublicEvent({ value: 1 })]
+    }
+    const executed = MachineTest.run(machine, scenario)
+
+    expect<Effect.Success<typeof executed>>().type.toBe<MachineTest.Trace<typeof machine>>()
+    expect<Effect.Error<typeof executed>>().type.toBe<
+      MachineTest.RunFailure<MachineTest.RunError<typeof machine>, typeof machine>
+    >()
+
+    expect<Effect.Success<typeof executed>["initial"]["startingConfiguration"][number]>().type.toBe<"idle">()
+    expect<Effect.Success<typeof executed>["initial"]["initialEntryPaths"][number]>().type.toBe<"idle">()
+
+    type InitialMicrostep = MachineTest.Trace<typeof machine>["initial"]["plan"]["microsteps"][number]
+    type EventMicrostep = MachineTest.Trace<typeof machine>["steps"][number]["plan"]["microsteps"][number]
+    expect<InitialMicrostep["transitions"][number]["source"]>().type.toBe<"idle">()
+    expect<EventMicrostep["transitions"][number]["trigger"]>().type.toBe<
+      Machine.Machine.TransitionTrigger<"PublicEvent" | "InternalEvent">
+    >()
+    expect<EventMicrostep["transitions"][number]["target"]>().type.toBe<"idle" | undefined>()
+    expect<EventMicrostep["transitions"][number]["resolvedTarget"]>().type.toBe<"idle" | undefined>()
+
+    const startup = Machine.planInitial(machine, new Input({ id: "test" }))
+    type StartupMicrostep = Effect.Success<typeof startup>["microsteps"][number]
+    expect<StartupMicrostep["transitions"][number]["source"]>().type.toBe<"idle">()
+    expect<StartupMicrostep["transitions"][number]["trigger"]>().type.toBe<
+      Machine.Machine.TransitionTrigger<"PublicEvent" | "InternalEvent">
+    >()
+  })
+
+  it("preserves the original cause in structured run failures", () => {
+    class PlanningFailure extends Data.TaggedError("PlanningFailure")<{}> {}
+    const failing = Machine.make({
+      states: States.states,
+      events: [PublicEvent],
+      initial: () =>
+        Effect.fail(new PlanningFailure()).pipe(
+          Effect.as(States.initial.idle(new Idle({})))
+        )
+    }).handle({ idle: {} })
+    const executed = MachineTest.run(failing, { events: [] })
+
+    expect<PlanningFailure>().type.toBeAssignableTo<Effect.Error<typeof executed>["cause"]>()
+    expect(Effect.flip(executed)).type.toBe<
+      Effect.Effect<
+        MachineTest.RunFailure<MachineTest.RunError<typeof failing>, typeof failing>,
+        MachineTest.Trace<typeof failing>
+      >
+    >()
+  })
+
+  it("keeps runtime commands on the public event protocol", () => {
+    const generated = MachineTest.runtimeCommands(machine)
+    expect(generated.arbitrary).type.toBe<
+      FastCheck.Arbitrary<ReadonlyArray<MachineTest.RuntimeCommand<PublicEvent>>>
+    >()
+    expect(MachineTest.sendCommand(new PublicEvent({ value: 1 }))).type.toBe<
+      MachineTest.RuntimeCommand<PublicEvent>
+    >()
+    expect(MachineTest.sendCommand(new InternalEvent({}))).type.not.toBeAssignableTo<
+      MachineTest.RuntimeCommand<PublicEvent>
+    >()
+    expect(MachineTest.advanceCommand<PublicEvent>(100)).type.toBe<MachineTest.RuntimeCommand<PublicEvent>>()
+    expect(MachineTest.stopCommand<PublicEvent>()).type.toBe<MachineTest.RuntimeCommand<PublicEvent>>()
+    expect(MachineTest.checkpointCommand<PublicEvent>("after sends")).type.toBe<
+      MachineTest.RuntimeCommand<PublicEvent>
+    >()
+  })
+
+  it("preserves model and assertion errors and services in runtime command checks", () => {
+    class ModelFailure extends Data.TaggedError("ModelFailure")<{}> {}
+    class InspectionFailure extends Data.TaggedError("InspectionFailure")<{}> {}
+    class AssertionFailure extends Data.TaggedError("AssertionFailure")<{}> {}
+    class ModelRequirement extends Context.Service<ModelRequirement, string>()("ModelRequirement") {}
+    class InspectionRequirement extends Context.Service<InspectionRequirement, string>()("InspectionRequirement") {}
+    class AssertionRequirement extends Context.Service<AssertionRequirement, string>()("AssertionRequirement") {}
+    const started = Machine.start(machine, new Input({ id: "test" }))
+    type Ref = Effect.Success<typeof started>
+    const ref = null as unknown as Ref
+    const executed = MachineTest.runRuntimeCommands(ref, [
+      MachineTest.sendCommand(new PublicEvent({ value: 1 }))
+    ], {
+      initialModel: 0,
+      transition: (model) =>
+        Effect.gen(function*() {
+          yield* ModelRequirement
+          if (model < 0) return yield* Effect.fail(new ModelFailure())
+          return {
+            model: model + 1,
+            expected: model + 1,
+            synchronize: MachineTest.RuntimeSynchronization.next
+          }
+        }),
+      inspect: () =>
+        Effect.gen(function*() {
+          const inspected = yield* InspectionRequirement
+          if (inspected.length === 0) return yield* Effect.fail(new InspectionFailure())
+          return inspected
+        }),
+      assert: () =>
+        Effect.gen(function*() {
+          yield* AssertionRequirement
+          return yield* Effect.fail(new AssertionFailure())
+        })
+    })
+
+    expect<Effect.Success<typeof executed>["finalModel"]>().type.toBe<number>()
+    expect<Effect.Success<typeof executed>["records"][number]["actual"]["inspected"]>().type.toBe<
+      string | undefined
+    >()
+    expect<Effect.Services<typeof executed>>().type.toBe<
+      ModelRequirement | InspectionRequirement | AssertionRequirement
+    >()
+    expect<Effect.Error<typeof executed>["cause"]>().type.toBe<
+      Cause.Cause<ModelFailure | InspectionFailure | AssertionFailure | MachineTest.RuntimeObservationError>
+    >()
+    expect<Effect.Error<typeof executed>["command"]>().type.toBe<MachineTest.RuntimeCommand<PublicEvent>>()
+  })
+})

--- a/typetest/MachineTestCoverage.tst.ts
+++ b/typetest/MachineTestCoverage.tst.ts
@@ -1,0 +1,59 @@
+import * as Effect from "effect/Effect"
+import * as Graph from "effect/Graph"
+import * as Schema from "effect/Schema"
+import { describe, expect, it } from "tstyche"
+import { Machine } from "../src/index.js"
+import { MachineTest } from "../src/testing.js"
+
+describe("MachineTest coverage and observed graph", () => {
+  class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", {}) {}
+  class Done extends Schema.TaggedClass<Done>("Done")("Done", {}) {}
+  class Start extends Schema.TaggedClass<Start>("Start")("Start", {}) {}
+
+  const States = Machine.defineStates({ idle: Idle, done: Done })
+  const machine = Machine.make({
+    states: States.states,
+    events: [Start],
+    initial: () => States.initial.idle(new Idle({}))
+  }).handle({
+    idle: {
+      on: {
+        Start: {
+          targets: ["done"],
+          transition: ({ target }) => target.full.done(new Done({}))
+        }
+      }
+    },
+    done: {}
+  })
+  const trace = {} as MachineTest.Trace<typeof machine>
+
+  it("preserves machine-specific paths and public event tags in coverage", () => {
+    const result = MachineTest.coverage(machine, trace)
+
+    expect(result).type.toBe<MachineTest.Coverage<typeof machine>>()
+    if (result.events.available) expect(result.events.hits[0]!.tag).type.toBe<"Start">()
+    expect(result.states.activation.hits[0]!.path).type.toBe<"idle" | "done">()
+    expect(result.transitions.hits[0]!.source).type.toBe<"idle" | "done">()
+    expect(result.transitions.hits[0]!.trigger).type.toBe<Machine.Machine.TransitionTrigger<"Start">>()
+  })
+
+  it("returns an Effect graph with typed nodes and concrete edge evidence", () => {
+    const result = MachineTest.observedGraph(machine, trace)
+
+    expect<Effect.Success<typeof result>>().type.toBe<MachineTest.ObservedGraph<typeof machine>>()
+    expect<Effect.Success<typeof result>["graph"]>().type.toBe<
+      Graph.DirectedGraph<
+        MachineTest.ObservedGraphNode<typeof machine>,
+        MachineTest.ObservedGraphEdge<typeof machine>
+      >
+    >()
+    expect<Effect.Error<typeof result>>().type.toBe<Machine.MachineSchemaEncodeError>()
+    expect<Effect.Services<typeof result>>().type.toBe<never>()
+
+    type Node = MachineTest.ObservedGraphNode<typeof machine>
+    type Edge = MachineTest.ObservedGraphEdge<typeof machine>
+    expect<Node["configuration"][number]>().type.toBe<"idle" | "done">()
+    expect<Extract<Edge, { readonly _tag: "Event" }>["event"]>().type.toBe<Start>()
+  })
+})

--- a/typetest/MachineTestFiniteModel.tst.ts
+++ b/typetest/MachineTestFiniteModel.tst.ts
@@ -1,0 +1,118 @@
+import { FastCheck } from "effect/testing"
+import { describe, expect, it } from "tstyche"
+import { Machine } from "../src/index.js"
+import { MachineTest } from "../src/testing.js"
+
+describe("MachineTest finite models", () => {
+  const generated = MachineTest.finiteModels({
+    maxRoots: 2,
+    maxDepth: 3,
+    maxChildren: 2,
+    maxParallelRegions: 2,
+    maxEvents: 2,
+    maxTransitions: 8,
+    maxHistoryStates: 2
+  })
+
+  it("exposes the model arbitrary and resolved diagnostics", () => {
+    expect(generated.arbitrary).type.toBe<FastCheck.Arbitrary<MachineTest.FiniteModel>>()
+    expect(generated.diagnostics.limits.maxRoots).type.toBe<1 | 2 | 3>()
+    expect(generated.diagnostics.limits.maxParallelRegions).type.toBe<2 | 3>()
+    expect(generated.diagnostics.limits.maxHistoryStates).type.toBe<number>()
+    expect(generated.diagnostics.guarantees.parallelStates).type.toBe<true>()
+    expect(generated.diagnostics.guarantees.historyStates).type.toBe<true>()
+    expect(generated.diagnostics.guarantees.historyLeaveResumeSequences).type.toBe<true>()
+    expect(generated.diagnostics.guarantees.historyValueScenarios).type.toBe<true>()
+    expect(generated.diagnostics.guarantees.structurallyValid).type.toBe<true>()
+    expect(generated.diagnostics.guarantees.eventlessTransitions).type.toBe<false>()
+  })
+
+  it("models atomic, final, compound, and parallel nodes", () => {
+    const state = {} as MachineTest.FiniteState
+    expect(state._tag).type.toBe<"Atomic" | "Final" | "Compound" | "Parallel" | "History">()
+    if (state._tag === "Compound") {
+      expect(state.initial).type.toBe<string>()
+      expect(state.states).type.toBe<ReadonlyArray<MachineTest.FiniteState>>()
+    }
+    if (state._tag === "Final") {
+      expect(state.output).type.toBe<string>()
+    }
+    if (state._tag === "Parallel") {
+      expect(state).type.toBe<MachineTest.FiniteParallelState>()
+      expect(state.output).type.toBe<string>()
+      expect(state.states).type.toBe<ReadonlyArray<MachineTest.FiniteState>>()
+    }
+    if (state._tag === "History") {
+      expect(state).type.toBe<MachineTest.FiniteHistoryState>()
+      expect(state.history).type.toBe<"shallow" | "deep">()
+      expect(state.fallback).type.toBe<string>()
+    }
+  })
+
+  it("compiles to the public erased machine boundary", () => {
+    const model: MachineTest.FiniteModel = {
+      roots: [{ _tag: "Atomic", key: "idle", value: 0 }],
+      initial: "idle",
+      events: ["Tick"],
+      transitions: [{ source: "idle", event: "Tick", target: "idle", reenter: false }]
+    }
+    const machine = MachineTest.compileModel(model)
+    expect(machine).type.toBe<Machine.Machine.Any>()
+    expect(MachineTest.scenarios(machine).arbitrary).type.toBe<
+      FastCheck.Arbitrary<MachineTest.Scenario<Machine.Machine.Any>>
+    >()
+  })
+
+  it("accepts a typed parallel model with deterministic output", () => {
+    const model: MachineTest.FiniteModel = {
+      roots: [{
+        _tag: "Parallel",
+        key: "root",
+        value: 0,
+        output: "complete",
+        states: [
+          { _tag: "Atomic", key: "left", value: 1 },
+          { _tag: "Atomic", key: "right", value: 2 }
+        ]
+      }],
+      initial: "root",
+      events: ["Tick"],
+      transitions: []
+    }
+    expect(model.roots[0]).type.toBe<MachineTest.FiniteState | undefined>()
+    expect(MachineTest.compileModel(model)).type.toBe<Machine.Machine.Any>()
+  })
+
+  it("accepts typed history pseudo-states and history transition targets", () => {
+    const history: MachineTest.FiniteHistoryState = {
+      _tag: "History",
+      key: "recent",
+      history: "deep",
+      fallback: "root.idle"
+    }
+    const model: MachineTest.FiniteModel = {
+      roots: [{
+        _tag: "Compound",
+        key: "root",
+        value: 0,
+        initial: "idle",
+        states: [{ _tag: "Atomic", key: "idle", value: 1 }, history]
+      }],
+      initial: "root",
+      events: ["Restore"],
+      transitions: [{ source: "root.idle", event: "Restore", target: "root.recent", reenter: true }]
+    }
+    expect(model.roots[0]).type.toBe<MachineTest.FiniteState | undefined>()
+  })
+
+  it("exposes exact generated history scenarios", () => {
+    const model = {} as MachineTest.FiniteModel
+    const scenario = {} as MachineTest.FiniteHistoryScenario
+    expect(model.historyScenarios).type.toBe<ReadonlyArray<MachineTest.FiniteHistoryScenario> | undefined>()
+    expect(scenario.historyType).type.toBe<"shallow" | "deep">()
+    expect(scenario.mutation).type.toBe<MachineTest.FiniteHistoryMutation>()
+    expect(scenario.leave).type.toBe<MachineTest.FiniteHistoryTransfer>()
+    expect(scenario.resume).type.toBe<MachineTest.FiniteHistoryTransfer>()
+    expect(scenario.events).type.toBe<readonly [mutation: string, leave: string, resume: string]>()
+  })
+})

--- a/typetest/MachineTestReferenceModel.tst.ts
+++ b/typetest/MachineTestReferenceModel.tst.ts
@@ -1,0 +1,46 @@
+import { Effect } from "effect"
+import { describe, expect, it } from "tstyche"
+import { MachineTest } from "../src/testing.js"
+
+describe("MachineTest finite-model reference interpreter", () => {
+  const model: MachineTest.FiniteModel = {
+    roots: [{ _tag: "Atomic", key: "idle", value: 0 }],
+    initial: "idle",
+    events: ["Tick"],
+    transitions: [{ source: "idle", event: "Tick", reenter: false }]
+  }
+  const reference = MachineTest.interpretModel(model, ["Tick"])
+
+  it("exposes stable reference state, step, and trace types", () => {
+    expect(reference).type.toBe<MachineTest.ReferenceTrace>()
+    expect(reference.initial).type.toBe<MachineTest.ReferenceInitialStep>()
+    expect(reference.initial.state).type.toBe<MachineTest.ReferenceState>()
+    expect(reference.steps[0]!).type.toBe<MachineTest.ReferenceStep>()
+    expect(reference.steps[0]!.microsteps[0]!).type.toBe<MachineTest.ReferenceMicrostep>()
+    expect(reference.steps[0]!.microsteps[0]!.transitions).type.toBe<
+      ReadonlyArray<MachineTest.ReferenceTransition>
+    >()
+    expect(reference.initial.state.values.idle).type.toBe<MachineTest.ReferenceStateValue | undefined>()
+    expect(reference.initial.state.completions[0]).type.toBe<MachineTest.ReferenceCompletion | undefined>()
+    expect(reference.initial.state.history.idle).type.toBe<MachineTest.ReferenceHistoryRecord | undefined>()
+    expect(reference.initial.state.status).type.toBe<"active" | "done">()
+    expect(reference.initial.state.output).type.toBe<string | undefined>()
+  })
+
+  it("returns an Effect with only the structured model-verification error", () => {
+    const machine = MachineTest.compileModel(model)
+    const trace = {} as MachineTest.Trace<typeof machine>
+    const verified = MachineTest.verifyModel(model, trace)
+
+    expect<Effect.Success<typeof verified>>().type.toBe<void>()
+    expect<Effect.Error<typeof verified>>().type.toBe<MachineTest.ModelVerificationError>()
+    expect<Effect.Services<typeof verified>>().type.toBe<never>()
+
+    const mismatch = {} as MachineTest.ModelVerificationMismatch
+    expect(mismatch.location).type.toBe<MachineTest.ModelVerificationLocation>()
+    expect(mismatch.location.phase).type.toBe<"initial" | "event" | "final">()
+    expect(mismatch.field).type.toBe<MachineTest.ModelVerificationField>()
+    expect(mismatch.expected).type.toBe<unknown>()
+    expect(mismatch.actual).type.toBe<unknown>()
+  })
+})

--- a/typetest/MachineTestVerification.tst.ts
+++ b/typetest/MachineTestVerification.tst.ts
@@ -1,0 +1,38 @@
+import { Effect, Schema } from "effect"
+import { describe, expect, it } from "tstyche"
+import { Machine } from "../src/index.js"
+import { MachineTest } from "../src/testing.js"
+
+describe("MachineTest.verify", () => {
+  class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", {}) {}
+  class Tick extends Schema.TaggedClass<Tick>("Tick")("Tick", {}) {}
+
+  const States = Machine.defineStates({ idle: Idle })
+  const machine = Machine.make({
+    states: States.states,
+    events: [Tick],
+    initial: () => States.initial.idle(new Idle({}))
+  }).handle({ idle: {} })
+
+  const trace = {} as MachineTest.Trace<typeof machine>
+  const verified = MachineTest.verify(machine, trace)
+
+  it("has a void success and structured verification error", () => {
+    expect<Effect.Success<typeof verified>>().type.toBe<void>()
+    expect<Effect.Error<typeof verified>>().type.toBe<MachineTest.VerificationError>()
+    expect<Effect.Services<typeof verified>>().type.toBe<never>()
+
+    const error = {} as Effect.Error<typeof verified>
+    expect(error.violations[0]!.law).type.toBe<MachineTest.VerificationLaw>()
+    expect(error.violations[0]!.eventIndex).type.toBe<number | undefined>()
+    expect(error.violations[0]!.microstepIndex).type.toBe<number | undefined>()
+    expect(error.violations[0]!.path).type.toBe<string | undefined>()
+  })
+
+  it("accepts only canonical law groups", () => {
+    const options: MachineTest.VerifyOptions = {
+      laws: ["configuration", "microsteps", "completion", "history", "targetBounds"]
+    }
+    expect(options.laws).type.toBe<ReadonlyArray<MachineTest.VerificationLawGroup> | undefined>()
+  })
+})


### PR DESCRIPTION
## Summary

- Add a separate `@typeonce/effect-machine/testing` entrypoint for schema-derived scenarios, replayable planner traces, independent statechart-law verification, and structured failure diagnostics.
- Add shrinkable finite statechart models plus an independent reference interpreter covering compound, parallel, completion, targetless, reentry, and shallow/deep history semantics.
- Add value-sensitive generated history witnesses, trace coverage, full logical-snapshot observed graphs backed by Effect Graph, and live runtime command models using Effect TestClock.
- Expose retained transition evidence from planner microsteps and fix defects found by differential/property testing: cross-root reentry boundaries, simultaneous parallel target application, and recorded nested-history restoration through inactive ancestors.
- Keep static exhaustiveness and arbitrary Effect execution out of the claims: graphs represent observed behavior, while live-runtime checking uses a caller-supplied reference reducer and explicit synchronization.

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check` — 307 runtime tests; 124 type tests / 534 assertions; strict consumer and pack validation
- [x] Relevant example checks, when examples changed — no example packages changed
- [ ] Reviewed the automated type-performance report, when the public TypeScript API or inference changed — pending PR workflow; local `pnpm perf:types` passed with no root-import regression

## Notes

- The first-use fallback for a nested history target still cannot construct values for inactive ancestors above its direct owner; recorded history restoration now can. This existing boundary is documented in the public API and guides.
- The new runtime command runner deliberately treats `send` as enqueue acceptance and uses `Until` or terminal observations as the reliable drain barrier.
