### PR TITLE
Add choice pseudo-states

### DIFF
--- a/.changeset/fuzzy-dodos-choose.md
+++ b/.changeset/fuzzy-dodos-choose.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Add schema-free choice pseudo-states and transition annotations for immediately routing to one of several declared targets with ordinary typed control flow.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ masquerade as an internal result.
 
 ## Statechart structure
 
-`Machine.defineStates` accepts atomic, compound, parallel, final, and history
+`Machine.defineStates` accepts atomic, compound, parallel, final, history, and choice
 nodes:
 
 ```ts
@@ -204,6 +204,44 @@ parent, not on the final leaf.
 Put data on the narrowest state where it is valid. If several sibling phases
 share data, prefer storing it on their compound parent instead of copying it
 into every child state.
+
+### Choice states
+
+A choice is a transition-only pseudo-state used to show where one typed
+transition selects between multiple destinations. It has no schema, never
+becomes active, and never appears in a snapshot. Declare the choice in the
+state tree, then annotate an object-form event, eventless, or completion
+transition with its path and the possible targets:
+
+```ts
+const States = Machine.defineStates({
+  Editing,
+  Validate: { type: "choice" },
+  Accepted,
+  Rejected
+})
+
+const machine = Machine.make({
+  states: States.states,
+  events: [Submit],
+  initial: () => States.initial.Editing.from()
+}).handle({
+  Editing: {
+    on: {
+      Submit: {
+        choice: "Validate",
+        targets: ["Accepted", "Rejected"],
+        transition: ({ state, target }) => isValid(state) ? target.full.Accepted.from() : target.full.Rejected.from()
+      }
+    }
+  }
+})
+```
+
+The transition callback performs the check directly, retaining its precise
+source state and event types. A choice transition must declare at least one
+possible target and return one of those targets. Inspection tools expose the
+choice path without executing the callback.
 
 ### History states
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -104,7 +104,7 @@ its extra control is required:
   the same operation with a returned transition value, not a separate action
   API.
 
-## Atomic, compound, parallel, and history states
+## Atomic, compound, parallel, history, and choice states
 
 Use an atomic state when no child phase can be active beneath it.
 
@@ -200,6 +200,26 @@ const machine = Machine.make({
 
 Do not repeat `type: "final"` in `handle`. Execution APIs reject a machine
 until every declared output schema has an implementation.
+
+Declare `{ type: "choice" }` for a transition-only routing node. Choice nodes
+have no schema, are excluded from active state identifiers and snapshots, and
+cannot be selected as a compound initial child. Annotate the incoming
+object-form transition with the choice path and every possible destination;
+perform the decision with ordinary TypeScript control flow in that transition:
+
+```ts
+Submit: {
+  choice: "validate",
+  targets: ["accepted", "rejected"],
+  transition: ({ state, target }) =>
+    isValid(state) ? target.full.accepted.from() : target.full.rejected.from()
+}
+```
+
+This form preserves the incoming handler's precise source-state and event
+types. A choice annotation requires a non-empty `targets` tuple and the
+callback must return a target. Choice nodes are structural metadata and never
+create an extra runtime microstep.
 
 Declare a history pseudo-state below the active parent whose configuration it
 should remember. It has no schema, is excluded from active state identifiers,

--- a/examples/visualizer/src/graph.test.ts
+++ b/examples/visualizer/src/graph.test.ts
@@ -1,3 +1,5 @@
+import { Machine } from "@typeonce/effect-machine"
+import { Schema } from "effect"
 import { describe, expect, it } from "vitest"
 import { buildDiagramGraph } from "./graph.ts"
 import { VisualizerMachine } from "./machine.ts"
@@ -31,5 +33,31 @@ describe("diagram graph", () => {
       }
     })
     expect(graph.transitions.every(({ targets }) => targets.type === "declared")).toBe(true)
+  })
+
+  it("routes annotated transitions through choice nodes", () => {
+    class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", {}) {}
+    class Done extends Schema.TaggedClass<Done>("Done")("Done", {}) {}
+    class Go extends Schema.TaggedClass<Go>("Go")("Go", {}) {}
+    const states = Machine.defineStates({ idle: Idle, decide: { type: "choice" }, done: Done })
+    const machine = Machine.make({
+      states: states.states,
+      events: [Go],
+      initial: () => states.initial.idle(new Idle({}))
+    }).handle({
+      idle: {
+        on: {
+          Go: {
+            choice: "decide",
+            targets: ["done"],
+            transition: ({ target }) => target.full.done(new Done({}))
+          }
+        }
+      }
+    })
+
+    const graph = buildDiagramGraph(machine)
+    expect(graph.nodes.find(({ path }) => path === "decide")?.type).toBe("choice")
+    expect(graph.transitions[0]).toMatchObject({ choice: "decide" })
   })
 })

--- a/examples/visualizer/src/graph.ts
+++ b/examples/visualizer/src/graph.ts
@@ -4,6 +4,7 @@ const leafWidth = 112
 const leafHeight = 58
 const historyWidth = 100
 const historyHeight = 46
+const choiceSize = 46
 const groupMinWidth = 164
 const groupHeader = 36
 const groupPadding = 14
@@ -32,6 +33,7 @@ export interface DiagramTransition {
     | { readonly type: "always" }
     | { readonly type: "done" }
   readonly reenter: boolean
+  readonly choice?: string
   readonly targets:
     | { readonly type: "dynamic" }
     | { readonly type: "declared"; readonly paths: ReadonlyArray<string> }
@@ -69,7 +71,9 @@ export const buildDiagramGraph = <M extends Machine.Machine.Any>(machine: M): Di
     if (node === undefined) throw new Error(`Missing diagram node: ${path}`)
     const childPaths = children.get(path) ?? []
     const result = childPaths.length === 0
-      ? node.type === "history"
+      ? node.type === "choice"
+        ? { width: choiceSize, height: choiceSize }
+        : node.type === "history"
         ? { width: historyWidth, height: historyHeight }
         : { width: leafWidth, height: leafHeight }
       : (() => {
@@ -140,7 +144,8 @@ export const buildDiagramGraph = <M extends Machine.Machine.Any>(machine: M): Di
       source: definition.source,
       trigger: definition.trigger,
       reenter: definition.reenter,
-      targets: definition.targets
+      targets: definition.targets,
+      ...(definition.choice === undefined ? {} : { choice: definition.choice })
     }))
   }
 }

--- a/examples/visualizer/src/main.ts
+++ b/examples/visualizer/src/main.ts
@@ -127,7 +127,7 @@ const eventPoint = (transition: DiagramTransition): { readonly x: number; readon
   const source = nodesByPath.get(transition.source)
   if (source === undefined) return { x: 0, y: 0 }
   if (transition.targets.type === "declared" && transition.targets.paths.length > 0) {
-    const target = nodesByPath.get(transition.targets.paths[0]!)
+    const target = nodesByPath.get(transition.choice ?? transition.targets.paths[0]!)
     if (target !== undefined) {
       const from = center(source)
       const to = center(target)
@@ -173,12 +173,15 @@ const drawNode = (node: DiagramNode, group: boolean): void => {
   const element = svgElement("g", { class: `state-node ${group ? "state-group" : "state-leaf"}` })
   element.dataset.nodePath = node.path
   const box = svgElement("rect", {
-    x: node.x,
-    y: node.y,
-    width: node.width,
-    height: node.height,
-    rx: group ? 16 : node.type === "history" ? 24 : 10,
-    class: "state-box"
+    x: node.type === "choice" ? node.x + 10 : node.x,
+    y: node.type === "choice" ? node.y + 10 : node.y,
+    width: node.type === "choice" ? node.width - 20 : node.width,
+    height: node.type === "choice" ? node.height - 20 : node.height,
+    rx: group ? 16 : node.type === "history" ? 24 : node.type === "choice" ? 0 : 10,
+    class: "state-box",
+    ...(node.type === "choice"
+      ? { transform: `rotate(45 ${node.x + node.width / 2} ${node.y + node.height / 2})` }
+      : {})
   })
   const label = svgElement("text", {
     x: node.x + (group ? 15 : node.width / 2),
@@ -186,7 +189,7 @@ const drawNode = (node: DiagramNode, group: boolean): void => {
     class: "state-label",
     "text-anchor": group ? "start" : "middle"
   })
-  label.textContent = node.key
+  label.textContent = node.type === "choice" ? "?" : node.key
   element.append(box, label)
   if (group) {
     const kind = svgElement("text", {
@@ -199,6 +202,7 @@ const drawNode = (node: DiagramNode, group: boolean): void => {
     element.append(kind)
   }
   if (node.type === "history") element.classList.add("is-history")
+  if (node.type === "choice") element.classList.add("is-choice")
   svg.append(element)
   nodeElements.set(node.path, element)
 }
@@ -209,11 +213,20 @@ for (const node of grouped.sort((left, right) => left.depth - right.depth)) draw
 for (const transition of graph.transitions) {
   const source = nodesByPath.get(transition.source)
   if (source === undefined || transition.targets.type !== "declared") continue
+  const choice = transition.choice === undefined ? undefined : nodesByPath.get(transition.choice)
+  if (choice !== undefined) {
+    const path = svgElement("path", {
+      d: edgePath(source, choice),
+      class: `transition-edge${transition.reenter ? " is-reenter" : ""}`,
+      "marker-end": "url(#arrow)"
+    })
+    svg.append(path)
+  }
   for (const targetPath of transition.targets.paths) {
     const target = nodesByPath.get(targetPath)
     if (target === undefined) continue
     const path = svgElement("path", {
-      d: edgePath(source, target),
+      d: edgePath(choice ?? source, target),
       class: `transition-edge${transition.reenter ? " is-reenter" : ""}`,
       "marker-end": "url(#arrow)"
     })

--- a/examples/visualizer/src/styles.css
+++ b/examples/visualizer/src/styles.css
@@ -229,6 +229,10 @@ h1 {
   stroke-dasharray: 4 4;
 }
 
+.state-node.is-choice > .state-box {
+  fill: #fff8e7;
+}
+
 .transition-edge {
   fill: none;
   stroke: #87847d;

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -93,9 +93,9 @@ type IsAny<A> = 0 extends (1 & A) ? true : false
  *
  * **Details**
  *
- * Machines support atomic, compound, parallel, and final states together with
- * completion transitions, eventless transitions, raised events, actions,
- * spawned children, and state-scoped invokes. Schemas validate machine
+ * Machines support atomic, compound, parallel, final, history, and choice
+ * states together with completion transitions, eventless transitions, raised
+ * events, actions, spawned children, and state-scoped invokes. Schemas validate machine
  * boundaries while preserving decoded state, event, output, error, and service
  * types throughout planning and execution.
  *
@@ -436,6 +436,9 @@ type ActiveStateKey<States extends Machine.StateSchemas> = Machine.ActiveStateKe
 
 type HistoryStateKey<States extends Machine.StateSchemas> = Machine.HistoryStateKey<States>
 
+type IsPseudoStateNode<Node> = Node extends Machine.HistoryStateNodeConfig | Machine.ChoiceStateNodeConfig ? true
+  : false
+
 type ValidateStateTree<States extends Machine.StateSchemas, AllowHistory extends boolean = false> = {
   readonly [Key in keyof States]: ValidateStateNode<States[Key], AllowHistory>
 }
@@ -443,6 +446,7 @@ type ValidateStateTree<States extends Machine.StateSchemas, AllowHistory extends
 type ValidateStateNode<Node, AllowHistory extends boolean> = Node extends Machine.HistoryStateNodeConfig ?
   AllowHistory extends true ? ValidateHistoryStateNode<Node>
   : StateDefinitionError<"History states must be declared below an active parent state">
+  : Node extends Machine.ChoiceStateNodeConfig ? ValidateChoiceStateNode<Node>
   : Node extends Machine.TaggedSchema ? unknown
   : Node extends { readonly schema: Machine.TaggedSchema } ? ValidateStateNodeConfig<Node>
   : StateDefinitionError<"State nodes must be tagged schemas or state node configs">
@@ -451,6 +455,11 @@ type ValidateHistoryStateNode<Node extends Machine.HistoryStateNodeConfig> = [
   Extract<keyof Node, "schema" | "states" | "initial" | "output">
 ] extends [never] ? unknown
   : StateDefinitionError<"History states cannot declare schemas, children, initial states, or output">
+
+type ValidateChoiceStateNode<Node extends Machine.ChoiceStateNodeConfig> = [
+  Extract<keyof Node, "schema" | "states" | "initial" | "output" | "history">
+] extends [never] ? unknown
+  : StateDefinitionError<"Choice states cannot declare schemas, children, initial states, output, or history">
 
 type ValidateStateNodeConfig<Node extends { readonly schema: Machine.TaggedSchema }> = Node extends
   { readonly states: infer Children } ? ValidateStateNodeWithChildren<Node, Children>
@@ -497,6 +506,7 @@ type DefineStateTreeInput<States extends Machine.StateSchemas> = {
 
 type DefineStateNodeInput<Node> = Node extends Machine.TaggedSchema ? Node
   : Node extends Machine.HistoryStateNodeConfig ? Machine.HistoryStateNodeConfig
+  : Node extends Machine.ChoiceStateNodeConfig ? Machine.ChoiceStateNodeConfig
   : Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ?
     Omit<Node, "states"> & { readonly states: DefineStateTreeInput<Children> }
   : Node extends { readonly states: infer Children extends Machine.StateSchemas } ? Omit<Node, "initial" | "states"> & {
@@ -1867,6 +1877,21 @@ export declare namespace Machine {
   }
 
   /**
+   * Transition-only pseudo-state that records where a transition chooses
+   * between multiple declared destinations.
+   *
+   * Choice nodes never become active and therefore do not declare a state
+   * value schema or lifecycle handlers. The decision remains in the incoming
+   * transition callback so its source state and event stay precisely typed.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface ChoiceStateNodeConfig {
+    readonly type: "choice"
+  }
+
+  /**
    * Configuration accepted for an object state node.
    *
    * @category models
@@ -1877,6 +1902,7 @@ export declare namespace Machine {
     | CompoundStateNodeConfig
     | ParallelStateNodeConfig
     | HistoryStateNodeConfig
+    | ChoiceStateNodeConfig
 
   /**
    * Object state tree keyed by state path.
@@ -1996,10 +2022,10 @@ export declare namespace Machine {
     readonly key: string
     readonly schema: TaggedSchema | undefined
     readonly output: Schema.Top | undefined
-    readonly type: "atomic" | "compound" | "parallel" | "final" | "history"
+    readonly type: "atomic" | "compound" | "parallel" | "final" | "history" | "choice"
     readonly history: "shallow" | "deep" | undefined
     readonly parent: Path | undefined
-    /** Active child paths. History pseudo-states are available through their `parent` relationship. */
+    /** Active child paths. Pseudo-states are available through their `parent` relationship. */
     readonly children: ReadonlyArray<Path>
     readonly initial: Path | undefined
     readonly order: number
@@ -2066,12 +2092,15 @@ export declare namespace Machine {
   export interface TransitionDefinition<
     SourcePath extends string = string,
     EventTag extends PropertyKey = PropertyKey,
-    TargetPath extends string = SourcePath
+    TargetPath extends string = SourcePath,
+    ChoicePath extends string = never
   > {
     readonly source: SourcePath
     readonly trigger: TransitionTrigger<EventTag>
     readonly reenter: boolean
     readonly targets: TransitionTargets<TargetPath>
+    /** Structural choice pseudo-state traversed by this transition. */
+    readonly choice?: ChoicePath
   }
 
   /**
@@ -2128,7 +2157,7 @@ export declare namespace Machine {
     States extends StateSchemas,
     Prefix extends string = ""
   > = {
-    readonly [Key in Extract<keyof States, string>]: States[Key] extends HistoryStateNodeConfig ? never
+    readonly [Key in Extract<keyof States, string>]: IsPseudoStateNode<States[Key]> extends true ? never
       : States[Key] extends { readonly states: infer Children }
         ? Children extends StateSchemas ?
           JoinPath<Prefix, Key> | StateIdentifierWithPrefix<Children, JoinPath<Prefix, Key>>
@@ -2150,7 +2179,18 @@ export declare namespace Machine {
    * @category utility types
    * @since 4.0.0
    */
-  export type StateNodeIdentifier<States extends StateSchemas> = StateIdentifier<States> | HistoryIdentifier<States>
+  export type StateNodeIdentifier<States extends StateSchemas> =
+    | StateIdentifier<States>
+    | HistoryIdentifier<States>
+    | ChoiceIdentifier<States>
+
+  /** Extracts transition-only choice pseudo-state paths in a definition. */
+  export type ChoiceIdentifier<States extends StateSchemas> = ChoiceIdentifierWithPrefix<States>
+
+  /** Extracts paths that may be returned as concrete transition targets. */
+  export type TransitionTargetIdentifier<States extends StateSchemas> =
+    | StateIdentifier<States>
+    | HistoryIdentifier<States>
 
   /** @internal */
   export type HistoryIdentifierWithPrefix<
@@ -2163,9 +2203,20 @@ export declare namespace Machine {
       : never
   }[Extract<keyof States, string>]
 
+  /** @internal */
+  export type ChoiceIdentifierWithPrefix<
+    States extends StateSchemas,
+    Prefix extends string = ""
+  > = {
+    readonly [Key in Extract<keyof States, string>]: States[Key] extends ChoiceStateNodeConfig ? JoinPath<Prefix, Key>
+      : States[Key] extends { readonly states: infer Children extends StateSchemas } ?
+        ChoiceIdentifierWithPrefix<Children, JoinPath<Prefix, Key>>
+      : never
+  }[Extract<keyof States, string>]
+
   /** Active keys directly declared in a state tree. */
   export type ActiveStateKey<States extends StateSchemas> = {
-    readonly [Key in Extract<keyof States, string>]: States[Key] extends HistoryStateNodeConfig ? never : Key
+    readonly [Key in Extract<keyof States, string>]: IsPseudoStateNode<States[Key]> extends true ? never : Key
   }[Extract<keyof States, string>]
 
   /** History pseudo-state keys directly declared in a state tree. */
@@ -3599,8 +3650,9 @@ export declare namespace Machine {
     readonly always?:
       | ((context: AlwaysContext<States, Events, Emits, StateId>) => HandlerResult<States, any, any>)
       | {
+        readonly choice?: ChoiceIdentifier<States>
         /** Statically declared upper bound of possible target paths. */
-        readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
+        readonly targets?: ReadonlyArray<TransitionTargetIdentifier<States>>
         readonly transition: (
           context: AlwaysContext<States, Events, Emits, StateId>
         ) => HandlerResult<States, any, any>
@@ -3608,8 +3660,9 @@ export declare namespace Machine {
     readonly onDone?:
       | ((context: DoneContext<States, Events, Emits, StateId>) => HandlerResult<States, any, any>)
       | {
+        readonly choice?: ChoiceIdentifier<States>
         /** Statically declared upper bound of possible target paths. */
-        readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
+        readonly targets?: ReadonlyArray<TransitionTargetIdentifier<States>>
         readonly transition: (
           context: DoneContext<States, Events, Emits, StateId>
         ) => HandlerResult<States, any, any>
@@ -3621,12 +3674,13 @@ export declare namespace Machine {
         ) => HandlerResult<States, any, any>)
         | {
           readonly reenter?: boolean
+          readonly choice?: ChoiceIdentifier<States>
           /**
            * Upper bound of state or history paths this handler may target.
            * Returning `void` is always permitted. Declaring a parent state also
            * permits concrete descendant targets below it.
            */
-          readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
+          readonly targets?: ReadonlyArray<TransitionTargetIdentifier<States>>
           readonly transition: (
             context: HandlerContext<States, Events, Emits, StateId, EventTag, E, R>
           ) => HandlerResult<States, any, any>
@@ -3930,6 +3984,51 @@ export declare namespace Machine {
     >
     : never
 
+  type TransitionSuccess<Result> = Result extends Effect.Effect<infer Success, any, any> ? TransitionSuccess<Success>
+    : Result extends StateConstruction<infer Constructed> ? TransitionSuccess<Constructed>
+    : Result
+
+  type ChoiceTransitionValidation<
+    StateId extends string,
+    Trigger extends PropertyKey,
+    Transition
+  > = Transition extends { readonly choice: string } ?
+    Transition extends { readonly targets: readonly [string, ...ReadonlyArray<string>] } ?
+      undefined extends TransitionSuccess<EventTransitionReturn<Transition>> ? HandlerValidationError<
+          "Choice transition must return a target",
+          StateId,
+          Trigger
+        >
+      : unknown
+    : HandlerValidationError<"Choice transition must declare at least one target", StateId, Trigger>
+    : unknown
+
+  type HandlerOnChoiceValidationErrors<StateId extends string, On> = {
+    readonly [
+      EventTag in keyof On as unknown extends ChoiceTransitionValidation<StateId, EventTag, On[EventTag]> ? never
+        : EventTag
+    ]: ChoiceTransitionValidation<StateId, EventTag, On[EventTag]>
+  }
+
+  type HandlerOnChoiceValidation<StateId extends string, Config> = "on" extends keyof Config ?
+    Config extends { readonly on?: infer On } ? HandlerOnChoiceValidationErrors<
+        StateId,
+        NonNullable<On>
+      > extends infer Errors ? keyof Errors extends never ? unknown
+        : { readonly on: Errors }
+      : never
+    : unknown
+    : unknown
+
+  type HandlerDirectChoiceValidation<
+    StateId extends string,
+    Config,
+    Trigger extends "always" | "onDone",
+    Transition = Config extends { readonly [Key in Trigger]?: infer Value } ? NonNullable<Value> : never,
+    Validation = ChoiceTransitionValidation<StateId, Trigger, Transition>
+  > = Trigger extends keyof Config ? unknown extends Validation ? unknown : { readonly [Key in Trigger]: Validation }
+    : unknown
+
   type HandlerOnTargetValidationErrors<StateId extends string, On> = {
     readonly [
       EventTag in keyof On as [UndeclaredTransitionTarget<On[EventTag]>] extends [never] ? never
@@ -4056,8 +4155,11 @@ export declare namespace Machine {
     & HandlerUnknownConfigKeyValidation<StateId, Config>
     & HandlerOnKeyValidation<Events, StateId, Config>
     & HandlerOnTargetValidation<StateId, Config>
+    & HandlerOnChoiceValidation<StateId, Config>
     & HandlerDirectTargetValidation<StateId, Config, "always">
     & HandlerDirectTargetValidation<StateId, Config, "onDone">
+    & HandlerDirectChoiceValidation<StateId, Config, "always">
+    & HandlerDirectChoiceValidation<StateId, Config, "onDone">
     & HandlerInvokeOutputValidation<Events, StateId, Config>
     & HandlerInvokeEmitsValidation<Events, StateId, Config>
     & HandlerInvokeSnapshotValidation<Events, StateId, Config>
@@ -4501,8 +4603,9 @@ export declare namespace Machine {
       | ((context: HandlerContext<States, Events, Emits, StateId, EventTag, E, R>) => HandlerResult<States, E, R>)
       | {
         readonly reenter?: boolean
+        readonly choice?: ChoiceIdentifier<States>
         /** Statically declared upper bound of possible target paths. */
-        readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
+        readonly targets?: ReadonlyArray<TransitionTargetIdentifier<States>>
         readonly transition: (
           context: HandlerContext<States, Events, Emits, StateId, EventTag, E, R>
         ) => HandlerResult<States, E, R>
@@ -4531,7 +4634,8 @@ export declare namespace Machine {
     readonly always?:
       | ((context: AlwaysContext<States, Events, Emits, StateId>) => HandlerResult<States, E, R>)
       | {
-        readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
+        readonly choice?: ChoiceIdentifier<States>
+        readonly targets?: ReadonlyArray<TransitionTargetIdentifier<States>>
         readonly transition: (
           context: AlwaysContext<States, Events, Emits, StateId>
         ) => HandlerResult<States, E, R>
@@ -4539,7 +4643,8 @@ export declare namespace Machine {
     readonly onDone?:
       | ((context: DoneContext<States, Events, Emits, StateId>) => HandlerResult<States, E, R>)
       | {
-        readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
+        readonly choice?: ChoiceIdentifier<States>
+        readonly targets?: ReadonlyArray<TransitionTargetIdentifier<States>>
         readonly transition: (
           context: DoneContext<States, Events, Emits, StateId>
         ) => HandlerResult<States, E, R>
@@ -4604,6 +4709,20 @@ const validateTransitionTargets = (
   trigger: PropertyKey,
   transition: unknown
 ): void => {
+  if (typeof transition === "object" && transition !== null && hasProperty(transition, "choice")) {
+    const choice = transition.choice
+    const choiceNode = typeof choice === "string" ? stateNodes.byPath.get(choice) : undefined
+    if (choiceNode?.type !== "choice") {
+      throw new Error(
+        `Machine transition for state "${path}" on "${String(trigger)}" declares unknown choice "${String(choice)}"`
+      )
+    }
+    if (!hasProperty(transition, "targets") || !Array.isArray(transition.targets) || transition.targets.length === 0) {
+      throw new Error(
+        `Machine choice transition for state "${path}" on "${String(trigger)}" must declare at least one target`
+      )
+    }
+  }
   if (typeof transition !== "object" || transition === null || !hasProperty(transition, "targets")) {
     return
   }
@@ -4613,7 +4732,8 @@ const validateTransitionTargets = (
     )
   }
   for (const target of transition.targets) {
-    if (typeof target !== "string" || !stateNodes.byPath.has(target)) {
+    const targetNode = typeof target === "string" ? stateNodes.byPath.get(target) : undefined
+    if (targetNode === undefined || targetNode.type === "choice") {
       throw new Error(
         `Machine transition for state "${path}" on "${String(trigger)}" declares unknown target "${String(target)}"`
       )
@@ -4724,6 +4844,10 @@ type SnapshotBuilderOptions = {
   readonly prefix: string
 }
 
+const isPseudoStateDefinition = (definition: Machine.TaggedSchema | Machine.StateNodeConfig): boolean =>
+  (definition as { readonly type?: unknown }).type === "history" ||
+  (definition as { readonly type?: unknown }).type === "choice"
+
 type FromMethodKind = "leaf" | "nested"
 
 const withFrom = <Method extends (value: unknown, ...args: ReadonlyArray<any>) => unknown>(
@@ -4748,7 +4872,7 @@ const makeSnapshotBuilder = (
 ): unknown => {
   const builder: Record<string, unknown> = {}
   for (const key of Object.keys(states)) {
-    if ((states[key] as { readonly type?: unknown }).type === "history") {
+    if (isPseudoStateDefinition(states[key])) {
       continue
     }
     const path = options.prefix === "" ? key : `${options.prefix}.${key}`
@@ -4777,7 +4901,7 @@ const makeParallelSnapshotBuilder = (
     enumerable: false
   })
   for (const key of Object.keys(states)) {
-    if ((states[key] as { readonly type?: unknown }).type === "history") {
+    if (isPseudoStateDefinition(states[key])) {
       continue
     }
     if (hasProperty(regions, key)) {
@@ -4810,7 +4934,7 @@ const getParallelSnapshotBuilderRegions = (
     SnapshotBuilderStateTypeId
   ]
   for (const key of Object.keys(states)) {
-    if ((states[key] as { readonly type?: unknown }).type === "history") {
+    if (isPseudoStateDefinition(states[key])) {
       continue
     }
     if (!hasProperty(regions, key)) {
@@ -6014,10 +6138,10 @@ export const planInitial: <
  *
  * **Details**
  *
- * The result includes atomic, compound, parallel, final, and history nodes.
+ * The result includes atomic, compound, parallel, final, history, and choice nodes.
  * Use each node's `parent` property to reconstruct the complete hierarchy.
- * History pseudo-states are intentionally omitted from `children` because they
- * can never appear in an active configuration.
+ * History and choice pseudo-states are intentionally omitted from `children`
+ * because they can never appear in an active configuration.
  *
  * @category getters
  * @since 4.0.0
@@ -6049,14 +6173,16 @@ export const transitionDefinitions = <M extends Machine.Any>(
   Machine.TransitionDefinition<
     Machine.StateIdentifier<Machine.States<M>>,
     Machine.TagOf<Machine.Events<M>[number]>,
-    Machine.StateNodeIdentifier<Machine.States<M>>
+    Machine.TransitionTargetIdentifier<Machine.States<M>>,
+    Machine.ChoiceIdentifier<Machine.States<M>>
   >
 > =>
   Model.transitionDefinitions(machine) as ReadonlyArray<
     Machine.TransitionDefinition<
       Machine.StateIdentifier<Machine.States<M>>,
       Machine.TagOf<Machine.Events<M>[number]>,
-      Machine.StateNodeIdentifier<Machine.States<M>>
+      Machine.TransitionTargetIdentifier<Machine.States<M>>,
+      Machine.ChoiceIdentifier<Machine.States<M>>
     >
   >
 

--- a/src/internal/machineModel.ts
+++ b/src/internal/machineModel.ts
@@ -243,15 +243,18 @@ export const getStateNodeDefinition = (
 ): {
   readonly schema: Machine.TaggedSchema | undefined
   readonly output: Schema.Top | undefined
-  readonly type: "atomic" | "compound" | "parallel" | "final" | "history"
+  readonly type: "atomic" | "compound" | "parallel" | "final" | "history" | "choice"
   readonly initial: string | undefined
   readonly states: Machine.StateTree | undefined
 } => {
-  if (!Schema.isSchema(definition) && (definition as any).type === "history") {
+  if (
+    !Schema.isSchema(definition) && ((definition as any).type === "history" || (definition as any).type === "choice")
+  ) {
+    const type = (definition as any).type as "history" | "choice"
     return {
       schema: undefined,
       output: undefined,
-      type: "history",
+      type,
       initial: undefined,
       states: undefined
     }
@@ -332,9 +335,12 @@ export const compileStateNodes = (states: Machine.StateSchemas): Machine.StateNo
       }
       byPath.set(path, node)
       order += 1
-      if (definition.type === "history") {
+      if (definition.type === "history" || definition.type === "choice") {
         if (parent === undefined) {
-          throw new Error(`Machine history state "${path}" must belong to a parent state`)
+          if (definition.type === "history") {
+            throw new Error(`Machine history state "${path}" must belong to a parent state`)
+          }
+          continue
         }
         continue
       }
@@ -363,10 +369,15 @@ const transitionTargets = (handler: unknown): Machine.TransitionTargets =>
     ? { type: "declared", paths: Array.from(handler.targets as ReadonlyArray<string>) }
     : dynamicTransitionTargets
 
+const transitionChoice = (handler: unknown): { readonly choice: string } | {} =>
+  typeof handler === "object" && handler !== null && "choice" in handler && typeof handler.choice === "string"
+    ? { choice: handler.choice }
+    : {}
+
 export const transitionDefinitions = (
   machine: Machine.Any
-): ReadonlyArray<Machine.TransitionDefinition> => {
-  const definitions: Array<Machine.TransitionDefinition> = []
+): ReadonlyArray<Machine.TransitionDefinition<string, PropertyKey, string, string>> => {
+  const definitions: Array<Machine.TransitionDefinition<string, PropertyKey, string, string>> = []
   for (const node of machine.stateNodes.byPath.values()) {
     const config = machine.handlers[node.path] as Machine.AnyStateConfig | undefined
     if (config === undefined) {
@@ -378,7 +389,8 @@ export const transitionDefinitions = (
         source: node.path,
         trigger: { type: "event", event },
         reenter: typeof handler === "object" && handler !== null && handler.reenter === true,
-        targets: transitionTargets(handler)
+        targets: transitionTargets(handler),
+        ...transitionChoice(handler)
       })
     }
     if (config.always !== undefined) {
@@ -386,7 +398,8 @@ export const transitionDefinitions = (
         source: node.path,
         trigger: { type: "always" },
         reenter: false,
-        targets: transitionTargets(config.always)
+        targets: transitionTargets(config.always),
+        ...transitionChoice(config.always)
       })
     }
     if (config.onDone !== undefined) {
@@ -394,7 +407,8 @@ export const transitionDefinitions = (
         source: node.path,
         trigger: { type: "done" },
         reenter: false,
-        targets: transitionTargets(config.onDone)
+        targets: transitionTargets(config.onDone),
+        ...transitionChoice(config.onDone)
       })
     }
   }
@@ -625,8 +639,8 @@ export const getNode = (machine: Machine.Any, path: string): Machine.StateNode =
 }
 
 export const getStateNodeSchema = (node: Machine.StateNode): Machine.TaggedSchema => {
-  if (node.schema === undefined || node.type === "history") {
-    throw new Error(`Machine history state "${node.path}" has no active value schema`)
+  if (node.schema === undefined) {
+    throw new Error(`Machine pseudo-state "${node.path}" has no active value schema`)
   }
   return node.schema
 }

--- a/src/internal/machinePlanner.ts
+++ b/src/internal/machinePlanner.ts
@@ -229,12 +229,14 @@ type EventTransition<States extends Machine.StateSchemas, E, R, Context> =
   | TransitionHandler<States, E, R, Context>
   | {
     readonly reenter?: boolean
+    readonly choice?: string
     readonly targets?: ReadonlyArray<string>
     readonly transition: TransitionHandler<States, E, R, Context>
   }
 
 type MicrostepTransition<States extends Machine.StateSchemas, E, R, Context> = {
   readonly reenter: boolean
+  readonly choice: string | undefined
   readonly targets: ReadonlyArray<string> | undefined
   readonly transition: TransitionHandler<States, E, R, Context>
 }
@@ -246,9 +248,10 @@ const normalizeTransition = <States extends Machine.StateSchemas, E, R, Context>
     return undefined
   }
   return typeof transition === "function"
-    ? { reenter: false, targets: undefined, transition }
+    ? { reenter: false, choice: undefined, targets: undefined, transition }
     : {
       reenter: transition.reenter === true,
+      choice: transition.choice,
       targets: transition.targets,
       transition: transition.transition
     }
@@ -998,6 +1001,13 @@ const collectEvaluatedTransition = Effect.fnUntraced(function*<
     selection.transition.transition,
     selection.context
   )
+  if (selection.transition.choice !== undefined && transitionResult.state === undefined) {
+    return yield* Effect.die(
+      new Error(
+        `Machine choice transition through "${selection.transition.choice}" from "${selection.sourcePath}" must return a target`
+      )
+    )
+  }
   const unresolvedTarget = transitionResult.state === undefined
     ? undefined
     : transitionResult.state as

--- a/test/MachineChoice.test.ts
+++ b/test/MachineChoice.test.ts
@@ -1,0 +1,144 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Cause, Effect, Schema } from "effect"
+import { Machine } from "../src/index.js"
+
+class Editing extends Schema.TaggedClass<Editing>("Editing")("Editing", {
+  valid: Schema.Boolean
+}) {}
+class Accepted extends Schema.TaggedClass<Accepted>("Accepted")("Accepted", {}) {}
+class Rejected extends Schema.TaggedClass<Rejected>("Rejected")("Rejected", {}) {}
+class Submit extends Schema.TaggedClass<Submit>("Submit")("Submit", {}) {}
+
+const States = Machine.defineStates({
+  editing: Editing,
+  validate: { type: "choice" },
+  accepted: Accepted,
+  rejected: Rejected
+})
+
+const makeMachine = (valid: boolean) =>
+  Machine.make({
+    states: States.states,
+    events: [Submit],
+    initial: () => States.initial.editing(new Editing({ valid }))
+  }).handle({
+    editing: {
+      on: {
+        Submit: {
+          choice: "validate",
+          targets: ["accepted", "rejected"],
+          transition: ({ state, target }) =>
+            state.valid
+              ? target.full.accepted(new Accepted({}))
+              : target.full.rejected(new Rejected({}))
+        }
+      }
+    }
+  })
+
+describe("Machine choice states", () => {
+  it.effect("immediately redirects through a choice without activating it", () =>
+    Effect.gen(function*() {
+      const acceptedMachine = makeMachine(true)
+      const rejectedMachine = makeMachine(false)
+      const acceptedInitial = (yield* Machine.planInitial(acceptedMachine)).state
+      const rejectedInitial = (yield* Machine.planInitial(rejectedMachine)).state
+
+      const accepted = yield* Machine.plan(acceptedMachine, acceptedInitial, new Submit({}))
+      const rejected = yield* Machine.plan(rejectedMachine, rejectedInitial, new Submit({}))
+
+      assert.strictEqual(accepted.next.path, "accepted")
+      assert.strictEqual(rejected.next.path, "rejected")
+      assert.lengthOf(accepted.microsteps, 1)
+      assert.deepStrictEqual(accepted.microsteps[0]?.exitPaths, ["editing"])
+      assert.deepStrictEqual(accepted.microsteps[0]?.entryPaths, ["accepted"])
+      assert.deepStrictEqual(Machine.configuration(acceptedMachine, accepted.next).map(({ path }) => path), [
+        "accepted"
+      ])
+    }))
+
+  it("exposes choices structurally and annotates the incoming transition", () => {
+    const machine = makeMachine(true)
+
+    assert.deepStrictEqual(Machine.stateNodes(machine).map(({ path, type }) => ({ path, type })), [
+      { path: "editing", type: "atomic" },
+      { path: "validate", type: "choice" },
+      { path: "accepted", type: "atomic" },
+      { path: "rejected", type: "atomic" }
+    ])
+    assert.deepStrictEqual(Machine.transitionDefinitions(machine), [
+      {
+        source: "editing",
+        trigger: { type: "event", event: "Submit" },
+        reenter: false,
+        targets: { type: "declared", paths: ["accepted", "rejected"] },
+        choice: "validate"
+      }
+    ])
+  })
+
+  it("rejects invalid choice metadata at construction", () => {
+    const base = Machine.make({
+      states: States.states,
+      events: [Submit],
+      initial: () => States.initial.editing(new Editing({ valid: true }))
+    })
+
+    assert.throws(
+      () =>
+        (base.handle as any)({
+          editing: {
+            on: {
+              Submit: {
+                choice: "missing",
+                targets: ["accepted"],
+                transition: () => undefined
+              }
+            }
+          }
+        }),
+      /declares unknown choice "missing"/
+    )
+    assert.throws(
+      () =>
+        (base.handle as any)({
+          editing: {
+            on: {
+              Submit: {
+                choice: "validate",
+                targets: [],
+                transition: () => undefined
+              }
+            }
+          }
+        }),
+      /must declare at least one target/
+    )
+  })
+
+  it.effect("fails unsafe choice transitions that return no target", () =>
+    Effect.gen(function*() {
+      const machine = (Machine.make({
+        states: States.states,
+        events: [Submit],
+        initial: () => States.initial.editing(new Editing({ valid: true }))
+      }).handle as any)({
+        editing: {
+          on: {
+            Submit: {
+              choice: "validate",
+              targets: ["accepted"],
+              transition: () => undefined
+            }
+          }
+        }
+      })
+      const initial = (yield* Machine.planInitial(machine)).state
+      const exit = yield* Effect.exit(Machine.plan(machine, initial, new Submit({})))
+
+      assert.strictEqual(exit._tag, "Failure")
+      if (exit._tag === "Failure") {
+        assert.include(Cause.pretty(exit.cause), "must return a target")
+      }
+    }))
+})

--- a/test/visualization/text.ts
+++ b/test/visualization/text.ts
@@ -1,7 +1,7 @@
 interface StateNode {
   readonly path: string
   readonly key: string
-  readonly type: "atomic" | "compound" | "parallel" | "final" | "history"
+  readonly type: "atomic" | "compound" | "parallel" | "final" | "history" | "choice"
   readonly history: "shallow" | "deep" | undefined
   readonly parent: string | undefined
   readonly children: ReadonlyArray<string>
@@ -26,6 +26,7 @@ interface TransitionDefinition {
       readonly type: "done"
     }
   readonly reenter: boolean
+  readonly choice?: string
   readonly targets:
     | {
       readonly type: "dynamic"
@@ -57,6 +58,8 @@ const nodeLabel = (node: StateNode, active: ReadonlySet<string>): string => {
 
 const triggerLabels = (definitions: ReadonlyArray<TransitionDefinition>): ReadonlyArray<string> => {
   const labels: Array<string> = []
+  const choice = (definition: TransitionDefinition): string =>
+    definition.choice === undefined ? "" : ` via ${definition.choice.slice(definition.choice.lastIndexOf(".") + 1)}`
   const targets = (definition: TransitionDefinition): string =>
     definition.targets.type === "dynamic" ?
       ""
@@ -66,7 +69,9 @@ const triggerLabels = (definitions: ReadonlyArray<TransitionDefinition>): Readon
   const events = definitions.flatMap((definition) =>
     definition.trigger.type === "event" ?
       [
-        `${String(definition.trigger.event)}${definition.reenter ? " [reenter]" : ""}${targets(definition)}`
+        `${String(definition.trigger.event)}${definition.reenter ? " [reenter]" : ""}${choice(definition)}${
+          targets(definition)
+        }`
       ]
       : []
   )
@@ -76,9 +81,9 @@ const triggerLabels = (definitions: ReadonlyArray<TransitionDefinition>): Readon
   }
   for (const definition of definitions) {
     if (definition.trigger.type === "always") {
-      labels.push(`◇ always${definition.reenter ? " [reenter]" : ""}${targets(definition)}`)
+      labels.push(`◇ always${definition.reenter ? " [reenter]" : ""}${choice(definition)}${targets(definition)}`)
     } else if (definition.trigger.type === "done") {
-      labels.push(`◇ done${definition.reenter ? " [reenter]" : ""}${targets(definition)}`)
+      labels.push(`◇ done${definition.reenter ? " [reenter]" : ""}${choice(definition)}${targets(definition)}`)
     }
   }
   return labels

--- a/typetest/MachineChoice.tst.ts
+++ b/typetest/MachineChoice.tst.ts
@@ -1,0 +1,143 @@
+import { Effect, Schema } from "effect"
+import { describe, expect, it } from "tstyche"
+import { Machine } from "../src/index.js"
+
+class Editing extends Schema.TaggedClass<Editing>("Editing")("Editing", { valid: Schema.Boolean }) {}
+class Accepted extends Schema.TaggedClass<Accepted>("Accepted")("Accepted", {}) {}
+class Rejected extends Schema.TaggedClass<Rejected>("Rejected")("Rejected", {}) {}
+class Submit extends Schema.TaggedClass<Submit>("Submit")("Submit", {}) {}
+
+const States = Machine.defineStates({
+  editing: Editing,
+  validate: { type: "choice" },
+  accepted: Accepted,
+  rejected: Rejected
+})
+
+describe("Machine choice states", () => {
+  it("separates active and choice identifiers", () => {
+    expect<Machine.Machine.StateIdentifier<typeof States.states>>().type.toBe<
+      "editing" | "accepted" | "rejected"
+    >()
+    expect<Machine.Machine.ChoiceIdentifier<typeof States.states>>().type.toBe<"validate">()
+    expect<Machine.Machine.StateNodeIdentifier<typeof States.states>>().type.toBe<
+      "editing" | "validate" | "accepted" | "rejected"
+    >()
+    expect(States.initial).type.not.toHaveProperty("validate")
+  })
+
+  it("preserves source context and validates choice transitions", () => {
+    const machine = Machine.make({
+      states: States.states,
+      events: [Submit],
+      initial: () => States.initial.editing(new Editing({ valid: true }))
+    })
+    const target = machine.makeTargetBuilder("editing")
+    const valid = {
+      editing: {
+        on: {
+          Submit: {
+            choice: "validate",
+            targets: ["accepted", "rejected"],
+            transition: ({ state, event, target }: Machine.Machine.HandlerContext<
+              typeof States.states,
+              readonly [typeof Submit],
+              readonly [],
+              "editing",
+              "Submit",
+              never,
+              never
+            >) => {
+              expect(state).type.toBe<Editing>()
+              expect(event).type.toBe<Submit>()
+              return state.valid
+                ? target.full.accepted(new Accepted({}))
+                : target.full.rejected(new Rejected({}))
+            }
+          }
+        }
+      }
+    } as const
+    const effectful = {
+      editing: {
+        on: {
+          Submit: {
+            choice: "validate",
+            targets: ["accepted"],
+            transition: () => Effect.succeed(target.full.accepted(new Accepted({})))
+          }
+        }
+      }
+    } as const
+    const missingTarget = {
+      editing: {
+        on: {
+          Submit: {
+            choice: "validate",
+            transition: () => target.full.accepted(new Accepted({}))
+          }
+        }
+      }
+    } as const
+    const emptyTargets = {
+      editing: {
+        on: {
+          Submit: {
+            choice: "validate",
+            targets: [],
+            transition: () => target.full.accepted(new Accepted({}))
+          }
+        }
+      }
+    } as const
+    const noResult = {
+      editing: {
+        on: {
+          Submit: {
+            choice: "validate",
+            targets: ["accepted"],
+            transition: () => undefined
+          }
+        }
+      }
+    } as const
+    const unknownChoice = {
+      editing: {
+        on: {
+          Submit: {
+            choice: "accepted",
+            targets: ["accepted"],
+            transition: () => target.full.accepted(new Accepted({}))
+          }
+        }
+      }
+    } as const
+
+    expect(machine.handle).type.toBeCallableWith(valid)
+    expect(machine.handle).type.toBeCallableWith(effectful)
+    expect(machine.handle).type.not.toBeCallableWith(missingTarget)
+    expect(machine.handle).type.not.toBeCallableWith(emptyTargets)
+    expect(machine.handle).type.not.toBeCallableWith(noResult)
+    expect(machine.handle).type.not.toBeCallableWith(unknownChoice)
+
+    const definition = Machine.transitionDefinitions(machine.handle(valid))[0]!
+    expect(definition.choice).type.toBe<"validate" | undefined>()
+  })
+
+  it("rejects active-state properties and initial selection", () => {
+    expect(Machine.defineStates).type.not.toBeCallableWith({
+      editing: Editing,
+      validate: { type: "choice", schema: Accepted }
+    })
+    expect(Machine.defineStates).type.not.toBeCallableWith({
+      root: {
+        schema: Editing,
+        initial: "validate",
+        states: {
+          editing: Editing,
+          validate: { type: "choice" }
+        }
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- add schema-free `choice` pseudo-states that remain outside active state identifiers and snapshots
- annotate event, eventless, and completion transitions with a typed choice path and require a non-empty declared target set
- preserve same-microstep transition semantics, validate unsafe configurations at runtime, and expose choice routing through inspection APIs
- render choice nodes and routed edges in the visualizer example
- document the API and add runtime, inference, inspection, and visualization coverage

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

Added `.changeset/fuzzy-dodos-choose.md` with a minor release.

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed

Additional validation:

- `pnpm check` in `examples/visualizer`
- `pnpm perf:types`
