### PR TITLE
Add transition snapshots and structural metadata

### DIFF
--- a/.changeset/rich-machines-inspect.md
+++ b/.changeset/rich-machines-inspect.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Expose a captured full machine snapshot to event, eventless, and completion transition contexts; add serializable state-owned activity inspection for invokes, timers, and child machines; and surface resolved Effect Schema annotations plus descriptive pseudo-state annotations through state-node inspection.

--- a/README.md
+++ b/README.md
@@ -379,6 +379,39 @@ Refresh: {
 keyed by full dotted paths, such as `parents["Form.Editing"]`; `context.parent`
 provides the immediate parent directly and is `undefined` at a root state.
 
+Event, eventless, and completion transition contexts also expose `snapshot`, a
+read-only view of the complete logical configuration captured at the beginning
+of that transition microstep. This lets one parallel region inspect a sibling
+without copying active-state facts into parent values:
+
+```ts
+BufferReady: ;
+;(({ snapshot, target }) =>
+  States.matches(snapshot, "Player.Network.Online")
+    ? target.local.Playing(State.cases.Playing.make({}))
+    : undefined)
+```
+
+All non-conflicting handlers selected together observe the same captured
+snapshot. An Effectful handler keeps that value; it does not read mutable live
+runtime state later. `snapshot` is intentionally absent from entry, exit,
+invoke, and choice contexts. In particular, startup and chained choices may run
+before a complete stable snapshot containing their pseudo-source exists.
+
+Effect Schema annotations are the metadata source for active states. Annotate
+the schema itself; `Machine.stateNodes` exposes the resolved annotation map:
+
+```ts
+const Saving = State.cases.Saving.annotate({
+  title: "Saving document",
+  description: "Persisting local changes to the server"
+})
+```
+
+Schema-less choice and history nodes accept only descriptive `title`,
+`description`, and `documentation` annotations. Titles may be used as display
+labels, but structural paths remain the only identity and targeting mechanism.
+
 ## Planning Effects and staged actions
 
 An Effect returned by a transition handler is part of planning. Use it to read
@@ -471,6 +504,14 @@ const Editor = Machine.child("editor", EditorMachine)
 Descriptors are matched by id and machine identity, so independently created
 descriptors for the same pair address the same child without a global cache.
 Exporting one descriptor remains the clearest module boundary.
+
+`Machine.activityDefinitions(machine)` inspects state-owned work without
+executing it. Static descriptors report their source path, lifecycle id, and
+kind. Timers also report normalized duration and emitted event tag;
+`invokeEffect` mappings are described as dynamic; invoked machines expose only
+safe child identity. A function-valued `invoke` factory is reported as dynamic
+and is never evaluated during inspection. The result is serializable and does
+not contain Effects, closures, services, or child runtimes.
 
 ## Reactivity
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -347,6 +347,47 @@ parents["Route.Ready.Editing"]
 
 Do not guess short properties such as `parents.Ready`.
 
+### Inspecting the full transition configuration
+
+Event, `always`, and `onDone` transition contexts include a fully typed
+`snapshot`. It is the complete logical snapshot at the beginning of that
+microstep, before any selected transition is applied:
+
+```ts
+BufferReady: ({ snapshot, target }) =>
+  States.matches(snapshot, "Player.Network.Online")
+    ? target.local.Playing(new Playing({}))
+    : undefined
+```
+
+Use the existing `States.matches`, `States.get`, `States.getWithParents`, and
+`States.getSnapshot` helpers for cross-region reads. Parallel transitions
+selected in one microstep receive the same capture. Effectful handlers retain
+that captured value rather than consulting live runtime state.
+
+Do not expect `snapshot` in entry, exit, invoke, initializer, history-default,
+or choice contexts. Choice is an important soundness boundary: a startup or
+chained choice can run without a complete stable configuration containing the
+pseudo-source, so the API does not fabricate a partial `Machine.Snapshot`.
+
+### State annotations
+
+Attach active-state metadata through Effect Schema:
+
+```ts
+const Saving = State.cases.Saving.annotate({
+  title: "Saving document",
+  description: "Persisting local changes to the server",
+  documentation: "https://docs.example.test/saving"
+})
+```
+
+`Machine.stateNodes(machine)` returns the resolved annotation map. Choice and
+history definitions may declare an `annotations` object containing only
+`title`, `description`, and `documentation`. These values are descriptive;
+they cannot change behavior, identity, or targeting. Visualization may show a
+title, while the structural path remains authoritative.
+
 Use `Machine.retag(TargetCase, source, patch?)` when sibling state payloads
 share fields. It removes the source discriminator, reuses only compatible
 fields, and requires a patch for every missing or incompatible required field.
@@ -507,6 +548,25 @@ canonicalized. Prefer exporting one descriptor as the application boundary.
 Use the separate
 `Machine.childAddress<Event>(id)` constructor only for lower-level process
 logic that does not have a complete machine descriptor.
+
+### Inspecting state-owned activities
+
+Use `Machine.activityDefinitions(machine)` to inspect invokes without running
+them. Static `Machine.invoke`, `Machine.invokeEffect`, `Machine.after`, and
+`Machine.invokeMachine` descriptors expose serializable ownership metadata:
+
+```ts
+Machine.activityDefinitions(machine)
+// [{ source: "Loading", id: "load-timeout", type: "timer",
+//    duration: "10s", event: "LoadTimedOut" }]
+```
+
+Effect success/failure mappers are closures and therefore appear as dynamic
+outcomes. Child machines expose descriptor identity, never their runtime or
+implementation. A function-valued `invoke` factory is represented as a dynamic
+activity because inspection must not evaluate user code. The existing invoke
+helpers remain the only execution API; this metadata does not add lifecycle
+configuration syntax or affect execution.
 
 ## AtomMachine and React
 

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -5,7 +5,7 @@
  */
 
 import type * as Cause from "effect/Cause"
-import type * as Duration from "effect/Duration"
+import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
 import * as Inspectable from "effect/Inspectable"
 import * as Option from "effect/Option"
@@ -15,6 +15,7 @@ import type * as Schema from "effect/Schema"
 import type * as Scope from "effect/Scope"
 import type * as Stream from "effect/Stream"
 import type * as Types from "effect/Types"
+import * as Activities from "./internal/machineActivities.js"
 import type {
   ChildAlreadyExistsError,
   InfiniteTransitionError,
@@ -1869,6 +1870,28 @@ export declare namespace Machine {
   export type TaggedSchema = Schema.Top & { readonly Type: { readonly _tag: PropertyKey } }
 
   /**
+   * Descriptive annotations exposed for compiled state nodes.
+   *
+   * Schema-backed states resolve their complete Effect Schema annotation map.
+   * Pseudo-states accept only the descriptive fields below. Annotations never
+   * affect state identity, targeting, or runtime behavior.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface StateNodeAnnotations extends Schema.Annotations.Annotations {
+    readonly title?: string | undefined
+    readonly description?: string | undefined
+    readonly documentation?: string | undefined
+  }
+
+  /** Descriptive annotations accepted by schema-less pseudo-states. */
+  export type PseudoStateAnnotations = Pick<
+    StateNodeAnnotations,
+    "title" | "description" | "documentation"
+  >
+
+  /**
    * Configuration accepted for an atomic object state node.
    *
    * @category models
@@ -1928,6 +1951,7 @@ export declare namespace Machine {
     readonly type: "history"
     /** Defaults to shallow history. */
     readonly history?: "shallow" | "deep"
+    readonly annotations?: PseudoStateAnnotations
   }
 
   /**
@@ -1942,6 +1966,7 @@ export declare namespace Machine {
    */
   export interface ChoiceStateNodeConfig {
     readonly type: "choice"
+    readonly annotations?: PseudoStateAnnotations
   }
 
   /**
@@ -2075,10 +2100,12 @@ export declare namespace Machine {
     readonly key: string
     readonly schema: TaggedSchema | undefined
     readonly output: Schema.Top | undefined
+    /** Resolved Effect Schema annotations, or descriptive pseudo-state annotations. */
+    readonly annotations: Readonly<StateNodeAnnotations> | undefined
     readonly type: "atomic" | "compound" | "parallel" | "final" | "history" | "choice"
     readonly history: "shallow" | "deep" | undefined
     readonly parent: Path | undefined
-    /** Active child paths. History pseudo-states are available through their `parent` relationship. */
+    /** Active child paths. Pseudo-states are available through their `parent` relationship. */
     readonly children: ReadonlyArray<Path>
     readonly initial: Path | undefined
     readonly order: number
@@ -2155,6 +2182,18 @@ export declare namespace Machine {
     readonly reenter: boolean
     readonly targets: TransitionTargets<TargetPath>
   }
+
+  /**
+   * Serializable description of state-owned work.
+   *
+   * Static invoke descriptors expose their lifecycle id and kind without
+   * retaining Effects, closures, services, or child runtimes. A function-valued
+   * invoke factory is reported as dynamic and is never evaluated by inspection.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export type ActivityDefinition<SourcePath extends string = string> = Activities.ActivityDefinition<SourcePath>
 
   /**
    * Transition retained after hierarchy precedence and conflict resolution for
@@ -3174,6 +3213,8 @@ export declare namespace Machine {
     readonly state: StateByIdentifier<States, StateId>
     readonly parent: ParentStateValue<States, StateId>
     readonly parents: ParentStateValues<States, StateId>
+    /** Complete logical configuration captured at the start of this microstep. */
+    readonly snapshot: Snapshot<States>
     readonly event: EventByTag<Events, EventTag>
     readonly runtime: RuntimeEffect<Events, Emits>
 
@@ -3261,6 +3302,8 @@ export declare namespace Machine {
     readonly state: StateByIdentifier<States, StateId>
     readonly parent: ParentStateValue<States, StateId>
     readonly parents: ParentStateValues<States, StateId>
+    /** Complete logical configuration captured at the start of this microstep. */
+    readonly snapshot: Snapshot<States>
     readonly event: LifecycleEvent<Events>
     readonly runtime: RuntimeEffect<Events, Emits>
 
@@ -3289,6 +3332,8 @@ export declare namespace Machine {
     readonly state: StateByIdentifier<States, StateId>
     readonly parent: ParentStateValue<States, StateId>
     readonly parents: ParentStateValues<States, StateId>
+    /** Complete logical configuration captured at the start of this microstep. */
+    readonly snapshot: Snapshot<States>
     readonly event: LifecycleEvent<Events>
     readonly output: CompletionOutputByIdentifier<States, StateId>
     readonly runtime: RuntimeEffect<Events, Emits>
@@ -3725,6 +3770,8 @@ export declare namespace Machine {
       readonly requirements: Types.Covariant<ChildRequirements>
       readonly initialError: Types.Covariant<ChildInitialError>
     }
+    /** @internal Serializable descriptor metadata used by inspection. */
+    readonly [Activities.ActivityMetadataTypeId]?: Activities.StaticActivityMetadata
     readonly id: string
     /**
      * Optional parent-local address for sending events to this invocation.
@@ -5948,7 +5995,11 @@ export const invoke = <
   ChildRequirements,
   ChildOutput,
   ChildInitialError
-> => ({ ...config, [InvokeTypeId]: undefined as any })
+> => ({
+  ...config,
+  [InvokeTypeId]: undefined as any,
+  [Activities.ActivityMetadataTypeId]: { type: "process" }
+})
 
 type InvokeEffectResult<Requirements, Event> = Machine.InvokeConfig<
   any,
@@ -6020,8 +6071,8 @@ export const invokeEffect = <
     readonly effect: Effect.Effect<unknown, unknown, unknown>
     readonly onSuccess: (value: unknown) => unknown
     readonly onFailure?: (error: unknown) => unknown
-  }) =>
-    invoke({
+  }) => ({
+    ...invoke({
       id: config.id,
       src: () =>
         effect(
@@ -6032,7 +6083,15 @@ export const invokeEffect = <
               onSuccess: (value) => Effect.succeed(config.onSuccess(value))
             })
         )
-    }))(config as any) as any
+    }),
+    [Activities.ActivityMetadataTypeId]: {
+      type: "effect",
+      outcomes: {
+        success: "dynamic",
+        failure: config.onFailure === undefined ? "none" : "dynamic"
+      }
+    }
+  }))(config as any) as any
 
 /**
  * Creates a cancellable state-scoped delayed event.
@@ -6048,11 +6107,17 @@ export const after = <Event extends { readonly _tag: PropertyKey }>(
   duration: Duration.Input,
   event: Event,
   options?: { readonly id?: InvokeLifecycleId }
-): InvokeEffectResult<never, Event> =>
-  invoke({
+): InvokeEffectResult<never, Event> => ({
+  ...invoke({
     id: options?.id ?? `Machine.after:${String(event._tag)}`,
     src: () => effect(Effect.as(Effect.sleep(duration), event))
-  })
+  }),
+  [Activities.ActivityMetadataTypeId]: {
+    type: "timer",
+    duration: Duration.format(Duration.fromInputUnsafe(duration)),
+    event: String(event._tag)
+  }
+})
 
 type RetagFields<Target extends Machine.TaggedSchema> = Omit<Target["~type.make.in"], "_tag">
 
@@ -6317,6 +6382,13 @@ export const invokeMachine: {
         : (internalProcess.toProcessLogic as any)(machine, config.input),
     snapshot: config.snapshot,
     onDone: config.onDone,
+    [Activities.ActivityMetadataTypeId]: {
+      type: "machine",
+      child: {
+        id: config.child.id,
+        machineId: machine.id ?? null
+      }
+    },
     [InvokeTypeId]: undefined as any
   }
 }) as any
@@ -6426,10 +6498,11 @@ export const planInitial: <
  *
  * **Details**
  *
- * The result includes atomic, compound, parallel, final, and history nodes.
- * Use each node's `parent` property to reconstruct the complete hierarchy.
- * History pseudo-states are intentionally omitted from `children` because they
- * can never appear in an active configuration.
+ * The result includes atomic, compound, parallel, final, history, and choice
+ * nodes together with their resolved descriptive annotations. Use each node's
+ * `parent` property to reconstruct the complete hierarchy. Pseudo-states are
+ * intentionally omitted from `children` because they can never appear in an
+ * active configuration.
  *
  * @category getters
  * @since 4.0.0
@@ -6473,13 +6546,33 @@ export const transitionDefinitions = <M extends Machine.Any>(
   >
 
 /**
+ * Returns serializable descriptions of every state-owned activity.
+ *
+ * **Details**
+ *
+ * Static `invoke`, `invokeEffect`, `after`, and `invokeMachine` descriptors
+ * expose stable ownership and lifecycle metadata without serializing runtime
+ * values. Function-valued invoke factories are represented as dynamic and are
+ * never evaluated during inspection.
+ *
+ * @category getters
+ * @since 4.0.0
+ */
+export const activityDefinitions = <M extends Machine.Any>(
+  machine: M
+): ReadonlyArray<Machine.ActivityDefinition<Machine.StateIdentifier<Machine.States<M>>>> =>
+  Activities.activityDefinitions(machine) as ReadonlyArray<
+    Machine.ActivityDefinition<Machine.StateIdentifier<Machine.States<M>>>
+  >
+
+/**
  * Returns every state node active in a decoded snapshot, in definition order.
  *
  * **Details**
  *
  * Active compound ancestors and parallel regions are included together with
- * their active descendants. History pseudo-states are never active and are not
- * returned.
+ * their active descendants. History and choice pseudo-states are never active
+ * and are not returned.
  *
  * @category getters
  * @since 4.0.0

--- a/src/internal/machineActivities.ts
+++ b/src/internal/machineActivities.ts
@@ -1,0 +1,108 @@
+/**
+ * Serializable structural metadata for state-owned machine activities.
+ *
+ * @since 4.0.0
+ */
+
+/** @internal */
+export const ActivityMetadataTypeId: unique symbol = Symbol.for("effect/Machine/ActivityMetadata")
+
+/** @internal */
+export type StaticActivityMetadata =
+  | {
+    readonly type: "process"
+  }
+  | {
+    readonly type: "effect"
+    readonly outcomes: {
+      readonly success: "dynamic"
+      readonly failure: "dynamic" | "none"
+    }
+  }
+  | {
+    readonly type: "timer"
+    readonly duration: string
+    readonly event: string
+  }
+  | {
+    readonly type: "machine"
+    readonly child: {
+      readonly id: string
+      readonly machineId: string | null
+    }
+  }
+
+/** @internal */
+export type ActivityDefinition<Source extends string = string> =
+  | ({
+    readonly source: Source
+    readonly id: string
+  } & StaticActivityMetadata)
+  | {
+    readonly source: Source
+    readonly type: "dynamic"
+  }
+
+interface ActivityDescriptor {
+  readonly id: string
+  readonly [ActivityMetadataTypeId]: StaticActivityMetadata
+}
+
+interface InspectableMachine {
+  readonly handlers: unknown
+  readonly stateNodes: {
+    readonly byPath: {
+      values(): Iterable<{ readonly path: string }>
+    }
+  }
+}
+
+const isObject = (value: unknown): value is object =>
+  (typeof value === "object" && value !== null) || typeof value === "function"
+
+const getProperty = (value: unknown, key: PropertyKey): unknown => isObject(value) ? Reflect.get(value, key) : undefined
+
+const hasActivityMetadata = (value: unknown): value is ActivityDescriptor =>
+  isObject(value) && typeof getProperty(value, "id") === "string" &&
+  isObject(getProperty(value, ActivityMetadataTypeId))
+
+const appendStaticDefinition = (
+  definitions: Array<ActivityDefinition>,
+  source: string,
+  descriptor: unknown
+): void => {
+  if (!hasActivityMetadata(descriptor)) {
+    return
+  }
+  definitions.push({
+    source,
+    id: descriptor.id,
+    ...descriptor[ActivityMetadataTypeId]
+  })
+}
+
+/**
+ * Collects state-owned activity descriptions without executing user code.
+ *
+ * Function-valued invoke definitions depend on an entry context and are
+ * therefore represented as dynamic. Static descriptors are returned in state
+ * definition order and descriptor array order.
+ *
+ * @internal
+ */
+export const activityDefinitions = (machine: InspectableMachine): ReadonlyArray<ActivityDefinition> => {
+  const definitions: Array<ActivityDefinition> = []
+  for (const node of machine.stateNodes.byPath.values()) {
+    const invoke = getProperty(getProperty(machine.handlers, node.path), "invoke")
+    if (typeof invoke === "function") {
+      definitions.push({ source: node.path, type: "dynamic" })
+    } else if (Array.isArray(invoke)) {
+      for (const descriptor of invoke) {
+        appendStaticDefinition(definitions, node.path, descriptor)
+      }
+    } else {
+      appendStaticDefinition(definitions, node.path, invoke)
+    }
+  }
+  return definitions
+}

--- a/src/internal/machineModel.ts
+++ b/src/internal/machineModel.ts
@@ -265,6 +265,7 @@ export const getStateNodeDefinition = (
 ): {
   readonly schema: Machine.TaggedSchema | undefined
   readonly output: Schema.Top | undefined
+  readonly annotations: Readonly<Machine.StateNodeAnnotations> | undefined
   readonly type: "atomic" | "compound" | "parallel" | "final" | "history" | "choice"
   readonly initial: string | undefined
   readonly states: Machine.StateTree | undefined
@@ -273,6 +274,7 @@ export const getStateNodeDefinition = (
     return {
       schema: undefined,
       output: undefined,
+      annotations: (definition as Machine.HistoryStateNodeConfig).annotations,
       type: "history",
       initial: undefined,
       states: undefined
@@ -282,6 +284,7 @@ export const getStateNodeDefinition = (
     return {
       schema: undefined,
       output: undefined,
+      annotations: (definition as Machine.ChoiceStateNodeConfig).annotations,
       type: "choice",
       initial: undefined,
       states: undefined
@@ -291,6 +294,7 @@ export const getStateNodeDefinition = (
     return {
       schema: definition as Machine.TaggedSchema,
       output: undefined,
+      annotations: Schema.resolveAnnotations(definition),
       type: "atomic",
       initial: undefined,
       states: undefined
@@ -310,6 +314,7 @@ export const getStateNodeDefinition = (
       return {
         schema: definition.schema as Machine.TaggedSchema,
         output: Schema.isSchema((definition as any).output) ? (definition as any).output as Schema.Top : undefined,
+        annotations: Schema.resolveAnnotations(definition.schema),
         type: "parallel",
         initial: undefined,
         states: (definition as any).states as Machine.StateTree
@@ -321,6 +326,7 @@ export const getStateNodeDefinition = (
     return {
       schema: definition.schema as Machine.TaggedSchema,
       output: undefined,
+      annotations: Schema.resolveAnnotations(definition.schema),
       type: "compound",
       initial: (definition as any).initial,
       states: (definition as any).states as Machine.StateTree
@@ -329,6 +335,7 @@ export const getStateNodeDefinition = (
   return {
     schema: definition.schema as Machine.TaggedSchema,
     output: Schema.isSchema((definition as any).output) ? (definition as any).output as Schema.Top : undefined,
+    annotations: Schema.resolveAnnotations(definition.schema),
     type: definition.type === "final" ? "final" : "atomic",
     initial: undefined,
     states: undefined
@@ -352,6 +359,7 @@ export const compileStateNodes = (states: Machine.StateSchemas): Machine.StateNo
         key,
         schema: definition.schema,
         output: definition.output,
+        annotations: definition.annotations,
         type: definition.type,
         parent,
         children: [] as ReadonlyArray<string>,

--- a/src/internal/machinePlanner.ts
+++ b/src/internal/machinePlanner.ts
@@ -642,12 +642,14 @@ const makeTransitionContext = <
   machine: Machine<States, Events, any, any, any, any, any, any, any, any, Emits>,
   configuration: ActiveConfiguration,
   path: string,
-  event: Machine.EventByTag<Events, EventTag>
+  event: Machine.EventByTag<Events, EventTag>,
+  snapshot: Machine.Snapshot<States>
 ): Machine.HandlerContext<States, Events, Emits, StateId, EventTag, any, any> => ({
   state: getActiveValue(configuration, path) as Machine.StateByIdentifier<States, StateId>,
   parent: getParentValue(machine, configuration, path) as Machine.ParentStateValue<States, StateId>,
   parents: getParentValues(machine, configuration, path) as Machine.ParentStateValues<States, StateId>,
   event,
+  snapshot,
   ...makePlanningCapabilities<Machine.EventOf<Events>, Machine.EmitOf<Emits>>(),
   target: machine.makeTargetBuilder(path as StateId)
 })
@@ -662,13 +664,15 @@ const makeDoneContext = <
   configuration: ActiveConfiguration,
   path: string,
   event: Machine.LifecycleEvent<Events>,
-  output: unknown
+  output: unknown,
+  snapshot: Machine.Snapshot<States>
 ): Machine.DoneContext<States, Events, Emits, StateId> => ({
   state: getActiveValue(configuration, path) as Machine.StateByIdentifier<States, StateId>,
   parent: getParentValue(machine, configuration, path) as Machine.ParentStateValue<States, StateId>,
   parents: getParentValues(machine, configuration, path) as Machine.ParentStateValues<States, StateId>,
   event,
   output: output as Machine.CompletionOutputByIdentifier<States, StateId>,
+  snapshot,
   ...makePlanningCapabilities<Machine.EventOf<Events>, Machine.EmitOf<Emits>>(),
   target: machine.makeTargetBuilder(path as StateId)
 })
@@ -739,6 +743,8 @@ const selectAlwaysTransitions = <
     >
   > = []
   const selectedSources = new Set<string>()
+  let snapshot: Machine.Snapshot<States> | undefined
+  const capturedSnapshot = () => snapshot ??= snapshotFromConfiguration<States>(machine, configuration)
   for (const leaf of getActiveLeafPaths(machine, configuration)) {
     for (const path of getLeafCandidatePaths(machine, leaf)) {
       const always = normalizeTransition(machine.handlers[path]?.always)
@@ -769,6 +775,7 @@ const selectAlwaysTransitions = <
                 Machine.StateIdentifier<States>
               >,
               event,
+              snapshot: capturedSnapshot(),
               ...makePlanningCapabilities<Machine.EventOf<Events>, Machine.EmitOf<Emits>>(),
               target: machine.makeTargetBuilder(path as Machine.StateIdentifier<States>)
             }
@@ -809,6 +816,8 @@ const selectDoneTransitions = <
     >
   > = []
   const selectedSources = new Set<string>()
+  let snapshot: Machine.Snapshot<States> | undefined
+  const capturedSnapshot = () => snapshot ??= snapshotFromConfiguration<States>(machine, configuration)
   for (const completion of completions) {
     const onDone = normalizeTransition(machine.handlers[completion.path]?.onDone)
     if (onDone !== undefined && !selectedSources.has(completion.path)) {
@@ -828,7 +837,8 @@ const selectDoneTransitions = <
           configuration,
           completion.path,
           event,
-          completion.output
+          completion.output,
+          capturedSnapshot()
         )
       })
     }
@@ -871,6 +881,8 @@ const selectEventTransitions = <
     >
   > = []
   const selectedSources = new Set<string>()
+  let snapshot: Machine.Snapshot<States> | undefined
+  const capturedSnapshot = () => snapshot ??= snapshotFromConfiguration<States>(machine, configuration)
   for (const leaf of getActiveLeafPaths(machine, configuration)) {
     for (const path of getLeafCandidatePaths(machine, leaf)) {
       const transition = normalizeTransition(machine.handlers[path]?.on?.[event._tag])
@@ -901,7 +913,7 @@ const selectEventTransitions = <
               Emits,
               Machine.StateIdentifier<States>,
               Machine.TagOf<Events[number]>
-            >(machine as any, configuration, path, event)
+            >(machine as any, configuration, path, event, capturedSnapshot())
           })
         }
         break

--- a/test/MachineActivities.test.ts
+++ b/test/MachineActivities.test.ts
@@ -1,0 +1,277 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Duration, Effect, Schema } from "effect"
+import { FastCheck } from "effect/testing"
+import { Machine } from "../src/index.js"
+import {
+  activityDefinitions,
+  ActivityMetadataTypeId,
+  type StaticActivityMetadata
+} from "../src/internal/machineActivities.js"
+import { makeTextRenderer } from "./visualization/text.js"
+
+class Loading extends Schema.TaggedClass<Loading>("Loading")("Loading", {}) {}
+class Dynamic extends Schema.TaggedClass<Dynamic>("Dynamic")("Dynamic", {}) {}
+class ChildIdle extends Schema.TaggedClass<ChildIdle>("ChildIdle")("ChildIdle", {}) {}
+class WorkSucceeded extends Schema.TaggedClass<WorkSucceeded>("WorkSucceeded")("WorkSucceeded", {}) {}
+class WorkFailed extends Schema.TaggedClass<WorkFailed>("WorkFailed")("WorkFailed", {}) {}
+class LoadTimedOut extends Schema.TaggedClass<LoadTimedOut>("LoadTimedOut")("LoadTimedOut", {}) {}
+
+const childStates = Machine.defineStates({ ChildIdle })
+const childMachine = Machine.make({
+  id: "document-worker",
+  states: childStates.states,
+  events: [],
+  initial: () => childStates.initial.ChildIdle(new ChildIdle({}))
+})
+const child = Machine.child("child", childMachine)
+
+let dynamicFactoryEvaluations = 0
+const timerDuration = "10 seconds"
+const timerEvent = new LoadTimedOut({})
+const activityStates = Machine.defineStates({ Loading, Dynamic })
+const activityMachine = Machine.make({
+  id: "activity-inspection",
+  states: activityStates.states,
+  events: [WorkSucceeded, WorkFailed, LoadTimedOut],
+  initial: () => activityStates.initial.Loading(new Loading({}))
+}).handle({
+  Loading: {
+    invoke: [
+      Machine.invoke({
+        id: "poll-server",
+        src: () => Machine.effect(Effect.void)
+      }),
+      Machine.invokeEffect({
+        id: "load-document",
+        effect: Effect.fail("unavailable").pipe(Effect.as(1)),
+        onSuccess: () => new WorkSucceeded({}),
+        onFailure: () => new WorkFailed({})
+      }),
+      Machine.after(timerDuration, timerEvent, { id: "load-timeout" }),
+      Machine.invokeMachine({ child })
+    ]
+  },
+  Dynamic: {
+    invoke: () => {
+      dynamicFactoryEvaluations++
+      return Machine.invoke({
+        id: "context-owned",
+        src: () => Machine.effect(Effect.void)
+      })
+    }
+  }
+})
+
+const renderActivityMachine = makeTextRenderer<
+  typeof activityMachine,
+  Machine.Machine.Snapshot<typeof activityStates.states>
+>(Machine)
+
+const descriptor = (id: string, metadata: StaticActivityMetadata) => ({
+  id,
+  [ActivityMetadataTypeId]: metadata
+})
+
+const machine = {
+  stateNodes: {
+    byPath: new Map([
+      ["Idle", { path: "Idle" }],
+      ["Loading", { path: "Loading" }],
+      ["Parent", { path: "Parent" }],
+      ["Parent.Active", { path: "Parent.Active" }],
+      ["Dynamic", { path: "Dynamic" }]
+    ])
+  },
+  handlers: {
+    Loading: {
+      invoke: [
+        descriptor("load-document", {
+          type: "effect",
+          outcomes: { success: "dynamic", failure: "dynamic" }
+        }),
+        descriptor("load-timeout", {
+          type: "timer",
+          duration: "10s",
+          event: "LoadTimedOut"
+        })
+      ]
+    },
+    "Parent.Active": {
+      invoke: descriptor("child", {
+        type: "machine",
+        child: { id: "child", machineId: "document-worker" }
+      })
+    },
+    Dynamic: {
+      invoke: () => descriptor("runtime-dependent", { type: "process" })
+    }
+  }
+}
+
+describe("machine activity metadata", () => {
+  it("inspects all public helper descriptors without retaining runtime values", () => {
+    const expected: ReadonlyArray<
+      Machine.Machine.ActivityDefinition<Machine.Machine.StateIdentifier<typeof activityStates.states>>
+    > = [
+      {
+        source: "Loading",
+        id: "poll-server",
+        type: "process"
+      },
+      {
+        source: "Loading",
+        id: "load-document",
+        type: "effect",
+        outcomes: { success: "dynamic", failure: "dynamic" }
+      },
+      {
+        source: "Loading",
+        id: "load-timeout",
+        type: "timer",
+        duration: "10s",
+        event: "LoadTimedOut"
+      },
+      {
+        source: "Loading",
+        id: "child",
+        type: "machine",
+        child: { id: "child", machineId: "document-worker" }
+      },
+      {
+        source: "Dynamic",
+        type: "dynamic"
+      }
+    ]
+
+    assert.deepStrictEqual(Machine.activityDefinitions(activityMachine), expected)
+    assert.deepStrictEqual(Machine.activityDefinitions(activityMachine), expected)
+    assert.deepStrictEqual(JSON.parse(JSON.stringify(Machine.activityDefinitions(activityMachine))), expected)
+    const timer = Machine.activityDefinitions(activityMachine).find(({ type }) => type === "timer")
+    assert(timer?.type === "timer")
+    assert.strictEqual(timer.duration, Duration.format(Duration.fromInputUnsafe(timerDuration)))
+    assert.strictEqual(timer.event, String(timerEvent._tag))
+    assert.strictEqual(dynamicFactoryEvaluations, 0)
+  })
+
+  it("only reports public definitions owned by real active state nodes", () => {
+    const paths = new Set(Machine.stateNodes(activityMachine).map(({ path }) => path))
+    assert(Machine.activityDefinitions(activityMachine).every(({ source }) => paths.has(source)))
+  })
+
+  it.effect.prop(
+    "keeps generated timer ids, durations, events, and owners aligned with helper declarations",
+    {
+      durationMillis: FastCheck.integer({ min: 0, max: 604_800_000 }),
+      idSuffix: FastCheck.nat({ max: 1_000_000 })
+    },
+    ({ durationMillis, idSuffix }) =>
+      Effect.sync(() => {
+        const id = `generated-timer-${idSuffix}`
+        const generated = Machine.make({
+          states: activityStates.states,
+          events: [LoadTimedOut],
+          initial: () => activityStates.initial.Loading(new Loading({}))
+        }).handle({
+          Loading: {
+            invoke: Machine.after(durationMillis, timerEvent, { id })
+          }
+        })
+        const definition = Machine.activityDefinitions(generated)[0]
+
+        assert.deepStrictEqual(definition, {
+          source: "Loading",
+          id,
+          type: "timer",
+          duration: Duration.format(Duration.fromInputUnsafe(durationMillis)),
+          event: "LoadTimedOut"
+        })
+        assert(Machine.stateNodes(generated).some(({ path }) => path === definition?.source))
+      }),
+    { fastCheck: { numRuns: 100, seed: 68_241 } }
+  )
+
+  it("collects static descriptors in topology and declaration order", () => {
+    assert.deepStrictEqual(activityDefinitions(machine), [
+      {
+        source: "Loading",
+        id: "load-document",
+        type: "effect",
+        outcomes: { success: "dynamic", failure: "dynamic" }
+      },
+      {
+        source: "Loading",
+        id: "load-timeout",
+        type: "timer",
+        duration: "10s",
+        event: "LoadTimedOut"
+      },
+      {
+        source: "Parent.Active",
+        id: "child",
+        type: "machine",
+        child: { id: "child", machineId: "document-worker" }
+      },
+      {
+        source: "Dynamic",
+        type: "dynamic"
+      }
+    ])
+  })
+
+  it("does not evaluate dynamic factories while inspecting", () => {
+    let evaluations = 0
+    const dynamic = {
+      stateNodes: { byPath: new Map([["Active", { path: "Active" }]]) },
+      handlers: {
+        Active: {
+          invoke: () => {
+            evaluations++
+            return descriptor("runtime-dependent", { type: "process" })
+          }
+        }
+      }
+    }
+
+    assert.deepStrictEqual(activityDefinitions(dynamic), [{ source: "Active", type: "dynamic" }])
+    assert.deepStrictEqual(activityDefinitions(dynamic), [{ source: "Active", type: "dynamic" }])
+    assert.strictEqual(evaluations, 0)
+  })
+
+  it("only reports definitions owned by compiled state nodes", () => {
+    const withUnknownHandler = {
+      ...machine,
+      handlers: {
+        ...machine.handlers,
+        Missing: {
+          invoke: descriptor("orphan", { type: "process" })
+        }
+      }
+    }
+
+    const definitions = activityDefinitions(withUnknownHandler)
+    const paths = new Set(Array.from(withUnknownHandler.stateNodes.byPath.values(), ({ path }) => path))
+
+    assert(definitions.every(({ source }) => paths.has(source)))
+    assert.notInclude(definitions.map((definition) => "id" in definition ? definition.id : undefined), "orphan")
+  })
+
+  it("renders activities beneath their owning state", () => {
+    assert.strictEqual(
+      renderActivityMachine(activityMachine, activityStates.initial.Loading(new Loading({}))),
+      [
+        "activity-inspection",
+        "● active  ○ inactive  ◇ transition (→ declared, ∅ none, omitted dynamic)  ◆ activity",
+        "",
+        "├─ ● Loading",
+        "│  ├─ ◆ process: poll-server",
+        "│  ├─ ◆ effect: load-document [success: dynamic, failure: dynamic]",
+        "│  ├─ ◆ timer: load-timeout [10s] → LoadTimedOut",
+        "│  └─ ◆ machine: child → document-worker",
+        "└─ ○ Dynamic",
+        "   └─ ◆ activity: dynamic",
+        "",
+        "Candidate events: none"
+      ].join("\n")
+    )
+  })
+})

--- a/test/MachineAnnotations.test.ts
+++ b/test/MachineAnnotations.test.ts
@@ -1,0 +1,91 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Schema } from "effect"
+import { Machine } from "../src/index.js"
+
+class Workflow extends Schema.TaggedClass<Workflow>("Workflow")("Workflow", {}) {}
+class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", {}) {}
+class Done extends Schema.TaggedClass<Done>("Done")("Done", {}) {}
+
+const AnnotatedWorkflow = Workflow.annotate({
+  title: "Document workflow",
+  description: "Coordinates the document lifecycle",
+  documentation: "https://example.test/docs/workflow",
+  designOwner: "editor-platform"
+})
+
+const AnnotatedIdle = Idle.annotate({
+  title: "Waiting for edits",
+  description: "No persistence work is active"
+})
+
+const States = Machine.defineStates({
+  Workflow: {
+    schema: AnnotatedWorkflow,
+    initial: "Idle",
+    states: {
+      Idle: AnnotatedIdle,
+      Routing: {
+        type: "choice",
+        annotations: {
+          title: "Select persistence route",
+          description: "Routes according to the current document"
+        }
+      },
+      Recent: {
+        type: "history",
+        history: "deep",
+        annotations: {
+          title: "Previous workflow state",
+          documentation: "https://example.test/docs/history"
+        }
+      },
+      Done
+    }
+  }
+})
+
+const machine = Machine.make({
+  states: States.states,
+  events: [],
+  initial: () => States.initial.Workflow(new Workflow({}), (workflow) => workflow.Idle(new Idle({})))
+})
+
+describe("Machine state annotations", () => {
+  it("resolves complete Effect Schema annotations for active state nodes", () => {
+    const nodes = new Map(Machine.stateNodes(machine).map((node) => [node.path, node]))
+
+    const workflow = nodes.get("Workflow")
+    assert.strictEqual(workflow?.annotations?.title, "Document workflow")
+    assert.strictEqual(workflow?.annotations?.description, "Coordinates the document lifecycle")
+    assert.strictEqual(workflow?.annotations?.documentation, "https://example.test/docs/workflow")
+    assert.strictEqual(workflow?.annotations?.designOwner, "editor-platform")
+
+    const idle = nodes.get("Workflow.Idle")
+    assert.strictEqual(idle?.annotations?.title, "Waiting for edits")
+    assert.strictEqual(idle?.annotations?.description, "No persistence work is active")
+
+    assert.strictEqual(nodes.get("Workflow.Done")?.annotations?.title, undefined)
+  })
+
+  it("carries descriptive choice and history annotations without changing topology", () => {
+    const nodes = new Map(Machine.stateNodes(machine).map((node) => [node.path, node]))
+    const choice = nodes.get("Workflow.Routing")
+    const history = nodes.get("Workflow.Recent")
+
+    assert.deepStrictEqual(choice?.annotations, {
+      title: "Select persistence route",
+      description: "Routes according to the current document"
+    })
+    assert.strictEqual(choice?.type, "choice")
+    assert.strictEqual(choice?.schema, undefined)
+
+    assert.deepStrictEqual(history?.annotations, {
+      title: "Previous workflow state",
+      documentation: "https://example.test/docs/history"
+    })
+    assert.strictEqual(history?.type, "history")
+    assert.strictEqual(history?.history, "deep")
+    assert.strictEqual(history?.schema, undefined)
+    assert.deepStrictEqual(nodes.get("Workflow")?.children, ["Workflow.Idle", "Workflow.Done"])
+  })
+})

--- a/test/MachineAnnotationsVisualization.test.ts
+++ b/test/MachineAnnotationsVisualization.test.ts
@@ -1,0 +1,60 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Schema } from "effect"
+import { Machine } from "../src/index.js"
+import { makeTextRenderer } from "./visualization/text.js"
+
+class Workflow extends Schema.TaggedClass<Workflow>("Workflow")("Workflow", {}) {}
+class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", {}) {}
+class Done extends Schema.TaggedClass<Done>("Done")("Done", {}) {}
+
+const AnnotatedWorkflow = Workflow.annotate({ title: "Document workflow" })
+const AnnotatedIdle = Idle.annotate({ title: "Waiting for edits" })
+
+const States = Machine.defineStates({
+  Workflow: {
+    schema: AnnotatedWorkflow,
+    initial: "Idle",
+    states: {
+      Idle: AnnotatedIdle,
+      Routing: {
+        type: "choice",
+        annotations: { title: "Select persistence route" }
+      },
+      Recent: {
+        type: "history",
+        history: "deep",
+        annotations: { title: "Previous workflow state" }
+      },
+      Done
+    }
+  }
+})
+
+const machine = Machine.make({
+  states: States.states,
+  events: [],
+  initial: () => States.initial.Workflow(new Workflow({}), (workflow) => workflow.Idle(new Idle({})))
+})
+
+const renderMachine = makeTextRenderer<
+  typeof machine,
+  Machine.Machine.Snapshot<typeof States.states>
+>(Machine)
+
+describe("Machine annotation visualization", () => {
+  it("uses titles for active, choice, and history display while preserving structural keys", () => {
+    assert.strictEqual(
+      renderMachine(machine),
+      [
+        "Machine",
+        "● active  ○ inactive  ◇ transition (→ declared, ∅ none, omitted dynamic)",
+        "",
+        "└─ ○ Document workflow (Workflow) [compound, initial: Idle]",
+        "   ├─ ○ Waiting for edits (Idle)",
+        "   ├─ ○ Select persistence route (Routing) [choice]",
+        "   ├─ ○ Previous workflow state (Recent) [history, deep]",
+        "   └─ ○ Done"
+      ].join("\n")
+    )
+  })
+})

--- a/test/MachineSnapshotContext.test.ts
+++ b/test/MachineSnapshotContext.test.ts
@@ -1,0 +1,230 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Option, Schema } from "effect"
+import { Machine } from "../src/index.js"
+
+class System extends Schema.TaggedClass<System>("System")("System", {}) {}
+class Playback extends Schema.TaggedClass<Playback>("Playback")("Playback", {}) {}
+class Buffering extends Schema.TaggedClass<Buffering>("Buffering")("Buffering", {}) {}
+class Playing extends Schema.TaggedClass<Playing>("Playing")("Playing", {}) {}
+class Network extends Schema.TaggedClass<Network>("Network")("Network", {}) {}
+class Online extends Schema.TaggedClass<Online>("Online")("Online", {}) {}
+class Offline extends Schema.TaggedClass<Offline>("Offline")("Offline", {}) {}
+class BufferReady extends Schema.TaggedClass<BufferReady>("BufferReady")("BufferReady", {}) {}
+class Disconnect extends Schema.TaggedClass<Disconnect>("Disconnect")("Disconnect", {}) {}
+
+const States = Machine.defineStates({
+  System: {
+    schema: System,
+    type: "parallel",
+    states: {
+      Playback: {
+        schema: Playback,
+        initial: "Buffering",
+        states: { Buffering, Playing }
+      },
+      Network: {
+        schema: Network,
+        initial: "Online",
+        states: { Online, Offline }
+      }
+    }
+  }
+})
+
+const initial = () =>
+  States.initial.System(
+    new System({}),
+    (system) =>
+      system
+        .Playback(new Playback({}), (playback) => playback.Buffering(new Buffering({})))
+        .Network(new Network({}), (network) => network.Online(new Online({})))
+  )
+
+describe("Machine transition snapshot context", () => {
+  it.effect("lets an effectful event handler inspect a sibling region", () =>
+    Effect.gen(function*() {
+      let captured: Machine.Machine.Snapshot<typeof States.states> | undefined
+      const machine = Machine.make({
+        states: States.states,
+        events: [BufferReady],
+        initial
+      }).handle({
+        System: {
+          states: {
+            Playback: {
+              states: {
+                Buffering: {
+                  on: {
+                    BufferReady: ({ snapshot, target }) =>
+                      Effect.sync(() => {
+                        captured = snapshot
+                        return States.matches(snapshot, "System.Network.Online")
+                          ? target.local.Playing(new Playing({}))
+                          : undefined
+                      })
+                  }
+                }
+              }
+            }
+          }
+        }
+      })
+
+      const plan = yield* Machine.plan(machine, initial(), new BufferReady({}))
+
+      assert.strictEqual(States.matches(plan.next, "System.Playback.Playing"), true)
+      assert.strictEqual(States.matches(captured!, "System.Playback.Buffering"), true)
+      assert.strictEqual(States.matches(captured!, "System.Network.Online"), true)
+      assert.deepStrictEqual(
+        States.get(captured!, "System.Network.Online"),
+        Option.some(new Online({}))
+      )
+    }))
+
+  it.effect("shares one beginning-of-microstep snapshot across parallel transitions", () =>
+    Effect.gen(function*() {
+      const captured: Array<Machine.Machine.Snapshot<typeof States.states>> = []
+      const machine = Machine.make({
+        states: States.states,
+        events: [Disconnect],
+        initial
+      }).handle({
+        System: {
+          states: {
+            Playback: {
+              states: {
+                Buffering: {
+                  on: {
+                    Disconnect: ({ snapshot, target }) => {
+                      captured.push(snapshot)
+                      return target.local.Playing(new Playing({}))
+                    }
+                  }
+                }
+              }
+            },
+            Network: {
+              states: {
+                Online: {
+                  on: {
+                    Disconnect: ({ snapshot, target }) =>
+                      Effect.sync(() => {
+                        captured.push(snapshot)
+                        return target.local.Offline(new Offline({}))
+                      })
+                  }
+                }
+              }
+            }
+          }
+        }
+      })
+
+      const plan = yield* Machine.plan(machine, initial(), new Disconnect({}))
+
+      assert.lengthOf(plan.microsteps[0]!.transitions, 2)
+      assert.lengthOf(captured, 2)
+      assert.strictEqual(captured[0], captured[1])
+      assert.strictEqual(States.matches(captured[0]!, "System.Playback.Buffering"), true)
+      assert.strictEqual(States.matches(captured[0]!, "System.Network.Online"), true)
+      assert.strictEqual(States.matches(plan.next, "System.Playback.Playing"), true)
+      assert.strictEqual(States.matches(plan.next, "System.Network.Offline"), true)
+    }))
+
+  it.effect("captures the complete configuration for an eventless transition", () =>
+    Effect.gen(function*() {
+      let captured: Machine.Machine.Snapshot<typeof States.states> | undefined
+      const machine = Machine.make({
+        states: States.states,
+        events: [],
+        initial
+      }).handle({
+        System: {
+          states: {
+            Playback: {
+              states: {
+                Buffering: {
+                  always: ({ snapshot, target }) => {
+                    captured = snapshot
+                    return States.matches(snapshot, "System.Network.Online")
+                      ? target.local.Playing(new Playing({}))
+                      : undefined
+                  }
+                }
+              }
+            }
+          }
+        }
+      })
+
+      const plan = yield* Machine.planInitial(machine)
+
+      assert.strictEqual(States.matches(captured!, "System.Playback.Buffering"), true)
+      assert.strictEqual(States.matches(captured!, "System.Network.Online"), true)
+      assert.strictEqual(States.matches(plan.state, "System.Playback.Playing"), true)
+    }))
+
+  it.effect("captures completed state and sibling regions for onDone", () =>
+    Effect.gen(function*() {
+      class Work extends Schema.TaggedClass<Work>("Work")("Work", {}) {}
+      class Finished extends Schema.TaggedClass<Finished>("Finished")("Finished", {}) {}
+      class Restarted extends Schema.TaggedClass<Restarted>("Restarted")("Restarted", {}) {}
+      class Monitor extends Schema.TaggedClass<Monitor>("Monitor")("Monitor", {}) {}
+      class Active extends Schema.TaggedClass<Active>("Active")("Active", {}) {}
+      const completionStates = Machine.defineStates({
+        System: {
+          schema: System,
+          type: "parallel",
+          states: {
+            Work: {
+              schema: Work,
+              initial: "Finished",
+              states: {
+                Finished: { schema: Finished, type: "final" },
+                Restarted
+              }
+            },
+            Monitor: {
+              schema: Monitor,
+              initial: "Active",
+              states: { Active }
+            }
+          }
+        }
+      })
+      let captured: Machine.Machine.Snapshot<typeof completionStates.states> | undefined
+      const machine = Machine.make({
+        states: completionStates.states,
+        events: [],
+        initial: () =>
+          completionStates.initial.System(
+            new System({}),
+            (system) =>
+              system
+                .Work(new Work({}), (work) => work.Finished(new Finished({})))
+                .Monitor(new Monitor({}), (monitor) => monitor.Active(new Active({})))
+          )
+      }).handle({
+        System: {
+          states: {
+            Work: {
+              onDone: ({ snapshot, target }) => {
+                captured = snapshot
+                return target.local.Restarted(new Restarted({}))
+              }
+            }
+          }
+        }
+      })
+
+      const plan = yield* Machine.planInitial(machine)
+
+      assert.strictEqual(completionStates.matches(captured!, "System.Work.Finished"), true)
+      assert.strictEqual(completionStates.matches(captured!, "System.Monitor.Active"), true)
+      assert.deepStrictEqual(captured!.completed, [{ path: "System.Work.Finished", output: undefined }, {
+        path: "System.Work",
+        output: undefined
+      }])
+      assert.strictEqual(completionStates.matches(plan.state, "System.Work.Restarted"), true)
+    }))
+})

--- a/test/visualization/text.ts
+++ b/test/visualization/text.ts
@@ -1,6 +1,9 @@
 interface StateNode {
   readonly path: string
   readonly key: string
+  readonly annotations: {
+    readonly title?: string | undefined
+  } | undefined
   readonly type: "atomic" | "compound" | "parallel" | "final" | "history" | "choice"
   readonly history: "shallow" | "deep" | undefined
   readonly parent: string | undefined
@@ -39,15 +42,53 @@ interface TransitionDefinition {
     }
 }
 
+type ActivityDefinition =
+  | {
+    readonly source: string
+    readonly type: "dynamic"
+  }
+  | {
+    readonly source: string
+    readonly id: string
+    readonly type: "process"
+  }
+  | {
+    readonly source: string
+    readonly id: string
+    readonly type: "effect"
+    readonly outcomes: {
+      readonly success: "dynamic"
+      readonly failure: "dynamic" | "none"
+    }
+  }
+  | {
+    readonly source: string
+    readonly id: string
+    readonly type: "timer"
+    readonly duration: string
+    readonly event: string
+  }
+  | {
+    readonly source: string
+    readonly id: string
+    readonly type: "machine"
+    readonly child: {
+      readonly id: string
+      readonly machineId: string | null
+    }
+  }
+
 interface InspectionApi<Machine, Snapshot> {
   readonly stateNodes: (machine: Machine) => ReadonlyArray<StateNode>
   readonly transitionDefinitions: (machine: Machine) => ReadonlyArray<TransitionDefinition>
+  readonly activityDefinitions?: (machine: Machine) => ReadonlyArray<ActivityDefinition>
   readonly configuration: (machine: Machine, snapshot: Snapshot) => ReadonlyArray<StateNode>
   readonly enabled: (machine: Machine, snapshot: Snapshot) => ReadonlyArray<PropertyKey>
 }
 
 const nodeLabel = (node: StateNode, active: ReadonlySet<string>): string => {
   const status = active.has(node.path) ? "●" : "○"
+  const label = node.annotations?.title === undefined ? node.key : `${node.annotations.title} (${node.key})`
   const details: Array<string> = node.type === "atomic" ? [] : [node.type]
   if (node.initial !== undefined) {
     details.push(`initial: ${node.initial.slice(node.path.length + 1)}`)
@@ -55,7 +96,7 @@ const nodeLabel = (node: StateNode, active: ReadonlySet<string>): string => {
   if (node.history !== undefined) {
     details.push(node.history)
   }
-  return details.length === 0 ? `${status} ${node.key}` : `${status} ${node.key} [${details.join(", ")}]`
+  return details.length === 0 ? `${status} ${label}` : `${status} ${label} [${details.join(", ")}]`
 }
 
 const triggerLabels = (definitions: ReadonlyArray<TransitionDefinition>): ReadonlyArray<string> => {
@@ -89,6 +130,23 @@ const triggerLabels = (definitions: ReadonlyArray<TransitionDefinition>): Readon
   return labels
 }
 
+const activityLabel = (definition: ActivityDefinition): string => {
+  switch (definition.type) {
+    case "dynamic":
+      return "◆ activity: dynamic"
+    case "process":
+      return `◆ process: ${definition.id}`
+    case "effect":
+      return `◆ effect: ${definition.id} [success: ${definition.outcomes.success}, failure: ${definition.outcomes.failure}]`
+    case "timer":
+      return `◆ timer: ${definition.id} [${definition.duration}] → ${definition.event}`
+    case "machine": {
+      const identity = definition.child.machineId === null ? definition.child.id : definition.child.machineId
+      return `◆ machine: ${definition.id} → ${identity}`
+    }
+  }
+}
+
 /**
  * Builds an experimental text renderer around a machine module's public
  * inspection functions. Keeping the module injectable lets examples use their
@@ -107,6 +165,7 @@ export const makeTextRenderer = <Machine extends MachineValue, Snapshot>(
   )
   const children = new Map<string | undefined, Array<StateNode>>()
   const transitions = new Map<string, Array<TransitionDefinition>>()
+  const activities = new Map<string, Array<ActivityDefinition>>()
 
   for (const node of nodes) {
     const siblings = children.get(node.parent) ?? []
@@ -119,18 +178,26 @@ export const makeTextRenderer = <Machine extends MachineValue, Snapshot>(
     registrations.push(definition)
     transitions.set(definition.source, registrations)
   }
+  for (const definition of inspection.activityDefinitions?.(machine) ?? []) {
+    const registrations = activities.get(definition.source) ?? []
+    registrations.push(definition)
+    activities.set(definition.source, registrations)
+  }
 
   const lines = [
     machine.id ?? "Machine",
-    "● active  ○ inactive  ◇ transition (→ declared, ∅ none, omitted dynamic)",
+    activities.size === 0
+      ? "● active  ○ inactive  ◇ transition (→ declared, ∅ none, omitted dynamic)"
+      : "● active  ○ inactive  ◇ transition (→ declared, ∅ none, omitted dynamic)  ◆ activity",
     ""
   ]
   const visit = (node: StateNode, prefix: string, isLast: boolean): void => {
     lines.push(`${prefix}${isLast ? "└─" : "├─"} ${nodeLabel(node, active)}`)
     const descendants = children.get(node.path) ?? []
     const registrations = transitions.get(node.path) ?? []
+    const ownedActivities = activities.get(node.path) ?? []
     const childPrefix = `${prefix}${isLast ? "   " : "│  "}`
-    const labels = triggerLabels(registrations)
+    const labels = [...triggerLabels(registrations), ...ownedActivities.map(activityLabel)]
     const itemCount = labels.length + descendants.length
     labels.forEach((label, index) => {
       lines.push(`${childPrefix}${index === itemCount - 1 ? "└─" : "├─"} ${label}`)

--- a/typetest/MachineActivities.tst.ts
+++ b/typetest/MachineActivities.tst.ts
@@ -1,0 +1,42 @@
+import { Schema } from "effect"
+import { describe, expect, it } from "tstyche"
+import { Machine } from "../src/index.js"
+
+class Loading extends Schema.TaggedClass<Loading>("Loading")("Loading", {}) {}
+class Dynamic extends Schema.TaggedClass<Dynamic>("Dynamic")("Dynamic", {}) {}
+class TimedOut extends Schema.TaggedClass<TimedOut>("TimedOut")("TimedOut", {}) {}
+
+const States = Machine.defineStates({ Loading, Dynamic })
+const machine = Machine.make({
+  states: States.states,
+  events: [TimedOut],
+  initial: () => States.initial.Loading(new Loading({}))
+}).handle({
+  Loading: {
+    invoke: Machine.after("1 second", new TimedOut({}), { id: "timeout" })
+  },
+  Dynamic: {
+    invoke: () => Machine.after("2 seconds", new TimedOut({}))
+  }
+})
+
+describe("Machine activity inspection", () => {
+  it("preserves source path and activity kind unions", () => {
+    const definition = Machine.activityDefinitions(machine)[0]!
+
+    expect(definition.source).type.toBe<"Loading" | "Dynamic">()
+    expect(definition.type).type.toBe<"process" | "effect" | "timer" | "machine" | "dynamic">()
+  })
+
+  it("narrows kind-specific descriptive metadata", () => {
+    const definition = Machine.activityDefinitions(machine)[0]!
+
+    if (definition.type === "timer") {
+      expect(definition.id).type.toBe<string>()
+      expect(definition.duration).type.toBe<string>()
+      expect(definition.event).type.toBe<string>()
+    } else if (definition.type === "dynamic") {
+      expect(definition).type.not.toHaveProperty("id")
+    }
+  })
+})

--- a/typetest/MachineAnnotations.tst.ts
+++ b/typetest/MachineAnnotations.tst.ts
@@ -1,0 +1,108 @@
+import { Schema } from "effect"
+import { describe, expect, it } from "tstyche"
+import { Machine } from "../src/index.js"
+
+class Workflow extends Schema.TaggedClass<Workflow>("Workflow")("Workflow", {}) {}
+class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", {}) {}
+
+const AnnotatedWorkflow = Workflow.annotate({
+  title: "Document workflow",
+  description: "Coordinates the document lifecycle",
+  documentation: "https://example.test/docs/workflow",
+  designOwner: "editor-platform"
+})
+
+const States = Machine.defineStates({
+  Workflow: {
+    schema: AnnotatedWorkflow,
+    initial: "Idle",
+    states: {
+      Idle,
+      Routing: {
+        type: "choice",
+        annotations: {
+          title: "Select persistence route",
+          description: "Routes according to the current document"
+        }
+      },
+      Recent: {
+        type: "history",
+        annotations: {
+          title: "Previous workflow state",
+          documentation: "https://example.test/docs/history"
+        }
+      }
+    }
+  }
+})
+
+const machine = Machine.make({
+  states: States.states,
+  events: [],
+  initial: () => States.initial.Workflow(new Workflow({}), (workflow) => workflow.Idle(new Idle({})))
+})
+
+describe("Machine state annotations", () => {
+  it("exposes typed resolved annotations on every state node", () => {
+    const node = Machine.stateNodes(machine)[0]!
+    expect(node.annotations).type.toBe<Readonly<Machine.Machine.StateNodeAnnotations> | undefined>()
+    expect(node.annotations?.title).type.toBe<string | undefined>()
+    expect(node.annotations?.description).type.toBe<string | undefined>()
+    expect(node.annotations?.documentation).type.toBe<string | undefined>()
+    expect(node.annotations?.designOwner).type.toBe<unknown>()
+  })
+
+  it("limits pseudo-state annotations to descriptive metadata", () => {
+    expect(Machine.defineStates).type.not.toBeCallableWith({
+      Workflow: {
+        schema: Workflow,
+        initial: "Idle",
+        states: {
+          Idle,
+          Invalid: { type: "choice", annotations: { arbitrary: () => 1 } }
+        }
+      }
+    })
+    expect(Machine.defineStates).type.not.toBeCallableWith({
+      Workflow: {
+        schema: Workflow,
+        initial: "Idle",
+        states: {
+          Idle,
+          Invalid: { type: "history", annotations: { title: () => "Executable" } }
+        }
+      }
+    })
+  })
+
+  it("keeps schema-backed APIs unavailable to annotated pseudo-states", () => {
+    expect(Machine.defineStates).type.not.toBeCallableWith({
+      Workflow: {
+        schema: Workflow,
+        initial: "Idle",
+        states: {
+          Idle,
+          Invalid: {
+            type: "choice",
+            schema: Idle,
+            annotations: { title: "Still a pseudo-state" }
+          }
+        }
+      }
+    })
+    expect(Machine.defineStates).type.not.toBeCallableWith({
+      Workflow: {
+        schema: Workflow,
+        initial: "Idle",
+        states: {
+          Idle,
+          Invalid: {
+            type: "history",
+            states: { Idle },
+            annotations: { title: "Still a pseudo-state" }
+          }
+        }
+      }
+    })
+  })
+})

--- a/typetest/MachineSnapshotContext.tst.ts
+++ b/typetest/MachineSnapshotContext.tst.ts
@@ -1,0 +1,116 @@
+import { Schema } from "effect"
+import { describe, expect, it } from "tstyche"
+import { Machine } from "../src/index.js"
+
+class Root extends Schema.TaggedClass<Root>("Root")("Root", {}) {}
+class Left extends Schema.TaggedClass<Left>("Left")("Left", {}) {}
+class LeftIdle extends Schema.TaggedClass<LeftIdle>("LeftIdle")("LeftIdle", {}) {}
+class LeftDone extends Schema.TaggedClass<LeftDone>("LeftDone")("LeftDone", {}) {}
+class Right extends Schema.TaggedClass<Right>("Right")("Right", {}) {}
+class RightIdle extends Schema.TaggedClass<RightIdle>("RightIdle")("RightIdle", {}) {}
+class Advance extends Schema.TaggedClass<Advance>("Advance")("Advance", {}) {}
+
+const States = Machine.defineStates({
+  Root: {
+    schema: Root,
+    type: "parallel",
+    states: {
+      Left: {
+        schema: Left,
+        initial: "LeftIdle",
+        states: {
+          LeftIdle,
+          LeftDone: { schema: LeftDone, type: "final" }
+        }
+      },
+      Right: {
+        schema: Right,
+        initial: "RightIdle",
+        states: { RightIdle }
+      }
+    }
+  }
+})
+
+describe("Machine transition snapshot context", () => {
+  it("infers the complete machine snapshot for event, always, and onDone handlers", () => {
+    Machine.make({
+      states: States.states,
+      events: [Advance],
+      initial: () =>
+        States.initial.Root(
+          new Root({}),
+          (root) =>
+            root
+              .Left(new Left({}), (left) => left.LeftIdle(new LeftIdle({})))
+              .Right(new Right({}), (right) => right.RightIdle(new RightIdle({})))
+        )
+    }).handle({
+      Root: {
+        states: {
+          Left: {
+            onDone: ({ snapshot, target }) => {
+              expect(snapshot).type.toBe<Machine.Machine.Snapshot<typeof States.states>>()
+              expect(States.matches).type.toBeCallableWith(snapshot, "Root.Right.RightIdle")
+              expect(States.get).type.toBeCallableWith(snapshot, "Root.Right.RightIdle")
+              expect(States.getSnapshot).type.toBeCallableWith(snapshot, "Root.Right.RightIdle")
+              return target.local.LeftIdle(new LeftIdle({}))
+            },
+            states: {
+              LeftIdle: {
+                always: ({ snapshot }) => {
+                  expect(snapshot).type.toBe<Machine.Machine.Snapshot<typeof States.states>>()
+                  return undefined
+                },
+                on: {
+                  Advance: ({ snapshot, target }) => {
+                    expect(snapshot).type.toBe<Machine.Machine.Snapshot<typeof States.states>>()
+                    expect(States.matches(snapshot, "Root.Right.RightIdle")).type.toBe<boolean>()
+                    return target.local.LeftDone(new LeftDone({}))
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+  })
+
+  it("does not expose a fabricated snapshot to choices or state actions", () => {
+    class Flow extends Schema.TaggedClass<Flow>("Flow")("Flow", {}) {}
+    class Active extends Schema.TaggedClass<Active>("Active")("Active", {}) {}
+    const choiceStates = Machine.defineStates({
+      Flow: {
+        schema: Flow,
+        initial: "Routing",
+        states: {
+          Routing: { type: "choice" },
+          Active
+        }
+      }
+    })
+    Machine.make({
+      states: choiceStates.states,
+      events: [],
+      initial: () => choiceStates.initial.Flow(new Flow({}), (flow) => flow.Routing())
+    }).handle({
+      Flow: {
+        entry: (context) => {
+          expect(context).type.not.toHaveProperty("snapshot")
+        },
+        states: {
+          Routing: {
+            choice: {
+              targets: ["Flow.Active"],
+              transition: (context) => {
+                expect(context).type.not.toHaveProperty("snapshot")
+                return context.target.local.Active(new Active({}))
+              }
+            }
+          }
+        }
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- expose one fully typed, read-only full logical snapshot to event, eventless, and completion transition contexts, captured at the beginning of each microstep and shared across simultaneous parallel transitions
- add serializable `Machine.activityDefinitions` metadata for process invokes, Effects, timers, child machines, and unevaluated dynamic factories, and render owned activities in the structural text visualization
- resolve Effect Schema annotations into `Machine.stateNodes`, support descriptive annotations on choice/history pseudo-states, and use titles as display labels without changing structural identity
- document the context, lifecycle, inspection, and annotation contracts and add focused runtime, property, compiler, and visualization coverage

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

Added `.changeset/rich-machines-inspect.md` as a minor change.

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed

No example package changed, so no example-local check was required.

Additional validation:

- `pnpm perf:types`
- 335 runtime tests passed
- 574 type assertions passed
- strict consumer and package verification passed
- generated activity invariants cover timer metadata agreement and real state-node ownership
