### PR TITLE
Fix first-use nested history fallbacks

### DIFF
--- a/.changeset/calm-histories-resume.md
+++ b/.changeset/calm-histories-resume.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Fix first-use nested history defaults by requiring a complete source-independent configuration containing the history owner and using it to rebuild inactive compound and parallel ancestors.

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 references/
 *.tgz
 .DS_Store
+.pnpm-store

--- a/README.md
+++ b/README.md
@@ -313,11 +313,37 @@ machine.handle({
 })
 ```
 
-A recorded nested history can rebuild inactive ancestors when it is restored.
-There is one current first-use boundary: if no history record exists, a nested
-history fallback constructs only its direct owner's snapshot and cannot
-reconstruct values for inactive ancestors above that owner. Those ancestors
-must already be active when that nested fallback is targeted.
+A history default is source-independent. It must construct a complete root
+configuration containing the history owner, including every inactive ancestor
+above a nested owner and every required region of a parallel ancestor. For a
+top-level owner, its owner snapshot is already a complete root snapshot.
+
+For example, a history node owned by `App.Workspace` can be targeted from an
+unrelated `Closed` root and supplies the complete `App` configuration on first
+use:
+
+```ts
+Workspace: {
+  history: {
+    resume: {
+      default: ({ target }) =>
+        target.App(
+          State.cases.App.make({ workspaceId: "default" }),
+          (app) =>
+            app.Workspace(
+              State.cases.Workspace.make({}),
+              (workspace) =>
+                workspace.Editing(State.cases.Editing.make({}))
+            )
+        )
+    }
+  }
+}
+```
+
+The containing branch is enforced statically: unrelated roots, sibling
+compound branches that omit the owner, owner-only nested snapshots, and
+incomplete parallel configurations are rejected.
 
 Deep history restores every remembered descendant value. Shallow history
 restores the parent and direct-child values, then follows normal initial paths.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -228,7 +228,8 @@ const States = Machine.defineStates({
 })
 ```
 
-Every history node needs a default parent snapshot for the first use:
+Every history node needs a source-independent default for the first use. The
+default is a complete root snapshot containing the history owner:
 
 ```ts
 checkout: {
@@ -256,10 +257,35 @@ payment: {
 }
 ```
 
-A recorded nested history can rebuild inactive ancestors. A first-use fallback
-cannot: it constructs the history node's direct parent snapshot, so it cannot
-currently reconstruct values for inactive ancestors above that owner. Those
-ancestors must already be active when an unrecorded nested history is targeted.
+A nested default must include every ancestor above its owner and every region
+of any parallel ancestor. The containing branch is checked statically, so an
+unrelated root, a sibling compound branch, a direct-owner-only nested snapshot,
+or an incomplete parallel configuration is rejected. A canonical nested
+default looks like:
+
+```ts
+Workspace: {
+  history: {
+    resume: {
+      default: ({ target }) =>
+        target.App(
+          State.cases.App.make({ workspaceId: "default" }),
+          (app) =>
+            app.Workspace(
+              State.cases.Workspace.make({}),
+              (workspace) =>
+                workspace.Editing(State.cases.Editing.make({}))
+            )
+        )
+    }
+  }
+}
+```
+
+On first use from an inactive root, this complete configuration is entered. If
+a parallel ancestor is already active, unaffected active regions are retained.
+Once a history record exists, shallow or deep recorded restoration wins over
+the default.
 
 The machine's readiness type tracks missing defaults and shallow initializers.
 History is an overwriteable register, not a stack: restoration does not consume
@@ -273,7 +299,7 @@ prior effects, actors, and timers are not rewound.
 | `target.local`   | The destination is inside the nearest compound scope containing the source | The compound value, active ancestors, and unrelated parallel regions              |
 | `target.branch`  | The destination is elsewhere under the active top-level root               | Omitted current ancestor values and parallel regions                              |
 | `target.full`    | The destination may be under any top-level root                            | Nothing is inferred for a newly selected root; build its complete active snapshot |
-| `target.history` | The destination is a declared history pseudo-state                         | Its parent's remembered configuration, or its default before the first capture; an unrecorded nested fallback requires ancestors above its owner to be active |
+| `target.history` | The destination is a declared history pseudo-state                         | Its parent's remembered configuration, or a source-independent complete default containing that owner before the first capture |
 
 Entering an inactive parallel state through `target.local` or `target.branch`
 requires a complete callback with one selection per region. A parallel state

--- a/examples/platformer/src/machine.ts
+++ b/examples/platformer/src/machine.ts
@@ -137,22 +137,6 @@ export const CharacterStates = Machine.defineStates({
   }
 })
 
-const initialPlaying = (): Machine.Machine.SnapshotByIdentifier<
-  typeof CharacterStates.states,
-  "Character.locomotion.Playing"
-> => ({
-  path: "Character.locomotion.Playing",
-  value: State.cases.Playing.make({}),
-  state: {
-    path: "Character.locomotion.Playing.Grounded",
-    value: State.cases.Grounded.make({}),
-    state: {
-      path: "Character.locomotion.Playing.Grounded.Standing",
-      value: State.cases.Standing.make({})
-    }
-  }
-})
-
 const initialCharacter = () =>
   CharacterStates.initial.Character(State.cases.Character.make({}), (character) =>
     character
@@ -185,7 +169,7 @@ export const CharacterMachine = Machine.make({
           Playing: {
             history: {
               resume: {
-                default: initialPlaying
+                default: initialCharacter
               }
             },
             on: {

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -865,6 +865,181 @@ type FullParallelBuilder<
       }
   }
 
+type HistorySnapshotArguments<
+  States extends Machine.StateSchemas,
+  StateId extends ActiveStateKey<States>,
+  Prefix extends string,
+  Owner extends string,
+  Path extends string = Machine.JoinPath<Prefix, StateId>
+> = Path extends Owner ? FullSnapshotArguments<States, StateId, Prefix>
+  : States[StateId] extends infer Node ?
+    Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ? [
+        value: Machine.NodeSchema<Node>["Type"],
+        states: (
+          builder: HistoryParallelBuilder<Children, Path, Owner>
+        ) => SnapshotBuilderComplete<HistorySnapshotRegions<Children, Path, Owner>>
+      ]
+    : Node extends { readonly states: infer Children extends Machine.StateSchemas } ? [
+        value: Machine.NodeSchema<Node>["Type"],
+        state: (
+          builder: HistorySnapshotBuilderWithPrefix<Children, Owner, Path>
+        ) => ConstructionResult<HistorySnapshotWithPrefix<Children, Owner, Path>>
+      ]
+    : never
+  : never
+
+type HistorySnapshotFromArguments<
+  States extends Machine.StateSchemas,
+  StateId extends ActiveStateKey<States>,
+  Prefix extends string,
+  Owner extends string,
+  Path extends string = Machine.JoinPath<Prefix, StateId>
+> = Path extends Owner ? FullSnapshotFromArguments<States, StateId, Prefix>
+  : States[StateId] extends infer Node ?
+    Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ? [
+        input: Machine.NodeSchema<Node>["~type.make.in"],
+        states: (
+          builder: HistoryParallelBuilder<Children, Path, Owner>
+        ) => SnapshotBuilderComplete<HistorySnapshotRegions<Children, Path, Owner>, boolean>
+      ]
+    : Node extends { readonly states: infer Children extends Machine.StateSchemas } ? [
+        input: Machine.NodeSchema<Node>["~type.make.in"],
+        state: (
+          builder: HistorySnapshotBuilderWithPrefix<Children, Owner, Path>
+        ) => ConstructionResult<HistorySnapshotWithPrefix<Children, Owner, Path>>
+      ]
+    : never
+  : never
+
+type HistorySnapshotResult<
+  States extends Machine.StateSchemas,
+  StateId extends ActiveStateKey<States>,
+  Prefix extends string,
+  Owner extends string,
+  Path extends string = Machine.JoinPath<Prefix, StateId>
+> = Path extends Owner ? FullSnapshotResult<States, StateId, Prefix>
+  : States[StateId] extends infer Node ?
+    Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ?
+      Machine.ParallelSnapshot<
+        Path,
+        Machine.NodeSchema<Node>["Type"],
+        HistorySnapshotRegions<Children, Path, Owner>
+      >
+    : Node extends { readonly states: infer Children extends Machine.StateSchemas } ? Machine.CompoundSnapshot<
+        Path,
+        Machine.NodeSchema<Node>["Type"],
+        HistorySnapshotWithPrefix<Children, Owner, Path>
+      >
+    : never
+  : never
+
+type HistorySnapshotMethod<
+  States extends Machine.StateSchemas,
+  StateId extends ActiveStateKey<States>,
+  Prefix extends string,
+  Owner extends string
+> =
+  & ((
+    ...args: HistorySnapshotArguments<States, StateId, Prefix, Owner>
+  ) => HistorySnapshotResult<States, StateId, Prefix, Owner>)
+  & FromMethod<
+    HistorySnapshotFromArguments<States, StateId, Prefix, Owner>,
+    HistorySnapshotResult<States, StateId, Prefix, Owner>
+  >
+
+type HistorySnapshotWithPrefix<
+  States extends Machine.StateSchemas,
+  Owner extends string,
+  Prefix extends string
+> = {
+  readonly [Key in ActiveStateKey<States>]: Owner extends
+    | Machine.JoinPath<Prefix, Key>
+    | `${Machine.JoinPath<Prefix, Key>}.${string}` ? HistorySnapshotResult<States, Key, Prefix, Owner>
+    : never
+}[ActiveStateKey<States>]
+
+type HistorySnapshotBuilderWithPrefix<
+  States extends Machine.StateSchemas,
+  Owner extends string,
+  Prefix extends string = ""
+> = {
+  readonly [
+    Key in ActiveStateKey<States> as Owner extends
+      | Machine.JoinPath<Prefix, Key>
+      | `${Machine.JoinPath<Prefix, Key>}.${string}` ? Key
+      : never
+  ]: HistorySnapshotMethod<States, Key, Prefix, Owner>
+}
+
+type HistorySnapshotRegions<
+  States extends Machine.StateSchemas,
+  Prefix extends string,
+  Owner extends string
+> = {
+  readonly [Key in ActiveStateKey<States>]: Owner extends
+    | Machine.JoinPath<Prefix, Key>
+    | `${Machine.JoinPath<Prefix, Key>}.${string}` ? HistorySnapshotResult<States, Key, Prefix, Owner>
+    : FullSnapshotResult<States, Key, Prefix>
+}
+
+type HistoryParallelBuilder<
+  States extends Machine.StateSchemas,
+  Prefix extends string,
+  Owner extends string,
+  Remaining extends ActiveStateKey<States> = ActiveStateKey<States>,
+  Regions = {},
+  Constructed extends boolean = false
+> =
+  & SnapshotBuilderComplete<Regions, Constructed>
+  & {
+    readonly [Key in Remaining]: Owner extends
+      | Machine.JoinPath<Prefix, Key>
+      | `${Machine.JoinPath<Prefix, Key>}.${string}` ?
+        & ((...args: HistorySnapshotArguments<States, Key, Prefix, Owner>) => HistoryParallelBuilder<
+          States,
+          Prefix,
+          Owner,
+          Exclude<Remaining, Key>,
+          Regions & { readonly [Region in Key]: HistorySnapshotResult<States, Key, Prefix, Owner> },
+          Constructed
+        >)
+        & {
+          readonly from: FromCallable<
+            HistorySnapshotFromArguments<States, Key, Prefix, Owner>,
+            HistoryParallelBuilder<
+              States,
+              Prefix,
+              Owner,
+              Exclude<Remaining, Key>,
+              Regions & { readonly [Region in Key]: HistorySnapshotResult<States, Key, Prefix, Owner> },
+              true
+            >
+          >
+        }
+      :
+        & ((...args: FullSnapshotArguments<States, Key, Prefix>) => HistoryParallelBuilder<
+          States,
+          Prefix,
+          Owner,
+          Exclude<Remaining, Key>,
+          Regions & { readonly [Region in Key]: FullSnapshotResult<States, Key, Prefix> },
+          Constructed
+        >)
+        & {
+          readonly from: FromCallable<
+            FullSnapshotFromArguments<States, Key, Prefix>,
+            HistoryParallelBuilder<
+              States,
+              Prefix,
+              Owner,
+              Exclude<Remaining, Key>,
+              Regions & { readonly [Region in Key]: FullSnapshotResult<States, Key, Prefix> },
+              true
+            >
+          >
+        }
+  }
+
 type ParentPath<Path extends string> = Path extends `${infer Parent}.${infer Child}`
   ? Child extends `${string}.${string}` ? `${Parent}.${ParentPath<Child>}` : Parent
   : never
@@ -1940,9 +2115,9 @@ export declare namespace Machine {
    *
    * History nodes are transition targets only. They never become active and
    * therefore do not declare a state value schema or lifecycle handlers.
-   * A recorded nested history can rebuild inactive ancestors. Before the
-   * first capture, however, a nested history fallback cannot reconstruct
-   * values for inactive ancestors above its direct owner.
+   * Both recorded history and a first-use default can rebuild inactive
+   * ancestors. A default is a complete root configuration containing the
+   * history owner, so its validity is independent of the transition source.
    *
    * @category models
    * @since 4.0.0
@@ -2919,6 +3094,21 @@ export declare namespace Machine {
     : AtomicSnapshot<Path, NodeSchema<States[StateId]>["Type"]>
 
   /**
+   * Extracts a complete root snapshot whose selected configuration contains a
+   * particular active state.
+   *
+   * Parallel ancestors still require every region, while compound ancestors
+   * are narrowed to the branch leading to `Owner`.
+   *
+   * @category utility types
+   * @since 4.0.0
+   */
+  export type CompleteSnapshotContaining<
+    States extends StateSchemas,
+    Owner extends StateIdentifier<States>
+  > = HistorySnapshotWithPrefix<States, Owner, "">
+
+  /**
    * Extracts the union of statechart snapshots represented by a state
    * definition.
    *
@@ -3064,6 +3254,17 @@ export declare namespace Machine {
    * @since 4.0.0
    */
   export type FullTargetBuilder<States extends StateSchemas> = FullSnapshotBuilderWithPrefix<States>
+
+  /**
+   * Builder for a complete fallback configuration containing a history owner.
+   *
+   * @category utility types
+   * @since 4.0.0
+   */
+  export type HistoryDefaultTargetBuilder<
+    States extends StateSchemas,
+    Owner extends StateIdentifier<States>
+  > = HistorySnapshotBuilderWithPrefix<States, Owner>
 
   /**
    * Builder for source-local transition targets.
@@ -3964,17 +4165,16 @@ export declare namespace Machine {
   > extends PlanningCapabilities<EventOf<Events>, EmitOf<Emits>> {
     readonly event: LifecycleEvent<Events>
     readonly runtime: RuntimeEffect<Events, Emits>
-    readonly target: FullTargetBuilder<States>
+    readonly target: HistoryDefaultTargetBuilder<States, ParentId>
     readonly parent: ParentId
   }
 
   /**
    * Typed fallback evaluated when a history node has no record yet.
    *
-   * The fallback constructs the history node's direct parent snapshot. It
-   * cannot currently provide values for inactive ancestors above that parent,
-   * so first-use fallback to a nested history requires those ancestors to
-   * already be active. Recorded nested history does not have this limitation.
+   * The fallback constructs a complete root configuration containing the
+   * history owner. This makes the default independent of the transition source
+   * and provides every inactive ancestor and required parallel region.
    */
   export type HistoryDefaultHandler<
     States extends StateSchemas,
@@ -3982,10 +4182,11 @@ export declare namespace Machine {
     Emits extends ReadonlyArray<TaggedSchema>,
     ParentId extends StateIdentifier<States>
   > = (context: HistoryDefaultContext<States, Events, Emits, ParentId>) =>
-    | SnapshotByIdentifier<States, ParentId>
-    | StateConstruction<SnapshotByIdentifier<States, ParentId>>
+    | CompleteSnapshotContaining<States, ParentId>
+    | StateConstruction<CompleteSnapshotContaining<States, ParentId>>
     | Effect.Effect<
-      SnapshotByIdentifier<States, ParentId> | StateConstruction<SnapshotByIdentifier<States, ParentId>>,
+      | CompleteSnapshotContaining<States, ParentId>
+      | StateConstruction<CompleteSnapshotContaining<States, ParentId>>,
       any,
       any
     >

--- a/src/internal/machinePlanner.ts
+++ b/src/internal/machinePlanner.ts
@@ -479,13 +479,21 @@ const resolveHistoryTarget = Effect.fnUntraced(function*(
     parent: target.parent
   })
   if (collected.state === undefined || isHistoryTarget(collected.state) || !isSnapshot(collected.state)) {
-    throw new Error(`Machine history default for "${target.path}" must return a concrete parent snapshot`)
+    throw new Error(`Machine history default for "${target.path}" must return a complete snapshot containing its owner`)
   }
-  if (String(collected.state.path) !== target.parent) {
-    throw new Error(`Machine history default for "${target.path}" must return state "${target.parent}"`)
+  const fallbackConfiguration = yield* normalizeConfigurationEffect(machine, collected.state as any)
+  if (!fallbackConfiguration.active.has(target.parent)) {
+    throw new Error(
+      `Machine history default for "${target.path}" returned a configuration that does not contain owner state "${target.parent}"`
+    )
   }
+  const snapshot = snapshotFromConfigurationAtPath(machine, fallbackConfiguration, target.parent)
+  const values = Object.fromEntries(fallbackConfiguration.values)
   return {
-    target: makeTarget(target.parent as any, collected.state.value as any, { snapshot: collected.state as any }),
+    target: makeTarget(target.parent as any, snapshot.value as any, {
+      snapshot: snapshot as any,
+      values: values as any
+    }),
     actions: collected.actions,
     raisedEvents: collected.raisedEvents,
     emittedEvents: collected.emittedEvents

--- a/src/internal/machineTestFiniteModel.ts
+++ b/src/internal/machineTestFiniteModel.ts
@@ -1265,13 +1265,12 @@ const makeHandlers = (
             const fallback = byPath.get(child.fallback)!
             const parts = child.fallback.split(".")
             const completeRoot = selectSnapshot(target, fallback.root, byPath, parts, 0)
-            const selected = findSnapshot(completeRoot, path)
-            if (selected === undefined) {
+            if (findSnapshot(completeRoot, path) === undefined) {
               throw new Error(
                 `MachineTest.compileModel could not construct history fallback for "${path}.${child.key}"`
               )
             }
-            return selected
+            return completeRoot
           }
         }]]
       }))

--- a/test/MachineHistory.test.ts
+++ b/test/MachineHistory.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Context, Data, Effect, Fiber, Schema, Stream } from "effect"
+import { Cause, Context, Data, Effect, Fiber, Schema, Stream } from "effect"
 import { Machine } from "../src/index.js"
 
 class Checkout extends Schema.TaggedClass<Checkout>("Checkout")("Checkout", {
@@ -71,6 +71,7 @@ class ResumeWorkspaceDeep extends Schema.TaggedClass<ResumeWorkspaceDeep>("Resum
   {}
 ) {}
 class RestoreEditor extends Schema.TaggedClass<RestoreEditor>("RestoreEditor")("RestoreEditor", {}) {}
+class DefaultEditor extends Schema.TaggedClass<DefaultEditor>("DefaultEditor")("DefaultEditor", {}) {}
 
 const CheckoutStates = Machine.defineStates({
   checkout: {
@@ -389,7 +390,7 @@ const nestedParallelSnapshot: Machine.Machine.Snapshot<typeof NestedHistoryState
 
 const nestedHistoryMachine = Machine.make({
   states: NestedHistoryStates.states,
-  events: [RestoreEditor],
+  events: [RestoreEditor, DefaultEditor],
   initial: () =>
     NestedHistoryStates.initial.workspace(
       new Workspace({ id: "workspace-1" }),
@@ -407,14 +408,17 @@ const nestedHistoryMachine = Machine.make({
       editor: {
         history: {
           exact: {
-            default: () => ({
-              path: "workspace.editor",
-              value: new Editor({ documentId: "fallback" }),
-              state: {
-                path: "workspace.editor.writing",
-                value: new Writing({ draft: "" })
-              }
-            })
+            default: () =>
+              NestedHistoryStates.initial.workspace(
+                new Workspace({ id: "fallback-workspace" }),
+                (workspace) =>
+                  workspace
+                    .editor(
+                      new Editor({ documentId: "fallback" }),
+                      (editor) => editor.writing(new Writing({ draft: "" }))
+                    )
+                    .sidebar(new Search({ query: "fallback" }))
+              )
           }
         },
         states: {
@@ -423,9 +427,11 @@ const nestedHistoryMachine = Machine.make({
               RestoreEditor: {
                 reenter: true,
                 transition: ({ target }) => target.history.workspace.editor.exact()
-              }
+              },
+              DefaultEditor: ({ target }) => target.history.workspace.editor.exact()
             }
-          }
+          },
+          writing: {}
         }
       }
     }
@@ -656,6 +662,57 @@ describe("Machine history states", () => {
         "workspace.editor",
         "workspace.editor.preview"
       ])
+    }))
+
+  it.effect("uses a nested first-use default while preserving an active parallel sibling", () =>
+    Effect.gen(function*() {
+      const restored = yield* Machine.plan(
+        nestedHistoryMachine,
+        nestedParallelSnapshot,
+        new DefaultEditor({})
+      )
+
+      assert.deepStrictEqual((restored.next as any).states.editor, {
+        path: "workspace.editor",
+        value: new Editor({ documentId: "fallback" }),
+        state: {
+          path: "workspace.editor.writing",
+          value: new Writing({ draft: "" })
+        }
+      })
+      assert.deepStrictEqual((restored.next as any).states.sidebar, {
+        path: "workspace.sidebar",
+        value: new Search({ query: "untouched" })
+      })
+      assert.strictEqual(restored.microsteps[0]?.transitions[0]?.target, "workspace.editor.exact")
+      assert.strictEqual(restored.microsteps[0]?.transitions[0]?.resolvedTarget, "workspace.editor")
+      assert.strictEqual(restored.next.history, undefined)
+    }))
+
+  it.effect("rejects a forged fallback that omits its declared owner with a precise diagnostic", () =>
+    Effect.gen(function*() {
+      const unsafe = makeCheckoutMachine(
+        CheckoutStates.initial.support(new Support({ ticket: "new" }))
+      ).handle({
+        checkout: {
+          history: {
+            exact: {
+              default: (() => CheckoutStates.initial.support(new Support({ ticket: "forged" }))) as any
+            }
+          }
+        }
+      })
+      const initial = yield* Machine.planInitial(unsafe)
+      const exit = yield* Effect.exit(Machine.plan(unsafe, initial.state, new ResumeDeep({})))
+
+      assert.strictEqual(exit._tag, "Failure")
+      if (exit._tag === "Failure") {
+        assert(Cause.hasDies(exit.cause))
+        assert.include(
+          Cause.pretty(exit.cause),
+          "Machine history default for \"checkout.exact\" returned a configuration that does not contain owner state \"checkout\""
+        )
+      }
     }))
 
   it.effect("runs effectful shallow initializers with their service and error channels", () =>

--- a/test/MachineTestReferenceModel.test.ts
+++ b/test/MachineTestReferenceModel.test.ts
@@ -1,5 +1,4 @@
 import { assert, describe, it } from "@effect/vitest"
-import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
 import * as Schema from "effect/Schema"
 import { FastCheck } from "effect/testing"
@@ -1337,16 +1336,22 @@ describe("MachineTest finite-model reference interpreter", () => {
       yield* MachineTest.verifyModel(model, trace)
     }))
 
-  it.effect("documents that nested fallback cannot reconstruct an inactive outer ancestor yet", () =>
+  it.effect("restores a first-use nested fallback through inactive compound and parallel ancestors", () =>
     Effect.gen(function*() {
       const model = inactiveOuterHistoryModel("outside")
       const machine = MachineTest.compileModel(model)
-      const exit = yield* Effect.exit(MachineTest.run(machine, { events: [event("Resume")] }))
+      const trace = yield* MachineTest.run(machine, { events: [event("Resume")] })
 
-      assert.strictEqual(exit._tag, "Failure")
-      if (exit._tag === "Failure") {
-        assert.include(Cause.pretty(exit.cause), "requires a value for ancestor state")
-      }
+      assert.deepStrictEqual(trace.finalConfiguration, [
+        "workspace",
+        "workspace.editor",
+        "workspace.editor.writing",
+        "workspace.sidebar",
+        "workspace.sidebar.closed"
+      ])
+      assert.deepStrictEqual((trace.final as any).history, undefined)
+      yield* MachineTest.verify(machine, trace)
+      yield* MachineTest.verifyModel(model, trace)
     }))
 
   it.effect("rejects consumed, shallow-as-deep, missing-region, and fallback-after-record mutations", () =>
@@ -1438,13 +1443,24 @@ describe("MachineTest finite-model reference interpreter", () => {
     // standing in for the mutation that must be captured and restored.
     return FastCheck.oneof(
       ...(historyScenarios.length === 0
-        ? [FastCheck.constant({ events: [] as ReadonlyArray<string>, scenario: undefined })]
-        : historyScenarios.map((scenario) => FastCheck.constant({ events: scenario.events, scenario }))),
+        ? [FastCheck.constant({ events: [] as ReadonlyArray<string>, scenario: undefined, firstUse: false })]
+        : historyScenarios.map((scenario) =>
+          FastCheck.constant({ events: scenario.events, scenario, firstUse: false })
+        )),
       ...(historyScenarios.length === 0
         ? []
-        : historyScenarios.map((scenario) => FastCheck.constant({ events: scenario.events, scenario }))),
-      randomEvents.map((events) => ({ events, scenario: undefined }))
-    ).map(({ events, scenario }) => ({ model, events, scenario }))
+        : historyScenarios.map((scenario) =>
+          FastCheck.constant({ events: [scenario.resume.event], scenario, firstUse: true })
+        )),
+      randomEvents.map((events) => ({ events, scenario: undefined, firstUse: false }))
+    ).map(({ events, firstUse, scenario }) => ({
+      model: firstUse && scenario !== undefined
+        ? { ...model, initial: scenario.resume.source.split(".")[0]!, historyScenarios: [] }
+        : model,
+      events,
+      scenario,
+      firstUse
+    }))
   })
 
   it.effect.prop(
@@ -1456,6 +1472,11 @@ describe("MachineTest finite-model reference interpreter", () => {
         Effect.tap((trace) => {
           if (generated.scenario === undefined) return Effect.void
           const scenario = generated.scenario
+          if (generated.firstUse) {
+            assert.include(trace.finalConfiguration, scenario.owner)
+            assert.ok(snapshotAtPath(trace.final, scenario.history) === undefined)
+            return Effect.void
+          }
           const mutated = snapshotAtPath(trace.steps[0]!.after, scenario.mutation.source) as any
           const restored = snapshotAtPath(trace.final, scenario.mutation.source) as any
           assert.strictEqual(mutated.value.value, scenario.mutation.value)

--- a/test/MachineVisualization.test.ts
+++ b/test/MachineVisualization.test.ts
@@ -64,14 +64,10 @@ const initial = States.initial.application(
       .connection(new Connection({}), (connection) => connection.online(new Online({})))
 )
 
-const initialWorkflow = (): Machine.Machine.SnapshotByIdentifier<typeof States.states, "application.workflow"> => ({
-  path: "application.workflow",
-  value: new Workflow({}),
-  state: {
-    path: "application.workflow.idle",
-    value: new Idle({})
-  }
-})
+const initialWorkflow = (): Machine.Machine.CompleteSnapshotContaining<
+  typeof States.states,
+  "application.workflow"
+> => initial
 
 const machine = Machine.make({
   id: "inspection-example",

--- a/typetest/MachineHistory.tst.ts
+++ b/typetest/MachineHistory.tst.ts
@@ -30,6 +30,20 @@ class InitialRequirement extends Context.Service<InitialRequirement, {
   readonly cardNumber: string
 }>()("test/MachineHistory/InitialRequirement") {}
 
+class FallbackRequirement extends Context.Service<FallbackRequirement, {
+  readonly workspaceId: string
+}>()("test/MachineHistory/FallbackRequirement") {}
+
+class App extends Schema.TaggedClass<App>("App")("App", {
+  session: Schema.String
+}) {}
+class Workspace extends Schema.TaggedClass<Workspace>("Workspace")("Workspace", {}) {}
+class Settings extends Schema.TaggedClass<Settings>("Settings")("Settings", {}) {}
+class Closed extends Schema.TaggedClass<Closed>("Closed")("Closed", {}) {}
+class Editor extends Schema.TaggedClass<Editor>("Editor")("Editor", {}) {}
+class Editing extends Schema.TaggedClass<Editing>("Editing")("Editing", {}) {}
+class Sidebar extends Schema.TaggedClass<Sidebar>("Sidebar")("Sidebar", {}) {}
+
 const States = Machine.defineStates({
   checkout: {
     schema: Checkout,
@@ -55,6 +69,63 @@ const States = Machine.defineStates({
   },
   support: Support
 })
+
+const NestedStates = Machine.defineStates({
+  App: {
+    schema: App,
+    initial: "Workspace",
+    states: {
+      Workspace: {
+        schema: Workspace,
+        type: "parallel",
+        states: {
+          Editor: {
+            schema: Editor,
+            initial: "Editing",
+            states: {
+              Editing
+            }
+          },
+          Sidebar,
+          resume: {
+            type: "history",
+            history: "deep"
+          }
+        }
+      },
+      Settings
+    }
+  },
+  Closed
+})
+
+const completeNestedFallback = (
+  target: Machine.Machine.HistoryDefaultTargetBuilder<typeof NestedStates.states, "App.Workspace">
+) =>
+  target.App(
+    new App({ session: "fallback" }),
+    (app) => {
+      expect(app).type.not.toHaveProperty("Settings")
+      return app.Workspace(
+        new Workspace({}),
+        (workspace) =>
+          workspace
+            .Editor(new Editor({}), (editor) => editor.Editing(new Editing({})))
+            .Sidebar(new Sidebar({}))
+      )
+    }
+  )
+
+const constructedNestedFallback = (
+  target: Machine.Machine.HistoryDefaultTargetBuilder<typeof NestedStates.states, "App.Workspace">,
+  session: string
+) =>
+  target.App.from({ session }, (app) =>
+    app.Workspace.from((workspace) =>
+      workspace
+        .Editor.from((editor) => editor.Editing.from())
+        .Sidebar.from()
+    ))
 
 describe("Machine history states", () => {
   it("separates active and history identifiers", () => {
@@ -135,7 +206,9 @@ describe("Machine history states", () => {
           recent: {
             default: ({ parent, target }) => {
               expect(parent).type.toBe<"checkout">()
-              expect(target).type.toBe<Machine.Machine.FullTargetBuilder<typeof States.states>>()
+              expect(target).type.toBe<
+                Machine.Machine.HistoryDefaultTargetBuilder<typeof States.states, "checkout">
+              >()
               return States.initial.checkout(
                 new Checkout({ orderId: "fallback" }),
                 (checkout) => checkout.shipping(new Shipping({ address: "" }))
@@ -203,6 +276,166 @@ describe("Machine history states", () => {
         }
       }
     })
+  })
+
+  it("accepts only complete root configurations containing a nested history owner", () => {
+    expect<Machine.Machine.CompleteSnapshotContaining<typeof NestedStates.states, "App.Workspace">>().type.toBe<
+      ReturnType<typeof completeNestedFallback>
+    >()
+
+    const machine = Machine.make({
+      states: NestedStates.states,
+      events: [Resume],
+      initial: () => NestedStates.initial.Closed(new Closed({}))
+    })
+
+    const complete = machine.handle({
+      App: {
+        states: {
+          Workspace: {
+            history: {
+              resume: {
+                default: ({ parent, target }) => {
+                  expect(parent).type.toBe<"App.Workspace">()
+                  expect(target).type.toBe<
+                    Machine.Machine.HistoryDefaultTargetBuilder<typeof NestedStates.states, "App.Workspace">
+                  >()
+                  expect(target).type.not.toHaveProperty("Closed")
+                  return completeNestedFallback(target)
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+    expect(Machine.planInitial).type.toBeCallableWith(complete)
+
+    expect(machine.handle).type.not.toBeCallableWith({
+      App: {
+        states: {
+          Workspace: {
+            history: {
+              resume: {
+                default: () => ({
+                  path: "Closed" as const,
+                  value: new Closed({})
+                })
+              }
+            }
+          }
+        }
+      }
+    })
+
+    expect(machine.handle).type.not.toBeCallableWith({
+      App: {
+        states: {
+          Workspace: {
+            history: {
+              resume: {
+                default: () => ({
+                  path: "App" as const,
+                  value: new App({ session: "sibling" }),
+                  state: {
+                    path: "App.Settings" as const,
+                    value: new Settings({})
+                  }
+                })
+              }
+            }
+          }
+        }
+      }
+    })
+
+    expect(machine.handle).type.not.toBeCallableWith({
+      App: {
+        states: {
+          Workspace: {
+            history: {
+              resume: {
+                default: () => ({
+                  path: "App.Workspace" as const,
+                  value: new Workspace({}),
+                  states: {
+                    Editor: {
+                      path: "App.Workspace.Editor" as const,
+                      value: new Editor({}),
+                      state: {
+                        path: "App.Workspace.Editor.Editing" as const,
+                        value: new Editing({})
+                      }
+                    },
+                    Sidebar: {
+                      path: "App.Workspace.Sidebar" as const,
+                      value: new Sidebar({})
+                    }
+                  }
+                })
+              }
+            }
+          }
+        }
+      }
+    })
+
+    expect(machine.handle).type.not.toBeCallableWith({
+      App: {
+        states: {
+          Workspace: {
+            history: {
+              resume: {
+                default: () => ({
+                  path: "App" as const,
+                  value: new App({ session: "missing-region" }),
+                  state: {
+                    path: "App.Workspace" as const,
+                    value: new Workspace({}),
+                    states: {
+                      Sidebar: {
+                        path: "App.Workspace.Sidebar" as const,
+                        value: new Sidebar({})
+                      }
+                    }
+                  }
+                })
+              }
+            }
+          }
+        }
+      }
+    })
+  })
+
+  it("preserves exact error and service inference for effectful nested defaults", () => {
+    const machine = Machine.make({
+      states: NestedStates.states,
+      events: [Resume],
+      initial: () => NestedStates.initial.Closed(new Closed({}))
+    }).handle({
+      App: {
+        states: {
+          Workspace: {
+            history: {
+              resume: {
+                default: ({ target }) =>
+                  Effect.gen(function*() {
+                    const requirement = yield* FallbackRequirement
+                    if (requirement.workspaceId === "") {
+                      return yield* Effect.fail("fallback-failed" as const)
+                    }
+                    return constructedNestedFallback(target, requirement.workspaceId)
+                  })
+              }
+            }
+          }
+        }
+      }
+    })
+
+    expect<Machine.Machine.Error<typeof machine>>().type.toBe<"fallback-failed">()
+    expect<Machine.Machine.Services<typeof machine>>().type.toBe<FallbackRequirement>()
   })
 
   it("tracks defaults and shallow initializers across successive handle calls", () => {


### PR DESCRIPTION
## Summary

- require every history default to build a complete, schema-valid root configuration whose selected branch contains the declared history owner
- resolve first-use nested fallbacks through inactive compound and parallel ancestors while retaining already-active unaffected parallel regions
- preserve recorded shallow/deep restoration and history target/resolved-target trace identity
- extend compiler, runtime, generated reference-model, documentation, and platformer example coverage

The root cause was that the public fallback contract only allowed a direct-owner snapshot and the planner required that exact path. A globally targetable nested history state therefore had no way to supply inactive ancestor values on first use. The new owner-constrained builder/result types make unsafe partial defaults unrepresentable, while runtime validation produces a deterministic diagnostic for forged values.

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

Added `.changeset/calm-histories-resume.md` as a patch correctness fix.

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed

Additional validation:

- `pnpm --dir examples/platformer check`
- `pnpm perf:types`
- 337 runtime tests and 586 TSTyche assertions pass
