### PR TITLE
Add logical runtime resumption

### DIFF
--- a/.changeset/fresh-machines-resume.md
+++ b/.changeset/fresh-machines-resume.md
@@ -1,0 +1,9 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Add first-class logical snapshot resumption with `Machine.resume`, plus lazy
+`AtomMachine.resume` and bound-runtime integration. Resumed machines validate
+decoded snapshots, preserve logical history and completion metadata, and create
+fresh managed invokes, children, scopes, and timers without replaying historical
+statechart work.

--- a/README.md
+++ b/README.md
@@ -597,8 +597,38 @@ contain the machine definition, machine version, services, subscriptions, or
 running child processes. Store machine identity and migration/version metadata
 alongside it.
 
+Resume a decoded logical snapshot explicitly:
+
+```ts
+const encoded = yield * Machine.encodeSnapshot(machine, snapshot)
+const decoded = yield * Machine.decodeSnapshot(machine, encoded)
+const ref = yield * Machine.resume(machine, decoded)
+```
+
+`resume` does not call `initial`, require machine input, or replay entry,
+transition, completion, eventless, raised-event, or emitted-event work that
+produced the snapshot. The decoded snapshot is the first published logical
+state. A final snapshot immediately yields a completed ref with its output.
+
+Resumption creates a fresh runtime. Invokes owned by active states start once in
+normal ancestor/document order and receive `Machine.InitialEvent` as their
+lifecycle event. `invokeEffect` runs again, invoked machines start from their
+own initial state, and `Machine.after` timers restart from their full declared
+duration. Spawned children, queued events, subscriptions, fibers, scopes,
+elapsed timer time, child snapshots, and prior `RuntimeSnapshot` status/errors
+are not restored. Completion and history metadata remain logical state and are
+not replayed. A changed machine definition does not cause `resume` itself to
+evaluate newly enabled `always` or `onDone` transitions.
+
+Reactive applications use `AtomMachine.resume(machine, decoded)` for a
+service-free machine or `AtomMachine.bind(runtime).resume(machine, decoded)`
+for a service-backed machine. These bridges have the same lazy one-runtime-per-
+registry ownership and disposal behavior as `AtomMachine.make`.
+
 `ClusterMachine` provides a separate persisted entity adapter. Its process-local
-restrictions and delivery guarantees are documented on that API.
+restrictions, checkpoint planning, and delivery guarantees are documented on
+that API. `Machine.resume` is logical resumption, not durable process or cluster
+restoration.
 
 ## Current limits
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -92,7 +92,8 @@ Choose one helper from the intent, and reach for the lower-level form only when
 its extra control is required:
 
 - Bind a shared Atom runtime once with `AtomMachine.bind(runtime)`, then use the
-  returned `make`. Use `AtomMachine.make(machine)` for a service-free machine.
+  returned `make` or `resume`. Use `AtomMachine.make(machine)` and
+  `AtomMachine.resume(machine, snapshot)` for service-free machines.
 - Use `Machine.invokeEffect` for a typed one-shot Effect and `Machine.after` for
   a timer. Use `Machine.invoke` with `Machine.effect` only for custom child
   process behavior or snapshot mapping.
@@ -668,15 +669,51 @@ Use `Machine.encodeSnapshot` and `Machine.decodeSnapshot` for validated logical
 statechart data. Persist machine identity and an application migration/version
 next to the encoded snapshot.
 
+The canonical resumption boundary is explicit:
+
+```ts
+const encoded = yield* Machine.encodeSnapshot(machine, snapshot)
+const decoded = yield* Machine.decodeSnapshot(machine, encoded)
+const ref = yield* Machine.resume(machine, decoded)
+```
+
+Pass only a decoded `Machine.Snapshot` to `resume`; encoded or arbitrary
+transport data belongs at `decodeSnapshot`. Resumption validates and normalizes
+the logical snapshot again, then publishes it as the fresh runtime's first
+state. It does not call the initial function, require machine input, or include
+initial-only failures and services in its Effect type.
+
 Encoding does not preserve:
 
 - running invokes or spawned children;
-- subscriptions, timers, or services;
+- subscriptions, queued events, fibers, scopes, timers, or services;
 - the machine definition;
 - application migration metadata.
 
-Do not treat decoding as resuming the previous process. It reconstructs logical
-state only.
+`resume` reconstructs runtime ownership from logical state only:
+
+- no historical entry, transition, completion, eventless, raise, or emit work
+  is replayed;
+- completion and history records survive but do not retrigger `onDone`;
+- active-state invokes start once in ordinary ancestor/document order with
+  `Machine.InitialEvent`;
+- `invokeEffect` restarts, `invokeMachine` creates a fresh child from its normal
+  initial state, and `Machine.after` restarts its complete duration;
+- inactive invokes, spawned children, child snapshots, elapsed timer time, and
+  prior `RuntimeSnapshot` status/errors are not restored;
+- a final logical snapshot creates an immediately completed ref;
+- `resume` itself does not evaluate `always` or `onDone`, including transitions
+  newly enabled by a changed machine definition. Later events use ordinary
+  planning semantics.
+
+Use `AtomMachine.resume(machine, decoded)` or
+`AtomMachine.bind(runtime).resume(machine, decoded)` for the same contract in a
+lazy atom bridge. Registry disposal stops the fresh invokes and timers exactly
+as it does for `AtomMachine.make`.
+
+This is not durable runtime restoration. `ClusterMachine` has a separate
+checkpoint/planning contract and process-local restrictions; do not substitute
+`Machine.resume` for cluster recovery.
 
 ## Common compiler errors
 

--- a/src/AtomMachine.ts
+++ b/src/AtomMachine.ts
@@ -58,6 +58,12 @@ type MachineRequirements<InitialR, R, Events, Emits> = ExcludeCompatibleMachineR
   Emits
 >
 
+type MachineResumeRequirements<R, Events, Emits> = ExcludeCompatibleMachineRuntime<
+  Machine.ExecutionServices<R>,
+  Events,
+  Emits
+>
+
 type MachineRuntimeError<E, R> =
   | E
   | Machine.ActionError<R>
@@ -74,6 +80,17 @@ type MachineStartError<InitialE, E, InitialR, R, RuntimeError = never> =
   | Machine.StartupError
   | Machine.StoppedError
   | RuntimeError
+
+const runMachineAtomEffect = <State, Event, Error, Output, StartError, Requirements>(
+  get: Atom.AtomContext,
+  start: Effect.Effect<Machine.MachineRef<State, Event, Error, Output>, StartError, Requirements>
+): Effect.Effect<never, StartError, Requirements> =>
+  Effect.scoped(
+    Effect.acquireRelease(start, (ref) => ref.stop).pipe(
+      Effect.tap((ref) => Effect.sync(() => get.setSelf(AsyncResult.success(ref)))),
+      Effect.flatMap(() => Effect.never)
+    )
+  )
 
 const startMachineAtomEffect = <
   const States extends Machine.Machine.StateSchemas,
@@ -118,16 +135,13 @@ const startMachineAtomEffect = <
   >,
   MachineStartError<InitialE, E, InitialR, R>,
   MachineRequirements<InitialR, R, Machine.Machine.EventOf<Events>, Machine.Machine.EmitOf<Emits>>
-> =>
-  Effect.scoped(
-    Effect.acquireRelease(
-      Machine.start(machine, ...args),
-      (ref) => ref.stop
-    ).pipe(
-      Effect.tap((ref) => Effect.sync(() => get.setSelf(AsyncResult.success(ref)))),
-      Effect.flatMap(() => Effect.never)
-    )
-  )
+> => runMachineAtomEffect(get, Machine.start(machine, ...args))
+
+const resumeMachineAtomEffect = (
+  get: Atom.AtomContext,
+  machine: Machine.Machine.Any,
+  snapshot: Machine.Machine.Snapshot<any>
+) => runMachineAtomEffect(get, Machine.resume(machine as any, snapshot as any))
 
 /**
  * Atoms backed by one running machine instance in an `AtomRegistry`.
@@ -781,11 +795,36 @@ type EnsureBoundRequirements<Services, M extends Machine.Machine.Any> = IsAny<Ma
     readonly [BoundRequirementsTypeId]: MissingBoundRequirements<Services, M>
   }
 
+type MachineResumeRequirementsOf<M extends Machine.Machine.Any> = MachineResumeRequirements<
+  Machine.Machine.Services<M>,
+  Machine.Machine.Event<M>,
+  Machine.Machine.Emit<M>
+>
+
+type MissingBoundResumeRequirements<Services, M extends Machine.Machine.Any> = Exclude<
+  ExternalRequirements<MachineResumeRequirementsOf<M>>,
+  Services
+>
+
+type EnsureBoundResumeRequirements<Services, M extends Machine.Machine.Any> =
+  IsAny<MachineResumeRequirementsOf<M>> extends true ? {
+      readonly [BoundRequirementsTypeId]: MachineResumeRequirementsOf<M>
+    }
+    : [MissingBoundResumeRequirements<Services, M>] extends [never] ? unknown
+    : {
+      readonly [BoundRequirementsTypeId]: MissingBoundResumeRequirements<Services, M>
+    }
+
 type EnsureMachineOutputImplementations<M extends Machine.Machine.Any> = IsAny<Machine.Machine.States<M>> extends true ?
   {
     readonly "~effect/reactivity/AtomMachine/ConcreteMachineRequired": M
   }
   : Machine.Machine.EnsureOutputImplementations<Machine.Machine.States<M>, Machine.Machine.OutputStates<M>>
+
+type EnsureMachineHistoryImplementations<M extends Machine.Machine.Any> = Machine.Machine.EnsureHistoryImplementations<
+  Machine.Machine.States<M>,
+  Machine.Machine.UnhandledStates<M>
+>
 
 type MachineInputArgsOf<M extends Machine.Machine.Any> = [
   ...Machine.Machine.InputArgs<Machine.Machine.Input<M>>
@@ -803,6 +842,14 @@ type MachineAtomOf<M extends Machine.Machine.Any, RuntimeError> = MachineAtom<
     Machine.Machine.Services<M>,
     RuntimeError
   >
+>
+
+type ResumedMachineAtomOf<M extends Machine.Machine.Any, RuntimeError> = MachineAtom<
+  Machine.Machine.Snapshot<Machine.Machine.States<M>>,
+  Machine.Machine.InputEvent<M>,
+  MachineRuntimeError<Machine.Machine.Error<M>, Machine.Machine.Services<M>>,
+  Machine.Machine.Output<M>,
+  Machine.MachineSchemaDecodeError | RuntimeError
 >
 
 /**
@@ -827,6 +874,16 @@ export interface Bound<Services, RuntimeError = never> {
       & EnsureMachineOutputImplementations<NoInfer<M>>,
     ...args: MachineInputArgsOf<M>
   ) => MachineAtomOf<M, RuntimeError>
+
+  /** Creates a lazy bridge from a decoded logical snapshot. */
+  readonly resume: <M extends Machine.Machine.Any>(
+    machine:
+      & M
+      & EnsureBoundResumeRequirements<Services, NoInfer<M>>
+      & EnsureMachineOutputImplementations<NoInfer<M>>
+      & EnsureMachineHistoryImplementations<NoInfer<M>>,
+    snapshot: Machine.Machine.Snapshot<Machine.Machine.States<M>>
+  ) => ResumedMachineAtomOf<M, RuntimeError>
 }
 
 /**
@@ -892,12 +949,45 @@ export const make: {
   return makeFromRefAtom(ref as any)
 }) as any
 
+/**
+ * Creates a lazy atom bridge from a decoded logical snapshot.
+ *
+ * The bridge owns one freshly resumed runtime per `AtomRegistry`, with the same
+ * lazy start and disposal semantics as {@link make}. The machine initial
+ * function and its input, errors, and services are not involved.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const resume: {
+  <M extends Machine.Machine.Any>(
+    machine:
+      & M
+      & EnsureNoExternalRequirements<MachineResumeRequirementsOf<NoInfer<M>>>
+      & EnsureMachineOutputImplementations<NoInfer<M>>
+      & EnsureMachineHistoryImplementations<NoInfer<M>>,
+    snapshot: Machine.Machine.Snapshot<Machine.Machine.States<M>>
+  ): ResumedMachineAtomOf<M, never>
+} = ((machine: Machine.Machine.Any, snapshot: Machine.Machine.Snapshot<any>) => {
+  const ref = Atom.make((get) => resumeMachineAtomEffect(get, machine, snapshot))
+  return makeFromRefAtom(ref as any)
+}) as any
+
 const makeWithRuntime = (
   runtime: Atom.AtomRuntime<any, any>,
   machine: Machine.Machine.Any,
   args: ReadonlyArray<unknown>
 ): MachineAtom<any, any, any, any, any> => {
   const ref = runtime.atom((get) => startMachineAtomEffect(get, machine as any, args as []))
+  return makeFromRefAtom(ref as any)
+}
+
+const resumeWithRuntime = (
+  runtime: Atom.AtomRuntime<any, any>,
+  machine: Machine.Machine.Any,
+  snapshot: Machine.Machine.Snapshot<any>
+): MachineAtom<any, any, any, any, any> => {
+  const ref = runtime.atom((get) => resumeMachineAtomEffect(get, machine, snapshot))
   return makeFromRefAtom(ref as any)
 }
 
@@ -919,5 +1009,8 @@ export const bind = <Services, RuntimeError>(
       makeWithRuntime(runtime, machine, args)) as Bound<
         Services,
         RuntimeError
-      >["make"]
+      >["make"],
+  resume:
+    ((machine: Machine.Machine.Any, snapshot: Machine.Machine.Snapshot<any>) =>
+      resumeWithRuntime(runtime, machine, snapshot)) as Bound<Services, RuntimeError>["resume"]
 })

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -7394,3 +7394,85 @@ export const start: <
     Machine.EmitOf<Emits>
   >
 > = internalProcess.start as any
+
+/**
+ * Starts a fresh managed runtime from a decoded logical snapshot.
+ *
+ * **Details**
+ *
+ * `resume` validates and normalizes the supplied snapshot before publishing it
+ * as the first state. It does not call the machine's initial function, replay
+ * entry or transition actions, re-deliver raised or emitted events, or
+ * re-evaluate historical completion and eventless transitions. Active-state
+ * invokes start once in ancestor and document order with {@link InitialEvent};
+ * delayed invokes restart their complete duration and invoked machines start
+ * from their own initial state.
+ *
+ * Only logical state, completion, and history metadata are resumed. Queues,
+ * scopes, subscriptions, fibers, spawned children, invoke progress, and prior
+ * runtime status are process-local and are not restored. A final snapshot
+ * immediately produces a completed ref with its current-machine output.
+ *
+ * Decode encoded data explicitly with {@link decodeSnapshot} before calling
+ * this function. Stable snapshots are hosted as supplied; newly enabled
+ * eventless or completion transitions in a changed machine definition are not
+ * evaluated merely because the runtime was resumed; only ordinary subsequent
+ * transition planning can enter and stabilize states.
+ *
+ * @see {@link decodeSnapshot} for the schema and transport boundary.
+ * @see {@link start} for ordinary initial startup.
+ * @category constructors
+ * @since 4.0.0
+ */
+export const resume: <
+  const States extends Machine.StateSchemas,
+  const Events extends ReadonlyArray<Machine.TaggedSchema>,
+  const Emits extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+  const Input extends Schema.Top = typeof Schema.Void,
+  UnhandledStates extends Machine.StateIdentifier<States> = Machine.StateIdentifier<States>,
+  E = never,
+  R = never,
+  InitialE = never,
+  InitialR = never,
+  FinalStates extends Machine.StateIdentifier<States> = never,
+  Output = never,
+  OutputStates extends Machine.StateIdentifier<States> = never,
+  InputEvents extends ReadonlyArray<Machine.TaggedSchema> = Events
+>(
+  machine:
+    & Machine<
+      States,
+      Events,
+      Input,
+      UnhandledStates,
+      E,
+      R,
+      InitialE,
+      InitialR,
+      FinalStates,
+      Output,
+      Emits,
+      OutputStates,
+      InputEvents
+    >
+    & Machine.EnsureOutputImplementations<States, OutputStates>
+    & Machine.EnsureHistoryImplementations<States, UnhandledStates>,
+  snapshot: Machine.Snapshot<States>
+) => Effect.Effect<
+  MachineRef<
+    Machine.Snapshot<States>,
+    Machine.EventOf<InputEvents>,
+    | E
+    | ActionError<R>
+    | InfiniteTransitionError
+    | MachineSchemaDecodeError
+    | StoppedError,
+    Output
+  >,
+  MachineSchemaDecodeError,
+  ExcludeCompatibleRuntime<
+    ExecutionServices<R>,
+    Machine.EventOf<Events>,
+    Machine.EmitOf<Emits>
+  >
+> = internalProcess.resume as any

--- a/src/internal/machineModel.ts
+++ b/src/internal/machineModel.ts
@@ -1604,6 +1604,46 @@ const getCompletionSchema = (
   return node.output ?? Schema.Void
 }
 
+/** Defensively validates and normalizes an in-memory logical snapshot. Unlike
+ * the transport decoder this consumes decoded schema values. */
+export const normalizeSnapshotEffect = <const States extends Machine.StateSchemas>(
+  machine: Machine.Any,
+  snapshot: Machine.Snapshot<States>
+): Effect.Effect<Machine.Snapshot<States>, MachineSchemaDecodeError> =>
+  Effect.gen(function*() {
+    const configuration = yield* normalizeConfigurationEffect(machine, snapshot)
+    const outputs = new Map<string, unknown>()
+    const completionPaths = new Set<string>()
+    const completions = snapshot.completed ?? []
+    if (!Array.isArray(completions)) {
+      throw new Error("Machine snapshot completion metadata must be an array")
+    }
+    for (const completion of completions) {
+      if (
+        typeof completion !== "object" || completion === null ||
+        typeof (completion as { readonly path?: unknown }).path !== "string"
+      ) {
+        throw new Error("Machine snapshot contains malformed completion metadata")
+      }
+      const path = completion.path
+      if (completionPaths.has(path)) {
+        throw new Error(`Machine snapshot contains duplicate completion "${path}"`)
+      }
+      if (!configuration.active.has(path) || !isActiveFinalNode(machine, configuration, path)) {
+        throw new Error(`Machine snapshot contains invalid completion "${path}"`)
+      }
+      completionPaths.add(path)
+      outputs.set(
+        path,
+        yield* decodeBoundary(machine, getCompletionSchema(machine, configuration, path), completion.output, {
+          boundary: "output",
+          state: path
+        })
+      )
+    }
+    return snapshotFromConfiguration<States>(machine, { ...configuration, outputs })
+  }).pipe(Effect.catchCause((cause) => failDecodeCause(machine, cause)))
+
 const validateEncodedConfiguration = (
   machine: Machine.Any,
   configuration: ActiveConfiguration

--- a/src/internal/machineProcess.ts
+++ b/src/internal/machineProcess.ts
@@ -38,6 +38,16 @@ interface InvokeSession {
   readonly path: string
 }
 
+type ProcessEntry<States extends Machine.StateSchemas, Input extends Schema.Top> =
+  | {
+    readonly _tag: "Initial"
+    readonly args: [...Machine.InputArgs<Input>]
+  }
+  | {
+    readonly _tag: "Resume"
+    readonly snapshot: Machine.Snapshot<States>
+  }
+
 const getInvokes = (
   config: Machine.AnyStateConfig | undefined,
   context: Machine.InvokeContext<any, any, any, any>
@@ -50,7 +60,7 @@ const getInvokes = (
   return Array.isArray(invokes) ? invokes as ReadonlyArray<AnyInvokeConfig> : [invokes as AnyInvokeConfig]
 }
 
-export const toProcessLogic: <
+const makeProcessLogic: <
   const States extends Machine.StateSchemas,
   const Events extends ReadonlyArray<Machine.TaggedSchema>,
   const Emits extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
@@ -64,7 +74,7 @@ export const toProcessLogic: <
   Output = never
 >(
   machine: Machine<States, Events, Input, UnhandledStates, E, R, InitialE, InitialR, FinalStates, Output, Emits>,
-  ...args: [...Machine.InputArgs<Input>]
+  entry: ProcessEntry<States, Input>
 ) => internalRuntime.ProcessLogic<
   Machine.Snapshot<States>,
   Machine.EventOf<Events>,
@@ -96,13 +106,16 @@ export const toProcessLogic: <
   Output = never
 >(
   machine: Machine<States, Events, Input, UnhandledStates, E, R, InitialE, InitialR, FinalStates, Output, Emits>,
-  ...args: [...Machine.InputArgs<Input>]
+  entry: ProcessEntry<States, Input>
 ) =>
   ({
     initial: (scope) =>
       internalRuntime.provideMachineRuntime(
         Effect.gen(function*() {
-          const planned = yield* internalPlanner.planInitial(machine, ...args)
+          if (entry._tag === "Resume") {
+            return yield* Model.normalizeSnapshotEffect(machine, entry.snapshot)
+          }
+          const planned = yield* internalPlanner.planInitial(machine, ...entry.args)
           const runtime = internalPlanner.makeLiveRuntime<Machine.EventOf<Events>, Machine.EmitOf<Emits>>(
             machine,
             scope
@@ -413,6 +426,46 @@ export const toProcessLogic: <
     | StoppedError
   >
 
+export const toProcessLogic: <
+  const States extends Machine.StateSchemas,
+  const Events extends ReadonlyArray<Machine.TaggedSchema>,
+  const Emits extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+  const Input extends Schema.Top = typeof Schema.Void,
+  UnhandledStates extends Machine.StateIdentifier<States> = Machine.StateIdentifier<States>,
+  E = never,
+  R = never,
+  InitialE = never,
+  InitialR = never,
+  FinalStates extends Machine.StateIdentifier<States> = never,
+  Output = never
+>(
+  machine: Machine<States, Events, Input, UnhandledStates, E, R, InitialE, InitialR, FinalStates, Output, Emits>,
+  ...args: [...Machine.InputArgs<Input>]
+) => internalRuntime.ProcessLogic<
+  Machine.Snapshot<States>,
+  Machine.EventOf<Events>,
+  E | ActionError<R> | InfiniteTransitionError | MachineSchemaDecodeError | StoppedError,
+  ExcludeCompatibleRuntime<
+    Exclude<ExecutionServices<InitialR | R>, internalRuntime.MachineRuntime>,
+    Machine.EventOf<Events>,
+    Machine.EmitOf<Emits>
+  >,
+  Output,
+  | InitialE
+  | E
+  | ActionError<InitialR | R>
+  | InfiniteTransitionError
+  | MachineSchemaDecodeError
+  | StartupError
+  | StoppedError
+> = (machine, ...args) => makeProcessLogic(machine, { _tag: "Initial", args })
+
+const toResumedProcessLogic = (
+  machine: Machine.Any,
+  snapshot: Machine.Snapshot<any>
+): internalRuntime.ProcessLogic<any, any, any, any, any, any> =>
+  (makeProcessLogic as any)(machine, { _tag: "Resume", snapshot })
+
 export const start: <
   const States extends Machine.StateSchemas,
   const Events extends ReadonlyArray<Machine.TaggedSchema>,
@@ -454,5 +507,39 @@ export const start: <
 > = (machine, ...args) =>
   internalRuntime.startProcess(
     toProcessLogic(machine, ...args),
+    machine.id === undefined ? undefined : { id: machine.id }
+  ) as any
+
+export const resume: <
+  const States extends Machine.StateSchemas,
+  const Events extends ReadonlyArray<Machine.TaggedSchema>,
+  const Emits extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+  const Input extends Schema.Top = typeof Schema.Void,
+  UnhandledStates extends Machine.StateIdentifier<States> = Machine.StateIdentifier<States>,
+  E = never,
+  R = never,
+  InitialE = never,
+  InitialR = never,
+  FinalStates extends Machine.StateIdentifier<States> = never,
+  Output = never
+>(
+  machine: Machine<States, Events, Input, UnhandledStates, E, R, InitialE, InitialR, FinalStates, Output, Emits>,
+  snapshot: Machine.Snapshot<States>
+) => Effect.Effect<
+  internalRuntime.MachineRef<
+    Machine.Snapshot<States>,
+    Machine.EventOf<Events>,
+    E | ActionError<R> | InfiniteTransitionError | MachineSchemaDecodeError | StoppedError,
+    Output
+  >,
+  MachineSchemaDecodeError,
+  ExcludeCompatibleRuntime<
+    Exclude<ExecutionServices<R>, internalRuntime.MachineRuntime>,
+    Machine.EventOf<Events>,
+    Machine.EmitOf<Emits>
+  >
+> = (machine, snapshot) =>
+  internalRuntime.startProcess(
+    toResumedProcessLogic(machine, snapshot),
     machine.id === undefined ? undefined : { id: machine.id }
   ) as any

--- a/test/AtomMachine.test.ts
+++ b/test/AtomMachine.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Context, Data, Deferred, Effect, Fiber, Layer, Option, Schema, Stream } from "effect"
+import { Cause, Context, Data, Deferred, Effect, Fiber, Layer, Option, Ref, Schema, Stream } from "effect"
 import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity"
 import { Machine } from "../src/index.js"
 import { AtomMachine } from "../src/reactivity.js"
@@ -127,6 +127,64 @@ const makeDelayedCounterMachine = (release: Deferred.Deferred<void>) =>
   })
 
 describe("AtomMachine", () => {
+  it.effect("resumes lazily once per registry and disposes the resumed runtime", () =>
+    Effect.gen(function*() {
+      const initialCalls = yield* Ref.make(0)
+      const invokeStarts = yield* Ref.make(0)
+      const invokeStopped = yield* Deferred.make<void>()
+      const machine = Machine.make({
+        states: CounterStates.states,
+        events: [Finish],
+        initial: () =>
+          Ref.update(initialCalls, (n) => n + 1).pipe(
+            Effect.as(CounterStates.initial.Count(new Count({ value: 0 })))
+          )
+      }).handle({
+        Count: {
+          invoke: Machine.invoke({
+            id: "active",
+            src: () =>
+              Machine.logic({
+                initial: () => Ref.update(invokeStarts, (n) => n + 1).pipe(Effect.as(undefined)),
+                run: () => Effect.never.pipe(Effect.onInterrupt(() => Deferred.succeed(invokeStopped, void 0)))
+              })
+          }),
+          on: {
+            Finish: ({ event, state, target }) => target.full.Count(new Count({ value: state.value + event.by }))
+          }
+        },
+        Done: {}
+      })
+      const bridge = AtomMachine.resume(machine, CounterStates.initial.Count(new Count({ value: 5 })))
+      const firstRegistry = AtomRegistry.make()
+      const secondRegistry = AtomRegistry.make()
+
+      const first = yield* AtomRegistry.getResult(firstRegistry, bridge.ref)
+      const firstAgain = yield* AtomRegistry.getResult(firstRegistry, bridge.ref)
+      const second = yield* AtomRegistry.getResult(secondRegistry, bridge.ref)
+      assert.strictEqual(first.sessionId, firstAgain.sessionId)
+      assert.strictEqual(first, firstAgain)
+      assert.notStrictEqual(first, second)
+      assert.deepStrictEqual(yield* AtomRegistry.getResult(firstRegistry, bridge.state), {
+        path: "Count",
+        value: new Count({ value: 5 })
+      })
+      assert.strictEqual(yield* Ref.get(initialCalls), 0)
+      assert.strictEqual(yield* Ref.get(invokeStarts), 2)
+
+      const stopped = yield* first.changes.pipe(
+        Stream.filter((snapshot) => snapshot.status === "stopped"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild
+      )
+      firstRegistry.dispose()
+      yield* Deferred.await(invokeStopped)
+      yield* Fiber.join(stopped)
+      assert.strictEqual((yield* first.snapshot).status, "stopped")
+      secondRegistry.dispose()
+    }))
+
   it.effect("reactively exposes an invoked child machine", () =>
     Effect.scoped(Effect.gen(function*() {
       const registry = yield* makeRegistry

--- a/test/MachineHistory.test.ts
+++ b/test/MachineHistory.test.ts
@@ -431,7 +431,11 @@ const nestedHistoryMachine = Machine.make({
               DefaultEditor: ({ target }) => target.history.workspace.editor.exact()
             }
           },
-          writing: {}
+          writing: {
+            on: {
+              DefaultEditor: ({ target }) => target.history.workspace.editor.exact()
+            }
+          }
         }
       }
     }
@@ -579,6 +583,22 @@ describe("Machine history states", () => {
       assert.strictEqual(valueError.state, "checkout.payment.verifying")
     }))
 
+  it.effect("preserves recorded history across encode, decode, and runtime resume", () =>
+    Effect.gen(function*() {
+      const original = checkoutPaymentVerifying("order-1", 2, "challenge-7")
+      const machine = makeCheckoutMachine(original)
+      const left = yield* Machine.plan(machine, original, new Leave({}))
+      const expected = yield* Machine.plan(machine, left.next, new ResumeDeep({}))
+      const encoded = yield* Machine.encodeSnapshot(machine, left.next)
+      const decoded = yield* Machine.decodeSnapshot(machine, JSON.parse(JSON.stringify(encoded)))
+      const ref = yield* Machine.resume(machine, decoded)
+
+      assert.deepStrictEqual((yield* ref.state).history, left.next.history)
+      yield* sendAndWaitForPath(ref, new ResumeDeep({}), "checkout")
+      assert.deepStrictEqual(yield* ref.state, expected.next)
+      yield* ref.stop
+    }))
+
   it.effect("captures the current subtree before resolving a reentering transition to its own history", () =>
     Effect.gen(function*() {
       let defaults = 0
@@ -687,6 +707,38 @@ describe("Machine history states", () => {
       assert.strictEqual(restored.microsteps[0]?.transitions[0]?.target, "workspace.editor.exact")
       assert.strictEqual(restored.microsteps[0]?.transitions[0]?.resolvedTarget, "workspace.editor")
       assert.strictEqual(restored.next.history, undefined)
+    }))
+
+  it.effect("resumes nested first-use and recorded history snapshots after codec round-trips", () =>
+    Effect.gen(function*() {
+      const encodedFirstUse = yield* Machine.encodeSnapshot(nestedHistoryMachine, nestedParallelSnapshot)
+      const decodedFirstUse = yield* Machine.decodeSnapshot(
+        nestedHistoryMachine,
+        JSON.parse(JSON.stringify(encodedFirstUse))
+      )
+      const firstUseRef = yield* Machine.resume(nestedHistoryMachine, decodedFirstUse)
+      yield* sendAndWaitForPath(firstUseRef, new DefaultEditor({}), "workspace.editor.writing")
+      const firstUseState = yield* firstUseRef.state
+      assert.deepStrictEqual((firstUseState as any).states.editor.value, new Editor({ documentId: "fallback" }))
+      assert.deepStrictEqual((firstUseState as any).states.sidebar, nestedParallelSnapshot.states.sidebar)
+      yield* firstUseRef.stop
+
+      const recorded = yield* Machine.plan(nestedHistoryMachine, nestedParallelSnapshot, new RestoreEditor({}))
+      const current = {
+        ...(yield* Machine.plan(nestedHistoryMachine, nestedParallelSnapshot, new DefaultEditor({}))).next,
+        history: recorded.next.history
+      } as Machine.Machine.Snapshot<typeof NestedHistoryStates.states>
+      const encodedRecorded = yield* Machine.encodeSnapshot(nestedHistoryMachine, current)
+      const decodedRecorded = yield* Machine.decodeSnapshot(
+        nestedHistoryMachine,
+        JSON.parse(JSON.stringify(encodedRecorded))
+      )
+      const recordedRef = yield* Machine.resume(nestedHistoryMachine, decodedRecorded)
+      yield* sendAndWaitForPath(recordedRef, new DefaultEditor({}), "workspace.editor.preview")
+      const restored = yield* recordedRef.state
+      assert.deepStrictEqual((restored as any).states.editor, nestedParallelSnapshot.states.editor)
+      assert.deepStrictEqual((restored as any).states.sidebar, nestedParallelSnapshot.states.sidebar)
+      yield* recordedRef.stop
     }))
 
   it.effect("rejects a forged fallback that omits its declared owner with a precise diagnostic", () =>

--- a/test/MachineResume.test.ts
+++ b/test/MachineResume.test.ts
@@ -1,0 +1,571 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Cause, Deferred, Effect, Fiber, Option, Ref, Schema, Stream } from "effect"
+import { TestClock } from "effect/testing"
+import { Machine } from "../src/index.js"
+
+const waitFor = <State, Event, Error, Output>(
+  ref: Machine.MachineRef<State, Event, Error, Output>,
+  predicate: (snapshot: Machine.RuntimeSnapshot<State, Error, Output>) => boolean
+) =>
+  ref.changes.pipe(
+    Stream.filter(predicate),
+    Stream.take(1),
+    Stream.runCollect,
+    Effect.map((values) => Array.from(values)[0]!)
+  )
+
+const sendAndWait = <State, Event, Error, Output>(
+  ref: Machine.MachineRef<State, Event, Error, Output>,
+  event: Event,
+  predicate: (snapshot: Machine.RuntimeSnapshot<State, Error, Output>) => boolean
+) =>
+  Effect.gen(function*() {
+    const fiber = yield* waitFor(ref, predicate).pipe(Effect.forkChild)
+    yield* ref.send(event)
+    return yield* Fiber.join(fiber)
+  })
+
+class Count extends Schema.TaggedClass<Count>("Count")("Count", { value: Schema.Number }) {}
+class Done extends Schema.TaggedClass<Done>("Done")("Done", { value: Schema.Number }) {}
+class Add extends Schema.TaggedClass<Add>("Add")("Add", { value: Schema.Number }) {}
+class Finish extends Schema.TaggedClass<Finish>("Finish")("Finish", {}) {}
+class Ping extends Schema.TaggedClass<Ping>("Ping")("Ping", {}) {}
+class Cancel extends Schema.TaggedClass<Cancel>("Cancel")("Cancel", {}) {}
+class Timeout extends Schema.TaggedClass<Timeout>("Timeout")("Timeout", {}) {}
+
+describe("Machine.resume", () => {
+  it.effect("hosts an atomic snapshot without initial or historical entry work", () =>
+    Effect.gen(function*() {
+      const initialCalls = yield* Ref.make(0)
+      const entries = yield* Ref.make(0)
+      const actions = yield* Ref.make(0)
+      const states = Machine.defineStates({ Count })
+      const machine = Machine.make({
+        states: states.states,
+        events: [Add],
+        initial: () =>
+          Ref.update(initialCalls, (n) => n + 1).pipe(
+            Effect.as(states.initial.Count(new Count({ value: 0 })))
+          )
+      }).handle({
+        Count: {
+          entry: () => Machine.action(Ref.update(entries, (n) => n + 1)),
+          on: {
+            Add: ({ event, state, target }) =>
+              Machine.action(
+                Ref.update(actions, (n) => n + 1),
+                target.full.Count(new Count({ value: state.value + event.value }))
+              )
+          }
+        }
+      })
+
+      const ref = yield* Machine.resume(machine, states.initial.Count(new Count({ value: 4 })))
+      assert.deepStrictEqual(yield* ref.state, states.initial.Count(new Count({ value: 4 })))
+      assert.strictEqual(yield* Ref.get(initialCalls), 0)
+      assert.strictEqual(yield* Ref.get(entries), 0)
+      assert.strictEqual(yield* Ref.get(actions), 0)
+
+      yield* sendAndWait(
+        ref,
+        new Add({ value: 3 }),
+        (snapshot) => snapshot.state.value.value === 7
+      )
+      assert.strictEqual(yield* Ref.get(entries), 0)
+      assert.strictEqual(yield* Ref.get(actions), 1)
+      yield* ref.stop
+      assert.instanceOf(yield* Effect.flip(ref.send(new Add({ value: 1 }))), Machine.StoppedError)
+    }))
+
+  it.effect("starts only active compound and parallel invokes in deterministic order", () =>
+    Effect.gen(function*() {
+      class Root extends Schema.TaggedClass<Root>("Root")("Root", {}) {}
+      class Left extends Schema.TaggedClass<Left>("Left")("Left", {}) {}
+      class LeftOn extends Schema.TaggedClass<LeftOn>("LeftOn")("LeftOn", {}) {}
+      class Right extends Schema.TaggedClass<Right>("Right")("Right", {}) {}
+      class RightOn extends Schema.TaggedClass<RightOn>("RightOn")("RightOn", {}) {}
+      class Inactive extends Schema.TaggedClass<Inactive>("Inactive")("Inactive", {}) {}
+      const starts = yield* Ref.make<ReadonlyArray<string>>([])
+      const lifecycleEvents: Array<boolean> = []
+      const invoked = (label: string) =>
+        Machine.invoke({
+          id: label,
+          src: () =>
+            Machine.logic({
+              initial: () => Ref.update(starts, (labels) => [...labels, label]).pipe(Effect.as(label)),
+              run: () => Effect.never
+            })
+        })
+      const restoredInvoke = (label: string) => (context: { readonly event: unknown }) => {
+        lifecycleEvents.push(Machine.isInitialEvent(context.event))
+        return invoked(label)
+      }
+      const states = Machine.defineStates({
+        Root: {
+          schema: Root,
+          type: "parallel",
+          states: {
+            left: {
+              schema: Left,
+              initial: "On",
+              states: { On: LeftOn, Off: Inactive }
+            },
+            right: {
+              schema: Right,
+              initial: "On",
+              states: { On: RightOn, Off: Inactive }
+            }
+          }
+        },
+        Inactive
+      })
+      const machine = Machine.make({
+        states: states.states,
+        events: [],
+        initial: () => states.initial.Inactive(new Inactive({}))
+      }).handle({
+        Root: {
+          invoke: restoredInvoke("root"),
+          states: {
+            left: {
+              invoke: restoredInvoke("left"),
+              states: { On: { invoke: restoredInvoke("left-leaf") } }
+            },
+            right: {
+              invoke: restoredInvoke("right"),
+              states: { On: { invoke: restoredInvoke("right-leaf") } }
+            }
+          }
+        },
+        Inactive: { invoke: restoredInvoke("inactive") }
+      })
+      const snapshot = states.initial.Root(new Root({}), (root) =>
+        root
+          .left(new Left({}), (left) => left.On(new LeftOn({})))
+          .right(new Right({}), (right) => right.On(new RightOn({}))))
+
+      const ref = yield* Machine.resume(machine, snapshot)
+      yield* Effect.forEach(Array.from({ length: 20 }), () => Effect.yieldNow, { discard: true })
+      assert.deepStrictEqual(yield* ref.state, snapshot)
+      assert.deepStrictEqual(yield* Ref.get(starts), ["root", "left", "right", "left-leaf", "right-leaf"])
+      assert.deepStrictEqual(lifecycleEvents, [true, true, true, true, true])
+      yield* ref.stop
+    }))
+
+  it.effect("preserves simultaneous parallel transition selection after resume", () =>
+    Effect.gen(function*() {
+      class Root extends Schema.TaggedClass<Root>("Root")("Root", {}) {}
+      class Left extends Schema.TaggedClass<Left>("Left")("Left", {}) {}
+      class LeftA extends Schema.TaggedClass<LeftA>("LeftA")("LeftA", {}) {}
+      class LeftB extends Schema.TaggedClass<LeftB>("LeftB")("LeftB", {}) {}
+      class Right extends Schema.TaggedClass<Right>("Right")("Right", {}) {}
+      class RightA extends Schema.TaggedClass<RightA>("RightA")("RightA", {}) {}
+      class RightB extends Schema.TaggedClass<RightB>("RightB")("RightB", {}) {}
+      class Advance extends Schema.TaggedClass<Advance>("Advance")("Advance", {}) {}
+      const states = Machine.defineStates({
+        Root: {
+          schema: Root,
+          type: "parallel",
+          states: {
+            left: { schema: Left, initial: "A", states: { A: LeftA, B: LeftB } },
+            right: { schema: Right, initial: "A", states: { A: RightA, B: RightB } }
+          }
+        }
+      })
+      const initial = states.initial.Root(new Root({}), (root) =>
+        root
+          .left(new Left({}), (left) => left.A(new LeftA({})))
+          .right(new Right({}), (right) => right.A(new RightA({}))))
+      const machine = Machine.make({ states: states.states, events: [Advance], initial: () => initial }).handle({
+        Root: {
+          states: {
+            left: {
+              states: { A: { on: { Advance: ({ target }) => target.local.B(new LeftB({})) } } }
+            },
+            right: {
+              states: { A: { on: { Advance: ({ target }) => target.local.B(new RightB({})) } } }
+            }
+          }
+        }
+      })
+      const ref = yield* Machine.resume(machine, initial)
+      yield* sendAndWait(
+        ref,
+        new Advance({}),
+        (snapshot) =>
+          snapshot.state.path === "Root" &&
+          snapshot.state.states.left.state.path === "Root.left.B" &&
+          snapshot.state.states.right.state.path === "Root.right.B"
+      )
+      assert.deepStrictEqual(yield* ref.state, {
+        path: "Root",
+        value: new Root({}),
+        states: {
+          left: {
+            path: "Root.left",
+            value: new Left({}),
+            state: { path: "Root.left.B", value: new LeftB({}) }
+          },
+          right: {
+            path: "Root.right",
+            value: new Right({}),
+            state: { path: "Root.right.B", value: new RightB({}) }
+          }
+        }
+      })
+      yield* ref.stop
+    }))
+
+  it.effect("resumes terminal snapshots as completed refs with current output", () =>
+    Effect.gen(function*() {
+      const states = Machine.defineStates({
+        Count,
+        Done: { schema: Done, type: "final", output: Schema.Number }
+      })
+      const machine = Machine.make({
+        states: states.states,
+        events: [Finish],
+        initial: () => states.initial.Count(new Count({ value: 0 }))
+      }).handle({
+        Count: { on: { Finish: ({ target }) => target.full.Done(new Done({ value: 9 })) } },
+        Done: { output: ({ state }) => state.value }
+      })
+      const logical = states.initial.Done(new Done({ value: 9 }))
+      const decoded = yield* Machine.decodeSnapshot(machine, yield* Machine.encodeSnapshot(machine, logical))
+      const ref = yield* Machine.resume(machine, decoded)
+
+      assert.strictEqual(yield* ref.join, 9)
+      assert.deepStrictEqual(yield* ref.snapshot, { status: "done", state: decoded, output: 9 })
+      assert.instanceOf(yield* Effect.flip(ref.send(new Finish({}))), Machine.StoppedError)
+    }))
+
+  it.effect("preserves completion metadata without retriggering historical onDone", () =>
+    Effect.gen(function*() {
+      class Flow extends Schema.TaggedClass<Flow>("Flow")("Flow", {}) {}
+      class Finished extends Schema.TaggedClass<Finished>("Finished")("Finished", {}) {}
+      class Next extends Schema.TaggedClass<Next>("Next")("Next", {}) {}
+      const states = Machine.defineStates({
+        Flow: {
+          schema: Flow,
+          initial: "Finished",
+          states: { Finished: { schema: Finished, type: "final" } }
+        },
+        Next
+      })
+      const logical: Machine.Machine.Snapshot<typeof states.states> = {
+        path: "Flow",
+        value: new Flow({}),
+        state: { path: "Flow.Finished", value: new Finished({}) },
+        completed: [
+          { path: "Flow.Finished", output: undefined },
+          { path: "Flow", output: undefined }
+        ]
+      }
+      const machine = Machine.make({ states: states.states, events: [Ping], initial: () => logical }).handle({
+        Flow: { onDone: ({ target }) => target.full.Next(new Next({})) },
+        Next: {}
+      })
+      const decoded = yield* Machine.decodeSnapshot(machine, yield* Machine.encodeSnapshot(machine, logical))
+      const ref = yield* Machine.resume(machine, decoded)
+
+      assert.deepStrictEqual(yield* ref.state, decoded)
+      yield* ref.send(new Ping({}))
+      yield* Effect.yieldNow
+      assert.deepStrictEqual(yield* ref.state, decoded)
+      yield* ref.stop
+    }))
+
+  it.effect("does not replay always transitions, including under a changed definition", () =>
+    Effect.gen(function*() {
+      class A extends Schema.TaggedClass<A>("A")("A", {}) {}
+      class B extends Schema.TaggedClass<B>("B")("B", {}) {}
+      const states = Machine.defineStates({ A, B })
+      const machine = Machine.make({
+        states: states.states,
+        events: [Ping],
+        initial: () => states.initial.A(new A({}))
+      }).handle({
+        A: { always: ({ target }) => target.full.B(new B({})) },
+        B: {}
+      })
+
+      const ref = yield* Machine.resume(machine, states.initial.A(new A({})))
+      assert.strictEqual((yield* ref.state).path, "A")
+      yield* ref.send(new Ping({}))
+      yield* Effect.yieldNow
+      assert.strictEqual((yield* ref.state).path, "A")
+      yield* ref.stop
+    }))
+
+  it.effect("restarts after timers at their full duration and cancels them on exit", () =>
+    Effect.gen(function*() {
+      class Waiting extends Schema.TaggedClass<Waiting>("Waiting")("Waiting", {}) {}
+      class Cancelled extends Schema.TaggedClass<Cancelled>("Cancelled")("Cancelled", {}) {}
+      class TimedOut extends Schema.TaggedClass<TimedOut>("TimedOut")("TimedOut", {}) {}
+      const states = Machine.defineStates({ Waiting, Cancelled, TimedOut })
+      const machine = Machine.make({
+        states: states.states,
+        events: [Cancel],
+        internalEvents: [Timeout],
+        initial: () => states.initial.Cancelled(new Cancelled({}))
+      }).handle({
+        Waiting: {
+          invoke: Machine.after("1 second", new Timeout({})),
+          on: {
+            Cancel: ({ target }) => target.full.Cancelled(new Cancelled({})),
+            Timeout: ({ target }) => target.full.TimedOut(new TimedOut({}))
+          }
+        },
+        Cancelled: {},
+        TimedOut: {}
+      })
+
+      const first = yield* Machine.resume(machine, states.initial.Waiting(new Waiting({})))
+      yield* TestClock.adjust("999 millis")
+      assert.strictEqual((yield* first.state).path, "Waiting")
+      yield* TestClock.adjust("1 millis")
+      yield* waitFor(first, (snapshot) => snapshot.state.path === "TimedOut")
+      yield* first.stop
+
+      const second = yield* Machine.resume(machine, states.initial.Waiting(new Waiting({})))
+      yield* sendAndWait(second, new Cancel({}), (snapshot) => snapshot.state.path === "Cancelled")
+      yield* TestClock.adjust("1 second")
+      assert.strictEqual((yield* second.state).path, "Cancelled")
+      yield* second.stop
+    }))
+
+  it.effect("restarts invokeEffect once and maps its result through the normal runtime", () =>
+    Effect.gen(function*() {
+      class Loading extends Schema.TaggedClass<Loading>("Loading")("Loading", {}) {}
+      class Loaded extends Schema.TaggedClass<Loaded>("Loaded")("Loaded", { value: Schema.String }) {}
+      class LoadedEvent extends Schema.TaggedClass<LoadedEvent>("LoadedEvent")("LoadedEvent", {
+        value: Schema.String
+      }) {}
+      const runs = yield* Ref.make(0)
+      const states = Machine.defineStates({ Loading, Loaded })
+      const machine = Machine.make({
+        states: states.states,
+        events: [],
+        internalEvents: [LoadedEvent],
+        initial: () => states.initial.Loaded(new Loaded({ value: "initial" }))
+      }).handle({
+        Loading: {
+          invoke: Machine.invokeEffect({
+            id: "load",
+            effect: Ref.updateAndGet(runs, (n) => n + 1).pipe(Effect.as("fresh")),
+            onSuccess: (value) => new LoadedEvent({ value })
+          }),
+          on: { LoadedEvent: ({ event, target }) => target.full.Loaded(new Loaded({ value: event.value })) }
+        },
+        Loaded: {}
+      })
+
+      const ref = yield* Machine.resume(machine, states.initial.Loading(new Loading({})))
+      yield* waitFor(ref, (snapshot) => snapshot.state.path === "Loaded")
+      assert.strictEqual(yield* Ref.get(runs), 1)
+      assert.deepStrictEqual(yield* ref.state, states.initial.Loaded(new Loaded({ value: "fresh" })))
+      yield* ref.stop
+    }))
+
+  it.effect("maps a restarted invokeEffect typed failure once", () =>
+    Effect.gen(function*() {
+      class Loading extends Schema.TaggedClass<Loading>("Loading")("Loading", {}) {}
+      class Failed extends Schema.TaggedClass<Failed>("Failed")("Failed", { message: Schema.String }) {}
+      class FailedEvent extends Schema.TaggedClass<FailedEvent>("FailedEvent")("FailedEvent", {
+        message: Schema.String
+      }) {}
+      class LoadFailure extends Schema.TaggedErrorClass<LoadFailure>("LoadFailure")("LoadFailure", {
+        message: Schema.String
+      }) {}
+      const runs = yield* Ref.make(0)
+      const states = Machine.defineStates({ Loading, Failed })
+      const machine = Machine.make({
+        states: states.states,
+        events: [],
+        internalEvents: [FailedEvent],
+        initial: () => states.initial.Failed(new Failed({ message: "initial" }))
+      }).handle({
+        Loading: {
+          invoke: Machine.invokeEffect({
+            id: "load",
+            effect: Ref.update(runs, (n) => n + 1).pipe(
+              Effect.andThen(Effect.fail(new LoadFailure({ message: "offline" })))
+            ),
+            onSuccess: (_value: never) => undefined,
+            onFailure: (error) => new FailedEvent({ message: error.message })
+          }),
+          on: { FailedEvent: ({ event, target }) => target.full.Failed(new Failed({ message: event.message })) }
+        },
+        Failed: {}
+      })
+
+      const ref = yield* Machine.resume(machine, states.initial.Loading(new Loading({})))
+      yield* waitFor(ref, (snapshot) => snapshot.state.path === "Failed")
+      assert.strictEqual(yield* Ref.get(runs), 1)
+      assert.deepStrictEqual(yield* ref.state, states.initial.Failed(new Failed({ message: "offline" })))
+      yield* ref.stop
+    }))
+
+  it.effect("starts an active invoked machine fresh and preserves child APIs", () =>
+    Effect.gen(function*() {
+      class Parent extends Schema.TaggedClass<Parent>("Parent")("Parent", {}) {}
+      class ChildIdle extends Schema.TaggedClass<ChildIdle>("ChildIdle")("ChildIdle", { value: Schema.Number }) {}
+      class ChildDone extends Schema.TaggedClass<ChildDone>("ChildDone")("ChildDone", { value: Schema.Number }) {}
+      class ChildFinish extends Schema.TaggedClass<ChildFinish>("ChildFinish")("ChildFinish", {}) {}
+      class ChildOutput extends Schema.TaggedClass<ChildOutput>("ChildOutput")("ChildOutput", {
+        value: Schema.Number
+      }) {}
+      const childStates = Machine.defineStates({
+        ChildIdle,
+        ChildDone: { schema: ChildDone, type: "final", output: Schema.Number }
+      })
+      const child = Machine.make({
+        states: childStates.states,
+        events: [ChildFinish],
+        initial: () => childStates.initial.ChildIdle(new ChildIdle({ value: 1 }))
+      }).handle({
+        ChildIdle: {
+          on: { ChildFinish: ({ state, target }) => target.full.ChildDone(new ChildDone({ value: state.value + 1 })) }
+        },
+        ChildDone: { output: ({ state }) => state.value }
+      })
+      const Child = Machine.child("child", child)
+      const states = Machine.defineStates({ Parent, ChildOutput })
+      const machine = Machine.make({
+        states: states.states,
+        events: [ChildOutput],
+        initial: () => states.initial.ChildOutput(new ChildOutput({ value: 0 }))
+      }).handle({
+        Parent: {
+          invoke: Machine.invokeMachine({
+            child: Child,
+            onDone: ({ output }) => new ChildOutput({ value: output })
+          }),
+          on: { ChildOutput: ({ event, target }) => target.full.ChildOutput(event) }
+        },
+        ChildOutput: {}
+      })
+
+      const ref = yield* Machine.resume(machine, states.initial.Parent(new Parent({})))
+      const active = yield* ref.childChanges(Child).pipe(
+        Stream.filter(Option.isSome),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.map((values) => values[0].value)
+      )
+      assert.deepStrictEqual(yield* active.state, childStates.initial.ChildIdle(new ChildIdle({ value: 1 })))
+      yield* active.send(new ChildFinish({}))
+      yield* waitFor(ref, (snapshot) => snapshot.state.path === "ChildOutput")
+      assert.deepStrictEqual(yield* ref.state, states.initial.ChildOutput(new ChildOutput({ value: 2 })))
+      assert(Option.isNone(yield* ref.child(Child)))
+      yield* ref.stop
+    }))
+
+  it.effect("rejects forged logical snapshots through typed boundary errors", () =>
+    Effect.gen(function*() {
+      class Root extends Schema.TaggedClass<Root>("Root")("Root", {}) {}
+      class Region extends Schema.TaggedClass<Region>("Region")("Region", {}) {}
+      class Leaf extends Schema.TaggedClass<Leaf>("Leaf")("Leaf", { value: Schema.Number }) {}
+      const states = Machine.defineStates({
+        Root: {
+          schema: Root,
+          type: "parallel",
+          states: {
+            left: { schema: Region, initial: "Leaf", states: { Leaf } },
+            right: { schema: Region, initial: "Leaf", states: { Leaf } }
+          }
+        }
+      })
+      const valid = states.initial.Root(new Root({}), (root) =>
+        root
+          .left(new Region({}), (left) => left.Leaf(new Leaf({ value: 1 })))
+          .right(new Region({}), (right) => right.Leaf(new Leaf({ value: 2 }))))
+      const machine = Machine.make({ states: states.states, events: [], initial: () => valid })
+      const forged: ReadonlyArray<unknown> = [
+        { path: "Missing", value: {} },
+        { path: "Root", value: new Root({}), states: { left: valid.states.left } },
+        {
+          ...valid,
+          states: {
+            ...valid.states,
+            left: { path: "Root.left", value: new Region({}) }
+          }
+        },
+        {
+          ...valid,
+          states: {
+            ...valid.states,
+            left: { ...valid.states.left, state: { ...valid.states.left.state, value: { _tag: "Leaf", value: "x" } } }
+          }
+        },
+        { ...valid, completed: [{ path: "Root.left.Leaf", output: undefined }] },
+        { ...valid, completed: {} },
+        { ...valid, history: { missing: { mode: "deep", active: [], values: {} } } }
+      ]
+
+      for (const snapshot of forged) {
+        const exit = yield* Effect.exit(Machine.resume(machine, snapshot as typeof valid))
+        assert(exit._tag === "Failure")
+        const error = Cause.findErrorOption(exit.cause)
+        assert(Option.isSome(error))
+        assert.instanceOf(error.value, Machine.MachineSchemaDecodeError)
+      }
+    }))
+
+  it.effect("obeys bounded encode/decode continuation equivalence", () =>
+    Effect.gen(function*() {
+      const states = Machine.defineStates({ Count })
+      const machine = Machine.make({
+        states: states.states,
+        events: [Add],
+        initial: () => states.initial.Count(new Count({ value: 0 }))
+      }).handle({
+        Count: {
+          on: {
+            Add: ({ event, state, target }) => target.full.Count(new Count({ value: state.value + event.value }))
+          }
+        }
+      })
+      const suffixes = [
+        [],
+        [1],
+        [-1, 2],
+        [3, 0, -2]
+      ] as const
+
+      for (const suffix of suffixes) {
+        const uninterrupted = yield* Machine.start(machine)
+        yield* sendAndWait(uninterrupted, new Add({ value: 5 }), (snapshot) => snapshot.state.value.value === 5)
+        const boundary = yield* uninterrupted.state
+
+        for (let index = 0; index < suffix.length; index++) {
+          const expected = 5 + suffix.slice(0, index + 1).reduce<number>((sum, value) => sum + value, 0)
+          yield* sendAndWait(
+            uninterrupted,
+            new Add({ value: suffix[index] }),
+            (snapshot) => snapshot.state.value.value === expected
+          )
+        }
+        const expected = yield* uninterrupted.state
+
+        const encoded = yield* Machine.encodeSnapshot(machine, boundary)
+        const decoded = yield* Machine.decodeSnapshot(machine, JSON.parse(JSON.stringify(encoded)))
+        const resumed = yield* Machine.resume(machine, decoded)
+        for (let index = 0; index < suffix.length; index++) {
+          const next = 5 + suffix.slice(0, index + 1).reduce<number>((sum, value) => sum + value, 0)
+          yield* sendAndWait(
+            resumed,
+            new Add({ value: suffix[index] }),
+            (snapshot) => snapshot.state.value.value === next
+          )
+        }
+        assert.deepStrictEqual(yield* resumed.state, expected)
+        assert.deepStrictEqual(
+          yield* Machine.encodeSnapshot(machine, yield* resumed.state),
+          yield* Machine.encodeSnapshot(machine, expected)
+        )
+        yield* uninterrupted.stop
+        yield* resumed.stop
+      }
+    }))
+})

--- a/typetest/MachineResume.tst.ts
+++ b/typetest/MachineResume.tst.ts
@@ -1,0 +1,108 @@
+import { Context, Effect, Layer, Schema } from "effect"
+import { AsyncResult, Atom } from "effect/unstable/reactivity"
+import { describe, expect, it } from "tstyche"
+import { Machine } from "../src/index.js"
+import { AtomMachine } from "../src/reactivity.js"
+
+class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", { value: Schema.Number }) {}
+class Tick extends Schema.TaggedClass<Tick>("Tick")("Tick", {}) {}
+class InitialService extends Context.Service<InitialService, string>()("test/resume/InitialService") {}
+class RuntimeService extends Context.Service<RuntimeService, string>()("test/resume/RuntimeService") {}
+class InitialFailure {
+  readonly _tag = "InitialFailure"
+}
+class RuntimeFailure {
+  readonly _tag = "RuntimeFailure"
+}
+class LayerFailure {
+  readonly _tag = "LayerFailure"
+}
+
+const States = Machine.defineStates({ Idle })
+type Snapshot = Machine.Machine.Snapshot<typeof States.states>
+
+const machine = Machine.make({
+  states: States.states,
+  events: [Tick],
+  input: Schema.Struct({ seed: Schema.Number }),
+  initial: (_input) =>
+    Effect.succeed(States.initial.Idle(new Idle({ value: 0 }))) as Effect.Effect<
+      Snapshot,
+      InitialFailure,
+      InitialService
+    >
+}).handle({
+  Idle: {
+    on: {
+      Tick: ({ state, target }) =>
+        Effect.succeed(target.full.Idle(new Idle({ value: state.value + 1 }))) as Effect.Effect<
+          Snapshot,
+          RuntimeFailure,
+          RuntimeService
+        >
+    }
+  }
+})
+
+const snapshot = States.initial.Idle(new Idle({ value: 3 }))
+
+describe("Machine logical resumption", () => {
+  it("excludes input and initial-only channels while preserving runtime inference", () => {
+    const resumed = Machine.resume(machine, snapshot)
+    type Ref = Effect.Success<typeof resumed>
+
+    expect<Effect.Error<typeof resumed>>().type.toBe<Machine.MachineSchemaDecodeError>()
+    expect<Effect.Services<typeof resumed>>().type.toBe<RuntimeService>()
+    expect<Effect.Error<Ref["join"]>>().type.toBe<
+      | RuntimeFailure
+      | Machine.InfiniteTransitionError
+      | Machine.MachineSchemaDecodeError
+      | Machine.StoppedError
+    >()
+    expect<Effect.Success<Ref["state"]>>().type.toBe<Snapshot>()
+    expect(Machine.resume).type.not.toBeCallableWith(machine, snapshot, { seed: 1 })
+    expect(Machine.resume).type.not.toBeCallableWith(machine, {
+      _tag: "MachineSnapshot",
+      active: [{ path: "Idle", value: { _tag: "Idle", value: 3 } }]
+    })
+  })
+
+  it("mirrors inference through direct and bound atom bridges", () => {
+    const runtime = Atom.runtime(Layer.succeed(RuntimeService, "runtime"))
+    const failingRuntime = Atom.runtime(
+      Layer.merge(
+        Layer.succeed(RuntimeService, "runtime"),
+        Layer.effectDiscard(Effect.fail(new LayerFailure()))
+      )
+    )
+    const bound = AtomMachine.bind(runtime)
+    const bridge = bound.resume(machine, snapshot)
+    const failing = AtomMachine.bind(failingRuntime).resume(machine, snapshot)
+    type RefFailure = Atom.Failure<typeof bridge.ref>
+    type ResultFailure = Atom.Failure<typeof bridge.result>
+
+    expect(AtomMachine.resume).type.not.toBeCallableWith(machine, snapshot)
+    expect(bound.resume).type.toBeCallableWith(machine, snapshot)
+    expect<RefFailure>().type.toBe<Machine.MachineSchemaDecodeError>()
+    expect<Extract<ResultFailure, RuntimeFailure>>().type.toBe<RuntimeFailure>()
+    expect<Extract<Atom.Failure<typeof failing.ref>, LayerFailure>>().type.toBe<LayerFailure>()
+    expect<Atom.Success<typeof bridge.state>>().type.toBe<Snapshot>()
+    expect<typeof bridge.ref>().type.toBe<
+      Atom.Atom<
+        AsyncResult.AsyncResult<
+          Machine.MachineRef<
+            Snapshot,
+            Tick,
+            | RuntimeFailure
+            | Machine.ActionError<RuntimeService>
+            | Machine.InfiniteTransitionError
+            | Machine.MachineSchemaDecodeError
+            | Machine.StoppedError,
+            never
+          >,
+          Machine.MachineSchemaDecodeError
+        >
+      >
+    >()
+  })
+})


### PR DESCRIPTION
## Summary

- Add `Machine.resume(machine, snapshot)` as the canonical typed boundary for starting a fresh managed runtime from a decoded logical snapshot.
- Defensively validate and normalize restored configurations, completion outputs, and history metadata without calling `initial` or replaying historical actions, emissions, completion, or eventless work.
- Restart active-state invokes with `Machine.InitialEvent`, full-duration timers, and fresh invoked child machines while preserving ordinary runtime commit and lifecycle behavior.
- Add `AtomMachine.resume` and `AtomMachine.bind(runtime).resume` with the same lazy per-registry ownership and disposal semantics as `make`.
- Add deterministic runtime/compiler/property coverage and nested-history integration after rebasing onto #26; document the logical resumption and non-durable-runtime contract.

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] `pnpm perf:types`
- [x] Relevant example checks not required because no example package changed
- [x] Reviewed the automated type-performance report

Local `pnpm check` passed 352 runtime tests, 140 compiler tests / 599 assertions, strict consumer validation, and package verification. The local type-performance run completed successfully with no import-only instantiation increase.
