### PR TITLE
Harden machine operation totality

### DIFF
--- a/.changeset/wise-machines-harden.md
+++ b/.changeset/wise-machines-harden.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Harden planning, snapshot round trips, and logical runtime resumption for valid typed machines. Initial choices no longer retain abandoned roots, history fallbacks resolve nested choices before snapshot normalization, and the independent finite-model oracle follows nested choice initializers.

--- a/src/internal/machinePlanner.ts
+++ b/src/internal/machinePlanner.ts
@@ -463,7 +463,8 @@ const resolveHistoryTarget = Effect.fnUntraced(function*(
       }),
       actions: completed.actions,
       raisedEvents: completed.raisedEvents,
-      emittedEvents: completed.emittedEvents
+      emittedEvents: completed.emittedEvents,
+      transitions: []
     }
   }
 
@@ -481,7 +482,37 @@ const resolveHistoryTarget = Effect.fnUntraced(function*(
   if (collected.state === undefined || isHistoryTarget(collected.state) || !isSnapshot(collected.state)) {
     throw new Error(`Machine history default for "${target.path}" must return a complete snapshot containing its owner`)
   }
-  const fallbackConfiguration = yield* normalizeConfigurationEffect(machine, collected.state as any)
+  const fallbackChoice = choiceFromTarget(collected.state)
+  const choiceResolution = fallbackChoice === undefined
+    ? undefined
+    : yield* resolveChoiceTarget(
+      machine,
+      {
+        active: new Set(),
+        values: new Map(),
+        outputs: new Map(),
+        history: configuration.history
+      },
+      collected.state,
+      event
+    )
+  let fallbackConfiguration = choiceResolution === undefined
+    ? yield* normalizeConfigurationEffect(machine, collected.state as any)
+    : yield* normalizeTargetConfigurationEffect(machine, {
+      active: new Set(),
+      values: new Map(),
+      outputs: new Map(),
+      history: configuration.history
+    }, choiceResolution.target as any)
+  for (const additionalTarget of choiceResolution?.additionalTargets ?? []) {
+    fallbackConfiguration = yield* normalizeTargetConfigurationEffect(
+      machine,
+      fallbackConfiguration,
+      additionalTarget as
+        | Machine.Snapshot<any>
+        | Machine.Target<any, string>
+    )
+  }
   if (!fallbackConfiguration.active.has(target.parent)) {
     throw new Error(
       `Machine history default for "${target.path}" returned a configuration that does not contain owner state "${target.parent}"`
@@ -494,9 +525,10 @@ const resolveHistoryTarget = Effect.fnUntraced(function*(
       snapshot: snapshot as any,
       values: values as any
     }),
-    actions: collected.actions,
-    raisedEvents: collected.raisedEvents,
-    emittedEvents: collected.emittedEvents
+    actions: [...collected.actions, ...(choiceResolution?.actions ?? [])],
+    raisedEvents: [...collected.raisedEvents, ...(choiceResolution?.raisedEvents ?? [])],
+    emittedEvents: [...collected.emittedEvents, ...(choiceResolution?.emittedEvents ?? [])],
+    transitions: choiceResolution?.transitions ?? []
   }
 })
 
@@ -1090,6 +1122,14 @@ const withChoiceValues = (target: unknown, values: Readonly<Record<string, unkno
   })
 }
 
+interface ResolvedChoiceTransition {
+  readonly source: string
+  readonly trigger: Machine.TransitionTrigger
+  readonly reenter: false
+  readonly target: string
+  readonly resolvedTarget: string
+}
+
 const resolveChoiceTarget = Effect.fnUntraced(function*(
   machine: Machine.Any,
   configuration: ActiveConfiguration,
@@ -1101,13 +1141,7 @@ const resolveChoiceTarget = Effect.fnUntraced(function*(
   const actions: Array<DeferredAction> = []
   const raisedEvents: Array<unknown> = []
   const emittedEvents: Array<unknown> = []
-  const transitions: Array<{
-    readonly source: string
-    readonly trigger: Machine.TransitionTrigger
-    readonly reenter: false
-    readonly target: string
-    readonly resolvedTarget: string
-  }> = []
+  const transitions: Array<ResolvedChoiceTransition> = []
   let iterations = 0
 
   while (pending.length > 0) {
@@ -1231,6 +1265,7 @@ const collectEvaluatedTransition = Effect.fnUntraced(function*<
     readonly actions: ReadonlyArray<DeferredAction>
     readonly raisedEvents: ReadonlyArray<unknown>
     readonly emittedEvents: ReadonlyArray<unknown>
+    readonly transitions: ReadonlyArray<ResolvedChoiceTransition>
   } | undefined
   const reenteredHistoryParent = choiceResolvedTarget !== undefined && isHistoryTarget(choiceResolvedTarget) &&
     selection.transition.reenter && state.active.has(choiceResolvedTarget.parent)
@@ -1269,6 +1304,7 @@ const collectEvaluatedTransition = Effect.fnUntraced(function*<
   const additionalHistoryActions: Array<DeferredAction> = []
   const additionalHistoryRaisedEvents: Array<unknown> = []
   const additionalHistoryEmittedEvents: Array<unknown> = []
+  const additionalHistoryChoiceTransitions: Array<ResolvedChoiceTransition> = []
   const additionalChoiceTargets: Array<
     Machine.Snapshot<States> | Machine.Target<States, Machine.StateIdentifier<States>>
   > = []
@@ -1287,6 +1323,7 @@ const collectEvaluatedTransition = Effect.fnUntraced(function*<
     additionalHistoryActions.push(...resolved.actions)
     additionalHistoryRaisedEvents.push(...resolved.raisedEvents)
     additionalHistoryEmittedEvents.push(...resolved.emittedEvents)
+    additionalHistoryChoiceTransitions.push(...resolved.transitions)
   }
   const targetPath = target === undefined
     ? undefined
@@ -1331,7 +1368,11 @@ const collectEvaluatedTransition = Effect.fnUntraced(function*<
       changed,
       exitPaths: [],
       entryPaths: [],
-      choiceTransitions: choiceResolution?.transitions ?? []
+      choiceTransitions: [
+        ...(choiceResolution?.transitions ?? []),
+        ...(historyResolution?.transitions ?? []),
+        ...additionalHistoryChoiceTransitions
+      ]
     } as EvaluatedTransition<States, Event, E, R, Context>
   }
 
@@ -1380,7 +1421,11 @@ const collectEvaluatedTransition = Effect.fnUntraced(function*<
         )
       )
       : getEntryPaths(machine, stateAfterTransition, boundary),
-    choiceTransitions: choiceResolution?.transitions ?? []
+    choiceTransitions: [
+      ...(choiceResolution?.transitions ?? []),
+      ...(historyResolution?.transitions ?? []),
+      ...additionalHistoryChoiceTransitions
+    ]
   } as EvaluatedTransition<States, Event, E, R, Context>
 })
 
@@ -1553,6 +1598,7 @@ export const planInitial: <
     const initialHistoryActions: Array<DeferredAction> = []
     const initialHistoryRaisedEvents: Array<unknown> = []
     const initialHistoryEmittedEvents: Array<unknown> = []
+    const initialHistoryChoiceTransitions: Array<ResolvedChoiceTransition> = []
     const resolvedInitialTargets: Array<unknown> = []
     for (
       const target of choiceResolution === undefined
@@ -1568,6 +1614,7 @@ export const planInitial: <
       initialHistoryActions.push(...history.actions)
       initialHistoryRaisedEvents.push(...history.raisedEvents)
       initialHistoryEmittedEvents.push(...history.emittedEvents)
+      initialHistoryChoiceTransitions.push(...history.transitions)
     }
     let resolvedConfiguration = choiceResolution === undefined
       ? yield* normalizeConfigurationEffect<States>(machine, state as Machine.Snapshot<States>)
@@ -1585,19 +1632,7 @@ export const planInitial: <
         additionalTarget as Machine.Snapshot<States> | Machine.Target<States, Machine.StateIdentifier<States>>
       )
     }
-    const configuration: ActiveConfiguration = initialChoice === undefined
-      ? resolvedConfiguration
-      : {
-        ...resolvedConfiguration,
-        active: new Set([
-          ...resolvedConfiguration.active,
-          ...Object.keys(initialChoice.values).filter((path) => {
-            const node = getNode(machine, path)
-            return node.type !== "choice" && node.type !== "history"
-          })
-        ]),
-        values: new Map([...Object.entries(initialChoice.values), ...resolvedConfiguration.values])
-      }
+    const configuration: ActiveConfiguration = resolvedConfiguration
     validateInitialConfiguration(machine, configuration)
     const startingState = snapshotFromConfiguration<States>(machine, configuration)
     const initialEntryPaths = getInitialEntryPaths(machine, configuration)
@@ -1634,7 +1669,7 @@ export const planInitial: <
         choiceResolution === undefined ? [] : [{
           next: configuration,
           event: InitialEvent,
-          transitions: choiceResolution.transitions,
+          transitions: [...choiceResolution.transitions, ...initialHistoryChoiceTransitions],
           actions: [...choiceResolution.actions, ...initialHistoryActions] as ReadonlyArray<Effect.Effect<void, E, R>>,
           raisedEvents: [
             ...choiceResolution.raisedEvents,

--- a/src/internal/machineTestReferenceModel.ts
+++ b/src/internal/machineTestReferenceModel.ts
@@ -622,6 +622,20 @@ const choiceResolvedTargetPath = (index: ModelIndex, path: string): string => {
   })!
 }
 
+const choiceChainResolvedTargetPath = (index: ModelIndex, path: string): string => {
+  let current = getState(index, path)
+  const seen = new Set<string>()
+  while (current.node._tag === "Choice") {
+    if (seen.has(current.path)) return choiceResolvedTargetPath(index, current.path)
+    seen.add(current.path)
+    const selected = getState(index, current.node.selected)
+    const nestedChoice = entryChoicePath(index, selected.path)
+    if (nestedChoice === undefined) return choiceResolvedTargetPath(index, current.path)
+    current = getState(index, nestedChoice)
+  }
+  return current.path
+}
+
 const isPathInSubtree = (path: string, root: string): boolean => path === root || path.startsWith(`${root}.`)
 
 const expandSelection = (
@@ -898,7 +912,7 @@ const transitionRecord = (index: ModelIndex, transition: FiniteTransition): Refe
     ? runtimeTargetPath(index, transition)
     : entryChoicePath(index, transition.target) === undefined
     ? runtimeTargetPath(index, transition)
-    : choiceResolvedTargetPath(index, entryChoicePath(index, transition.target)!)
+    : choiceChainResolvedTargetPath(index, entryChoicePath(index, transition.target)!)
 })
 
 const choiceTransitionRecords = (index: ModelIndex, path: string): ReadonlyArray<ReferenceTransition> => {
@@ -909,9 +923,8 @@ const choiceTransitionRecords = (index: ModelIndex, path: string): ReadonlyArray
     if (seen.has(current.path)) break
     seen.add(current.path)
     const selected = getState(index, current.node.selected)
-    const selectedTarget = selected.node._tag === "Choice"
-      ? selected.path
-      : choiceResolvedTargetPath(index, current.path)
+    const nestedChoice = entryChoicePath(index, selected.path)
+    const selectedTarget = nestedChoice ?? choiceResolvedTargetPath(index, current.path)
     records.push({
       source: current.path,
       trigger: { type: "choice" },
@@ -919,7 +932,8 @@ const choiceTransitionRecords = (index: ModelIndex, path: string): ReadonlyArray
       target: selectedTarget,
       resolvedTarget: choiceResolvedTargetPath(index, current.path)
     })
-    current = getState(index, resolveChoicePath(index, selected.path))
+    if (nestedChoice === undefined) break
+    current = getState(index, nestedChoice)
   }
   return records
 }
@@ -927,8 +941,7 @@ const choiceTransitionRecords = (index: ModelIndex, path: string): ReadonlyArray
 const initialChoiceTransitionRecords = (index: ModelIndex, path: string): ReadonlyArray<ReferenceTransition> => {
   const current = getState(index, path)
   if (current.node._tag === "Choice") {
-    const records = choiceTransitionRecords(index, current.path)
-    return [...records, ...initialChoiceTransitionRecords(index, resolveChoicePath(index, current.path))]
+    return choiceTransitionRecords(index, current.path)
   }
   if (current.node._tag === "Compound") {
     return initialChoiceTransitionRecords(index, initialChildPath(current))

--- a/test/MachineChoice.test.ts
+++ b/test/MachineChoice.test.ts
@@ -66,6 +66,47 @@ describe("Machine choice pseudo-states", () => {
       ])
     }))
 
+  it.effect("does not retain an abandoned initial root after a full choice target", () =>
+    Effect.gen(function*() {
+      class Outside extends Schema.TaggedClass<Outside>("InitialChoiceOutside")("InitialChoiceOutside", {}) {}
+      const states = Machine.defineStates({
+        Flow: {
+          schema: Flow,
+          initial: "Routing",
+          states: { Routing: { type: "choice" }, Approved }
+        },
+        Outside
+      })
+      const entries: Array<string> = []
+      const routed = Machine.make({
+        states: states.states,
+        events: [],
+        initial: () => states.initial.Flow(new Flow({ score: 80 }), (flow) => flow.Routing())
+      }).handle({
+        Flow: {
+          entry: () => Machine.action(Effect.sync(() => entries.push("Flow"))),
+          states: {
+            Routing: {
+              choice: {
+                targets: ["Outside"],
+                transition: ({ target }) => target.full.Outside(new Outside({}))
+              }
+            }
+          }
+        },
+        Outside: { entry: () => Machine.action(Effect.sync(() => entries.push("Outside"))) }
+      })
+
+      const plan = yield* Machine.planInitial(routed)
+      assert.deepStrictEqual(Machine.configuration(routed, plan.startingState).map(({ path }) => path), ["Outside"])
+      assert.deepStrictEqual(plan.initialEntryPaths, ["Outside"])
+      yield* Machine.runActions(plan.actions, {
+        raise: () => Effect.void,
+        sendParent: () => Effect.void
+      })
+      assert.deepStrictEqual(entries, ["Outside"])
+    }))
+
   it.effect("targets a choice from an event and preserves that event", () =>
     Effect.gen(function*() {
       const initial = yield* Machine.planInitial(machine)
@@ -495,6 +536,61 @@ describe("Machine choice pseudo-states", () => {
 
       const plan = yield* Machine.planInitial(initialHistory)
       assert.strictEqual(plan.state.state.path, "Flow.Active")
+    }))
+
+  it.effect("resolves a nested choice inside a first-use history fallback", () =>
+    Effect.gen(function*() {
+      class Active extends Schema.TaggedClass<Active>("FallbackChoiceActive")("FallbackChoiceActive", {}) {}
+      class Outside extends Schema.TaggedClass<Outside>("FallbackChoiceOutside")("FallbackChoiceOutside", {}) {}
+      class Resume extends Schema.TaggedClass<Resume>("FallbackChoiceResume")("FallbackChoiceResume", {}) {}
+      const states = Machine.defineStates({
+        Flow: {
+          schema: Flow,
+          initial: "Active",
+          states: {
+            Active,
+            Routing: { type: "choice" },
+            Recent: { type: "history" }
+          }
+        },
+        Outside
+      })
+      const historyChoice = Machine.make({
+        states: states.states,
+        events: [Resume],
+        initial: () => states.initial.Outside(new Outside({}))
+      }).handle({
+        Flow: {
+          history: {
+            Recent: {
+              default: ({ target }) => target.Flow(new Flow({ score: 1 }), (flow) => flow.Routing())
+            }
+          },
+          states: {
+            Routing: {
+              choice: {
+                targets: ["Flow.Active"],
+                transition: ({ target }) => target.local.Active(new Active({}))
+              }
+            }
+          }
+        },
+        Outside: {
+          on: { FallbackChoiceResume: ({ target }) => target.history.Flow.Recent() }
+        }
+      })
+
+      const initial = yield* Machine.planInitial(historyChoice)
+      const resumed = yield* Machine.plan(historyChoice, initial.state, new Resume({}))
+      assert.strictEqual(resumed.next.path, "Flow")
+      if (resumed.next.path === "Flow") assert.strictEqual(resumed.next.state.path, "Flow.Active")
+      assert.deepStrictEqual(
+        resumed.microsteps[0]?.transitions.map(({ source, trigger }) => ({ source, trigger: trigger.type })),
+        [
+          { source: "Outside", trigger: "event" },
+          { source: "Flow.Routing", trigger: "choice" }
+        ]
+      )
     }))
 
   it("inspects declared choice edges without executing the resolver", () => {

--- a/test/MachineResume.test.ts
+++ b/test/MachineResume.test.ts
@@ -77,6 +77,77 @@ describe("Machine.resume", () => {
       assert.instanceOf(yield* Effect.flip(ref.send(new Add({ value: 1 }))), Machine.StoppedError)
     }))
 
+  it.effect("matches controlled suffix work without replaying pre-boundary actions or raised events", () =>
+    Effect.gen(function*() {
+      class A extends Schema.TaggedClass<A>("ResumeWorkA")("ResumeWorkA", {}) {}
+      class B extends Schema.TaggedClass<B>("ResumeWorkB")("ResumeWorkB", {}) {}
+      class C extends Schema.TaggedClass<C>("ResumeWorkC")("ResumeWorkC", {}) {}
+      class Advance extends Schema.TaggedClass<Advance>("ResumeWorkAdvance")("ResumeWorkAdvance", {}) {}
+      class Raised extends Schema.TaggedClass<Raised>("ResumeWorkRaised")("ResumeWorkRaised", {}) {}
+      const states = Machine.defineStates({ A, B, C })
+      const makeMachine = (log: Array<string>) =>
+        Machine.make({
+          states: states.states,
+          events: [Advance, Raised],
+          initial: () => states.initial.A(new A({}))
+        }).handle({
+          A: {
+            entry: () => Machine.action(Effect.sync(() => log.push("entry:A"))),
+            exit: () => Machine.action(Effect.sync(() => log.push("exit:A"))),
+            on: {
+              ResumeWorkAdvance: Effect.fn(function*({ target }) {
+                const runtime = yield* Machine.runtime<{ readonly events: Raised }>()
+                yield* runtime.raise(new Raised({}))
+                yield* Machine.action(Effect.sync(() => log.push("transition:A-B")))
+                return target.full.B(new B({}))
+              })
+            }
+          },
+          B: {
+            entry: () => Machine.action(Effect.sync(() => log.push("entry:B"))),
+            exit: () => Machine.action(Effect.sync(() => log.push("exit:B"))),
+            on: {
+              ResumeWorkRaised: ({ target }) =>
+                Machine.action(
+                  Effect.sync(() => log.push("raised:B-C")),
+                  target.full.C(new C({}))
+                )
+            }
+          },
+          C: { entry: () => Machine.action(Effect.sync(() => log.push("entry:C"))) }
+        })
+
+      const uninterruptedLog: Array<string> = []
+      const uninterruptedMachine = makeMachine(uninterruptedLog)
+      const uninterrupted = yield* Machine.start(uninterruptedMachine)
+      const boundary = yield* uninterrupted.state
+      const encodedBoundary = yield* Machine.encodeSnapshot(uninterruptedMachine, boundary)
+      uninterruptedLog.length = 0
+      yield* sendAndWait(
+        uninterrupted,
+        new Advance({}),
+        (snapshot) => snapshot.state.path === "C"
+      )
+      const uninterruptedFinal = yield* uninterrupted.state
+      yield* uninterrupted.stop
+
+      const resumedLog: Array<string> = []
+      const resumedMachine = makeMachine(resumedLog)
+      const decodedBoundary = yield* Machine.decodeSnapshot(resumedMachine, encodedBoundary)
+      const resumed = yield* Machine.resume(resumedMachine, decodedBoundary)
+      assert.deepStrictEqual(resumedLog, [])
+      yield* sendAndWait(resumed, new Advance({}), (snapshot) => snapshot.state.path === "C")
+      const resumedFinal = yield* resumed.state
+
+      assert.deepStrictEqual(resumedLog, uninterruptedLog)
+      assert.deepStrictEqual(resumedLog, ["exit:A", "transition:A-B", "entry:B", "exit:B", "raised:B-C", "entry:C"])
+      assert.deepStrictEqual(
+        yield* Machine.encodeSnapshot(resumedMachine, resumedFinal),
+        yield* Machine.encodeSnapshot(uninterruptedMachine, uninterruptedFinal)
+      )
+      yield* resumed.stop
+    }))
+
   it.effect("starts only active compound and parallel invokes in deterministic order", () =>
     Effect.gen(function*() {
       class Root extends Schema.TaggedClass<Root>("Root")("Root", {}) {}

--- a/test/MachineTestReferenceModel.test.ts
+++ b/test/MachineTestReferenceModel.test.ts
@@ -112,6 +112,62 @@ describe("MachineTest finite-model reference interpreter", () => {
       yield* MachineTest.verifyModel(model, trace)
     }))
 
+  it.effect("follows choice chains entered through a selected compound initializer", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [
+          { _tag: "Atomic", key: "idle", value: 0 },
+          {
+            _tag: "Compound",
+            key: "workflow",
+            value: 1,
+            initial: "route",
+            states: [
+              {
+                _tag: "Compound",
+                key: "running",
+                value: 2,
+                initial: "phase",
+                states: [
+                  { _tag: "Atomic", key: "ready", value: 3 },
+                  {
+                    _tag: "Choice",
+                    key: "phase",
+                    targets: ["workflow.running.ready"],
+                    selected: "workflow.running.ready"
+                  }
+                ]
+              },
+              {
+                _tag: "Choice",
+                key: "route",
+                targets: ["workflow.running"],
+                selected: "workflow.running"
+              }
+            ]
+          }
+        ],
+        initial: "idle",
+        events: ["Start"],
+        transitions: [{ source: "idle", event: "Start", target: "workflow", reenter: false }]
+      }
+      const reference = MachineTest.interpretModel(model, ["Start"])
+
+      assert.deepStrictEqual(
+        reference.steps[0]!.microsteps[0]!.transitions.map(({ source }) => source),
+        ["idle", "workflow.route", "workflow.running.phase"]
+      )
+      assert.deepStrictEqual(reference.final.activePaths, [
+        "workflow",
+        "workflow.running",
+        "workflow.running.ready"
+      ])
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Start")] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
   it.effect("lets a child transition preempt an enabled parallel ancestor", () =>
     Effect.gen(function*() {
       const model = parallelWorkflow([

--- a/test/MachineTotality.test.ts
+++ b/test/MachineTotality.test.ts
@@ -1,0 +1,307 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Cause, Effect, Exit, Fiber, Schema, Stream } from "effect"
+import { FastCheck } from "effect/testing"
+import { isDeepStrictEqual } from "node:util"
+import { Machine } from "../src/index.js"
+import { MachineTest } from "../src/testing.js"
+
+const generatedModels = MachineTest.finiteModels({
+  maxRoots: 3,
+  maxDepth: 4,
+  maxChildren: 3,
+  maxParallelRegions: 3,
+  maxEvents: 5,
+  maxTransitions: 24,
+  maxHistoryStates: 2,
+  maxChoiceStates: 2
+})
+
+const generatedCases = generatedModels.arbitrary.chain((model) =>
+  FastCheck.tuple(
+    FastCheck.array(FastCheck.constantFrom(...model.events), { minLength: 0, maxLength: 12 }),
+    FastCheck.nat({ max: 12 })
+  ).map(([events, boundary]) => ({
+    model,
+    events,
+    boundary: Math.min(boundary, events.length)
+  }))
+)
+
+const generatedResumeCases = generatedCases.map((generated) => {
+  const reference = MachineTest.interpretModel(generated.model, generated.events)
+  let lastObservable = -1
+  for (let index = 0; index < reference.steps.length; index++) {
+    if (reference.steps[index]!.microsteps.length > 0) lastObservable = index
+  }
+  const events = lastObservable < 0 ? [] : generated.events.slice(0, lastObservable + 1)
+  return {
+    ...generated,
+    events,
+    boundary: Math.min(generated.boundary, events.length)
+  }
+})
+
+const assertNoUnexpectedDefect: <A, E>(
+  operation: string,
+  exit: Exit.Exit<A, E>
+) => asserts exit is Exit.Success<A, E> = (operation, exit) => {
+  if (Exit.isFailure(exit) && Cause.hasDies(exit.cause)) {
+    assert.fail(`${operation} produced an unexpected defect:\n${Cause.pretty(exit.cause)}`)
+  }
+  if (Exit.isFailure(exit)) {
+    assert.fail(`${operation} unexpectedly failed:\n${Cause.pretty(exit.cause)}`)
+  }
+}
+
+const encodeWithoutDefect = Effect.fn(function*(machine: any, snapshot: unknown, label: string) {
+  const exit = yield* Effect.exit(Machine.encodeSnapshot(machine, snapshot as any))
+  assertNoUnexpectedDefect(label, exit)
+  return exit.value
+})
+
+const decodeWithoutDefect = Effect.fn(function*(machine: any, encoded: unknown, label: string) {
+  const exit = yield* Effect.exit(Machine.decodeSnapshot(machine, encoded))
+  assertNoUnexpectedDefect(label, exit)
+  return exit.value
+})
+
+const canonicalLogicalSnapshot = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(canonicalLogicalSnapshot)
+  if (typeof value !== "object" || value === null) return value
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [
+      key,
+      key === "completed" && Array.isArray(child)
+        ? child.slice().sort((left, right) => String(left.path).localeCompare(String(right.path))).map(
+          canonicalLogicalSnapshot
+        )
+        : canonicalLogicalSnapshot(child)
+    ])
+  )
+}
+
+const assertLogicalSnapshotEquivalent = Effect.fn(function*(
+  machine: any,
+  expected: unknown,
+  actual: unknown,
+  label: string
+) {
+  const expectedEncoded = yield* encodeWithoutDefect(machine, expected, `${label} expected encoding`)
+  const actualEncoded = yield* encodeWithoutDefect(machine, actual, `${label} actual encoding`)
+  assert.deepStrictEqual(
+    canonicalLogicalSnapshot(actual),
+    canonicalLogicalSnapshot(expected),
+    `${label} logical snapshot`
+  )
+  assert.deepStrictEqual(actualEncoded, expectedEncoded, label)
+  assert.deepStrictEqual(
+    Machine.configuration(machine, actual as any).map(({ path }) => path),
+    Machine.configuration(machine, expected as any).map(({ path }) => path),
+    `${label} configuration`
+  )
+})
+
+const reachableSnapshots = (trace: MachineTest.Trace<Machine.Machine.Any>): ReadonlyArray<unknown> => [
+  trace.initial.plan.state,
+  ...trace.steps.map(({ after }) => after)
+]
+
+const waitForSnapshot = <State, Event, Error, Output>(
+  ref: Machine.MachineRef<State, Event, Error, Output>,
+  predicate: (snapshot: Machine.RuntimeSnapshot<State, Error, Output>) => boolean
+) =>
+  ref.changes.pipe(
+    Stream.filter(predicate),
+    Stream.take(1),
+    Stream.runCollect,
+    Effect.map((snapshots) => Array.from(snapshots)[0]!)
+  )
+
+const deliverAndObserve = Effect.fn(function*(
+  machine: any,
+  ref: Machine.MachineRef<any, any, any, any>,
+  event: { readonly _tag: string },
+  planned: { readonly next: unknown; readonly microsteps: ReadonlyArray<unknown> },
+  index: number
+) {
+  if (planned.microsteps.length === 0) {
+    const sendExit = yield* Effect.exit(ref.send(event))
+    assertNoUnexpectedDefect(`post-resume send ${index}`, sendExit)
+    return planned.next
+  }
+
+  const expected = yield* encodeWithoutDefect(machine, planned.next, `post-resume expected ${index}`)
+  const observed = yield* waitForSnapshot(
+    ref,
+    (snapshot) => snapshot.status === "error" || isDeepStrictEqual(snapshot.state, planned.next)
+  ).pipe(Effect.forkChild)
+  const sendExit = yield* Effect.exit(ref.send(event))
+  assertNoUnexpectedDefect(`post-resume send ${index}`, sendExit)
+  const published = yield* Fiber.join(observed)
+  if (published.status === "error") {
+    assert.fail(`post-resume event ${index} failed:\n${Cause.pretty(published.cause)}`)
+  }
+  const actual = yield* encodeWithoutDefect(machine, published.state, `post-resume observed ${index}`)
+  assert.deepStrictEqual(actual, expected, `post-resume event ${index}`)
+  return planned.next
+})
+
+describe("machine operation totality", () => {
+  it.effect.prop(
+    "never defects while planning or round-tripping reachable snapshots from valid finite models",
+    { generated: generatedCases },
+    ({ generated }) =>
+      Effect.gen(function*() {
+        const machine: any = MachineTest.compileModel(generated.model)
+        const scenario = { events: generated.events.map((_tag) => ({ _tag })) }
+
+        const initialExit = yield* Effect.exit(Machine.planInitial(machine))
+        assertNoUnexpectedDefect("planInitial", initialExit)
+        let current = initialExit.value.state
+        for (let index = 0; index < scenario.events.length; index++) {
+          const stepExit = yield* Effect.exit(Machine.plan(machine, current, scenario.events[index]!))
+          assertNoUnexpectedDefect(`plan ${index}`, stepExit)
+          current = stepExit.value.next
+        }
+
+        const trace = yield* MachineTest.run(machine, scenario)
+        yield* MachineTest.verify(machine, trace)
+        yield* MachineTest.verifyModel(generated.model, trace)
+
+        for (const [index, snapshot] of reachableSnapshots(trace).entries()) {
+          const encoded = yield* encodeWithoutDefect(machine, snapshot, `encodeSnapshot ${index}`)
+          const transported = JSON.parse(JSON.stringify(encoded))
+          const decoded = yield* decodeWithoutDefect(machine, transported, `decodeSnapshot ${index}`)
+          yield* assertLogicalSnapshotEquivalent(machine, snapshot, decoded, `snapshot ${index}`)
+        }
+      }),
+    { fastCheck: { numRuns: 150, seed: 61_607 } }
+  )
+
+  it.effect.prop(
+    "resumes a round-tripped stable boundary and preserves continuation semantics",
+    { generated: generatedResumeCases },
+    ({ generated }) =>
+      Effect.gen(function*() {
+        const machine: any = MachineTest.compileModel(generated.model)
+        const events = generated.events.map((_tag) => ({ _tag }))
+        const fullTrace = yield* MachineTest.run(machine, { events })
+        yield* MachineTest.verify(machine, fullTrace)
+        yield* MachineTest.verifyModel(generated.model, fullTrace)
+        const boundary = generated.boundary === 0
+          ? fullTrace.initial.plan.state
+          : fullTrace.steps[generated.boundary - 1]!.after
+        const suffix = fullTrace.steps.slice(generated.boundary)
+
+        const encoded = yield* encodeWithoutDefect(machine, boundary, "resume boundary encode")
+        const decoded = yield* decodeWithoutDefect(machine, encoded, "resume boundary decode")
+        const resumeExit = yield* Effect.exit(Machine.resume(machine, decoded))
+        assertNoUnexpectedDefect("resume", resumeExit)
+        const ref = resumeExit.value
+
+        const initialRuntime = yield* ref.snapshot
+        if (initialRuntime.status === "error") {
+          assert.fail(`resume published a failed snapshot:\n${Cause.pretty(initialRuntime.cause)}`)
+        }
+        yield* assertLogicalSnapshotEquivalent(machine, decoded, initialRuntime.state, "resumed boundary")
+
+        if (initialRuntime.status === "active") {
+          for (let index = 0; index < suffix.length; index++) {
+            const runtime = yield* ref.snapshot
+            if (runtime.status !== "active") break
+            const step = suffix[index]!
+            yield* deliverAndObserve(machine, ref, step.event, step.plan, index)
+          }
+        }
+
+        const finalRuntime = yield* ref.snapshot
+        if (finalRuntime.status === "error") {
+          assert.fail(`resumed continuation failed:\n${Cause.pretty(finalRuntime.cause)}`)
+        }
+        yield* assertLogicalSnapshotEquivalent(machine, fullTrace.final, finalRuntime.state, "resumed continuation")
+        yield* ref.stop
+      }),
+    { fastCheck: { numRuns: 75, seed: 72_719 } }
+  )
+
+  it.effect("round-trips transformed state values and completion output", () =>
+    Effect.gen(function*() {
+      const Value = Schema.TaggedStruct("Value", { amount: Schema.NumberFromString })
+      const Done = Schema.TaggedStruct("Done", {})
+      const Finish = Schema.TaggedStruct("Finish", {})
+      const states = Machine.defineStates({
+        Value,
+        Done: { schema: Done, type: "final", output: Schema.NumberFromString }
+      })
+      const machine = Machine.make({
+        states: states.states,
+        events: [Finish],
+        initial: () => states.initial.Value({ _tag: "Value", amount: 42 })
+      }).handle({
+        Value: { on: { Finish: ({ target }) => target.full.Done({ _tag: "Done" }) } },
+        Done: { output: () => 42 }
+      })
+      const plan = yield* Machine.planInitial(machine)
+      const done = yield* Machine.plan(machine, plan.state, { _tag: "Finish" })
+
+      for (const snapshot of [plan.state, done.next]) {
+        const encoded = yield* Machine.encodeSnapshot(machine, snapshot)
+        const transported = JSON.parse(JSON.stringify(encoded))
+        const decoded = yield* Machine.decodeSnapshot(machine, transported)
+        assert.deepStrictEqual(canonicalLogicalSnapshot(decoded), canonicalLogicalSnapshot(snapshot))
+        assert.deepStrictEqual(yield* Machine.encodeSnapshot(machine, decoded), encoded)
+      }
+    }))
+
+  it.effect("distinguishes modeled failures from user-origin defects", () =>
+    Effect.gen(function*() {
+      const Stable = Schema.TaggedStruct("FailurePartitionStable", {})
+      const Trigger = Schema.TaggedStruct("FailurePartitionTrigger", {})
+      const states = Machine.defineStates({ Stable })
+      const typedFailure = { _tag: "ExpectedHandlerFailure" } as const
+      const failing = Machine.make({
+        states: states.states,
+        events: [Trigger],
+        initial: () => states.initial.Stable({ _tag: "FailurePartitionStable" })
+      }).handle({ Stable: { on: { FailurePartitionTrigger: () => Effect.fail(typedFailure) } } })
+      const initial = yield* Machine.planInitial(failing)
+      assert.strictEqual(
+        yield* Effect.flip(Machine.plan(failing, initial.state, { _tag: "FailurePartitionTrigger" })),
+        typedFailure
+      )
+
+      const invalid = yield* Machine.decodeSnapshot(failing, { _tag: "not-a-snapshot" }).pipe(Effect.flip)
+      assert.instanceOf(invalid, Machine.MachineSchemaDecodeError)
+
+      const userSentinel = { source: "user" }
+      const defecting = Machine.make({
+        states: states.states,
+        events: [Trigger],
+        initial: () => states.initial.Stable({ _tag: "FailurePartitionStable" })
+      }).handle({ Stable: { on: { FailurePartitionTrigger: () => Effect.die(userSentinel) } } })
+      const defectExit = yield* Effect.exit(
+        Machine.plan(defecting, initial.state, { _tag: "FailurePartitionTrigger" })
+      )
+      assert.strictEqual(Exit.isFailure(defectExit), true)
+      if (Exit.isFailure(defectExit)) {
+        const reason = defectExit.cause.reasons.find(Cause.isDieReason)
+        assert.strictEqual(reason?.defect, userSentinel)
+      }
+
+      const looping = Machine.make({
+        states: states.states,
+        events: [],
+        initial: () => states.initial.Stable({ _tag: "FailurePartitionStable" })
+      }).handle({
+        Stable: {
+          always: {
+            reenter: true,
+            targets: ["Stable"],
+            transition: ({ target }) => target.full.Stable({ _tag: "FailurePartitionStable" })
+          }
+        }
+      })
+      const cycle = yield* Machine.planInitial(looping).pipe(Effect.flip)
+      assert.instanceOf(cycle, Machine.InfiniteTransitionError)
+    }))
+})


### PR DESCRIPTION
## Summary

- Add deterministic generated properties proving valid finite machines do not defect during planning, stable snapshot JSON round trips, resume, or post-resume event delivery.
- Fix initial choices that route to another root so the abandoned root is not retained in the initial configuration or lifecycle work.
- Resolve nested choices inside first-use history fallbacks before snapshot normalization, preserving their actions, raised/emitted events, and inspected transition identities.
- Fix the independent finite-model oracle to follow choice chains entered through selected compound initializers.
- Add focused coverage for transformed state/output schemas, controlled resumed action and raised-event traces, modeled failures versus user defects, and every minimized valid-input regression found by the new properties.

## Root causes

- Initial-choice planning re-merged every provisional value after the selected target had already been normalized. A `target.full` choice to another root therefore reintroduced the abandoned initial root.
- History defaults normalized their returned complete snapshot before resolving nested choice pseudo-states, causing a valid typed fallback to reach snapshot validation with a pseudo-state in its active structure.
- The reference interpreter advanced directly to the selected compound and stopped instead of following that compound's choice initializer chain.

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

Added `.changeset/wise-machines-harden.md` as a patch release. No public API was added.

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed

No examples changed. Public TypeScript signatures and inference did not change, so a local `pnpm perf:types` run was not required; the automated report can confirm no regression.

`pnpm check` passed with 20 runtime test files / 360 tests, 15 type-test files / 140 tests, strict consumer validation, and package verification.
