### PR TITLE
Fix type performance comment permission

### DIFF
--- a/.github/workflows/type-performance-comment.yml
+++ b/.github/workflows/type-performance-comment.yml
@@ -13,7 +13,7 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   comment:


### PR DESCRIPTION
## Summary

- Grant the type-performance report workflow write access to pull requests.
- Fix the 403 returned when the trusted `workflow_run` job creates or updates its PR comment.

The benchmark, artifact download, and report rendering already succeeded. Only the final PR timeline comment was rejected because the job had `pull-requests: read`.

## Changeset

- [ ] Added or updated for a library or package-metadata change
- [x] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (not applicable; no examples changed)
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed (not applicable; no TypeScript API change)

<!--
The type-performance workflow posts and updates the base-versus-PR comparison automatically.
Do not copy a manually measured table into this description.
-->
