### PR TITLE
Harden statechart modeling and verification

### DIFF
--- a/.changeset/brave-machines-observe.md
+++ b/.changeset/brave-machines-observe.md
@@ -5,3 +5,5 @@
 Add an Effect-native `@typeonce/effect-machine/testing` entrypoint with schema-derived scenarios, replayable planner traces, independent statechart law and finite-model verification for compound, parallel, and history states, trace coverage, observed Effect graphs, and live runtime command models.
 
 Expose retained planner transition evidence and correct reentry boundaries, simultaneous parallel target application, and recorded nested-history restoration through inactive ancestors.
+
+Model finite transitions through one discriminated `event | always | done` trigger representation, with independent stabilization, completion ordering, cycle detection, generated mixed-trigger models, managed-runtime differential checks, and activity-lifecycle command verification. Hand-authored finite models now migrate event transitions from `{ source, event, ... }` to `{ source, trigger: { type: "event", event }, ... }`.

--- a/.changeset/quiet-spiders-inspect.md
+++ b/.changeset/quiet-spiders-inspect.md
@@ -3,3 +3,5 @@
 ---
 
 Add public getters for inspecting compiled state nodes, registered transition handlers, declared transition targets, and the active state configuration of a snapshot. Event, eventless, and completion handlers may declare an upper bound of target paths that is checked against inferred and runtime results.
+
+Represent compiled state-node inspection as a six-way discriminated union so atomic, compound, parallel, final, history, and choice metadata narrow without impossible field combinations.

--- a/.changeset/strong-machines-guard.md
+++ b/.changeset/strong-machines-guard.md
@@ -1,0 +1,7 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Harden machine execution and definitions while preserving the existing Effect-native API. Self-stop now uses supervisor-owned terminal arbitration without initialization or worker deadlocks; execution adapters consistently reject incomplete output, history, and choice implementations; finite-union event tags narrow correctly; and machine guards verify the runtime brand value.
+
+State definitions now reject unknown node properties and unsafe state keys at compile time and runtime with path-local diagnostics. Add deterministic lifecycle, adversarial snapshot-codec, type-performance, activity-lifecycle, and planner-versus-runtime verification coverage.

--- a/perf/types/adapter-readiness-control.ts
+++ b/perf/types/adapter-readiness-control.ts
@@ -1,0 +1,51 @@
+import { Machine } from "@typeonce/effect-machine"
+import { Schema } from "effect"
+
+export const Flow = Schema.TaggedStruct("Flow", {})
+export const Idle = Schema.TaggedStruct("Idle", {})
+export const Ready = Schema.TaggedStruct("Ready", {})
+
+export const States = Machine.defineStates({
+  Flow: {
+    schema: Flow,
+    initial: "Idle",
+    states: {
+      Idle,
+      Route: {
+        type: "choice"
+      },
+      recent: {
+        type: "history",
+        history: "deep"
+      }
+    }
+  },
+  Ready
+})
+
+export const snapshot = States.initial.Ready(Ready.make({}))
+
+export const machine = Machine.make({
+  id: "perf-readiness",
+  states: States.states,
+  events: [],
+  initial: () => snapshot
+}).handle({
+  Flow: {
+    history: {
+      recent: {
+        default: ({ target }) => target.Flow(Flow.make({}), (flow) => flow.Idle(Idle.make({})))
+      }
+    },
+    states: {
+      Idle: {},
+      Route: {
+        choice: {
+          targets: ["Ready"],
+          transition: ({ target }) => target.full.Ready(Ready.make({}))
+        }
+      }
+    }
+  },
+  Ready: {}
+})

--- a/perf/types/adapter-readiness.ts
+++ b/perf/types/adapter-readiness.ts
@@ -1,0 +1,38 @@
+import { Machine } from "@typeonce/effect-machine"
+import { ClusterMachine } from "@typeonce/effect-machine/cluster"
+import { AtomMachine } from "@typeonce/effect-machine/reactivity"
+import { Atom } from "effect/unstable/reactivity"
+import { machine, snapshot } from "./adapter-readiness-control.js"
+
+type Equal<Left, Right> = (<Type>() => Type extends Left ? 1 : 2) extends (<Type>() => Type extends Right ? 1 : 2) ?
+  true :
+  false
+type Expect<Value extends true> = Value
+type IsAny<Value> = 0 extends 1 & Value ? true : false
+
+const child = Machine.child("ready-child", machine)
+const atom = AtomMachine.make(machine)
+const resumedAtom = AtomMachine.resume(machine, snapshot)
+const cluster = ClusterMachine.make("ReadyEntity", machine, { version: "1" })
+
+declare const bound: AtomMachine.Bound<never>
+const boundAtom = bound.make(machine)
+const boundResumedAtom = bound.resume(machine, snapshot)
+
+type StateIsNotAny = Expect<Equal<IsAny<Machine.Machine.States<typeof machine>>, false>>
+type ErrorIsNotAny = Expect<Equal<IsAny<Machine.Machine.Error<typeof machine>>, false>>
+type AtomEventIsExact = Expect<
+  Equal<typeof atom.send extends Atom.Writable<any, infer Event> ? Event : unknown, never>
+>
+type BoundAtomEventIsExact = Expect<
+  Equal<typeof boundAtom.send extends Atom.Writable<any, infer Event> ? Event : unknown, never>
+>
+
+void Machine.planInitial(machine)
+void Machine.start(machine)
+void Machine.resume(machine, snapshot)
+void Machine.invokeMachine({ child })
+void resumedAtom
+void cluster
+void boundResumedAtom
+export type { AtomEventIsExact, BoundAtomEventIsExact, ErrorIsNotAny, StateIsNotAny }

--- a/perf/types/composition-control.ts
+++ b/perf/types/composition-control.ts
@@ -1,0 +1,79 @@
+import { Machine } from "@typeonce/effect-machine"
+import { Schema } from "effect"
+
+export const App = Schema.TaggedStruct("App", {})
+export const Workspace = Schema.TaggedStruct("Workspace", {})
+export const Editor = Schema.TaggedStruct("Editor", {})
+export const Editing = Schema.TaggedStruct("Editing", {})
+export const EditorDone = Schema.TaggedStruct("EditorDone", { value: Schema.String })
+export const Sync = Schema.TaggedStruct("Sync", {})
+export const SyncIdle = Schema.TaggedStruct("SyncIdle", {})
+export const SyncDone = Schema.TaggedStruct("SyncDone", { value: Schema.Number })
+
+export const WorkspaceOutput = Schema.Struct({
+  Editor: Schema.String,
+  Sync: Schema.Number
+})
+
+export const States = Machine.defineStates({
+  App: {
+    schema: App,
+    initial: "Workspace",
+    states: {
+      Workspace: {
+        schema: Workspace,
+        type: "parallel",
+        output: WorkspaceOutput,
+        states: {
+          Editor: {
+            schema: Editor,
+            initial: "Editing",
+            states: {
+              Editing,
+              Done: {
+                schema: EditorDone,
+                type: "final",
+                output: Schema.String
+              }
+            }
+          },
+          Sync: {
+            schema: Sync,
+            initial: "Idle",
+            states: {
+              Idle: SyncIdle,
+              Done: {
+                schema: SyncDone,
+                type: "final",
+                output: Schema.Number
+              }
+            }
+          },
+          recent: {
+            type: "history",
+            history: "deep"
+          }
+        }
+      },
+      Route: {
+        type: "choice"
+      }
+    }
+  }
+})
+
+export const initialWorkspace = () =>
+  States.initial.App(App.make({}), (app) =>
+    app.Workspace(
+      Workspace.make({}),
+      (workspace) =>
+        workspace
+          .Editor(Editor.make({}), (editor) => editor.Editing(Editing.make({})))
+          .Sync(Sync.make({}), (sync) => sync.Idle(SyncIdle.make({})))
+    ))
+
+export const machine = Machine.make({
+  states: States.states,
+  events: [],
+  initial: initialWorkspace
+})

--- a/perf/types/composition.ts
+++ b/perf/types/composition.ts
@@ -1,0 +1,99 @@
+import { Machine } from "@typeonce/effect-machine"
+import { Context, Data, Effect } from "effect"
+import {
+  App,
+  Editing,
+  Editor,
+  EditorDone,
+  initialWorkspace,
+  machine,
+  States,
+  Sync,
+  SyncDone,
+  SyncIdle,
+  Workspace
+} from "./composition-control.js"
+
+type Equal<Left, Right> = (<Type>() => Type extends Left ? 1 : 2) extends (<Type>() => Type extends Right ? 1 : 2) ?
+  true :
+  false
+type Expect<Value extends true> = Value
+type IsAny<Value> = 0 extends 1 & Value ? true : false
+
+class CompositionService extends Context.Service<CompositionService, string>()(
+  "perf/composition/CompositionService"
+) {}
+class CompositionFailure extends Data.TaggedError("CompositionFailure")<{}> {}
+
+const handled = machine.handle({
+  App: {
+    states: {
+      Workspace: {
+        history: {
+          recent: {
+            default: () => initialWorkspace()
+          }
+        },
+        output: ({ outputs }) => ({
+          Editor: outputs.Editor,
+          Sync: outputs.Sync
+        }),
+        states: {
+          Editor: {
+            states: {
+              Editing: {
+                entry: () =>
+                  Effect.flatMap(
+                    CompositionService,
+                    () => Math.random() > 2 ? Effect.fail(new CompositionFailure()) : Effect.void
+                  )
+              },
+              Done: {
+                output: ({ state }) => state.value
+              }
+            }
+          },
+          Sync: {
+            states: {
+              Idle: {},
+              Done: {
+                output: ({ state }) => state.value
+              }
+            }
+          }
+        }
+      },
+      Route: {
+        choice: {
+          targets: ["App"],
+          transition: ({ target }) =>
+            target.full.App(App.make({}), (app) =>
+              app.Workspace(
+                Workspace.make({}),
+                (workspace) =>
+                  workspace
+                    .Editor(Editor.make({}), (editor) => editor.Editing(Editing.make({})))
+                    .Sync(Sync.make({}), (sync) => sync.Idle(SyncIdle.make({})))
+              ))
+        }
+      }
+    }
+  }
+})
+
+type ErrorIsExact = Expect<Equal<Machine.Machine.Error<typeof handled>, CompositionFailure>>
+type ServicesAreExact = Expect<Equal<Machine.Machine.Services<typeof handled>, CompositionService>>
+type OutputIsExact = Expect<
+  Equal<
+    Machine.Machine.OutputByIdentifier<typeof States.states, "App.Workspace">,
+    { readonly Editor: string; readonly Sync: number }
+  >
+>
+type EveryStateIsHandled = Expect<Equal<Machine.Machine.UnhandledStates<typeof handled>, never>>
+type ErrorIsNotAny = Expect<Equal<IsAny<Machine.Machine.Error<typeof handled>>, false>>
+type ServicesAreNotAny = Expect<Equal<IsAny<Machine.Machine.Services<typeof handled>>, false>>
+
+void EditorDone
+void SyncDone
+void Machine.planInitial(handled)
+export type { ErrorIsExact, ErrorIsNotAny, EveryStateIsHandled, OutputIsExact, ServicesAreExact, ServicesAreNotAny }

--- a/perf/types/exact-channels-control.ts
+++ b/perf/types/exact-channels-control.ts
@@ -1,0 +1,34 @@
+import { Machine } from "@typeonce/effect-machine"
+import { Context, Data, Effect, Schema } from "effect"
+
+export const Idle = Schema.TaggedStruct("Idle", { value: Schema.Number })
+export const Done = Schema.TaggedStruct("Done", { value: Schema.String })
+export const Start = Schema.TaggedStruct("Start", { value: Schema.String })
+export const Loaded = Schema.TaggedStruct("Loaded", { value: Schema.String })
+export const Notice = Schema.TaggedStruct("Notice", { value: Schema.String })
+export const Input = Schema.Struct({ seed: Schema.Number })
+
+export class InitialService extends Context.Service<InitialService, string>()("perf/channels/InitialService") {}
+export class InitialFailure extends Data.TaggedError("InitialFailure")<{}> {}
+
+export const States = Machine.defineStates({
+  Idle,
+  Done: {
+    schema: Done,
+    type: "final",
+    output: Schema.String
+  }
+})
+
+export const machine = Machine.make({
+  states: States.states,
+  events: [Start],
+  internalEvents: [Loaded],
+  emits: [Notice],
+  input: Input,
+  initial: (input) =>
+    Effect.flatMap(InitialService, () =>
+      input.seed < 0
+        ? Effect.fail(new InitialFailure())
+        : Effect.succeed(States.initial.Idle(Idle.make({ value: input.seed }))))
+})

--- a/perf/types/exact-channels.ts
+++ b/perf/types/exact-channels.ts
@@ -1,0 +1,81 @@
+import { Machine } from "@typeonce/effect-machine"
+import { Context, Data, Effect } from "effect"
+import {
+  Done,
+  InitialFailure,
+  InitialService,
+  Loaded,
+  machine,
+  Notice,
+  Start,
+  States
+} from "./exact-channels-control.js"
+
+type Equal<Left, Right> = (<Type>() => Type extends Left ? 1 : 2) extends (<Type>() => Type extends Right ? 1 : 2) ?
+  true :
+  false
+type Expect<Value extends true> = Value
+type IsAny<Value> = 0 extends 1 & Value ? true : false
+
+export class RuntimeService extends Context.Service<RuntimeService, string>()("perf/channels/RuntimeService") {}
+export class ActionService extends Context.Service<ActionService, string>()("perf/channels/ActionService") {}
+export class RuntimeFailure extends Data.TaggedError("RuntimeFailure")<{}> {}
+export class ActionFailure extends Data.TaggedError("ActionFailure")<{}> {}
+
+const complete = machine.handle({
+  Idle: {
+    entry: () =>
+      Machine.action(
+        Effect.flatMap(ActionService, () => Math.random() > 2 ? Effect.fail(new ActionFailure()) : Effect.void)
+      ),
+    on: {
+      Start: ({ event, target }) =>
+        Effect.flatMap(RuntimeService, () =>
+          Math.random() > 2
+            ? Effect.fail(new RuntimeFailure())
+            : Effect.succeed(target.full.Done(Done.make({ value: event.value })))),
+      Loaded: ({ event, target }) => target.full.Done(Done.make({ value: event.value }))
+    }
+  },
+  Done: {
+    output: ({ state }) => state.value
+  }
+})
+
+type InputIsExact = Expect<Equal<Machine.Machine.Input<typeof complete>["Type"], { readonly seed: number }>>
+type InputEventIsExact = Expect<Equal<Machine.Machine.InputEvent<typeof complete>, typeof Start.Type>>
+type EventIsExact = Expect<Equal<Machine.Machine.Event<typeof complete>, typeof Start.Type | typeof Loaded.Type>>
+type EmitIsExact = Expect<Equal<Machine.Machine.Emit<typeof complete>, typeof Notice.Type>>
+type InitialErrorIsExact = Expect<Equal<Machine.Machine.InitialError<typeof complete>, InitialFailure>>
+type InitialServicesAreExact = Expect<Equal<Machine.Machine.InitialServices<typeof complete>, InitialService>>
+type ErrorIsExact = Expect<Equal<Machine.Machine.Error<typeof complete>, RuntimeFailure>>
+type ServicesAreExact = Expect<
+  Equal<
+    Machine.Machine.Services<typeof complete>,
+    RuntimeService | Machine.ActionRequirement<ActionFailure, ActionService>
+  >
+>
+type OutputIsExact = Expect<Equal<Machine.Machine.Output<typeof complete>, string>>
+type OutputStatesAreExact = Expect<Equal<Machine.Machine.OutputStates<typeof complete>, "Done">>
+type ErrorIsNotAny = Expect<Equal<IsAny<Machine.Machine.Error<typeof complete>>, false>>
+type ServicesAreNotAny = Expect<Equal<IsAny<Machine.Machine.Services<typeof complete>>, false>>
+type OutputIsNotAny = Expect<Equal<IsAny<Machine.Machine.Output<typeof complete>>, false>>
+
+void States
+void Machine.planInitial(complete, { seed: 1 })
+void Machine.start(complete, { seed: 1 })
+export type {
+  EmitIsExact,
+  ErrorIsExact,
+  ErrorIsNotAny,
+  EventIsExact,
+  InitialErrorIsExact,
+  InitialServicesAreExact,
+  InputEventIsExact,
+  InputIsExact,
+  OutputIsExact,
+  OutputIsNotAny,
+  OutputStatesAreExact,
+  ServicesAreExact,
+  ServicesAreNotAny
+}

--- a/perf/types/successive-handle-control.ts
+++ b/perf/types/successive-handle-control.ts
@@ -1,0 +1,40 @@
+import { Machine } from "@typeonce/effect-machine"
+import { Schema } from "effect"
+
+export const Flow = Schema.TaggedStruct("Flow", {})
+export const Idle = Schema.TaggedStruct("Idle", {})
+export const Running = Schema.TaggedStruct("Running", {})
+export const Done = Schema.TaggedStruct("Done", { value: Schema.String })
+export const Start = Schema.TaggedStruct("Start", {})
+export const Finish = Schema.TaggedStruct("Finish", { value: Schema.String })
+
+export const States = Machine.defineStates({
+  Flow: {
+    schema: Flow,
+    initial: "Idle",
+    states: {
+      Idle,
+      Running,
+      Done: {
+        schema: Done,
+        type: "final",
+        output: Schema.String
+      },
+      Route: {
+        type: "choice"
+      },
+      recent: {
+        type: "history",
+        history: "deep"
+      }
+    }
+  }
+})
+
+export const initialIdle = () => States.initial.Flow(Flow.make({}), (flow) => flow.Idle(Idle.make({})))
+
+export const machine = Machine.make({
+  states: States.states,
+  events: [Start, Finish],
+  initial: initialIdle
+})

--- a/perf/types/successive-handle.ts
+++ b/perf/types/successive-handle.ts
@@ -1,0 +1,84 @@
+import { Machine } from "@typeonce/effect-machine"
+import { Context, Data, Effect } from "effect"
+import { Done, Flow, Idle, initialIdle, machine, Running } from "./successive-handle-control.js"
+
+type Equal<Left, Right> = (<Type>() => Type extends Left ? 1 : 2) extends (<Type>() => Type extends Right ? 1 : 2) ?
+  true :
+  false
+type Expect<Value extends true> = Value
+type IsAny<Value> = 0 extends 1 & Value ? true : false
+
+class IdleService extends Context.Service<IdleService, string>()("perf/successive/IdleService") {}
+class RunningService extends Context.Service<RunningService, string>()("perf/successive/RunningService") {}
+class IdleFailure extends Data.TaggedError("IdleFailure")<{}> {}
+class RunningFailure extends Data.TaggedError("RunningFailure")<{}> {}
+
+const withFlow = machine.handle({
+  Flow: {
+    history: {
+      recent: {
+        default: () => initialIdle()
+      }
+    },
+    states: {
+      Route: {
+        choice: {
+          targets: ["Flow.Idle"],
+          transition: ({ target }) => target.local.Idle(Idle.make({}))
+        }
+      }
+    }
+  }
+})
+
+const withIdle = withFlow.handle({
+  Flow: {
+    states: {
+      Idle: {
+        on: {
+          Start: ({ target }) =>
+            Effect.flatMap(IdleService, () =>
+              Math.random() > 2
+                ? Effect.fail(new IdleFailure())
+                : Effect.succeed(target.local.Running(Running.make({}))))
+        }
+      }
+    }
+  }
+})
+
+const withRunning = withIdle.handle({
+  Flow: {
+    states: {
+      Running: {
+        on: {
+          Finish: ({ event, target }) =>
+            Effect.flatMap(RunningService, () =>
+              Math.random() > 2
+                ? Effect.fail(new RunningFailure())
+                : Effect.succeed(target.local.Done(Done.make({ value: event.value }))))
+        }
+      }
+    }
+  }
+})
+
+const complete = withRunning.handle({
+  Flow: {
+    states: {
+      Done: {
+        output: ({ state }) => state.value
+      }
+    }
+  }
+})
+
+type ErrorIsExact = Expect<Equal<Machine.Machine.Error<typeof complete>, IdleFailure | RunningFailure>>
+type ServicesAreExact = Expect<Equal<Machine.Machine.Services<typeof complete>, IdleService | RunningService>>
+type OutputIsExact = Expect<Equal<Machine.Machine.Output<typeof complete>, string>>
+type EveryStateIsHandled = Expect<Equal<Machine.Machine.UnhandledStates<typeof complete>, never>>
+type ErrorIsNotAny = Expect<Equal<IsAny<Machine.Machine.Error<typeof complete>>, false>>
+type ServicesAreNotAny = Expect<Equal<IsAny<Machine.Machine.Services<typeof complete>>, false>>
+
+void Machine.planInitial(complete)
+export type { ErrorIsExact, ErrorIsNotAny, EveryStateIsHandled, OutputIsExact, ServicesAreExact, ServicesAreNotAny }

--- a/scripts/type-performance.mjs
+++ b/scripts/type-performance.mjs
@@ -30,6 +30,8 @@ for (let index = 2; index < process.argv.length; index += 1) {
 const root = options.root
 const tsc = resolve(root, "node_modules", "typescript", "bin", "tsc")
 
+// Instantiation counts are deterministic for the pinned compiler. Budgets keep
+// roughly thirty percent headroom; wall-clock check time is never gated.
 const scenarios = [
   {
     id: "effect-only",
@@ -46,7 +48,9 @@ const scenarios = [
     id: "define-states",
     label: "Machine.defineStates (3 states)",
     file: "define-states.ts",
-    control: "import-only"
+    control: "import-only",
+    maxInstantiations: 3_800,
+    maxMarginalInstantiations: 3_700
   },
   {
     id: "make-control",
@@ -58,13 +62,17 @@ const scenarios = [
     id: "make",
     label: "Machine.make (3 states, 2 events)",
     file: "make.ts",
-    control: "make-control"
+    control: "make-control",
+    maxInstantiations: 11_000,
+    maxMarginalInstantiations: 7_500
   },
   {
     id: "handle",
     label: "machine.handle (3 states, 2 transitions)",
     file: "handle.ts",
-    control: "make"
+    control: "make",
+    maxInstantiations: 30_000,
+    maxMarginalInstantiations: 19_000
   },
   {
     id: "handle-depth-8-control",
@@ -76,7 +84,9 @@ const scenarios = [
     id: "handle-depth-8",
     label: "machine.handle (depth 8)",
     file: "handle-depth-8.ts",
-    control: "handle-depth-8-control"
+    control: "handle-depth-8-control",
+    maxInstantiations: 145_000,
+    maxMarginalInstantiations: 136_000
   },
   {
     id: "handle-depth-12-control",
@@ -88,7 +98,9 @@ const scenarios = [
     id: "handle-depth-12",
     label: "machine.handle (depth 12)",
     file: "handle-depth-12.ts",
-    control: "handle-depth-12-control"
+    control: "handle-depth-12-control",
+    maxInstantiations: 160_000,
+    maxMarginalInstantiations: 150_000
   },
   {
     id: "handle-depth-16-control",
@@ -100,7 +112,9 @@ const scenarios = [
     id: "handle-depth-16",
     label: "machine.handle (depth 16)",
     file: "handle-depth-16.ts",
-    control: "handle-depth-16-control"
+    control: "handle-depth-16-control",
+    maxInstantiations: 180_000,
+    maxMarginalInstantiations: 168_000
   },
   {
     id: "handle-depth-24-control",
@@ -112,7 +126,9 @@ const scenarios = [
     id: "handle-depth-24",
     label: "machine.handle (depth 24)",
     file: "handle-depth-24.ts",
-    control: "handle-depth-24-control"
+    control: "handle-depth-24-control",
+    maxInstantiations: 230_000,
+    maxMarginalInstantiations: 215_000
   },
   {
     id: "handle-depth-wide-16-control",
@@ -124,7 +140,65 @@ const scenarios = [
     id: "handle-depth-wide-16",
     label: "machine.handle (wide depth 16)",
     file: "handle-depth-wide-16.ts",
-    control: "handle-depth-wide-16-control"
+    control: "handle-depth-wide-16-control",
+    maxInstantiations: 268_000,
+    maxMarginalInstantiations: 255_000
+  },
+  {
+    id: "composition-control",
+    label: "parallel/history/choice control",
+    file: "composition-control.ts",
+    hidden: true
+  },
+  {
+    id: "composition",
+    label: "machine.handle (parallel/history/choice)",
+    file: "composition.ts",
+    control: "composition-control",
+    maxInstantiations: 165_000,
+    maxMarginalInstantiations: 142_000
+  },
+  {
+    id: "successive-handle-control",
+    label: "successive machine.handle control",
+    file: "successive-handle-control.ts",
+    hidden: true
+  },
+  {
+    id: "successive-handle",
+    label: "machine.handle (4 successive calls)",
+    file: "successive-handle.ts",
+    control: "successive-handle-control",
+    maxInstantiations: 166_000,
+    maxMarginalInstantiations: 147_000
+  },
+  {
+    id: "exact-channels-control",
+    label: "exact machine channels control",
+    file: "exact-channels-control.ts",
+    hidden: true
+  },
+  {
+    id: "exact-channels",
+    label: "machine exact input/output/error/services",
+    file: "exact-channels.ts",
+    control: "exact-channels-control",
+    maxInstantiations: 138_000,
+    maxMarginalInstantiations: 123_000
+  },
+  {
+    id: "adapter-readiness-control",
+    label: "adapter readiness control",
+    file: "adapter-readiness-control.ts",
+    hidden: true
+  },
+  {
+    id: "adapter-readiness",
+    label: "execution adapter readiness",
+    file: "adapter-readiness.ts",
+    control: "adapter-readiness-control",
+    maxInstantiations: 158_000,
+    maxMarginalInstantiations: 125_000
   }
 ]
 
@@ -199,6 +273,35 @@ for (const scenario of scenarios) {
 const visibleScenarios = scenarios.filter(
   (scenario) => scenario.hidden !== true && results.has(scenario.id)
 )
+
+for (const scenario of visibleScenarios) {
+  const result = results.get(scenario.id)
+  const control = scenario.control === undefined ? undefined : results.get(scenario.control)
+  const marginalInstantiations = control === undefined
+    ? undefined
+    : result.instantiations - control.instantiations
+
+  if (
+    scenario.maxInstantiations !== undefined &&
+    result.instantiations > scenario.maxInstantiations
+  ) {
+    throw new Error(
+      `Type-performance budget exceeded for ${scenario.id}: ` +
+        `${result.instantiations} instantiations > ${scenario.maxInstantiations}`
+    )
+  }
+  if (
+    scenario.maxMarginalInstantiations !== undefined &&
+    marginalInstantiations !== undefined &&
+    marginalInstantiations > scenario.maxMarginalInstantiations
+  ) {
+    throw new Error(
+      `Marginal type-performance budget exceeded for ${scenario.id}: ` +
+        `${marginalInstantiations} instantiations > ${scenario.maxMarginalInstantiations}`
+    )
+  }
+}
+
 const rows = visibleScenarios.map((scenario) => {
   const result = results.get(scenario.id)
   const control = scenario.control === undefined ? undefined : results.get(scenario.control)
@@ -229,6 +332,8 @@ if (options.json) {
             instantiations: result.instantiations,
             marginalInstantiations:
               control === undefined ? null : result.instantiations - control.instantiations,
+            maxInstantiations: scenario.maxInstantiations ?? null,
+            maxMarginalInstantiations: scenario.maxMarginalInstantiations ?? null,
             checkTimeSeconds: result.checkTime
           }
         })
@@ -278,3 +383,4 @@ for (const row of rows) {
 
 console.log("\nMarginal is measured against the matching setup without that API call.")
 console.log("Check time is informational; instantiations are the stable comparison metric.")
+console.log("Configured total and marginal instantiation budgets are enforced before reporting.")

--- a/src/AtomMachine.ts
+++ b/src/AtomMachine.ts
@@ -13,6 +13,7 @@ import type * as Scope from "effect/Scope"
 import * as Stream from "effect/Stream"
 import { AsyncResult, Atom, type AtomRegistry } from "effect/unstable/reactivity"
 import * as Model from "./internal/machineModel.js"
+import type { EnsureExecutable } from "./internal/machineReadiness.js"
 import * as Machine from "./Machine.js"
 
 /**
@@ -124,7 +125,7 @@ const startMachineAtomEffect = <
       OutputStates,
       InputEvents
     >
-    & Machine.Machine.EnsureOutputImplementations<States, OutputStates>,
+    & EnsureExecutable<States, UnhandledStates, OutputStates>,
   args: [...Machine.Machine.InputArgs<Input>]
 ): Effect.Effect<
   Machine.MachineRef<
@@ -815,16 +816,14 @@ type EnsureBoundResumeRequirements<Services, M extends Machine.Machine.Any> =
       readonly [BoundRequirementsTypeId]: MissingBoundResumeRequirements<Services, M>
     }
 
-type EnsureMachineOutputImplementations<M extends Machine.Machine.Any> = IsAny<Machine.Machine.States<M>> extends true ?
-  {
+type EnsureMachineExecutable<M extends Machine.Machine.Any> = IsAny<Machine.Machine.States<M>> extends true ? {
     readonly "~effect/reactivity/AtomMachine/ConcreteMachineRequired": M
   }
-  : Machine.Machine.EnsureOutputImplementations<Machine.Machine.States<M>, Machine.Machine.OutputStates<M>>
-
-type EnsureMachineHistoryImplementations<M extends Machine.Machine.Any> = Machine.Machine.EnsureHistoryImplementations<
-  Machine.Machine.States<M>,
-  Machine.Machine.UnhandledStates<M>
->
+  : EnsureExecutable<
+    Machine.Machine.States<M>,
+    Machine.Machine.UnhandledStates<M>,
+    Machine.Machine.OutputStates<M>
+  >
 
 type MachineInputArgsOf<M extends Machine.Machine.Any> = [
   ...Machine.Machine.InputArgs<Machine.Machine.Input<M>>
@@ -871,7 +870,7 @@ export interface Bound<Services, RuntimeError = never> {
     machine:
       & M
       & EnsureBoundRequirements<Services, NoInfer<M>>
-      & EnsureMachineOutputImplementations<NoInfer<M>>,
+      & EnsureMachineExecutable<NoInfer<M>>,
     ...args: MachineInputArgsOf<M>
   ) => MachineAtomOf<M, RuntimeError>
 
@@ -880,8 +879,7 @@ export interface Bound<Services, RuntimeError = never> {
     machine:
       & M
       & EnsureBoundResumeRequirements<Services, NoInfer<M>>
-      & EnsureMachineOutputImplementations<NoInfer<M>>
-      & EnsureMachineHistoryImplementations<NoInfer<M>>,
+      & EnsureMachineExecutable<NoInfer<M>>,
     snapshot: Machine.Machine.Snapshot<Machine.Machine.States<M>>
   ) => ResumedMachineAtomOf<M, RuntimeError>
 }
@@ -935,7 +933,7 @@ export const make: {
           Machine.Machine.EmitOf<Emits>
         >
       >
-      & Machine.Machine.EnsureOutputImplementations<States, OutputStates>,
+      & EnsureExecutable<States, UnhandledStates, OutputStates>,
     ...args: [...Machine.Machine.InputArgs<Input>]
   ): MachineAtom<
     Machine.Machine.Snapshot<States>,
@@ -964,8 +962,7 @@ export const resume: {
     machine:
       & M
       & EnsureNoExternalRequirements<MachineResumeRequirementsOf<NoInfer<M>>>
-      & EnsureMachineOutputImplementations<NoInfer<M>>
-      & EnsureMachineHistoryImplementations<NoInfer<M>>,
+      & EnsureMachineExecutable<NoInfer<M>>,
     snapshot: Machine.Machine.Snapshot<Machine.Machine.States<M>>
   ): ResumedMachineAtomOf<M, never>
 } = ((machine: Machine.Machine.Any, snapshot: Machine.Machine.Snapshot<any>) => {

--- a/src/ClusterMachine.ts
+++ b/src/ClusterMachine.ts
@@ -19,6 +19,7 @@ import {
   Snowflake
 } from "effect/unstable/cluster"
 import { Rpc } from "effect/unstable/rpc"
+import type { EnsureExecutable } from "./internal/machineReadiness.js"
 import * as Machine from "./Machine.js"
 
 type EntityAddress = EntityAddress.EntityAddress
@@ -425,7 +426,7 @@ export const make = <
       OutputStates,
       InputEvents
     >
-    & Machine.Machine.EnsureOutputImplementations<States, OutputStates>,
+    & EnsureExecutable<States, UnhandledStates, OutputStates>,
   options: {
     readonly version: string
   },

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -29,7 +29,9 @@ import { ProcessLocalError as ProcessLocalErrorValue } from "./internal/machineE
 import * as Model from "./internal/machineModel.js"
 import * as internalPlanner from "./internal/machinePlanner.js"
 import * as internalProcess from "./internal/machineProcess.js"
+import type { EnsureExecutable } from "./internal/machineReadiness.js"
 import * as internalRuntime from "./internal/machineRuntime.js"
+import * as StateDefinition from "./internal/machineStateDefinition.js"
 
 /**
  * String literal type used as the runtime type identifier for `Machine`
@@ -429,8 +431,14 @@ type EnsureCompatibleRuntime<Requirements, Events, Emits> = [IncompatibleRuntime
   readonly [RuntimeCompatibilityErrorTypeId]: IncompatibleRuntime<Requirements, Events, Emits>
 }
 
-type StateDefinitionError<Message extends string> = {
+type StateDefinitionError<
+  Message extends string,
+  Path extends PropertyKey = never,
+  Details extends PropertyKey = never
+> = {
   readonly "~effect/Machine/DefinitionError": Message
+  readonly path: Path
+  readonly details: Details
 }
 
 type ActiveStateKey<States extends Machine.StateSchemas> = Machine.ActiveStateKey<States>
@@ -439,18 +447,79 @@ type HistoryStateKey<States extends Machine.StateSchemas> = Machine.HistoryState
 
 type ChoiceStateKey<States extends Machine.StateSchemas> = Machine.ChoiceStateKey<States>
 
-type ValidateStateTree<States extends Machine.StateSchemas, AllowHistory extends boolean = false> = {
-  readonly [Key in keyof States]: ValidateStateNode<States[Key], AllowHistory>
+type StateDefinitionPath<Prefix extends string, Key extends PropertyKey> = Key extends string ?
+  Key extends "" ? Prefix extends "" ? "<empty>" : `${Prefix}.<empty>`
+  : Prefix extends "" ? Key
+  : `${Prefix}.${Key}`
+  : Key extends number ? Prefix extends "" ? `${Key}` : `${Prefix}.${Key}`
+  : Prefix extends "" ? "<symbol>"
+  : `${Prefix}.<symbol>`
+
+type ValidateStateKey<Key extends PropertyKey, Prefix extends string> = Key extends symbol ?
+  StateDefinitionError<"State keys must be strings, not symbols", StateDefinitionPath<Prefix, Key>, Key>
+  : Key extends number ?
+    StateDefinitionError<"State keys cannot use numeric forms", StateDefinitionPath<Prefix, Key>, Key>
+  : Key extends "" ? StateDefinitionError<"State keys cannot be empty", StateDefinitionPath<Prefix, Key>, Key>
+  : Key extends "__proto__" ?
+    StateDefinitionError<"The state key \"__proto__\" is not allowed", StateDefinitionPath<Prefix, Key>, Key>
+  : Key extends `${string}.${string}` ?
+    StateDefinitionError<"State keys cannot contain \".\"", StateDefinitionPath<Prefix, Key>, Key>
+  : Key extends `${number}` ?
+    StateDefinitionError<"State keys cannot use numeric forms", StateDefinitionPath<Prefix, Key>, Key>
+  : unknown
+
+type ValidateStateTree<
+  States extends Machine.StateSchemas,
+  AllowHistory extends boolean = false,
+  Prefix extends string = ""
+> = {
+  readonly [Key in keyof States]:
+    & ValidateStateKey<Key, Prefix>
+    & ValidateStateNode<States[Key], AllowHistory, StateDefinitionPath<Prefix, Key>>
 }
 
-type ValidateStateNode<Node, AllowHistory extends boolean> = Node extends Machine.HistoryStateNodeConfig ?
-  AllowHistory extends true ? ValidateHistoryStateNode<Node>
-  : StateDefinitionError<"History states must be declared below an active parent state">
-  : Node extends Machine.ChoiceStateNodeConfig ? AllowHistory extends true ? ValidateChoiceStateNode<Node>
-    : StateDefinitionError<"Choice states must be declared below an active parent state">
-  : Node extends Machine.TaggedSchema ? unknown
-  : Node extends { readonly schema: Machine.TaggedSchema } ? ValidateStateNodeConfig<Node>
-  : StateDefinitionError<"State nodes must be tagged schemas or state node configs">
+type UnknownStateNodeProperty<Node, Kind extends StateDefinition.StateNodeKind> = Exclude<
+  keyof Node,
+  StateDefinition.AllowedStateNodeProperty<Kind>
+>
+
+type ValidateExactStateNodeProperties<
+  Node,
+  Kind extends StateDefinition.StateNodeKind,
+  Path extends PropertyKey
+> = [UnknownStateNodeProperty<Node, Kind>] extends [never] ? unknown
+  : StateDefinitionError<
+    "State nodes cannot declare properties outside their state kind",
+    Path,
+    Extract<UnknownStateNodeProperty<Node, Kind>, PropertyKey>
+  >
+
+type UnknownPseudoAnnotationProperty<Node> = Node extends { readonly annotations: infer Annotations } ?
+  Exclude<keyof Annotations, StateDefinition.AllowedPseudoStateAnnotationProperty>
+  : never
+
+type ValidatePseudoStateAnnotations<Node, Path extends PropertyKey> = [UnknownPseudoAnnotationProperty<Node>] extends
+  [never] ? unknown
+  : StateDefinitionError<
+    "Pseudo-state annotations contain unknown properties",
+    Path,
+    Extract<UnknownPseudoAnnotationProperty<Node>, PropertyKey>
+  >
+
+type ValidateStateNode<Node, AllowHistory extends boolean, Path extends PropertyKey> = Node extends
+  Machine.TaggedSchema ? unknown
+  : Node extends Machine.HistoryStateNodeConfig ?
+      & ValidateExactStateNodeProperties<Node, "history", Path>
+      & ValidatePseudoStateAnnotations<Node, Path>
+      & (AllowHistory extends true ? ValidateHistoryStateNode<Node>
+        : StateDefinitionError<"History states must be declared below an active parent state", Path>)
+  : Node extends Machine.ChoiceStateNodeConfig ?
+      & ValidateExactStateNodeProperties<Node, "choice", Path>
+      & ValidatePseudoStateAnnotations<Node, Path>
+      & (AllowHistory extends true ? ValidateChoiceStateNode<Node>
+        : StateDefinitionError<"Choice states must be declared below an active parent state", Path>)
+  : Node extends { readonly schema: Machine.TaggedSchema } ? ValidateStateNodeConfig<Node, Path>
+  : StateDefinitionError<"State nodes must be tagged schemas or state node configs", Path>
 
 type ValidateHistoryStateNode<Node extends Machine.HistoryStateNodeConfig> = [
   Extract<keyof Node, "schema" | "states" | "initial" | "output" | "choice">
@@ -462,9 +531,21 @@ type ValidateChoiceStateNode<Node extends Machine.ChoiceStateNodeConfig> = [
 ] extends [never] ? unknown
   : StateDefinitionError<"Choice states cannot declare schemas, children, initial states, output, or history">
 
-type ValidateStateNodeConfig<Node extends { readonly schema: Machine.TaggedSchema }> = Node extends
-  { readonly states: infer Children } ? ValidateStateNodeWithChildren<Node, Children>
-  : ValidateStateNodeWithoutChildren<Node>
+type ValidateStateNodeConfig<
+  Node extends { readonly schema: Machine.TaggedSchema },
+  Path extends PropertyKey
+> = Node extends { readonly type: "parallel" } ?
+    & ValidateExactStateNodeProperties<Node, "parallel", Path>
+    & ValidateStateNodeWithChildren<Node, Node extends { readonly states: infer Children } ? Children : never, Path>
+  : Node extends { readonly type: "final" } ?
+      & ValidateExactStateNodeProperties<Node, "final", Path>
+      & ValidateStateNodeWithoutChildren<Node>
+  : Node extends { readonly states: infer Children } ?
+      & ValidateExactStateNodeProperties<Node, "compound", Path>
+      & ValidateStateNodeWithChildren<Node, Children, Path>
+  :
+    & ValidateExactStateNodeProperties<Node, "atomic", Path>
+    & ValidateStateNodeWithoutChildren<Node>
 
 type ValidateOutputSchema<Node> = "output" extends keyof Node ? Node extends { readonly output: Schema.Top } ? unknown
   : StateDefinitionError<"State output must be a schema">
@@ -472,22 +553,24 @@ type ValidateOutputSchema<Node> = "output" extends keyof Node ? Node extends { r
 
 type ValidateStateNodeWithChildren<
   Node extends { readonly schema: Machine.TaggedSchema },
-  Children
+  Children,
+  Path extends PropertyKey
 > = Children extends Machine.StateSchemas ?
   Node extends { readonly type: "final" } ? StateDefinitionError<"Final states cannot declare child states">
   : Node extends { readonly type: "parallel" } ?
     "initial" extends keyof Node ? StateDefinitionError<"Parallel states cannot declare an initial child">
-    : { readonly states: ValidateStateTree<Children, true> } & ValidateOutputSchema<Node>
+    : { readonly states: ValidateStateTree<Children, true, Extract<Path, string>> } & ValidateOutputSchema<Node>
   : "output" extends keyof Node ? StateDefinitionError<"Only final and parallel states can declare output">
-  : ValidateCompoundStateNode<Node, Children>
+  : ValidateCompoundStateNode<Node, Children, Path>
   : StateDefinitionError<"Child states must be a state tree">
 
 type ValidateCompoundStateNode<
   Node extends { readonly schema: Machine.TaggedSchema },
-  Children extends Machine.StateSchemas
+  Children extends Machine.StateSchemas,
+  Path extends PropertyKey
 > = Node extends { readonly initial: infer Initial } ?
   Initial extends ActiveStateKey<Children> | ChoiceStateKey<Children> ? {
-      readonly states: ValidateStateTree<Children, true>
+      readonly states: ValidateStateTree<Children, true, Extract<Path, string>>
     }
   : StateDefinitionError<"Compound initial must be one of its direct child keys">
   : StateDefinitionError<"Compound states must declare an initial child">
@@ -2160,6 +2243,9 @@ export declare namespace Machine {
   /**
    * Object state tree keyed by state path.
    *
+   * Keys must be non-empty, non-numeric strings without `.`. The
+   * prototype-mutating key `__proto__` and symbol keys are not accepted.
+   *
    * @category models
    * @since 4.0.0
    */
@@ -2264,27 +2350,120 @@ export declare namespace Machine {
    */
   export type ValidateStateSchemas<States extends StateSchemas> = ValidateStateTree<States>
 
+  /** Properties shared by every compiled state-node variant. */
+  export interface StateNodeBase<Path extends string = string> {
+    readonly path: Path
+    readonly key: string
+    /** Resolved Effect Schema annotations, or descriptive pseudo-state annotations. */
+    readonly annotations: Readonly<StateNodeAnnotations> | undefined
+    readonly order: number
+  }
+
+  /** Runtime metadata for a compiled atomic state. */
+  export interface AtomicStateNode<OwnPath extends string = string, ActivePath extends string = OwnPath>
+    extends StateNodeBase<OwnPath>
+  {
+    readonly type: "atomic"
+    readonly schema: TaggedSchema
+    readonly output: undefined
+    readonly history: undefined
+    readonly parent: ActivePath | undefined
+    readonly children: readonly []
+    readonly initial: undefined
+  }
+
+  /** Runtime metadata for a compiled compound state. */
+  export interface CompoundStateNode<
+    OwnPath extends string = string,
+    ActivePath extends string = OwnPath,
+    ChoicePath extends string = ActivePath
+  > extends StateNodeBase<OwnPath> {
+    readonly type: "compound"
+    readonly schema: TaggedSchema
+    readonly output: undefined
+    readonly history: undefined
+    readonly parent: ActivePath | undefined
+    /** Active child paths. Pseudo-states are available through their `parent` relationship. */
+    readonly children: ReadonlyArray<ActivePath>
+    readonly initial: ActivePath | ChoicePath
+  }
+
+  /** Runtime metadata for a compiled parallel state. */
+  export interface ParallelStateNode<OwnPath extends string = string, ActivePath extends string = OwnPath>
+    extends StateNodeBase<OwnPath>
+  {
+    readonly type: "parallel"
+    readonly schema: TaggedSchema
+    readonly output: Schema.Top | undefined
+    readonly history: undefined
+    readonly parent: ActivePath | undefined
+    /** Active child paths. Pseudo-states are available through their `parent` relationship. */
+    readonly children: ReadonlyArray<ActivePath>
+    readonly initial: undefined
+  }
+
+  /** Runtime metadata for a compiled final state. */
+  export interface FinalStateNode<OwnPath extends string = string, ActivePath extends string = OwnPath>
+    extends StateNodeBase<OwnPath>
+  {
+    readonly type: "final"
+    readonly schema: TaggedSchema
+    readonly output: Schema.Top | undefined
+    readonly history: undefined
+    readonly parent: ActivePath | undefined
+    readonly children: readonly []
+    readonly initial: undefined
+  }
+
+  /** Runtime metadata for a compiled history pseudo-state. */
+  export interface HistoryStateNode<OwnPath extends string = string, ActivePath extends string = string>
+    extends StateNodeBase<OwnPath>
+  {
+    readonly type: "history"
+    readonly schema: undefined
+    readonly output: undefined
+    readonly history: "shallow" | "deep"
+    readonly parent: ActivePath
+    readonly children: readonly []
+    readonly initial: undefined
+  }
+
+  /** Runtime metadata for a compiled choice pseudo-state. */
+  export interface ChoiceStateNode<OwnPath extends string = string, ActivePath extends string = string>
+    extends StateNodeBase<OwnPath>
+  {
+    readonly type: "choice"
+    readonly schema: undefined
+    readonly output: undefined
+    readonly history: undefined
+    readonly parent: ActivePath
+    readonly children: readonly []
+    readonly initial: undefined
+  }
+
   /**
    * Runtime metadata for a compiled state node.
+   *
+   * The `type` discriminator narrows every kind-specific topology and schema
+   * property while preserving a uniform inspection shape.
    *
    * @category models
    * @since 4.0.0
    */
-  export interface StateNode<Path extends string = string> {
-    readonly path: Path
-    readonly key: string
-    readonly schema: TaggedSchema | undefined
-    readonly output: Schema.Top | undefined
-    /** Resolved Effect Schema annotations, or descriptive pseudo-state annotations. */
-    readonly annotations: Readonly<StateNodeAnnotations> | undefined
-    readonly type: "atomic" | "compound" | "parallel" | "final" | "history" | "choice"
-    readonly history: "shallow" | "deep" | undefined
-    readonly parent: Path | undefined
-    /** Active child paths. Pseudo-states are available through their `parent` relationship. */
-    readonly children: ReadonlyArray<Path>
-    readonly initial: Path | undefined
-    readonly order: number
-  }
+  export type ActiveStateNode<ActivePath extends string = string, ChoicePath extends string = ActivePath> =
+    | AtomicStateNode<ActivePath, ActivePath>
+    | CompoundStateNode<ActivePath, ActivePath, ChoicePath>
+    | ParallelStateNode<ActivePath, ActivePath>
+    | FinalStateNode<ActivePath, ActivePath>
+
+  export type StateNode<
+    ActivePath extends string = string,
+    HistoryPath extends string = ActivePath,
+    ChoicePath extends string = ActivePath
+  > =
+    | ActiveStateNode<ActivePath, ChoicePath>
+    | HistoryStateNode<HistoryPath, ActivePath>
+    | ChoiceStateNode<ChoicePath, ActivePath>
 
   /**
    * Runtime lookup table for state nodes.
@@ -2292,9 +2471,13 @@ export declare namespace Machine {
    * @category models
    * @since 4.0.0
    */
-  export interface StateNodes<Path extends string = string> {
-    readonly byPath: ReadonlyMap<Path, StateNode<Path>>
-    readonly roots: ReadonlyArray<Path>
+  export interface StateNodes<
+    ActivePath extends string = string,
+    HistoryPath extends string = ActivePath,
+    ChoicePath extends string = ActivePath
+  > {
+    readonly byPath: ReadonlyMap<ActivePath | HistoryPath | ChoicePath, StateNode<ActivePath, HistoryPath, ChoicePath>>
+    readonly roots: ReadonlyArray<ActivePath>
   }
 
   /**
@@ -3167,7 +3350,15 @@ export declare namespace Machine {
   export type EventByTag<
     Events extends ReadonlyArray<TaggedSchema>,
     Tag extends TagOf<Events[number]>
-  > = Extract<EventOf<Events>, { readonly _tag: Tag }>
+  > =
+    | Extract<EventOf<Events>, { readonly _tag: Tag }>
+    | (EventOf<Events> extends infer Event ? Event extends {
+        readonly _tag: infer EventTag extends PropertyKey
+      } ? [EventTag] extends [Tag] ? never
+        : [Tag] extends [EventTag] ? Omit<Event, "_tag"> & { readonly _tag: Tag }
+        : never
+      : never
+      : never)
 
   /**
    * Opaque state construction returned by a builder's `.from` method.
@@ -5151,7 +5342,7 @@ const makeHandle = (self: Machine.Any): Machine.Any["handle"] =>
  */
 export const isMachine = (
   u: unknown
-): u is Machine.Any => hasProperty(u, TypeId)
+): u is Machine.Any => hasProperty(u, TypeId) && u[TypeId] === TypeId
 
 /**
  * Returns `true` if a state snapshot is final for a machine.
@@ -5668,22 +5859,25 @@ const makeTargetBuilder = <const States extends Machine.StateSchemas>(
  */
 export const defineStates: DefineStates = (<const States extends Machine.StateSchemas>(
   states: States
-): Machine.DefinedStates<States> => ({
-  states: states as States,
-  initial: makeSnapshotBuilder(states as States, { mode: "initial", prefix: "" }) as Machine.InitialBuilder<States>,
-  get: ((snapshot, path) =>
-    Model.getSnapshotByPath(snapshot, path).pipe(
-      Option.map((snapshot) => snapshot.value)
-    )) as Machine.DefinedStates<States>["get"],
-  getWithParents: ((snapshot, path) => {
-    const parents: Record<string, unknown> = {}
-    return Model.getSnapshotByPath(snapshot, path, parents).pipe(
-      Option.map((snapshot) => ({ value: snapshot.value, parents }))
-    )
-  }) as Machine.DefinedStates<States>["getWithParents"],
-  getSnapshot: Model.getSnapshotByPath as unknown as Machine.DefinedStates<States>["getSnapshot"],
-  matches: (snapshot, path) => Option.isSome(Model.getSnapshotByPath(snapshot, path))
-})) as DefineStates
+): Machine.DefinedStates<States> => {
+  StateDefinition.validateStateDefinitions(states, "Machine.defineStates")
+  return {
+    states: states as States,
+    initial: makeSnapshotBuilder(states as States, { mode: "initial", prefix: "" }) as Machine.InitialBuilder<States>,
+    get: ((snapshot, path) =>
+      Model.getSnapshotByPath(snapshot, path).pipe(
+        Option.map((snapshot) => snapshot.value)
+      )) as Machine.DefinedStates<States>["get"],
+    getWithParents: ((snapshot, path) => {
+      const parents: Record<string, unknown> = {}
+      return Model.getSnapshotByPath(snapshot, path, parents).pipe(
+        Option.map((snapshot) => ({ value: snapshot.value, parents }))
+      )
+    }) as Machine.DefinedStates<States>["getWithParents"],
+    getSnapshot: Model.getSnapshotByPath as unknown as Machine.DefinedStates<States>["getSnapshot"],
+    matches: (snapshot, path) => Option.isSome(Model.getSnapshotByPath(snapshot, path))
+  }
+}) as DefineStates
 
 type MakeConfig<
   States extends Machine.StateSchemas,
@@ -5829,6 +6023,7 @@ export const make: Make = (<
     readonly initial: (...args: [...Machine.InputArgs<Input>]) => Machine.InitialResult<States, InitialE, InitialR>
   }
 ): MakeResult<States, InputEvents, Emits, Input, InitialE, InitialR, InternalEvents> => {
+  StateDefinition.validateStateDefinitions(config.states, "Machine.make")
   const self = Object.create(Proto)
   self.states = config.states
   self.events = config.events
@@ -6306,8 +6501,7 @@ export const invokeMachine: {
             OutputStates,
             InputEvents
           >
-          & Machine.EnsureOutputImplementations<States, OutputStates>
-          & Machine.EnsureHistoryImplementations<States, UnhandledStates>
+          & EnsureExecutable<States, UnhandledStates, OutputStates>
         >
         readonly snapshot?: (
           context: Machine.InvokeSnapshotContext<
@@ -6384,8 +6578,7 @@ export const invokeMachine: {
             OutputStates,
             InputEvents
           >
-          & Machine.EnsureOutputImplementations<States, OutputStates>
-          & Machine.EnsureHistoryImplementations<States, UnhandledStates>
+          & EnsureExecutable<States, UnhandledStates, OutputStates>
         >
         readonly snapshot?: (
           context: Machine.InvokeSnapshotContext<
@@ -6507,8 +6700,7 @@ export const planInitial: <
       OutputStates,
       InputEvents
     >
-    & Machine.EnsureOutputImplementations<States, OutputStates>
-    & Machine.EnsureHistoryImplementations<States, UnhandledStates>,
+    & EnsureExecutable<States, UnhandledStates, OutputStates>,
   ...args: [...Machine.InputArgs<Input>]
 ) => Effect.Effect<
   & {
@@ -6569,9 +6761,19 @@ export const planInitial: <
  */
 export const stateNodes = <M extends Machine.Any>(
   machine: M
-): ReadonlyArray<Machine.StateNode<Machine.StateNodeIdentifier<Machine.States<M>>>> =>
+): ReadonlyArray<
+  Machine.StateNode<
+    Machine.StateIdentifier<Machine.States<M>>,
+    Machine.HistoryIdentifier<Machine.States<M>>,
+    Machine.ChoiceIdentifier<Machine.States<M>>
+  >
+> =>
   Array.from(machine.stateNodes.byPath.values()) as unknown as ReadonlyArray<
-    Machine.StateNode<Machine.StateNodeIdentifier<Machine.States<M>>>
+    Machine.StateNode<
+      Machine.StateIdentifier<Machine.States<M>>,
+      Machine.HistoryIdentifier<Machine.States<M>>,
+      Machine.ChoiceIdentifier<Machine.States<M>>
+    >
   >
 
 /**
@@ -6640,11 +6842,19 @@ export const activityDefinitions = <M extends Machine.Any>(
 export const configuration = <M extends Machine.Any>(
   machine: M,
   state: Machine.Snapshot<Machine.States<M>>
-): ReadonlyArray<Machine.StateNode<Machine.StateIdentifier<Machine.States<M>>>> => {
-  const active = Model.normalizeConfiguration(machine, state).active
-  return stateNodes(machine).filter((node) => active.has(node.path)) as ReadonlyArray<
-    Machine.StateNode<Machine.StateIdentifier<Machine.States<M>>>
+): ReadonlyArray<
+  Machine.ActiveStateNode<
+    Machine.StateIdentifier<Machine.States<M>>,
+    Machine.ChoiceIdentifier<Machine.States<M>>
   >
+> => {
+  const active = Model.normalizeConfiguration(machine, state).active
+  return stateNodes(machine).filter(
+    (node): node is Machine.ActiveStateNode<
+      Machine.StateIdentifier<Machine.States<M>>,
+      Machine.ChoiceIdentifier<Machine.States<M>>
+    > => node.type !== "history" && node.type !== "choice" && active.has(node.path)
+  )
 }
 
 /**
@@ -6740,8 +6950,7 @@ export const plan: <
       OutputStates,
       InputEvents
     >
-    & Machine.EnsureOutputImplementations<States, OutputStates>
-    & Machine.EnsureHistoryImplementations<States, UnhandledStates>,
+    & EnsureExecutable<States, UnhandledStates, OutputStates>,
   state: Machine.Snapshot<States>,
   event: Machine.EventOf<InputEvents>
 ) => Effect.Effect<
@@ -7226,8 +7435,7 @@ export const start: <
       OutputStates,
       InputEvents
     >
-    & Machine.EnsureOutputImplementations<States, OutputStates>
-    & Machine.EnsureHistoryImplementations<States, UnhandledStates>,
+    & EnsureExecutable<States, UnhandledStates, OutputStates>,
   ...args: [...Machine.InputArgs<Input>]
 ) => Effect.Effect<
   MachineRef<
@@ -7314,8 +7522,7 @@ export const resume: <
       OutputStates,
       InputEvents
     >
-    & Machine.EnsureOutputImplementations<States, OutputStates>
-    & Machine.EnsureHistoryImplementations<States, UnhandledStates>,
+    & EnsureExecutable<States, UnhandledStates, OutputStates>,
   snapshot: Machine.Snapshot<States>
 ) => Effect.Effect<
   MachineRef<

--- a/src/MachineTest.ts
+++ b/src/MachineTest.ts
@@ -10,6 +10,7 @@ import * as Graph from "effect/Graph"
 import * as Schema from "effect/Schema"
 import * as SchemaAST from "effect/SchemaAST"
 import { FastCheck } from "effect/testing"
+import type { EnsureExecutable } from "./internal/machineReadiness.js"
 import type { FiniteModel } from "./internal/machineTestFiniteModel.js"
 import * as ReferenceModel from "./internal/machineTestReferenceModel.js"
 import * as Machine from "./Machine.js"
@@ -42,7 +43,9 @@ export {
 export {
   compileModel,
   type FiniteAtomicState,
+  type FiniteAutomaticTransition,
   type FiniteCompoundState,
+  type FiniteEventTransition,
   type FiniteFinalState,
   type FiniteHistoryMutation,
   type FiniteHistoryScenario,
@@ -55,7 +58,8 @@ export {
   finiteModels,
   type FiniteParallelState,
   type FiniteState,
-  type FiniteTransition
+  type FiniteTransition,
+  type FiniteTransitionTrigger
 } from "./internal/machineTestFiniteModel.js"
 
 export {
@@ -103,13 +107,10 @@ type ExcludeCompatibleRuntime<Requirements, Events, Emits> = Requirements extend
 
 type ReadyMachine<M extends AnyMachine> =
   & M
-  & Machine.Machine.EnsureOutputImplementations<
+  & EnsureExecutable<
     Machine.Machine.States<M>,
+    Machine.Machine.UnhandledStates<M>,
     Machine.Machine.OutputStates<M>
-  >
-  & Machine.Machine.EnsureHistoryImplementations<
-    Machine.Machine.States<M>,
-    Machine.Machine.UnhandledStates<M>
   >
 
 /**

--- a/src/internal/machineModel.ts
+++ b/src/internal/machineModel.ts
@@ -259,23 +259,72 @@ export const makeChoiceTarget = (
 
 export const isChoiceTarget = (u: unknown): u is ChoiceTarget => hasProperty(u, ChoiceTargetTypeId)
 
+interface NormalizedStateNodeDefinitionBase {
+  readonly annotations: Readonly<Machine.StateNodeAnnotations> | undefined
+}
+
+type NormalizedStateNodeDefinition =
+  | (NormalizedStateNodeDefinitionBase & {
+    readonly type: "atomic"
+    readonly schema: Machine.TaggedSchema
+    readonly output: undefined
+    readonly history: undefined
+    readonly initial: undefined
+    readonly states: undefined
+  })
+  | (NormalizedStateNodeDefinitionBase & {
+    readonly type: "compound"
+    readonly schema: Machine.TaggedSchema
+    readonly output: undefined
+    readonly history: undefined
+    readonly initial: string
+    readonly states: Machine.StateTree
+  })
+  | (NormalizedStateNodeDefinitionBase & {
+    readonly type: "parallel"
+    readonly schema: Machine.TaggedSchema
+    readonly output: Schema.Top | undefined
+    readonly history: undefined
+    readonly initial: undefined
+    readonly states: Machine.StateTree
+  })
+  | (NormalizedStateNodeDefinitionBase & {
+    readonly type: "final"
+    readonly schema: Machine.TaggedSchema
+    readonly output: Schema.Top | undefined
+    readonly history: undefined
+    readonly initial: undefined
+    readonly states: undefined
+  })
+  | (NormalizedStateNodeDefinitionBase & {
+    readonly type: "history"
+    readonly schema: undefined
+    readonly output: undefined
+    readonly history: "shallow" | "deep"
+    readonly initial: undefined
+    readonly states: undefined
+  })
+  | (NormalizedStateNodeDefinitionBase & {
+    readonly type: "choice"
+    readonly schema: undefined
+    readonly output: undefined
+    readonly history: undefined
+    readonly initial: undefined
+    readonly states: undefined
+  })
+
 export const getStateNodeDefinition = (
   path: string,
   definition: Machine.TaggedSchema | Machine.StateNodeConfig
-): {
-  readonly schema: Machine.TaggedSchema | undefined
-  readonly output: Schema.Top | undefined
-  readonly annotations: Readonly<Machine.StateNodeAnnotations> | undefined
-  readonly type: "atomic" | "compound" | "parallel" | "final" | "history" | "choice"
-  readonly initial: string | undefined
-  readonly states: Machine.StateTree | undefined
-} => {
+): NormalizedStateNodeDefinition => {
   if (!Schema.isSchema(definition) && (definition as any).type === "history") {
+    const history = definition as Machine.HistoryStateNodeConfig
     return {
       schema: undefined,
       output: undefined,
-      annotations: (definition as Machine.HistoryStateNodeConfig).annotations,
+      annotations: history.annotations,
       type: "history",
+      history: history.history === "deep" ? "deep" : "shallow",
       initial: undefined,
       states: undefined
     }
@@ -286,6 +335,7 @@ export const getStateNodeDefinition = (
       output: undefined,
       annotations: (definition as Machine.ChoiceStateNodeConfig).annotations,
       type: "choice",
+      history: undefined,
       initial: undefined,
       states: undefined
     }
@@ -296,6 +346,7 @@ export const getStateNodeDefinition = (
       output: undefined,
       annotations: Schema.resolveAnnotations(definition),
       type: "atomic",
+      history: undefined,
       initial: undefined,
       states: undefined
     }
@@ -316,6 +367,7 @@ export const getStateNodeDefinition = (
         output: Schema.isSchema((definition as any).output) ? (definition as any).output as Schema.Top : undefined,
         annotations: Schema.resolveAnnotations(definition.schema),
         type: "parallel",
+        history: undefined,
         initial: undefined,
         states: (definition as any).states as Machine.StateTree
       }
@@ -328,18 +380,31 @@ export const getStateNodeDefinition = (
       output: undefined,
       annotations: Schema.resolveAnnotations(definition.schema),
       type: "compound",
+      history: undefined,
       initial: (definition as any).initial,
       states: (definition as any).states as Machine.StateTree
     }
   }
-  return {
-    schema: definition.schema as Machine.TaggedSchema,
-    output: Schema.isSchema((definition as any).output) ? (definition as any).output as Schema.Top : undefined,
-    annotations: Schema.resolveAnnotations(definition.schema),
-    type: definition.type === "final" ? "final" : "atomic",
-    initial: undefined,
-    states: undefined
-  }
+  const output = Schema.isSchema((definition as any).output) ? (definition as any).output as Schema.Top : undefined
+  return definition.type === "final"
+    ? {
+      schema: definition.schema as Machine.TaggedSchema,
+      output,
+      annotations: Schema.resolveAnnotations(definition.schema),
+      type: "final",
+      history: undefined,
+      initial: undefined,
+      states: undefined
+    }
+    : {
+      schema: definition.schema as Machine.TaggedSchema,
+      output: undefined,
+      annotations: Schema.resolveAnnotations(definition.schema),
+      type: "atomic",
+      history: undefined,
+      initial: undefined,
+      states: undefined
+    }
 }
 
 export const compileStateNodes = (states: Machine.StateSchemas): Machine.StateNodes => {
@@ -354,40 +419,110 @@ export const compileStateNodes = (states: Machine.StateSchemas): Machine.StateNo
       }
       const path = parent === undefined ? key : `${parent}.${key}`
       const definition = getStateNodeDefinition(path, tree[key])
-      const node: Machine.StateNode = {
-        path,
-        key,
-        schema: definition.schema,
-        output: definition.output,
-        annotations: definition.annotations,
-        type: definition.type,
-        parent,
-        children: [] as ReadonlyArray<string>,
-        initial: definition.initial === undefined ? undefined : `${path}.${definition.initial}`,
-        history: definition.type === "history"
-          ? ((tree[key] as any).history === "deep" ? "deep" : "shallow")
-          : undefined,
-        order
+      let node: Machine.StateNode
+      let childStates: Machine.StateTree | undefined
+      const base = { path, key, annotations: definition.annotations, order }
+      switch (definition.type) {
+        case "atomic":
+          node = {
+            ...base,
+            type: "atomic",
+            schema: definition.schema,
+            output: undefined,
+            history: undefined,
+            parent,
+            children: [],
+            initial: undefined
+          }
+          break
+        case "compound":
+          node = {
+            ...base,
+            type: "compound",
+            schema: definition.schema,
+            output: undefined,
+            history: undefined,
+            parent,
+            children: [],
+            initial: `${path}.${definition.initial}`
+          }
+          childStates = definition.states
+          break
+        case "parallel":
+          node = {
+            ...base,
+            type: "parallel",
+            schema: definition.schema,
+            output: definition.output,
+            history: undefined,
+            parent,
+            children: [],
+            initial: undefined
+          }
+          childStates = definition.states
+          break
+        case "final":
+          node = {
+            ...base,
+            type: "final",
+            schema: definition.schema,
+            output: definition.output,
+            history: undefined,
+            parent,
+            children: [],
+            initial: undefined
+          }
+          break
+        case "history":
+          if (parent === undefined) {
+            throw new Error(`Machine history state "${path}" must belong to a parent state`)
+          }
+          node = {
+            ...base,
+            type: "history",
+            schema: undefined,
+            output: undefined,
+            history: definition.history,
+            parent,
+            children: [],
+            initial: undefined
+          }
+          break
+        case "choice":
+          if (parent === undefined) {
+            throw new Error(`Machine choice state "${path}" must belong to a parent state`)
+          }
+          node = {
+            ...base,
+            type: "choice",
+            schema: undefined,
+            output: undefined,
+            history: undefined,
+            parent,
+            children: [],
+            initial: undefined
+          }
+          break
       }
       byPath.set(path, node)
       order += 1
       if (definition.type === "history" || definition.type === "choice") {
-        if (parent === undefined) {
-          throw new Error(`Machine ${definition.type} state "${path}" must belong to a parent state`)
-        }
         continue
       }
       paths.push(path)
-      if (definition.states !== undefined) {
-        const children = compile(definition.states, path)
-        if (
-          node.type === "compound" &&
-          (node.initial === undefined ||
-            (!children.includes(node.initial) && byPath.get(node.initial)?.type !== "choice"))
-        ) {
-          throw new Error(`Machine.make expected compound state "${path}" initial child to exist`)
+      if (childStates !== undefined) {
+        const children = compile(childStates, path)
+        if (node.type === "compound") {
+          if (!children.includes(node.initial) && byPath.get(node.initial)?.type !== "choice") {
+            throw new Error(`Machine.make expected compound state "${path}" initial child to exist`)
+          }
+          node = { ...node, children }
+        } else if (node.type === "parallel") {
+          node = { ...node, children }
+        } else {
+          throw new Error(`Machine state "${path}" cannot declare child states`)
         }
-        ;(node as { children: ReadonlyArray<string> }).children = children
+        byPath.set(path, node)
       }
     }
     return paths
@@ -680,7 +815,7 @@ export const getNode = (machine: Machine.Any, path: string): Machine.StateNode =
 }
 
 export const getStateNodeSchema = (node: Machine.StateNode): Machine.TaggedSchema => {
-  if (node.schema === undefined || node.type === "history" || node.type === "choice") {
+  if (node.schema === undefined) {
     throw new Error(`Machine pseudo-state "${node.path}" has no active value schema`)
   }
   return node.schema

--- a/src/internal/machineReadiness.ts
+++ b/src/internal/machineReadiness.ts
@@ -1,0 +1,10 @@
+import type * as Machine from "../Machine.js"
+
+/** Canonical proof required before a machine can be planned or executed. */
+export type EnsureExecutable<
+  States extends Machine.Machine.StateSchemas,
+  UnhandledStates extends Machine.Machine.StateIdentifier<States>,
+  OutputStates extends Machine.Machine.StateIdentifier<States>
+> =
+  & Machine.Machine.EnsureOutputImplementations<States, OutputStates>
+  & Machine.Machine.EnsureHistoryImplementations<States, UnhandledStates>

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -10,7 +10,6 @@ import * as Context from "effect/Context"
 import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
-import * as Fiber from "effect/Fiber"
 import * as HashMap from "effect/HashMap"
 import * as Option from "effect/Option"
 import * as PubSub from "effect/PubSub"
@@ -301,10 +300,10 @@ const startInternal: <
   const sessionId = yield* options.runtime.nextSessionId
   const id = options.id ?? sessionId
   const queue = yield* Queue.unbounded<Event>()
-  const stopSelfDeferred = yield* Deferred.make<Effect.Effect<void>>()
+  const stopRequested = yield* Deferred.make<void>()
+  const terminalized = yield* Deferred.make<void>()
   const externalFailure = yield* Deferred.make<never, Error>()
   const done = yield* Deferred.make<Output, Error | StoppedError>()
-  const fiberRef = yield* Deferred.make<Fiber.Fiber<void>>()
   const changes = yield* PubSub.unbounded<Take.Take<VersionedSnapshot<State, Error, Output>>>({
     replay: 1
   })
@@ -319,8 +318,8 @@ const startInternal: <
 
   const cleanupStartupFailure = <A, E>(exit: Exit.Exit<A, E>): Effect.Effect<void> =>
     Exit.isFailure(exit)
-      ? Deferred.succeed(stopSelfDeferred, Effect.void).pipe(
-        Effect.andThen(closeChildren(exit))
+      ? closeChildren(exit).pipe(
+        Effect.ensuring(Deferred.succeed(terminalized, void 0))
       )
       : Effect.void
 
@@ -537,10 +536,21 @@ const startInternal: <
     >
   }
 
+  let initializing = true
+  const requestStop = Deferred.succeed(stopRequested, void 0).pipe(Effect.asVoid)
   const self: ProcessAddress<Event> = {
     id,
     sessionId,
-    stop: Deferred.await(stopSelfDeferred).pipe(Effect.flatMap((stopSelf) => stopSelf)),
+    // Initialization must finish constructing a state before a stopped
+    // snapshot can be published. A stop requested there is therefore recorded
+    // and returns so initialization can finish. Once running, the requesting
+    // process waits forever and is interrupted by the supervisor after the
+    // stop request wins, so execution never continues after `self.stop`.
+    stop: Effect.suspend(() =>
+      initializing
+        ? requestStop
+        : requestStop.pipe(Effect.andThen(Effect.never))
+    ),
     send: (event: Event) =>
       Queue.offer(queue, event).pipe(
         Effect.flatMap((accepted) => accepted ? Effect.void : Effect.fail(new StoppedError()))
@@ -557,7 +567,12 @@ const startInternal: <
     failCause: (cause) => Deferred.failCause(externalFailure, cause as Cause.Cause<Error>)
   }
 
-  const initial = yield* logic.initial(scope).pipe(Effect.onExit(cleanupStartupFailure))
+  const initial = yield* logic.initial(scope).pipe(
+    Effect.onExit(cleanupStartupFailure),
+    Effect.ensuring(Effect.sync(() => {
+      initializing = false
+    }))
+  )
   const current = yield* SynchronizedRef.make<VersionedSnapshot<State, Error, Output>>({
     revision: 0,
     snapshot: {
@@ -566,8 +581,6 @@ const startInternal: <
     }
   })
   const terminalizing = yield* Ref.make(false)
-  const terminalized = yield* Deferred.make<void>()
-
   const publishSnapshot = (
     snapshot: VersionedSnapshot<State, Error, Output>
   ): Effect.Effect<VersionedSnapshot<State, Error, Output>> =>
@@ -702,29 +715,64 @@ const startInternal: <
       )
     )
 
-  const stopSelf: Effect.Effect<void> = Effect.uninterruptible(
+  const reserveStoppedSnapshot = reserveTerminalSnapshot((snapshot) => ({
+    status: "stopped",
+    state: snapshot.state
+  }))
+
+  const reserveFailureSnapshot = (cause: Cause.Cause<Error>) =>
     reserveTerminalSnapshot((snapshot) => ({
-      status: "stopped",
-      state: snapshot.state
-    })).pipe(
+      status: "error",
+      state: snapshot.state,
+      cause
+    }))
+
+  const reserveSuccessSnapshot = (output: Output) =>
+    reserveTerminalSnapshot((snapshot) => ({
+      status: "done",
+      state: snapshot.state,
+      output
+    }))
+
+  const terminalizeReservedStop = (
+    snapshot: RuntimeSnapshot<State, Error, Output>
+  ): Effect.Effect<void> => {
+    const exit = Exit.void
+    return terminalizeWith(
+      snapshot,
+      exit,
+      Deferred.fail(done, new StoppedError())
+    )
+  }
+
+  const terminalizeReservedFailure = (
+    snapshot: RuntimeSnapshot<State, Error, Output>,
+    cause: Cause.Cause<Error>
+  ): Effect.Effect<void> => {
+    const exit = Exit.failCause(cause)
+    return terminalizeWith(snapshot, exit, Deferred.failCause(done, cause))
+  }
+
+  const terminalizeReservedSuccess = (
+    snapshot: RuntimeSnapshot<State, Error, Output>,
+    output: Output
+  ): Effect.Effect<void> => {
+    const exit = Exit.succeed(output)
+    return terminalizeWith(snapshot, exit, Deferred.succeed(done, output))
+  }
+
+  const terminalizeStop: Effect.Effect<void> = Effect.uninterruptible(
+    reserveStoppedSnapshot.pipe(
       Effect.flatMap((snapshot) =>
         snapshot === undefined
           ? Deferred.await(terminalized)
-          : Effect.suspend(() => {
-            const exit = Exit.void
-            return Deferred.await(fiberRef).pipe(
-              Effect.flatMap(Fiber.interrupt),
-              Effect.andThen(
-                terminalizeWith(
-                  snapshot,
-                  exit,
-                  Deferred.fail(done, new StoppedError())
-                )
-              )
-            )
-          })
+          : terminalizeReservedStop(snapshot)
       )
     )
+  )
+
+  const stop: Effect.Effect<void> = Effect.uninterruptible(
+    requestStop.pipe(Effect.andThen(Deferred.await(terminalized)))
   )
 
   const context: ProcessContext<State, Event> = {
@@ -746,7 +794,6 @@ const startInternal: <
   }
 
   yield* publishSnapshot(yield* SynchronizedRef.get(current))
-  yield* Deferred.succeed(stopSelfDeferred, stopSelf)
 
   const changesStream: Stream.Stream<RuntimeSnapshot<State, Error, Output>> = Stream.unwrap(
     Effect.gen(function*() {
@@ -766,38 +813,6 @@ const startInternal: <
     })
   )
 
-  const terminalizeFailure = (cause: Cause.Cause<Error>): Effect.Effect<void> =>
-    reserveTerminalSnapshot((snapshot) => ({
-      status: "error",
-      state: snapshot.state,
-      cause
-    })).pipe(
-      Effect.flatMap((snapshot) =>
-        snapshot === undefined
-          ? Effect.void
-          : Effect.suspend(() => {
-            const exit = Exit.failCause(cause)
-            return terminalizeWith(snapshot, exit, Deferred.failCause(done, cause))
-          })
-      )
-    )
-
-  const terminalizeSuccess = (output: Output): Effect.Effect<void> =>
-    reserveTerminalSnapshot((snapshot) => ({
-      status: "done",
-      state: snapshot.state,
-      output
-    })).pipe(
-      Effect.flatMap((snapshot) =>
-        snapshot === undefined
-          ? Effect.void
-          : Effect.suspend(() => {
-            const exit = Exit.succeed(output)
-            return terminalizeWith(snapshot, exit, Deferred.succeed(done, output))
-          })
-      )
-    )
-
   const ref: MachineRef<State, Event, Error, Output> = {
     id,
     sessionId,
@@ -805,7 +820,7 @@ const startInternal: <
     snapshot: SynchronizedRef.get(current).pipe(Effect.map((current) => current.snapshot)),
     changes: changesStream,
     join: Deferred.await(done),
-    stop: stopSelf,
+    stop,
     send: self.send,
     child: getChild,
     childChanges
@@ -815,17 +830,86 @@ const startInternal: <
     yield* options.onReady(ref)
   }
 
-  const runFiber: Effect.Effect<void, never, Requirements> = Effect.raceFirst(
-    logic.run(context),
-    Deferred.await(externalFailure)
-  ).pipe(
-    Effect.matchCauseEffect({
-      onFailure: terminalizeFailure,
-      onSuccess: terminalizeSuccess
-    })
+  type ProcessTermination =
+    | { readonly _tag: "Stopped"; readonly snapshot: RuntimeSnapshot<State, Error, Output> }
+    | {
+      readonly _tag: "Done"
+      readonly snapshot: RuntimeSnapshot<State, Error, Output>
+      readonly output: Output
+    }
+    | {
+      readonly _tag: "Failure"
+      readonly snapshot: RuntimeSnapshot<State, Error, Output>
+      readonly cause: Cause.Cause<Error>
+    }
+
+  const arbitration = yield* Deferred.make<ProcessTermination>()
+  // Only the actual worker and stop waiter are restored to interruptibility.
+  // Reserving a terminal snapshot, publishing the shared arbitration result,
+  // and terminalizing stay masked so scope interruption cannot abandon a
+  // reservation. Both contenders read the same result: a contender that loses
+  // the reservation cannot finish the race with a different outcome.
+  const runFiber: Effect.Effect<void, never, Requirements> = Effect.uninterruptibleMask((restore) =>
+    Deferred.poll(stopRequested).pipe(
+      Effect.flatMap((requested) => {
+        if (Option.isSome(requested)) {
+          return terminalizeStop
+        }
+        const awaitArbitration = Deferred.await(arbitration)
+        const completeArbitration = (termination: ProcessTermination) =>
+          Deferred.succeed(arbitration, termination).pipe(
+            Effect.andThen(awaitArbitration)
+          )
+        const stopContender = restore(Deferred.await(stopRequested)).pipe(
+          Effect.andThen(reserveStoppedSnapshot),
+          Effect.flatMap((snapshot) =>
+            snapshot === undefined
+              ? awaitArbitration
+              : completeArbitration({ _tag: "Stopped", snapshot })
+          )
+        )
+        const workerContender: Effect.Effect<ProcessTermination, never, Requirements> = restore(
+          Effect.raceFirst(
+            Effect.suspend(() => logic.run(context)),
+            Deferred.await(externalFailure)
+          )
+        ).pipe(
+          Effect.exit,
+          Effect.flatMap((exit) =>
+            Exit.isFailure(exit)
+              ? reserveFailureSnapshot(exit.cause).pipe(
+                Effect.flatMap((snapshot) =>
+                  snapshot === undefined
+                    ? awaitArbitration
+                    : completeArbitration({ _tag: "Failure", snapshot, cause: exit.cause })
+                )
+              )
+              : reserveSuccessSnapshot(exit.value).pipe(
+                Effect.flatMap((snapshot) =>
+                  snapshot === undefined
+                    ? awaitArbitration
+                    : completeArbitration({ _tag: "Done", snapshot, output: exit.value })
+                )
+              )
+          )
+        )
+        return Effect.raceFirst(workerContender, stopContender).pipe(
+          Effect.flatMap((termination) => {
+            switch (termination._tag) {
+              case "Stopped":
+                return terminalizeReservedStop(termination.snapshot)
+              case "Done":
+                return terminalizeReservedSuccess(termination.snapshot, termination.output)
+              case "Failure":
+                return terminalizeReservedFailure(termination.snapshot, termination.cause)
+            }
+          })
+        )
+      })
+    )
   )
 
-  const fiber = yield* runFiber.pipe(
+  yield* runFiber.pipe(
     (effect) =>
       options.fiberScope !== undefined ?
         Effect.forkIn(effect, options.fiberScope)
@@ -833,7 +917,6 @@ const startInternal: <
         Effect.forkDetach(effect)
         : Effect.forkChild(effect)
   )
-  yield* Deferred.succeed(fiberRef, fiber)
   yield* Effect.yieldNow
 
   return ref

--- a/src/internal/machineStateDefinition.ts
+++ b/src/internal/machineStateDefinition.ts
@@ -1,0 +1,270 @@
+import * as Schema from "effect/Schema"
+import * as SchemaAST from "effect/SchemaAST"
+
+export const StateNodePropertyPolicy = {
+  atomic: ["schema", "type"],
+  final: ["schema", "type", "output"],
+  compound: ["schema", "type", "initial", "states"],
+  parallel: ["schema", "type", "output", "states"],
+  history: ["type", "history", "annotations"],
+  choice: ["type", "annotations"]
+} as const
+
+export const PseudoStateAnnotationProperties = ["title", "description", "documentation"] as const
+
+export type StateNodeKind = keyof typeof StateNodePropertyPolicy
+
+export type AllowedStateNodeProperty<Kind extends StateNodeKind> = (typeof StateNodePropertyPolicy)[Kind][number]
+
+export type AllowedPseudoStateAnnotationProperty = (typeof PseudoStateAnnotationProperties)[number]
+
+export type StateDefinitionBoundary = "Machine.defineStates" | "Machine.make"
+
+const hasOwn = (value: object, key: PropertyKey): boolean => Object.prototype.hasOwnProperty.call(value, key)
+
+const displayPath = (parent: string, key: PropertyKey): string => {
+  const segment = typeof key === "symbol" ? `[${String(key)}]` : key === "" ? "<empty>" : String(key)
+  return parent === "" ? segment : `${parent}.${segment}`
+}
+
+const fail = (boundary: StateDefinitionBoundary, path: string, message: string): never => {
+  throw new Error(`${boundary} invalid state definition at "${path}": ${message}`)
+}
+
+const isNumericForm = (key: string): boolean => Number.isFinite(Number(key))
+
+type TaggedSchemaEvidence = "tagged" | "untagged" | "opaque"
+
+const unionEvidence = (evidence: ReadonlyArray<TaggedSchemaEvidence>): TaggedSchemaEvidence =>
+  evidence.length === 0 || evidence.some((result) => result === "untagged")
+    ? "untagged"
+    : evidence.every((result) => result === "tagged")
+    ? "tagged"
+    : "opaque"
+
+const propertyKeyEvidence = (
+  ast: SchemaAST.AST,
+  seen: ReadonlySet<SchemaAST.AST>
+): TaggedSchemaEvidence => {
+  if (seen.has(ast)) return "opaque"
+  if (SchemaAST.isString(ast) || SchemaAST.isNumber(ast) || SchemaAST.isSymbol(ast)) return "tagged"
+  if (SchemaAST.isTemplateLiteral(ast) || SchemaAST.isUniqueSymbol(ast) || SchemaAST.isEnum(ast)) return "tagged"
+  if (SchemaAST.isLiteral(ast)) {
+    return typeof ast.literal === "string" || typeof ast.literal === "number" ? "tagged" : "untagged"
+  }
+  const nextSeen = new Set(seen).add(ast)
+  if (SchemaAST.isUnion(ast)) return unionEvidence(ast.types.map((member) => propertyKeyEvidence(member, nextSeen)))
+  if (SchemaAST.isSuspend(ast)) return propertyKeyEvidence(ast.thunk(), nextSeen)
+  if (SchemaAST.isDeclaration(ast)) return "opaque"
+  return "untagged"
+}
+
+const taggedSchemaEvidence = (
+  ast: SchemaAST.AST,
+  seen: ReadonlySet<SchemaAST.AST> = new Set()
+): TaggedSchemaEvidence => {
+  if (seen.has(ast)) return "opaque"
+  if (SchemaAST.isObjects(ast)) {
+    const tag = ast.propertySignatures.find(({ name }) => name === "_tag")?.type
+    if (tag === undefined || SchemaAST.isOptional(tag)) return "untagged"
+    return propertyKeyEvidence(tag, new Set(seen).add(ast))
+  }
+  const nextSeen = new Set(seen).add(ast)
+  if (SchemaAST.isUnion(ast)) return unionEvidence(ast.types.map((member) => taggedSchemaEvidence(member, nextSeen)))
+  if (SchemaAST.isSuspend(ast)) return taggedSchemaEvidence(ast.thunk(), nextSeen)
+  // A declaration's decoded Type is intentionally opaque at runtime. Its type
+  // parameters describe values contained by the declaration, not its outer
+  // shape, so neither they nor private sentinel metadata can prove the public
+  // structural TaggedSchema contract without rejecting valid Schema.declare
+  // schemas or relying on an undocumented Effect export.
+  if (SchemaAST.isDeclaration(ast)) return "opaque"
+  return "untagged"
+}
+
+/**
+ * Rejects schemas whose decoded AST proves they cannot satisfy the structural
+ * `_tag: PropertyKey` contract of `Machine.TaggedSchema`. Declarations without
+ * sentinel metadata stay opaque: their Type is unavailable at runtime, so
+ * rejecting them would reject valid `Schema.declare` schemas. Consequently an
+ * unsafe cast or JavaScript caller can pass an opaque untagged declaration;
+ * this boundary only promises to reject schemas whose mismatch is provable.
+ */
+const isTaggedSchema = (value: unknown): value is Schema.Top =>
+  Schema.isSchema(value) && taggedSchemaEvidence(SchemaAST.toType(value.ast)) !== "untagged"
+
+const validateStateKey = (
+  boundary: StateDefinitionBoundary,
+  parent: string,
+  key: PropertyKey
+): string => {
+  const path = displayPath(parent, key)
+  if (typeof key === "symbol") {
+    return fail(boundary, path, "state keys must be strings, not symbols")
+  }
+  if (typeof key === "number") {
+    return fail(boundary, path, "state keys cannot use numeric forms")
+  }
+  if (key === "") {
+    return fail(boundary, path, "state keys cannot be empty")
+  }
+  if (key === "__proto__") {
+    return fail(boundary, path, "the state key \"__proto__\" is not allowed")
+  }
+  if (key.includes(".")) {
+    return fail(boundary, path, "state keys cannot contain \".\"")
+  }
+  if (isNumericForm(key)) {
+    return fail(boundary, path, "state keys cannot use numeric forms")
+  }
+  return path
+}
+
+const assertPlainRecord: (
+  boundary: StateDefinitionBoundary,
+  path: string,
+  value: unknown,
+  description: string
+) => asserts value is Readonly<Record<PropertyKey, unknown>> = (boundary, path, value, description) => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    fail(boundary, path, `${description} must be a plain record`)
+  }
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) {
+    fail(
+      boundary,
+      displayPath(path === "<root>" ? "" : path, "__proto__"),
+      `${description} must not declare an implicit "__proto__" state key`
+    )
+  }
+}
+
+const assertAllowedProperties = (
+  boundary: StateDefinitionBoundary,
+  path: string,
+  node: Readonly<Record<PropertyKey, unknown>>,
+  kind: StateNodeKind
+): void => {
+  const allowed = StateNodePropertyPolicy[kind] as ReadonlyArray<PropertyKey>
+  for (const property of Reflect.ownKeys(node)) {
+    if (!allowed.includes(property)) {
+      fail(boundary, path, `${kind} states cannot declare property "${String(property)}"`)
+    }
+  }
+}
+
+const validatePseudoAnnotations = (
+  boundary: StateDefinitionBoundary,
+  path: string,
+  annotations: unknown
+): void => {
+  assertPlainRecord(boundary, `${path}.annotations`, annotations, "pseudo-state annotations")
+  for (const property of Reflect.ownKeys(annotations)) {
+    if (!(PseudoStateAnnotationProperties as ReadonlyArray<PropertyKey>).includes(property)) {
+      fail(boundary, `${path}.annotations`, `pseudo-state annotations cannot declare property "${String(property)}"`)
+    }
+    if (typeof annotations[property] !== "string") {
+      fail(boundary, `${path}.annotations.${String(property)}`, "pseudo-state annotation values must be strings")
+    }
+  }
+}
+
+const validateStateTree = (
+  boundary: StateDefinitionBoundary,
+  states: unknown,
+  parent: string,
+  allowPseudoStates: boolean
+): void => {
+  const treePath = parent === "" ? "<root>" : parent
+  assertPlainRecord(boundary, treePath, states, "state trees")
+
+  for (const key of Reflect.ownKeys(states)) {
+    const path = validateStateKey(boundary, parent, key)
+    const node = states[key]
+
+    // Effect schemas have their own runtime properties. They are complete
+    // atomic node definitions and must be recognized before config validation.
+    if (Schema.isSchema(node)) {
+      if (!isTaggedSchema(node)) {
+        fail(boundary, path, "state schemas must decode to an object with a required PropertyKey _tag")
+      }
+      continue
+    }
+    assertPlainRecord(boundary, path, node, "state nodes")
+
+    const type = node.type
+    const kind: StateNodeKind = type === "history" ?
+      "history"
+      : type === "choice" ?
+      "choice"
+      : type === "parallel" ?
+      "parallel"
+      : type === "final" ?
+      "final"
+      : hasOwn(node, "states") ?
+      "compound"
+      : "atomic"
+
+    assertAllowedProperties(boundary, path, node, kind)
+
+    if (kind === "history" || kind === "choice") {
+      if (!allowPseudoStates) {
+        fail(boundary, path, `${kind} states must be declared below an active parent state`)
+      }
+      if (hasOwn(node, "annotations")) {
+        validatePseudoAnnotations(boundary, path, node.annotations)
+      }
+      if (kind === "history" && hasOwn(node, "history") && node.history !== "shallow" && node.history !== "deep") {
+        fail(boundary, `${path}.history`, "history must be \"shallow\" or \"deep\"")
+      }
+      continue
+    }
+
+    if (!hasOwn(node, "schema") || !isTaggedSchema(node.schema)) {
+      fail(boundary, `${path}.schema`, "active states must declare an Effect Schema with a required PropertyKey _tag")
+    }
+    if (kind === "atomic" && hasOwn(node, "type") && node.type !== "active") {
+      fail(boundary, `${path}.type`, "atomic state type must be \"active\"")
+    }
+    if (kind === "final" && node.type !== "final") {
+      fail(boundary, `${path}.type`, "final state type must be \"final\"")
+    }
+    if (kind === "compound" && hasOwn(node, "type") && node.type !== "active") {
+      fail(boundary, `${path}.type`, "compound state type must be \"active\"")
+    }
+    if (kind === "parallel" && node.type !== "parallel") {
+      fail(boundary, `${path}.type`, "parallel state type must be \"parallel\"")
+    }
+    if ((kind === "final" || kind === "parallel") && hasOwn(node, "output") && !Schema.isSchema(node.output)) {
+      fail(boundary, `${path}.output`, "state output must be an Effect Schema")
+    }
+    if (kind === "compound") {
+      if (typeof node.initial !== "string") {
+        fail(boundary, `${path}.initial`, "compound states must declare an initial child key")
+      }
+      const initialKey = node.initial as string
+      validateStateTree(boundary, node.states, path, true)
+      if (!hasOwn(node.states as object, initialKey)) {
+        fail(boundary, `${path}.initial`, `compound initial child "${initialKey}" does not exist`)
+      }
+      const initial = (node.states as Readonly<Record<PropertyKey, unknown>>)[initialKey]
+      if (
+        !Schema.isSchema(initial) && typeof initial === "object" && initial !== null &&
+        (initial as Readonly<Record<PropertyKey, unknown>>).type === "history"
+      ) {
+        fail(boundary, `${path}.initial`, "compound initial children cannot be history states")
+      }
+      continue
+    }
+    if (kind === "parallel") {
+      if (!hasOwn(node, "states")) {
+        fail(boundary, `${path}.states`, "parallel states must declare child regions")
+      }
+      validateStateTree(boundary, node.states, path, true)
+    }
+  }
+}
+
+export const validateStateDefinitions = (
+  states: unknown,
+  boundary: StateDefinitionBoundary
+): void => validateStateTree(boundary, states, "", false)

--- a/src/internal/machineTestFiniteModel.ts
+++ b/src/internal/machineTestFiniteModel.ts
@@ -1,6 +1,6 @@
 /**
- * Finite hierarchical, parallel, and history statechart models used by the public testing
- * module.
+ * Finite hierarchical, parallel, history, choice, and automatic-transition
+ * statechart models used by the public testing module.
  *
  * This module intentionally compiles through the public Machine API. It must
  * not share planner helpers with the implementation that later reference
@@ -118,20 +118,61 @@ export type FiniteState =
   | FiniteChoiceState
 
 /**
- * One deterministic event transition in a finite generated model.
+ * The single trigger representation used by generated and hand-authored finite
+ * transitions. Event, always, and completion registrations therefore share the
+ * same validation, compilation, and reference interpretation path.
  *
  * @category models
  * @since 4.0.0
  */
-export interface FiniteTransition {
+export type FiniteTransitionTrigger =
+  | { readonly type: "event"; readonly event: string }
+  | { readonly type: "always" }
+  | { readonly type: "done" }
+
+/**
+ * One deterministic transition in a finite generated model.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+interface FiniteTransitionBase {
   readonly source: string
-  readonly event: string
   /** Omission represents a targetless transition. */
   readonly target?: string
   /** Optional schema-valid value supplied for the declared target state. */
   readonly targetValue?: number
+}
+
+/**
+ * A public event transition may explicitly request source reentry.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type FiniteEventTransition = FiniteTransitionBase & {
+  readonly trigger: Extract<FiniteTransitionTrigger, { readonly type: "event" }>
   readonly reenter: boolean
 }
+
+/**
+ * An always or completion transition. Automatic transitions deliberately omit
+ * the event-only reentry option.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type FiniteAutomaticTransition = FiniteTransitionBase & {
+  readonly trigger: Exclude<FiniteTransitionTrigger, { readonly type: "event" }>
+}
+
+/**
+ * One deterministic event or automatic transition in a finite model.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type FiniteTransition = FiniteEventTransition | FiniteAutomaticTransition
 
 /**
  * The exact generated transition that changes a value before history capture.
@@ -254,7 +295,8 @@ export interface FiniteModelDiagnostics {
     readonly choiceInitialWitnesses: true
     readonly structurallyValid: true
     readonly shrinkPreservesValidity: true
-    readonly eventlessTransitions: false
+    readonly eventlessTransitions: true
+    readonly acyclicAutomaticTransitions: true
   }
 }
 
@@ -299,9 +341,12 @@ interface FlatFiniteState {
 
 interface TransitionCandidate {
   readonly source: string
-  readonly event: string
+  readonly trigger: FiniteTransitionTrigger
   readonly targets: ReadonlyArray<string>
 }
+
+const triggerKey = (trigger: FiniteTransitionTrigger): string =>
+  trigger.type === "event" ? `event:${trigger.event}` : trigger.type
 
 const defaults = {
   maxRoots: 3 as const,
@@ -610,47 +655,61 @@ const freezeModel = (
 
 const makeTransitionArbitrary = (
   roots: ReadonlyArray<FiniteState>,
+  initial: string,
   events: ReadonlyArray<string>,
   maxTransitions: number,
   historyScenarios: ReadonlyArray<FiniteHistoryScenario> = []
 ): FastCheck.Arbitrary<ReadonlyArray<FiniteTransition>> => {
   const states = flattenStates(roots)
   const sourceOrder = new Map(states.map((state, index) => [state.path, index]))
+  const stateByPath = new Map(states.map((state) => [state.path, state]))
+  const initiallyActive = new Set(
+    initialLeaves(stateByPath, initial).flatMap((leaf) => {
+      const parts = leaf.split(".")
+      return parts.map((_, index) => parts.slice(0, index + 1).join("."))
+    })
+  )
+  const triggerOrder = (trigger: FiniteTransitionTrigger): number =>
+    trigger.type === "event"
+      ? events.indexOf(trigger.event)
+      : events.length + (trigger.type === "always" ? 0 : 1)
   const orderTransitions = (transitions: ReadonlyArray<FiniteTransition>): ReadonlyArray<FiniteTransition> =>
     transitions.slice().sort((left, right) =>
       sourceOrder.get(left.source)! - sourceOrder.get(right.source)! ||
-      events.indexOf(left.event) - events.indexOf(right.event)
+      triggerOrder(left.trigger) - triggerOrder(right.trigger)
     )
   const active = states.filter(({ node }) => node._tag !== "Final" && node._tag !== "History" && node._tag !== "Choice")
   const mandatory = historyScenarios.flatMap((scenario): ReadonlyArray<FiniteTransition> => [
     {
       source: scenario.mutation.source,
-      event: scenario.mutation.event,
+      trigger: { type: "event", event: scenario.mutation.event },
       target: scenario.mutation.target,
       targetValue: scenario.mutation.value,
       reenter: false
     },
     {
       source: scenario.leave.source,
-      event: scenario.leave.event,
+      trigger: { type: "event", event: scenario.leave.event },
       target: scenario.leave.target,
       reenter: false
     },
     {
       source: scenario.resume.source,
-      event: scenario.resume.event,
+      trigger: { type: "event", event: scenario.resume.event },
       target: scenario.resume.target,
       reenter: false
     }
   ])
-  const mandatoryRegistrations = new Set(mandatory.map(({ source, event }) => `${source}\u0000${event}`))
+  const mandatoryRegistrations = new Set(
+    mandatory.map(({ source, trigger }) => `${source}\u0000${triggerKey(trigger)}`)
+  )
   const reservedEvents = new Set(
     historyScenarios.flatMap(({ leave, mutation }) => [leave.event, mutation.event])
   )
-  const candidates = active.flatMap(({ path: source, root }) =>
+  const eventCandidates = active.flatMap(({ path: source, root }) =>
     events.map((event): TransitionCandidate => ({
       source,
-      event,
+      trigger: { type: "event", event },
       // `branch` addresses the source root while `full` replaces another root.
       // Same-root targets may select any state, including a parallel state or
       // a compound state whose initial descent enters a parallel state. The
@@ -660,49 +719,127 @@ const makeTransitionArbitrary = (
       )
         .map(({ path }) => path)
     }))
-  ).filter(({ source, event }) =>
-    !mandatoryRegistrations.has(`${source}\u0000${event}`) &&
-    !reservedEvents.has(event)
+  ).filter(({ source, trigger }) =>
+    !mandatoryRegistrations.has(`${source}\u0000${triggerKey(trigger)}`) &&
+    (trigger.type !== "event" || !reservedEvents.has(trigger.event))
   )
-
-  return FastCheck.subarray(candidates, {
-    minLength: 0,
-    maxLength: Math.min(maxTransitions - mandatory.length, candidates.length)
-  }).chain((selected) => {
-    if (selected.length === 0) {
-      return FastCheck.constant<ReadonlyArray<FiniteTransition>>(orderTransitions(mandatory))
+  const exitsSourceTargets = (source: FlatFiniteState): ReadonlyArray<string> =>
+    states.filter((target, targetIndex) => {
+      if (
+        targetIndex <= sourceOrder.get(source.path)! || target.node._tag === "History" ||
+        target.node._tag === "Choice"
+      ) return false
+      // A generated automatic transition must make its source inactive. This
+      // gives the independent oracle a structurally acyclic witness instead of
+      // relying on runtime iteration bounds. A later sibling under a compound
+      // parent exits the source branch; a later root replaces the whole root.
+      if (source.parent === undefined) {
+        return target.parent === undefined && target.root !== source.root
+      }
+      return stateByPath.get(source.parent)?.node._tag === "Compound" && target.parent === source.parent
+    }).map(({ path }) => path)
+  const automaticCandidates: ReadonlyArray<TransitionCandidate> = historyScenarios.length === 0
+    ? [
+      ...active.flatMap((source): ReadonlyArray<TransitionCandidate> =>
+        source.node._tag !== "Atomic" ? [] : [{
+          source: source.path,
+          trigger: { type: "always" },
+          targets: exitsSourceTargets(source)
+        }]
+      ),
+      ...states.flatMap((source): ReadonlyArray<TransitionCandidate> =>
+        source.node._tag !== "Compound" && source.node._tag !== "Parallel" ? [] : [{
+          source: source.path,
+          trigger: { type: "done" },
+          targets: exitsSourceTargets(source)
+        }]
+      )
+    ].filter(({ targets }) => targets.length > 0)
+    : []
+  const completesOnEntry = (path: string): boolean => {
+    const state = stateByPath.get(path)!
+    if (state.node._tag === "Final") return true
+    if (state.node._tag === "Compound") {
+      const node = state.node
+      return node.states.some(({ key, _tag }) => key === node.initial && _tag === "Final")
     }
+    if (state.node._tag === "Parallel") {
+      return state.node.states
+        .filter(({ _tag }) => _tag !== "History" && _tag !== "Choice")
+        .every((child) => completesOnEntry(`${path}.${child.key}`))
+    }
+    return false
+  }
+  const materialize = (
+    selected: ReadonlyArray<TransitionCandidate>,
+    allowTargetlessEvents = true
+  ): FastCheck.Arbitrary<ReadonlyArray<FiniteTransition>> => {
+    if (selected.length === 0) return FastCheck.constant([])
     const decisions = selected.map((candidate) =>
       FastCheck.record({
-        targetIndex: FastCheck.integer({ min: 0, max: candidate.targets.length }),
+        // Targetless event transitions remain useful witnesses. Generated
+        // automatic transitions always exit their source so stabilization is
+        // acyclic by construction; targetless automatic semantics are covered
+        // by focused examples rather than mixed into the finite-model oracle.
+        targetIndex: FastCheck.integer({
+          min: candidate.trigger.type === "event" && allowTargetlessEvents ? 0 : 1,
+          max: candidate.targets.length
+        }),
         targetValueOffset: FastCheck.integer({ min: 0, max: 2 }),
         reenter: FastCheck.boolean()
       })
     )
     return FastCheck.tuple(...decisions).map((values) =>
-      orderTransitions([
-        ...mandatory,
-        ...selected.map((candidate, index): FiniteTransition => {
-          const decision = values[index]!
-          const target = decision.targetIndex === 0 ? undefined : candidate.targets[decision.targetIndex - 1]
-          const targetState = target === undefined ? undefined : states.find(({ path }) => path === target)
-          const targetValue = targetState?.node._tag === "Atomic" &&
-              decision.targetValueOffset !== 0
-            ? targetState.node.value + decision.targetValueOffset
-            : undefined
-          return target === undefined
-            ? { source: candidate.source, event: candidate.event, reenter: decision.reenter }
-            : {
-              source: candidate.source,
-              event: candidate.event,
-              target,
-              ...(targetValue === undefined ? {} : { targetValue }),
-              reenter: decision.reenter
-            }
-        })
-      ])
+      selected.map((candidate, index): FiniteTransition => {
+        const decision = values[index]!
+        const target = decision.targetIndex === 0 ? undefined : candidate.targets[decision.targetIndex - 1]
+        const targetState = target === undefined ? undefined : states.find(({ path }) => path === target)
+        const targetValue = targetState?.node._tag === "Atomic" &&
+            decision.targetValueOffset !== 0
+          ? targetState.node.value + decision.targetValueOffset
+          : undefined
+        const targetFields = target === undefined
+          ? {}
+          : { target, ...(targetValue === undefined ? {} : { targetValue }) }
+        const trigger = candidate.trigger
+        return trigger.type === "event"
+          ? { source: candidate.source, trigger, reenter: decision.reenter, ...targetFields }
+          : { source: candidate.source, trigger, ...targetFields }
+      })
     )
+  }
+  const optionalBudget = maxTransitions - mandatory.length
+  const general = FastCheck.subarray([...eventCandidates, ...automaticCandidates], {
+    minLength: 0,
+    maxLength: Math.min(optionalBudget, eventCandidates.length + automaticCandidates.length)
+  }).chain((selected) => materialize(selected).map((transitions) => orderTransitions([...mandatory, ...transitions])))
+
+  if (mandatory.length > 0 || optionalBudget < 2 || automaticCandidates.length === 0) return general
+
+  // Bias one branch toward a reachable public-event -> automatic-transition
+  // chain. The automatic edge itself still moves forward in document order,
+  // so combining the two trigger kinds cannot introduce an automatic cycle.
+  const chainCandidates = eventCandidates.flatMap((eventCandidate) => {
+    const source = stateByPath.get(eventCandidate.source)!
+    if (source.node._tag !== "Atomic" || !initiallyActive.has(source.path)) return []
+    return automaticCandidates.flatMap((automaticCandidate) => {
+      if (
+        automaticCandidate.source === eventCandidate.source ||
+        !eventCandidate.targets.includes(automaticCandidate.source) ||
+        (automaticCandidate.trigger.type === "done" && !completesOnEntry(automaticCandidate.source))
+      ) return []
+      return [{
+        event: { ...eventCandidate, targets: [automaticCandidate.source] },
+        automatic: automaticCandidate
+      }]
+    })
   })
+  if (chainCandidates.length === 0) return general
+
+  const chain = FastCheck.constantFrom(...chainCandidates).chain(({ automatic, event }) =>
+    materialize([event, automatic], false).map((transitions) => orderTransitions(transitions))
+  )
+  return FastCheck.oneof(general, chain)
 }
 
 /**
@@ -712,7 +849,9 @@ const makeTransitionArbitrary = (
  * Generation is composed from shrinkable topology, initial-state, event, and
  * transition decisions. Paths and transition candidates are rebuilt after a
  * topology shrink, so a shrink can never retain a dangling source or target.
- * Eventless transitions are intentionally outside this model stage.
+ * Generated automatic transitions are acyclic by construction: `always`
+ * transitions leave atomic sources and completion transitions leave compound
+ * or parallel sources. Separate focused witnesses cover cyclic stabilization.
  *
  * @category constructors
  * @since 4.0.0
@@ -746,7 +885,7 @@ export const finiteModels = (options: FiniteModelOptions = {}): FiniteModels => 
       const roots = generated.scenarios.length === 0
         ? addGeneratedChoices(generated.roots, limits.maxChoiceStates)
         : generated.roots
-      return makeTransitionArbitrary(roots, events, limits.maxTransitions, generated.scenarios).map(
+      return makeTransitionArbitrary(roots, initial, events, limits.maxTransitions, generated.scenarios).map(
         (transitions) => freezeModel(roots, initial, events, transitions, generated.scenarios)
       )
     })
@@ -766,7 +905,8 @@ export const finiteModels = (options: FiniteModelOptions = {}): FiniteModels => 
         choiceInitialWitnesses: true,
         structurallyValid: true,
         shrinkPreservesValidity: true,
-        eventlessTransitions: false
+        eventlessTransitions: true,
+        acyclicAutomaticTransitions: true
       }
     }
   }
@@ -892,13 +1032,24 @@ const validateModel = (model: FiniteModel): ReadonlyArray<FlatFiniteState> => {
     ) {
       throw new Error(`MachineTest.compileModel received invalid transition source "${transition.source}"`)
     }
-    if (!events.has(transition.event)) {
-      throw new Error(`MachineTest.compileModel received unknown transition event "${transition.event}"`)
+    if (transition.trigger.type === "event" && !events.has(transition.trigger.event)) {
+      throw new Error(`MachineTest.compileModel received unknown transition event "${transition.trigger.event}"`)
     }
-    const registration = `${transition.source}\u0000${transition.event}`
+    if (
+      transition.trigger.type === "done" && source.node._tag !== "Compound" && source.node._tag !== "Parallel"
+    ) {
+      throw new Error(
+        `MachineTest.compileModel received completion transition for non-composite "${transition.source}"`
+      )
+    }
+    if (transition.trigger.type !== "event" && "reenter" in transition) {
+      throw new Error(`MachineTest.compileModel received event-only reenter option from "${transition.source}"`)
+    }
+    const registration = `${transition.source}\u0000${triggerKey(transition.trigger)}`
     if (registrations.has(registration)) {
       throw new Error(
-        `MachineTest.compileModel received duplicate transition for "${transition.source}" on "${transition.event}"`
+        `MachineTest.compileModel received duplicate transition for "${transition.source}" on ` +
+          `"${triggerKey(transition.trigger)}"`
       )
     }
     registrations.add(registration)
@@ -996,14 +1147,16 @@ const validateModel = (model: FiniteModel): ReadonlyArray<FlatFiniteState> => {
     scenarioEvents.add(scenario.mutation.event)
     scenarioEvents.add(scenario.leave.event)
     for (const [expected, targetValue] of expectedTransitions) {
-      const registration = `${expected.source}\u0000${expected.event}`
+      const registration = `${expected.source}\u0000${triggerKey({ type: "event", event: expected.event })}`
       if (scenarioRegistrations.has(registration)) {
         throw new Error(`MachineTest.compileModel received duplicate history witness for "${scenario.history}"`)
       }
       scenarioRegistrations.add(registration)
       const transition = transitionsByRegistration.get(registration)
       if (
-        transition?.target !== expected.target || transition.reenter || transition.targetValue !== targetValue
+        transition?.trigger.type !== "event" || transition.trigger.event !== expected.event ||
+        transition.target !== expected.target || !("reenter" in transition) || transition.reenter ||
+        transition.targetValue !== targetValue
       ) {
         throw new Error(`MachineTest.compileModel could not replay history scenario for "${scenario.history}"`)
       }
@@ -1233,10 +1386,12 @@ const makeHandlers = (
       continue
     }
     const on: Record<string, unknown> = Object.create(null)
-    for (const [registration, transition] of transitions) {
-      if (!registration.startsWith(`${path}\u0000`)) continue
-      on[transition.event] = {
-        reenter: transition.reenter,
+    let always: unknown
+    let onDone: unknown
+    for (const transition of transitions.values()) {
+      if (transition.source !== path) continue
+      const config = {
+        ...("reenter" in transition ? { reenter: transition.reenter } : {}),
         ...(transition.target === undefined
           ? {}
           : {
@@ -1256,6 +1411,9 @@ const makeHandlers = (
           return selectSnapshot(builder, parts[0]!, byPath, parts, 0, path, transition.targetValue)
         }
       }
+      if (transition.trigger.type === "event") on[transition.trigger.event] = config
+      else if (transition.trigger.type === "always") always = config
+      else onDone = config
     }
     const history = node._tag === "Compound" || node._tag === "Parallel"
       ? Object.fromEntries(node.states.flatMap((child) => {
@@ -1277,6 +1435,8 @@ const makeHandlers = (
       : {}
     handlers[node.key] = {
       ...(Object.keys(on).length === 0 ? {} : { on }),
+      ...(always === undefined ? {} : { always }),
+      ...(onDone === undefined ? {} : { onDone }),
       ...(node._tag === "Compound" || node._tag === "Parallel"
         ? {
           ...(node._tag === "Parallel" ? { output: () => node.output } : {}),
@@ -1325,7 +1485,7 @@ export const compileModel = (model: FiniteModel): Machine.Machine.Any => {
     initial: () => selectSnapshot(defined.initial as any, initial.path, byPath, [initial.path], 0) as any
   })
   const transitions = new Map(model.transitions.map((transition) => [
-    `${transition.source}\u0000${transition.event}`,
+    `${transition.source}\u0000${triggerKey(transition.trigger)}`,
     transition
   ]))
   return machine.handle(makeHandlers(model.roots, undefined, byPath, transitions) as any) as Machine.Machine.Any

--- a/src/internal/machineTestReferenceModel.ts
+++ b/src/internal/machineTestReferenceModel.ts
@@ -1,6 +1,6 @@
 /**
- * Independent hierarchical, parallel, and history statechart semantics for finite test
- * models.
+ * Independent hierarchical, parallel, history, choice, and automatic-
+ * transition statechart semantics for finite test models.
  *
  * This module deliberately knows nothing about `Machine`, its snapshots, the
  * finite-model compiler, target builders, or planner internals. The actual
@@ -17,7 +17,8 @@ import type {
   FiniteHistoryState,
   FiniteModel,
   FiniteState,
-  FiniteTransition
+  FiniteTransition,
+  FiniteTransitionTrigger
 } from "./machineTestFiniteModel.js"
 
 /**
@@ -83,6 +84,8 @@ export interface ReferenceTransition {
   readonly source: string
   readonly trigger:
     | { readonly type: "event"; readonly event: string }
+    | { readonly type: "always" }
+    | { readonly type: "done" }
     | { readonly type: "choice" }
   readonly reenter: boolean
   readonly target: string | undefined
@@ -243,6 +246,11 @@ interface ModelIndex {
   readonly histories: ReadonlyArray<IndexedState & { readonly node: FiniteHistoryState }>
 }
 
+const triggerKey = (trigger: FiniteTransitionTrigger): string =>
+  trigger.type === "event" ? `event:${trigger.event}` : trigger.type
+
+const reenters = (transition: FiniteTransition): boolean => "reenter" in transition && transition.reenter
+
 const ControlOrder: unique symbol = Symbol("MachineTestReferenceControlOrder")
 
 type InternalReferenceState = ReferenceState & {
@@ -298,7 +306,7 @@ const indexModel = (model: FiniteModel): ModelIndex => {
   visit(model.roots, undefined, undefined, 1)
   const byPath = new Map(ordered.map((state) => [state.path, state]))
   const transitions = new Map(
-    model.transitions.map((transition) => [`${transition.source}\u0000${transition.event}`, transition])
+    model.transitions.map((transition) => [`${transition.source}\u0000${triggerKey(transition.trigger)}`, transition])
   )
   const histories = ordered.filter(
     (state): state is IndexedState & { readonly node: FiniteHistoryState } => state.node._tag === "History"
@@ -420,6 +428,10 @@ const settleCompletions = (index: ModelIndex, state: ReferenceState): ReferenceS
       output = current.node.output
     } else if (current.node._tag === "Compound") {
       const child = directActiveChild(index, state, current.path)
+      // A compound completes only when its direct active child is final. A
+      // completed compound child instead enables that child's `done`
+      // transition; completion propagates when it transitions to a final
+      // sibling of the parent.
       if (child?.node._tag !== "Final") return undefined
       output = complete(child.path)
     } else if (current.node._tag === "Parallel") {
@@ -530,14 +542,14 @@ const activeLeaves = (index: ModelIndex, state: ReferenceState): ReadonlyArray<s
 const selectTransitions = (
   index: ModelIndex,
   state: ReferenceState,
-  event: string
+  trigger: FiniteTransitionTrigger
 ): ReadonlyArray<SelectedTransition> => {
   const selections: Array<SelectedTransition> = []
   const selectedSources = new Set<string>()
   for (const leaf of activeLeaves(index, state)) {
     const candidates = pathsToRoot(index, leaf).slice().reverse()
     for (const source of candidates) {
-      const transition = index.transitions.get(`${source}\u0000${event}`)
+      const transition = index.transitions.get(`${source}\u0000${triggerKey(trigger)}`)
       if (transition === undefined) continue
       if (!selectedSources.has(source)) {
         selectedSources.add(source)
@@ -616,9 +628,8 @@ const choiceResolvedTargetPath = (index: ModelIndex, path: string): string => {
   if (selected.node._tag === "Choice") return choiceResolvedTargetPath(index, selected.path)
   return runtimeTargetPath(index, {
     source: choice.path,
-    event: "__choice__",
-    target: selected.path,
-    reenter: false
+    trigger: { type: "always" },
+    target: selected.path
   })!
 }
 
@@ -767,8 +778,8 @@ const resolveHistoryState = (
 ): ReferenceState => {
   const historyState = getState(index, transition.target!) as IndexedState & { readonly node: FiniteHistoryState }
   const owner = historyState.parent!
-  const reenteredOwner = transition.reenter && before.activePaths.includes(owner)
-  const provisionalBoundary = transition.reenter
+  const reenteredOwner = reenters(transition) && before.activePaths.includes(owner)
+  const provisionalBoundary = reenters(transition)
     ? getState(index, transition.source).parent
     : leastCommonAncestor(index, leaf, owner)
   const provisionalExitPaths = reenteredOwner
@@ -897,8 +908,8 @@ const targetState = (
 
 const transitionRecord = (index: ModelIndex, transition: FiniteTransition): ReferenceTransition => ({
   source: transition.source,
-  trigger: { type: "event", event: transition.event },
-  reenter: transition.reenter,
+  trigger: transition.trigger,
+  reenter: reenters(transition),
   // Retain the target identity returned by the compiler's selected builder;
   // the finite AST keeps the broader declared bound separately.
   target: transition.target !== undefined && getState(index, transition.target).node._tag === "History"
@@ -960,7 +971,7 @@ const evaluateTransition = (
   const { transition } = selection
   const targetPath = runtimeTargetPath(index, transition)
   const next = targetState(index, before, transition, selection.leaf)
-  const changed = transition.reenter || !samePaths(before.activePaths, next.activePaths)
+  const changed = reenters(transition) || !samePaths(before.activePaths, next.activePaths)
   if (!changed) {
     return { ...selection, next, targetPath, changed, exitPaths: [], entryPaths: [] }
   }
@@ -970,13 +981,13 @@ const evaluateTransition = (
   const choiceEntry = transition.target === undefined ? undefined : entryChoicePath(index, transition.target)
   const choiceResolvesToActiveAncestor = choiceEntry !== undefined &&
     isPathInSubtree(transition.source, resolveChoicePath(index, choiceEntry))
-  const boundary = transition.reenter
+  const boundary = reenters(transition)
     ? !choiceResolvesToActiveAncestor
       ? broadenBoundary(index, naturalBoundary, getState(index, transition.source).parent)
       : getState(index, transition.source).parent
     : naturalBoundary
   const historyTarget = transition.target === undefined ? undefined : getState(index, transition.target)
-  const reenteredHistoryOwner = historyTarget?.node._tag === "History" && transition.reenter &&
+  const reenteredHistoryOwner = historyTarget?.node._tag === "History" && reenters(transition) &&
     historyTarget.parent !== undefined && before.activePaths.includes(historyTarget.parent)
   return {
     ...selection,
@@ -1037,6 +1048,107 @@ const removeConflicts = (
   return retained
 }
 
+const applySelections = (
+  index: ModelIndex,
+  before: ReferenceState,
+  selected: ReadonlyArray<SelectedTransition>,
+  event: string
+): { readonly microstep: ReferenceMicrostep; readonly after: ReferenceState } => {
+  const retained = removeConflicts(index, selected.map((selection) => evaluateTransition(index, before, selection)))
+  const sorted = sortByDocumentOrder(index, retained)
+  let next = before
+  const applicationOrder = [
+    ...sorted.filter((transition) => !transition.changed),
+    ...sorted.filter((transition) => transition.changed)
+  ]
+  for (const evaluated of applicationOrder) {
+    next = targetState(index, next, evaluated.transition, evaluated.leaf)
+  }
+  const changed = sorted.some((transition) => transition.changed)
+  const exitPaths = lifecyclePaths(index, sorted.flatMap((transition) => transition.exitPaths), undefined, "exit")
+  const entryPaths = lifecyclePaths(index, sorted.flatMap((transition) => transition.entryPaths), undefined, "entry")
+  next = captureHistory(index, before, next, exitPaths)
+  const enteredChoice = sorted.some(({ transition }) =>
+    transition.target !== undefined && entryChoicePath(index, transition.target) !== undefined
+  )
+  if (enteredChoice) next = withControlOrder({ ...next, completions: [] }, controlOrder(next))
+
+  return {
+    microstep: {
+      next,
+      event,
+      transitions: sorted.flatMap(({ transition }) => {
+        const choice = transition.target === undefined ? undefined : entryChoicePath(index, transition.target)
+        return [
+          transitionRecord(index, transition),
+          ...(choice === undefined ? [] : choiceTransitionRecords(index, choice))
+        ]
+      }),
+      exitPaths,
+      entryPaths,
+      changed
+    },
+    after: settleCompletions(index, next)
+  }
+}
+
+const automaticTransitions = (
+  index: ModelIndex,
+  initial: ReferenceState,
+  event: string,
+  completedBefore: ReadonlyArray<ReferenceCompletion>,
+  refreshedByExit: ReadonlyArray<string> = []
+): { readonly state: ReferenceState; readonly microsteps: ReadonlyArray<ReferenceMicrostep> } => {
+  const microsteps: Array<ReferenceMicrostep> = []
+  let current = initial
+  let previousCompletions = completedBefore
+  const newlyCompleted = (
+    state: ReferenceState,
+    previous: ReadonlyArray<ReferenceCompletion>,
+    exited: ReadonlyArray<string>
+  ): ReadonlyArray<ReferenceCompletion> =>
+    state.completions.filter((completion) =>
+      (!previous.some(({ path }) => path === completion.path) || exited.includes(completion.path)) &&
+      index.transitions.has(`${completion.path}\u0000${triggerKey({ type: "done" })}`)
+    )
+  const pendingDone: Array<ReferenceCompletion> = [
+    ...newlyCompleted(current, previousCompletions, refreshedByExit)
+  ]
+  let shouldRunAlways = true
+  let iterations = 0
+
+  while (true) {
+    iterations += 1
+    if (iterations > 1000) {
+      throw new Error("MachineTest.interpretModel detected an infinite automatic-transition cycle")
+    }
+
+    const completion = pendingDone.shift()
+    if (completion !== undefined && current.activePaths.includes(completion.path)) {
+      const transition = index.transitions.get(`${completion.path}\u0000${triggerKey({ type: "done" })}`)!
+      const applied = applySelections(index, current, [{ transition, leaf: completion.path }], event)
+      microsteps.push(applied.microstep)
+      previousCompletions = current.completions
+      current = applied.after
+      pendingDone.push(...newlyCompleted(current, previousCompletions, applied.microstep.exitPaths))
+      shouldRunAlways = applied.microstep.changed
+      continue
+    }
+
+    if (current.status === "done") break
+    const always = shouldRunAlways ? selectTransitions(index, current, { type: "always" }) : []
+    if (always.length === 0) break
+    const applied = applySelections(index, current, always, event)
+    microsteps.push(applied.microstep)
+    previousCompletions = current.completions
+    current = applied.after
+    pendingDone.push(...newlyCompleted(current, previousCompletions, applied.microstep.exitPaths))
+    shouldRunAlways = applied.microstep.changed
+  }
+
+  return { state: current, microsteps }
+}
+
 const stepModel = (
   index: ModelIndex,
   before: ReferenceState,
@@ -1057,7 +1169,7 @@ const stepModel = (
     }
   }
 
-  const selected = selectTransitions(index, before, event)
+  const selected = selectTransitions(index, before, { type: "event", event })
   if (selected.length === 0) {
     return {
       index: stepIndex,
@@ -1070,48 +1182,22 @@ const stepModel = (
     }
   }
 
-  const retained = removeConflicts(index, selected.map((selection) => evaluateTransition(index, before, selection)))
-  const sorted = sortByDocumentOrder(index, retained)
-  let next = before
-  const applicationOrder = [
-    ...sorted.filter((transition) => !transition.changed),
-    ...sorted.filter((transition) => transition.changed)
-  ]
-  for (const evaluated of applicationOrder) {
-    next = targetState(index, next, evaluated.transition, evaluated.leaf)
-  }
-  const changed = sorted.some((transition) => transition.changed)
-  const exitPaths = lifecyclePaths(index, sorted.flatMap((transition) => transition.exitPaths), undefined, "exit")
-  const entryPaths = lifecyclePaths(index, sorted.flatMap((transition) => transition.entryPaths), undefined, "entry")
-  next = captureHistory(index, before, next, exitPaths)
-  const enteredChoice = sorted.some(({ transition }) =>
-    transition.target !== undefined && entryChoicePath(index, transition.target) !== undefined
-  )
-  if (enteredChoice) next = withControlOrder({ ...next, completions: [] }, controlOrder(next))
-
-  const microstep: ReferenceMicrostep = {
-    next,
+  const applied = applySelections(index, before, selected, event)
+  const stabilized = automaticTransitions(
+    index,
+    applied.after,
     event,
-    transitions: sorted.flatMap(({ transition }) => {
-      const choice = transition.target === undefined ? undefined : entryChoicePath(index, transition.target)
-      return [
-        transitionRecord(index, transition),
-        ...(choice === undefined ? [] : choiceTransitionRecords(index, choice))
-      ]
-    }),
-    exitPaths,
-    entryPaths,
-    changed
-  }
-  const after = settleCompletions(index, next)
+    before.completions,
+    applied.microstep.exitPaths
+  )
   return {
     index: stepIndex,
     event,
     before,
-    microsteps: [microstep],
-    after,
-    done: after.status === "done",
-    output: after.output
+    microsteps: [applied.microstep, ...stabilized.microsteps],
+    after: stabilized.state,
+    done: stabilized.state.status === "done",
+    output: stabilized.state.output
   }
 }
 
@@ -1134,23 +1220,27 @@ export const interpretModel = (
   const startingState = makeUnsettledState(index, model.initial)
   const initialState = settleCompletions(index, startingState)
   const initialChoiceTransitions = initialChoiceTransitionRecords(index, model.initial)
+  const stabilizedInitial = automaticTransitions(index, initialState, "InitialEvent", [])
   const initial: ReferenceInitialStep = {
     startingState,
     initialEntryPaths: startingState.activePaths,
-    state: initialState,
-    microsteps: initialChoiceTransitions.length === 0 ? [] : [{
-      next: startingState,
-      event: "InitialEvent",
-      transitions: initialChoiceTransitions,
-      exitPaths: [],
-      entryPaths: [],
-      changed: false
-    }],
-    done: initialState.status === "done",
-    output: initialState.output
+    state: stabilizedInitial.state,
+    microsteps: [
+      ...(initialChoiceTransitions.length === 0 ? [] : [{
+        next: startingState,
+        event: "InitialEvent",
+        transitions: initialChoiceTransitions,
+        exitPaths: [],
+        entryPaths: [],
+        changed: false
+      }]),
+      ...stabilizedInitial.microsteps
+    ],
+    done: stabilizedInitial.state.status === "done",
+    output: stabilizedInitial.state.output
   }
   const steps: Array<ReferenceStep> = []
-  let current = initialState
+  let current = stabilizedInitial.state
   for (let eventIndex = 0; eventIndex < events.length; eventIndex++) {
     const step = stepModel(index, current, events[eventIndex]!, eventIndex)
     steps.push(step)

--- a/test/Machine.test.ts
+++ b/test/Machine.test.ts
@@ -316,6 +316,18 @@ describe("Machine", () => {
       assert.deepStrictEqual(planned.state.value, new Idle({ userId: "user-1" }))
     }))
 
+  it("isMachine requires the machine brand value, not only its property key", () => {
+    const states = Machine.defineStates({ Idle })
+    const machine = Machine.make({
+      states: states.states,
+      events: [],
+      initial: () => states.initial.Idle(new Idle({ userId: "user-1" }))
+    })
+
+    assert.strictEqual(Machine.isMachine(machine), true)
+    assert.strictEqual(Machine.isMachine({ [Machine.TypeId]: "not-a-machine" }), false)
+  })
+
   it("retag constructs the target case without copying the source discriminator", () => {
     const result = Machine.retag(RequestSucceeded, new Submit({ value: "loaded" }))
 

--- a/test/MachineActivityLifecycleModel.test.ts
+++ b/test/MachineActivityLifecycleModel.test.ts
@@ -1,0 +1,460 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Deferred, Effect, Exit, Fiber, Schema, Stream } from "effect"
+import { TestClock } from "effect/testing"
+import { Machine } from "../src/index.js"
+import {
+  ActivityFailure,
+  countRecords,
+  expectedLifecycle,
+  lifecycleCommandSamples,
+  makeActivityProbe
+} from "./support/activityLifecycleModel.js"
+
+class Idle extends Schema.TaggedClass<Idle>("ActivityIdle")("Idle", {}) {}
+class Active extends Schema.TaggedClass<Active>("ActivityActive")("Active", {}) {}
+class Done extends Schema.TaggedClass<Done>("ActivityDone")("Done", { epoch: Schema.Number }) {}
+
+class Enter extends Schema.TaggedClass<Enter>("ActivityEnter")("Enter", {}) {}
+class Leave extends Schema.TaggedClass<Leave>("ActivityLeave")("Leave", {}) {}
+class Restart extends Schema.TaggedClass<Restart>("ActivityRestart")("Restart", {}) {}
+class QueueBarrier extends Schema.TaggedClass<QueueBarrier>("ActivityQueueBarrier")("QueueBarrier", {}) {}
+class Completed extends Schema.TaggedClass<Completed>("ActivityCompleted")("Completed", { epoch: Schema.Number }) {}
+class TimerFired extends Schema.TaggedClass<TimerFired>("ActivityTimerFired")("TimerFired", {}) {}
+
+const sendAndWaitForActiveState = <State, Event, Error, Output>(
+  actor: Machine.MachineRef<State, Event, Error, Output>,
+  event: Event,
+  predicate: (state: State) => boolean
+) =>
+  Effect.gen(function*() {
+    const observed = yield* actor.changes.pipe(
+      Stream.filter((snapshot) => snapshot.status === "active" && predicate(snapshot.state)),
+      Stream.take(1),
+      Stream.runDrain,
+      Effect.forkChild
+    )
+    yield* actor.send(event)
+    yield* Fiber.join(observed)
+  })
+
+const assertOneExitPerStart = (
+  records: ReadonlyArray<
+    | { readonly _tag: "Started"; readonly owner: string; readonly epoch: number }
+    | {
+      readonly _tag: "Exited"
+      readonly owner: string
+      readonly epoch: number
+      readonly outcome: "succeeded" | "cancelled" | "failed"
+    }
+  >
+) => {
+  const starts = records.filter((record) => record._tag === "Started")
+  for (const start of starts) {
+    assert.strictEqual(
+      records.filter((record) =>
+        record._tag === "Exited" && record.owner === start.owner && record.epoch === start.epoch
+      ).length,
+      1,
+      `activity ${start.owner} epoch ${start.epoch} must exit exactly once`
+    )
+  }
+}
+
+describe("machine activity lifecycle model", () => {
+  it.effect("matches exactly-once start and cancellation across generated lifecycle commands", () =>
+    Effect.gen(function*() {
+      const samples = lifecycleCommandSamples({ numRuns: 40, maxCommands: 20, seed: 82_419 })
+      yield* Effect.forEach(
+        samples,
+        (commands) =>
+          Effect.gen(function*() {
+            const probe = yield* makeActivityProbe
+            const states = Machine.defineStates({ Idle, Active })
+            const machine = Machine.make({
+              states: states.states,
+              events: [Enter, Leave, Restart],
+              initial: () => states.initial.Idle(new Idle({}))
+            }).handle({
+              Idle: {
+                on: {
+                  Enter: ({ target }) => target.full.Active(new Active({}))
+                }
+              },
+              Active: {
+                invoke: Machine.invoke({
+                  id: "activity",
+                  src: () => probe.logic("active", { _tag: "Blocked" })
+                }),
+                on: {
+                  Leave: ({ target }) => target.full.Idle(new Idle({})),
+                  Restart: {
+                    reenter: true,
+                    transition: ({ target }) => target.full.Active(new Active({}))
+                  }
+                }
+              }
+            })
+            const actor = yield* Machine.start(machine)
+            let active = false
+
+            for (const command of commands) {
+              switch (command) {
+                case "enter":
+                  yield* actor.send(new Enter({}))
+                  if (!active) {
+                    yield* probe.takeStarted
+                    active = true
+                  }
+                  break
+                case "leave":
+                  if (active) {
+                    yield* sendAndWaitForActiveState(actor, new Leave({}), (state) => state.path === "Idle")
+                    active = false
+                  } else {
+                    yield* actor.send(new Leave({}))
+                  }
+                  break
+                case "restart":
+                  yield* actor.send(new Restart({}))
+                  if (active) yield* probe.takeStarted
+                  break
+              }
+            }
+            yield* actor.stop
+
+            const expected = expectedLifecycle(commands)
+            const records = yield* probe.records
+            assert.strictEqual(countRecords(records, "starts"), expected.starts)
+            assert.strictEqual(countRecords(records, "cancelled"), expected.cancellations)
+            assert.strictEqual(countRecords(records, "succeeded"), 0)
+            assert.strictEqual(countRecords(records, "failed"), 0)
+            assertOneExitPerStart(records)
+          }),
+        { discard: true }
+      )
+    }))
+
+  it.effect("records immediate invoke completion and cleanup exactly once", () =>
+    Effect.gen(function*() {
+      const probe = yield* makeActivityProbe
+      const states = Machine.defineStates({
+        Active,
+        Done: { schema: Done, type: "final", output: Schema.Number }
+      })
+      const machine = Machine.make({
+        states: states.states,
+        events: [],
+        internalEvents: [Completed],
+        initial: () => states.initial.Active(new Active({}))
+      }).handle({
+        Active: {
+          invoke: Machine.invoke({
+            id: "immediate",
+            src: () => probe.immediate("immediate", (epoch) => new Completed({ epoch }))
+          }),
+          on: {
+            Completed: ({ event, target }) => target.full.Done(new Done({ epoch: event.epoch }))
+          }
+        },
+        Done: {
+          output: ({ state }) => state.epoch
+        }
+      })
+
+      const actor = yield* Machine.start(machine)
+      assert.strictEqual(yield* actor.join, 1)
+
+      const records = yield* probe.records
+      assert.strictEqual(countRecords(records, "starts", "immediate"), 1)
+      assert.strictEqual(countRecords(records, "succeeded", "immediate"), 1)
+      assertOneExitPerStart(records)
+    }))
+
+  it.effect("rejects stale cancellation completion from a previous re-entry epoch", () =>
+    Effect.gen(function*() {
+      const probe = yield* makeActivityProbe
+      class EpochActive extends Schema.TaggedClass<EpochActive>("ActivityEpochActive")("EpochActive", {
+        acknowledged: Schema.Number
+      }) {}
+      const states = Machine.defineStates({ Active: EpochActive, Done })
+      const machine = Machine.make({
+        states: states.states,
+        events: [Restart, QueueBarrier],
+        internalEvents: [Completed],
+        initial: () => states.initial.Active(new EpochActive({ acknowledged: 0 }))
+      }).handle({
+        Active: {
+          invoke: Machine.invoke({
+            id: "epoch",
+            src: () =>
+              probe.logic("epoch", {
+                _tag: "StaleOnCancel",
+                event: (epoch) => new Completed({ epoch })
+              })
+          }),
+          on: {
+            Restart: {
+              reenter: true,
+              transition: ({ state, target }) =>
+                target.full.Active(new EpochActive({ acknowledged: state.acknowledged }))
+            },
+            QueueBarrier: ({ state, target }) =>
+              target.full.Active(new EpochActive({ acknowledged: state.acknowledged + 1 })),
+            Completed: ({ event, target }) => target.full.Done(new Done({ epoch: event.epoch }))
+          }
+        },
+        Done: {}
+      })
+      const actor = yield* Machine.start(machine)
+      yield* probe.takeStarted
+
+      yield* actor.send(new Restart({}))
+      yield* probe.takeStarted
+      yield* actor.send(new Restart({}))
+      yield* probe.takeStarted
+
+      // The invoke token should suppress the old completion before enqueue.
+      // If it leaked, FIFO ordering would process it before this barrier and
+      // transition to Done, so the acknowledged Active publication could not
+      // occur.
+      yield* sendAndWaitForActiveState(
+        actor,
+        new QueueBarrier({}),
+        (state) => state.path === "Active" && state.value.acknowledged === 1
+      )
+
+      const active = yield* actor.snapshot
+      assert.strictEqual(active.status, "active")
+      if (active.status === "active") {
+        assert.strictEqual(active.state.path, "Active")
+        assert.instanceOf(active.state.value, EpochActive)
+        if (active.state.value instanceof EpochActive) {
+          assert.strictEqual(active.state.value.acknowledged, 1)
+        }
+      }
+      const beforeStop = yield* probe.records
+      assert.deepStrictEqual(
+        beforeStop.filter((record) => record._tag === "Started").map((record) => record.epoch),
+        [1, 2, 3]
+      )
+      assert.strictEqual(countRecords(beforeStop, "cancelled", "epoch"), 2)
+
+      yield* actor.stop
+
+      const records = yield* probe.records
+      assert.strictEqual(countRecords(records, "cancelled", "epoch"), 3)
+      assertOneExitPerStart(records)
+    }))
+
+  it.effect("cancels only the activity owned by an exited parallel region", () =>
+    Effect.gen(function*() {
+      const probe = yield* makeActivityProbe
+      class Root extends Schema.TaggedClass<Root>("ActivityRoot")("Root", {}) {}
+      class Left extends Schema.TaggedClass<Left>("ActivityLeft")("Left", {}) {}
+      class LeftActive extends Schema.TaggedClass<LeftActive>("ActivityLeftActive")("LeftActive", {}) {}
+      class LeftIdle extends Schema.TaggedClass<LeftIdle>("ActivityLeftIdle")("LeftIdle", {}) {}
+      class Right extends Schema.TaggedClass<Right>("ActivityRight")("Right", {}) {}
+      class RightActive extends Schema.TaggedClass<RightActive>("ActivityRightActive")("RightActive", {}) {}
+      class LeaveLeft extends Schema.TaggedClass<LeaveLeft>("ActivityLeaveLeft")("LeaveLeft", {}) {}
+      const machine = Machine.make({
+        states: {
+          Root: {
+            schema: Root,
+            type: "parallel",
+            states: {
+              left: {
+                schema: Left,
+                initial: "active",
+                states: { active: LeftActive, idle: LeftIdle }
+              },
+              right: {
+                schema: Right,
+                initial: "active",
+                states: { active: RightActive }
+              }
+            }
+          }
+        },
+        events: [LeaveLeft],
+        initial: () => ({
+          path: "Root" as const,
+          value: new Root({}),
+          states: {
+            left: {
+              path: "Root.left" as const,
+              value: new Left({}),
+              state: { path: "Root.left.active" as const, value: new LeftActive({}) }
+            },
+            right: {
+              path: "Root.right" as const,
+              value: new Right({}),
+              state: { path: "Root.right.active" as const, value: new RightActive({}) }
+            }
+          }
+        })
+      }).handle({
+        Root: {
+          states: {
+            left: {
+              states: {
+                active: {
+                  invoke: Machine.invoke({
+                    id: "left-activity",
+                    src: () => probe.logic("left", { _tag: "Blocked" })
+                  }),
+                  on: {
+                    LeaveLeft: ({ target }) => target.local.idle(new LeftIdle({}))
+                  }
+                }
+              }
+            },
+            right: {
+              states: {
+                active: {
+                  invoke: Machine.invoke({
+                    id: "right-activity",
+                    src: () => probe.logic("right", { _tag: "Blocked" })
+                  })
+                }
+              }
+            }
+          }
+        }
+      })
+      const actor = yield* Machine.start(machine)
+      yield* probe.takeStarted
+      yield* probe.takeStarted
+
+      yield* sendAndWaitForActiveState(
+        actor,
+        new LeaveLeft({}),
+        (state) => state.states.left.state.path === "Root.left.idle"
+      )
+
+      const afterLeftExit = yield* probe.records
+      assert.strictEqual(countRecords(afterLeftExit, "starts", "left"), 1)
+      assert.strictEqual(countRecords(afterLeftExit, "starts", "right"), 1)
+      assert.strictEqual(countRecords(afterLeftExit, "cancelled", "left"), 1)
+      assert.strictEqual(countRecords(afterLeftExit, "cancelled", "right"), 0)
+
+      yield* actor.stop
+
+      const records = yield* probe.records
+      assert.strictEqual(countRecords(records, "cancelled", "left"), 1)
+      assert.strictEqual(countRecords(records, "cancelled", "right"), 1)
+      assertOneExitPerStart(records)
+    }))
+
+  it.effect("cancels a state-owned timer before virtual time advances", () =>
+    Effect.gen(function*() {
+      const probe = yield* makeActivityProbe
+      const states = Machine.defineStates({ Idle, Active, Done })
+      const machine = Machine.make({
+        states: states.states,
+        events: [Leave],
+        internalEvents: [TimerFired],
+        initial: () => states.initial.Active(new Active({}))
+      }).handle({
+        Idle: {},
+        Active: {
+          invoke: [
+            Machine.invoke({
+              id: "timed-activity",
+              src: () => probe.logic("timed", { _tag: "Blocked" })
+            }),
+            Machine.after("1 hour", new TimerFired({}), { id: "deadline" })
+          ],
+          on: {
+            Leave: ({ target }) => target.full.Idle(new Idle({})),
+            TimerFired: ({ target }) => target.full.Done(new Done({ epoch: -1 }))
+          }
+        },
+        Done: {}
+      })
+      const actor = yield* Machine.start(machine)
+      yield* probe.takeStarted
+
+      yield* sendAndWaitForActiveState(actor, new Leave({}), (state) => state.path === "Idle")
+      yield* TestClock.adjust("2 hours")
+
+      const snapshot = yield* actor.snapshot
+      assert.strictEqual(snapshot.status, "active")
+      if (snapshot.status === "active") assert.strictEqual(snapshot.state.path, "Idle")
+      const records = yield* probe.records
+      assert.strictEqual(countRecords(records, "cancelled", "timed"), 1)
+      assertOneExitPerStart(records)
+      yield* actor.stop
+    }))
+
+  it.effect("cleans sibling activities when an invoked child fails", () =>
+    Effect.gen(function*() {
+      const probe = yield* makeActivityProbe
+      const states = Machine.defineStates({ Active })
+      const machine = Machine.make({
+        states: states.states,
+        events: [],
+        initial: () => states.initial.Active(new Active({}))
+      }).handle({
+        Active: {
+          invoke: [
+            Machine.invoke({
+              id: "failing",
+              src: () => probe.logic("failing", { _tag: "Failure" })
+            }),
+            Machine.invoke({
+              id: "sibling",
+              src: () => probe.logic("sibling", { _tag: "Blocked" })
+            })
+          ]
+        }
+      })
+      const actor = yield* Machine.start(machine)
+      const first = yield* probe.takeStarted
+      const second = yield* probe.takeStarted
+      const failing = first.owner === "failing" ? first : second
+
+      yield* Deferred.succeed(failing.release, void 0)
+      const failed = yield* Effect.exit(actor.join)
+
+      assert(Exit.isFailure(failed))
+      if (Exit.isFailure(failed)) {
+        assert.instanceOf(failed.cause.reasons.find((reason) => reason._tag === "Fail")?.error, ActivityFailure)
+      }
+      const records = yield* probe.records
+      assert.strictEqual(countRecords(records, "failed", "failing"), 1)
+      assert.strictEqual(countRecords(records, "cancelled", "sibling"), 1)
+      assertOneExitPerStart(records)
+    }))
+
+  it.effect("waits for every activity cleanup before parent stop completes", () =>
+    Effect.gen(function*() {
+      const probe = yield* makeActivityProbe
+      const states = Machine.defineStates({ Active })
+      const machine = Machine.make({
+        states: states.states,
+        events: [],
+        initial: () => states.initial.Active(new Active({}))
+      }).handle({
+        Active: {
+          invoke: [
+            Machine.invoke({ id: "first", src: () => probe.logic("first", { _tag: "Blocked" }) }),
+            Machine.invoke({ id: "second", src: () => probe.logic("second", { _tag: "Blocked" }) })
+          ]
+        }
+      })
+      const actor = yield* Machine.start(machine)
+      yield* probe.takeStarted
+      yield* probe.takeStarted
+
+      yield* actor.stop
+
+      const records = yield* probe.records
+      assert.strictEqual(countRecords(records, "cancelled", "first"), 1)
+      assert.strictEqual(countRecords(records, "cancelled", "second"), 1)
+      assertOneExitPerStart(records)
+      assert.strictEqual((yield* actor.snapshot).status, "stopped")
+
+      yield* actor.stop
+      assert.deepStrictEqual(yield* probe.records, records)
+    }))
+})

--- a/test/MachineInspection.test.ts
+++ b/test/MachineInspection.test.ts
@@ -1,0 +1,148 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Schema } from "effect"
+import { Machine } from "../src/index.js"
+
+class Root extends Schema.TaggedClass<Root>("InspectionRoot")("InspectionRoot", {}) {}
+class Flow extends Schema.TaggedClass<Flow>("InspectionFlow")("InspectionFlow", {}) {}
+class Idle extends Schema.TaggedClass<Idle>("InspectionIdle")("InspectionIdle", {}) {}
+class Done extends Schema.TaggedClass<Done>("InspectionDone")("InspectionDone", {}) {}
+class Side extends Schema.TaggedClass<Side>("InspectionSide")("InspectionSide", {}) {}
+class ChoiceFlow extends Schema.TaggedClass<ChoiceFlow>("InspectionChoiceFlow")("InspectionChoiceFlow", {}) {}
+class Ready extends Schema.TaggedClass<Ready>("InspectionReady")("InspectionReady", {}) {}
+
+const RootOutput = Schema.String
+const DoneOutput = Schema.Number
+
+const States = Machine.defineStates({
+  root: {
+    schema: Root,
+    type: "parallel",
+    output: RootOutput,
+    states: {
+      flow: {
+        schema: Flow,
+        initial: "idle",
+        states: {
+          idle: Idle,
+          done: { schema: Done, type: "final", output: DoneOutput },
+          recent: { type: "history", history: "deep" },
+          route: { type: "choice" }
+        }
+      },
+      side: Side
+    }
+  }
+})
+
+const machine = Machine.make({
+  states: States.states,
+  events: [],
+  initial: () =>
+    States.initial.root(new Root({}), (root) =>
+      root
+        .flow(new Flow({}), (flow) => flow.idle(new Idle({})))
+        .side(new Side({})))
+})
+
+const ChoiceStates = Machine.defineStates({
+  Flow: {
+    schema: ChoiceFlow,
+    initial: "Routing",
+    states: {
+      Routing: { type: "choice" },
+      Ready
+    }
+  }
+})
+
+const choiceMachine = Machine.make({
+  states: ChoiceStates.states,
+  events: [],
+  initial: () => ChoiceStates.initial.Flow(new ChoiceFlow({}), (flow) => flow.Routing())
+}).handle({
+  Flow: {
+    states: {
+      Routing: {
+        choice: {
+          targets: ["Flow.Ready"],
+          transition: ({ target }) => target.local.Ready(new Ready({}))
+        }
+      }
+    }
+  }
+})
+
+describe("Machine compiled state-node inspection", () => {
+  it("exposes exact metadata for all six state-node kinds", () => {
+    const nodes = new Map(Machine.stateNodes(machine).map((node) => [node.path, node]))
+
+    const parallel = nodes.get("root")!
+    assert.strictEqual(parallel.type, "parallel")
+    assert.strictEqual(parallel.schema, Root)
+    assert.strictEqual(parallel.output, RootOutput)
+    assert.strictEqual(parallel.history, undefined)
+    assert.strictEqual(parallel.initial, undefined)
+    assert.deepStrictEqual(parallel.children, ["root.flow", "root.side"])
+
+    const compound = nodes.get("root.flow")!
+    assert.strictEqual(compound.type, "compound")
+    assert.strictEqual(compound.schema, Flow)
+    assert.strictEqual(compound.output, undefined)
+    assert.strictEqual(compound.history, undefined)
+    assert.strictEqual(compound.initial, "root.flow.idle")
+    assert.deepStrictEqual(compound.children, ["root.flow.idle", "root.flow.done"])
+
+    const atomic = nodes.get("root.flow.idle")!
+    assert.strictEqual(atomic.type, "atomic")
+    assert.strictEqual(atomic.schema, Idle)
+    assert.strictEqual(atomic.output, undefined)
+    assert.strictEqual(atomic.history, undefined)
+    assert.strictEqual(atomic.initial, undefined)
+    assert.deepStrictEqual(atomic.children, [])
+
+    const final = nodes.get("root.flow.done")!
+    assert.strictEqual(final.type, "final")
+    assert.strictEqual(final.schema, Done)
+    assert.strictEqual(final.output, DoneOutput)
+    assert.strictEqual(final.history, undefined)
+    assert.strictEqual(final.initial, undefined)
+    assert.deepStrictEqual(final.children, [])
+
+    const history = nodes.get("root.flow.recent")!
+    assert.strictEqual(history.type, "history")
+    assert.strictEqual(history.schema, undefined)
+    assert.strictEqual(history.output, undefined)
+    assert.strictEqual(history.history, "deep")
+    assert.strictEqual(history.parent, "root.flow")
+    assert.strictEqual(history.initial, undefined)
+    assert.deepStrictEqual(history.children, [])
+
+    const choice = nodes.get("root.flow.route")!
+    assert.strictEqual(choice.type, "choice")
+    assert.strictEqual(choice.schema, undefined)
+    assert.strictEqual(choice.output, undefined)
+    assert.strictEqual(choice.history, undefined)
+    assert.strictEqual(choice.parent, "root.flow")
+    assert.strictEqual(choice.initial, undefined)
+    assert.deepStrictEqual(choice.children, [])
+  })
+
+  it.effect("retains a choice initial path while configurations expose only active nodes", () =>
+    Effect.gen(function*() {
+      const flow = Machine.stateNodes(choiceMachine).find((node) => node.path === "Flow")
+      assert(flow !== undefined)
+      assert.strictEqual(flow.type, "compound")
+      assert.strictEqual(flow.initial, "Flow.Routing")
+
+      const plan = yield* Machine.planInitial(choiceMachine)
+      assert.strictEqual(plan.state.path, "Flow")
+      assert.strictEqual(plan.state.state.path, "Flow.Ready")
+      assert.deepStrictEqual(
+        Machine.configuration(choiceMachine, plan.state).map(({ path, type }) => ({ path, type })),
+        [
+          { path: "Flow", type: "compound" },
+          { path: "Flow.Ready", type: "atomic" }
+        ]
+      )
+    }))
+})

--- a/test/MachineProcessLifecycle.test.ts
+++ b/test/MachineProcessLifecycle.test.ts
@@ -1,0 +1,319 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Cause, Deferred, Effect, Exit, Fiber, Ref, Stream } from "effect"
+import { Machine } from "../src/index.js"
+import * as MachineRuntime from "../src/internal/machineRuntime.js"
+
+describe("machine process lifecycle", () => {
+  it.effect("allows initialization to request and await self-stop before a run fiber exists", () =>
+    Effect.gen(function*() {
+      const initializedAfterStop = yield* Ref.make(false)
+      const runCount = yield* Ref.make(0)
+      const ref = yield* MachineRuntime.startProcess(
+        Machine.logic({
+          initial: ({ self }) =>
+            self.stop.pipe(
+              Effect.andThen(Ref.set(initializedAfterStop, true)),
+              Effect.as(1)
+            ),
+          run: () => Ref.update(runCount, (count) => count + 1).pipe(Effect.andThen(Effect.never))
+        })
+      )
+
+      const joined = yield* Effect.exit(ref.join)
+
+      assert.strictEqual(yield* Ref.get(initializedAfterStop), true)
+      assert.strictEqual(yield* Ref.get(runCount), 0)
+      assert.deepStrictEqual(yield* ref.snapshot, { status: "stopped", state: 1 })
+      assert(Exit.isFailure(joined))
+      if (Exit.isFailure(joined)) {
+        assert.instanceOf(joined.cause.reasons.find(Cause.isFailReason)?.error, Machine.StoppedError)
+      }
+    }))
+
+  it.effect("allows the run fiber to await self-stop without joining itself", () =>
+    Effect.gen(function*() {
+      const continuedAfterStop = yield* Ref.make(false)
+      const ref = yield* MachineRuntime.startProcess(
+        Machine.logic({
+          initial: 1,
+          run: ({ self }) =>
+            self.stop.pipe(
+              Effect.andThen(Ref.set(continuedAfterStop, true)),
+              Effect.andThen(Effect.succeed("unexpected"))
+            )
+        })
+      )
+
+      const joined = yield* Effect.exit(ref.join)
+
+      assert.strictEqual(yield* Ref.get(continuedAfterStop), false)
+      assert.deepStrictEqual(yield* ref.snapshot, { status: "stopped", state: 1 })
+      assert(Exit.isFailure(joined))
+      if (Exit.isFailure(joined)) {
+        assert.instanceOf(joined.cause.reasons.find(Cause.isFailReason)?.error, Machine.StoppedError)
+      }
+    }))
+
+  it.effect("terminalizes once when concurrent callers stop the same process", () =>
+    Effect.gen(function*() {
+      const cleanupCount = yield* Ref.make(0)
+      const ref = yield* MachineRuntime.startProcess(
+        Machine.logic({
+          initial: 1,
+          run: () =>
+            Effect.never.pipe(
+              Effect.ensuring(Ref.update(cleanupCount, (count) => count + 1))
+            )
+        })
+      )
+
+      yield* Effect.all([ref.stop, ref.stop, ref.stop], { concurrency: "unbounded" })
+      yield* Effect.yieldNow
+
+      assert.strictEqual(yield* Ref.get(cleanupCount), 1)
+      assert.deepStrictEqual(yield* ref.snapshot, { status: "stopped", state: 1 })
+      assert.instanceOf(yield* Effect.flip(ref.join), Machine.StoppedError)
+      assert.instanceOf(yield* Effect.flip(ref.send(undefined as never)), Machine.StoppedError)
+
+      const stopAgain = yield* ref.stop.pipe(Effect.forkChild)
+      yield* Fiber.join(stopAgain)
+      assert.strictEqual(yield* Ref.get(cleanupCount), 1)
+    }))
+
+  it.effect("freezes the stopped snapshot before interrupted worker finalizers run", () =>
+    Effect.gen(function*() {
+      const finalizerRan = yield* Ref.make(false)
+      const updateEvaluated = yield* Ref.make(false)
+      const ref = yield* MachineRuntime.startProcess(
+        Machine.logic({
+          initial: 1,
+          run: (context) =>
+            Effect.never.pipe(
+              Effect.ensuring(
+                Ref.set(finalizerRan, true).pipe(
+                  Effect.andThen(context.setState(2)),
+                  Effect.andThen(
+                    context.updateState((state) => Ref.set(updateEvaluated, true).pipe(Effect.as(state + 10)))
+                  )
+                )
+              )
+            )
+        })
+      )
+      const publications = yield* ref.changes.pipe(Stream.runCollect, Effect.forkChild)
+      yield* Effect.yieldNow
+
+      yield* ref.stop
+
+      assert.strictEqual(yield* Ref.get(finalizerRan), true)
+      assert.strictEqual(yield* Ref.get(updateEvaluated), false)
+      assert.deepStrictEqual(Array.from(yield* Fiber.join(publications)), [
+        { status: "active", state: 1 },
+        { status: "stopped", state: 1 }
+      ])
+      assert.deepStrictEqual(yield* ref.snapshot, { status: "stopped", state: 1 })
+    }))
+
+  it.effect("releases a child id after that child requests self-stop during initialization", () =>
+    Effect.gen(function*() {
+      const firstRunCount = yield* Ref.make(0)
+      const replacementReady = yield* Deferred.make<Machine.MachineRef<number, never>>()
+      const parent = yield* MachineRuntime.startProcess(
+        Machine.logic({
+          initial: undefined,
+          run: ({ spawn }) =>
+            Effect.gen(function*() {
+              const first = yield* spawn(
+                Machine.logic({
+                  initial: ({ self }) => self.stop.pipe(Effect.as(1)),
+                  run: () => Ref.update(firstRunCount, (count) => count + 1).pipe(Effect.andThen(Effect.never))
+                }),
+                { id: "worker" }
+              )
+              yield* Effect.exit(first.join)
+
+              const replacement = yield* spawn(
+                Machine.logic({
+                  initial: 2,
+                  run: () => Effect.never
+                }),
+                { id: "worker" }
+              )
+              yield* Deferred.succeed(replacementReady, replacement)
+              return yield* Effect.never
+            })
+        })
+      )
+
+      const replacement = yield* Deferred.await(replacementReady)
+
+      assert.strictEqual(yield* Ref.get(firstRunCount), 0)
+      assert.deepStrictEqual(yield* replacement.snapshot, { status: "active", state: 2 })
+
+      yield* parent.stop
+
+      assert.deepStrictEqual(yield* replacement.snapshot, { status: "stopped", state: 2 })
+    }))
+
+  it.effect("publishes and cleans up exactly once when stop races process completion", () =>
+    Effect.gen(function*() {
+      const cleanupCount = yield* Ref.make(0)
+      const release = yield* Deferred.make<void>()
+      const race = yield* Deferred.make<void>()
+      const ref = yield* MachineRuntime.startProcess(
+        Machine.logic({
+          initial: 1,
+          run: () =>
+            Deferred.await(release).pipe(
+              Effect.as("done"),
+              Effect.ensuring(Ref.update(cleanupCount, (count) => count + 1))
+            )
+        })
+      )
+      const terminalSnapshots = yield* ref.changes.pipe(
+        Stream.filter((snapshot) => snapshot.status !== "active"),
+        Stream.runCollect,
+        Effect.forkChild
+      )
+      const stopFiber = yield* Deferred.await(race).pipe(
+        Effect.andThen(ref.stop),
+        Effect.forkChild
+      )
+      const completionFiber = yield* Deferred.await(race).pipe(
+        Effect.andThen(Deferred.succeed(release, void 0)),
+        Effect.forkChild
+      )
+
+      yield* Deferred.succeed(race, void 0)
+      yield* Fiber.join(stopFiber)
+      yield* Fiber.join(completionFiber)
+      const published = Array.from(yield* Fiber.join(terminalSnapshots))
+      const snapshot = yield* ref.snapshot
+      const joined = yield* Effect.exit(ref.join)
+
+      assert.strictEqual(yield* Ref.get(cleanupCount), 1)
+      assert.strictEqual(published.length, 1)
+      assert.deepStrictEqual(published[0], snapshot)
+      assert(snapshot.status === "done" || snapshot.status === "stopped")
+      if (snapshot.status === "done") {
+        assert.deepStrictEqual(joined, Exit.succeed("done"))
+      } else {
+        assert(Exit.isFailure(joined))
+        if (Exit.isFailure(joined)) {
+          assert.instanceOf(joined.cause.reasons.find(Cause.isFailReason)?.error, Machine.StoppedError)
+        }
+      }
+    }))
+
+  it.effect("publishes and cleans up exactly once when stop races process failure", () =>
+    Effect.gen(function*() {
+      const cleanupCount = yield* Ref.make(0)
+      const release = yield* Deferred.make<void>()
+      const race = yield* Deferred.make<void>()
+      const ref = yield* MachineRuntime.startProcess(
+        Machine.logic({
+          initial: 1,
+          run: () =>
+            Deferred.await(release).pipe(
+              Effect.andThen(Effect.fail("failed")),
+              Effect.ensuring(Ref.update(cleanupCount, (count) => count + 1))
+            )
+        })
+      )
+      const terminalSnapshots = yield* ref.changes.pipe(
+        Stream.filter((snapshot) => snapshot.status !== "active"),
+        Stream.runCollect,
+        Effect.forkChild
+      )
+      const stopFiber = yield* Deferred.await(race).pipe(
+        Effect.andThen(ref.stop),
+        Effect.forkChild
+      )
+      const failureFiber = yield* Deferred.await(race).pipe(
+        Effect.andThen(Deferred.succeed(release, void 0)),
+        Effect.forkChild
+      )
+
+      yield* Deferred.succeed(race, void 0)
+      yield* Fiber.join(stopFiber)
+      yield* Fiber.join(failureFiber)
+      const published = Array.from(yield* Fiber.join(terminalSnapshots))
+      const snapshot = yield* ref.snapshot
+      const joined = yield* Effect.exit(ref.join)
+
+      assert.strictEqual(yield* Ref.get(cleanupCount), 1)
+      assert.strictEqual(published.length, 1)
+      assert.deepStrictEqual(published[0], snapshot)
+      assert(snapshot.status === "error" || snapshot.status === "stopped")
+      assert(Exit.isFailure(joined))
+      if (Exit.isFailure(joined)) {
+        const failure = joined.cause.reasons.find(Cause.isFailReason)
+        if (snapshot.status === "error") {
+          assert.strictEqual(failure?.error, "failed")
+        } else {
+          assert.instanceOf(failure?.error, Machine.StoppedError)
+        }
+      }
+    }))
+
+  it.effect("does not abandon terminalization across repeated stop-versus-worker races", () =>
+    Effect.gen(function*() {
+      yield* Effect.forEach(
+        Array.from({ length: 100 }, (_, index) => index),
+        (index) =>
+          Effect.gen(function*() {
+            const cleanupCount = yield* Ref.make(0)
+            const release = yield* Deferred.make<void>()
+            const race = yield* Deferred.make<void>()
+            const ref = yield* MachineRuntime.startProcess(
+              Machine.logic({
+                initial: index,
+                run: () =>
+                  Deferred.await(release).pipe(
+                    Effect.andThen(
+                      index % 2 === 0
+                        ? Effect.succeed(index)
+                        : Effect.fail(`failure-${index}`)
+                    ),
+                    Effect.ensuring(Ref.update(cleanupCount, (count) => count + 1))
+                  )
+              })
+            )
+            const stopFiber = yield* Deferred.await(race).pipe(
+              Effect.andThen(ref.stop),
+              Effect.forkChild
+            )
+            const workerFiber = yield* Deferred.await(race).pipe(
+              Effect.andThen(Deferred.succeed(release, void 0)),
+              Effect.forkChild
+            )
+
+            yield* Deferred.succeed(race, void 0)
+            yield* Fiber.join(stopFiber)
+            yield* Fiber.join(workerFiber)
+
+            const snapshot = yield* ref.snapshot
+            const joined = yield* Effect.exit(ref.join)
+            assert.strictEqual(yield* Ref.get(cleanupCount), 1)
+            assert.notStrictEqual(snapshot.status, "active")
+            switch (snapshot.status) {
+              case "done":
+                assert.strictEqual(index % 2, 0)
+                assert.deepStrictEqual(joined, Exit.succeed(index))
+                break
+              case "error":
+                assert.strictEqual(index % 2, 1)
+                assert(Exit.isFailure(joined))
+                break
+              case "stopped":
+                assert(Exit.isFailure(joined))
+                if (Exit.isFailure(joined)) {
+                  assert.instanceOf(joined.cause.reasons.find(Cause.isFailReason)?.error, Machine.StoppedError)
+                }
+                break
+            }
+          }),
+        { concurrency: "unbounded" }
+      )
+    }))
+})

--- a/test/MachineRuntimeDifferential.test.ts
+++ b/test/MachineRuntimeDifferential.test.ts
@@ -1,0 +1,386 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Cause, Data, Effect, Fiber, Ref, Schema, Stream } from "effect"
+import { FastCheck } from "effect/testing"
+import { Machine } from "../src/index.js"
+import { MachineTest } from "../src/testing.js"
+import { traceBoundary, traceSteps, verifyManagedExecution } from "./support/machineRuntimeDifferential.js"
+
+const event = (_tag: string): { readonly _tag: string } => ({ _tag })
+
+const parallelPaths = (model: MachineTest.FiniteModel): ReadonlyArray<string> => {
+  const paths: Array<string> = []
+  const visit = (states: ReadonlyArray<MachineTest.FiniteState>, parent?: string): void => {
+    for (const state of states) {
+      const path = parent === undefined ? state.key : `${parent}.${state.key}`
+      if (state._tag === "Parallel") paths.push(path)
+      if (state._tag === "Compound" || state._tag === "Parallel") visit(state.states, path)
+    }
+  }
+  visit(model.roots)
+  return paths
+}
+
+const generated = MachineTest.finiteModels({
+  maxRoots: 2,
+  maxDepth: 3,
+  maxChildren: 3,
+  maxParallelRegions: 3,
+  maxEvents: 3,
+  maxTransitions: 12,
+  maxHistoryStates: 1,
+  maxChoiceStates: 1
+})
+
+describe("pure planning and managed runtime differential", () => {
+  it.effect("matches deterministic generated start and resumed executions", () =>
+    Effect.gen(function*() {
+      const samples = FastCheck.sample(generated.arbitrary, { numRuns: 36, seed: 93_701 })
+      let activeParallel = 0
+      let eventful = 0
+      let resumedContinuation = 0
+
+      for (let sampleIndex = 0; sampleIndex < samples.length; sampleIndex++) {
+        const sampled = samples[sampleIndex]!
+        // Keep generated runtime inputs on deterministic, state-changing
+        // targets. Targetless and reentry publication semantics have focused
+        // witnesses elsewhere and can make a current-state subscription an
+        // ambiguous acknowledgement barrier.
+        const model: MachineTest.FiniteModel = {
+          ...sampled,
+          transitions: (sampled.historyScenarios?.length ?? 0) > 0
+            ? sampled.transitions
+            : sampled.transitions.filter((transition) =>
+              transition.trigger.type !== "event" ||
+              (transition.target !== undefined && "reenter" in transition && !transition.reenter &&
+                transition.target !== transition.source)
+            )
+        }
+        const requestedEvents = Array.from({ length: 6 }, (_, index) =>
+          model.events[(sampleIndex + index) % model.events.length]!)
+        const reference = MachineTest.interpretModel(model, requestedEvents)
+        // The independent reference interpreter chooses the useful prefix. A
+        // missing planner transition therefore cannot erase its own witness.
+        let lastTransitioning = -1
+        for (let index = 0; index < reference.steps.length; index++) {
+          const step = reference.steps[index]!
+          if (step.microsteps.length > 0) {
+            lastTransitioning = index
+          }
+          if (step.done) {
+            break
+          }
+        }
+        const events = lastTransitioning < 0 ? [] : requestedEvents.slice(0, lastTransitioning + 1)
+        const expected = MachineTest.interpretModel(model, events)
+        const machine = MachineTest.compileModel(model)
+        const trace = yield* MachineTest.run(machine, { events: events.map(event) })
+        yield* MachineTest.verifyModel(model, trace)
+
+        if (
+          expected.steps.some(({ microsteps }) =>
+            microsteps.some(({ transitions }) =>
+              transitions.some(({ trigger }) => trigger.type === "event")
+            )
+          )
+        ) eventful += 1
+        const parallel = new Set(parallelPaths(model))
+        if (
+          [expected.initial.state, ...expected.steps.map(({ after }) => after)].some(({ activePaths }) =>
+            activePaths.some((path) => parallel.has(path))
+          )
+        ) activeParallel += 1
+
+        yield* verifyManagedExecution({
+          machine,
+          open: Machine.start(machine as any),
+          initial: traceBoundary(trace, 0),
+          steps: traceSteps(trace),
+          label: `generated start ${sampleIndex}`
+        })
+
+        const boundary = trace.steps.length < 2 ? 0 : Math.max(1, Math.floor(trace.steps.length / 2))
+        const boundaryState = traceBoundary(trace, boundary)
+        const encoded = yield* Machine.encodeSnapshot(machine as any, boundaryState.state as any)
+        const decoded = yield* Machine.decodeSnapshot(machine as any, encoded)
+        yield* verifyManagedExecution({
+          machine,
+          open: Machine.resume(machine as any, decoded),
+          initial: boundaryState,
+          steps: traceSteps(trace, boundary),
+          label: `generated resume ${sampleIndex}:${boundary}`
+        })
+        if (boundary > 0 && boundary < trace.steps.length) resumedContinuation += 1
+      }
+
+      assert.ok(eventful > 0, "generated differential must execute public-event transitions")
+      assert.ok(activeParallel > 0, "generated differential must execute an active parallel configuration")
+      assert.ok(
+        resumedContinuation > 0,
+        "generated differential must resume after a noninitial boundary with a non-empty suffix"
+      )
+    }), 30_000)
+
+  it.effect("resumes a nonterminal boundary reached through always and completion stabilization", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [
+          {
+            _tag: "Compound",
+            key: "flow",
+            value: 0,
+            initial: "idle",
+            states: [
+              { _tag: "Atomic", key: "idle", value: 1 },
+              {
+                _tag: "Compound",
+                key: "work",
+                value: 2,
+                initial: "done",
+                states: [{ _tag: "Final", key: "done", value: 3, output: "work:done" }]
+              },
+              { _tag: "Atomic", key: "ready", value: 4 }
+            ]
+          },
+          { _tag: "Final", key: "complete", value: 5, output: "machine:done" }
+        ],
+        initial: "flow",
+        events: ["Finish"],
+        transitions: [
+          { source: "flow.idle", trigger: { type: "always" }, target: "flow.work" },
+          { source: "flow.work", trigger: { type: "done" }, target: "flow.ready" },
+          { source: "flow.ready", trigger: { type: "event", event: "Finish" }, target: "complete", reenter: false }
+        ]
+      }
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Finish")] })
+      yield* MachineTest.verifyModel(model, trace)
+      assert.deepStrictEqual(
+        trace.initial.plan.microsteps.flatMap((microstep) => microstep.transitions.map(({ trigger }) => trigger.type)),
+        ["always", "done"]
+      )
+      assert.strictEqual(trace.initial.plan.done, false)
+      assert.strictEqual(trace.initial.plan.state.path, "flow")
+      assert.strictEqual((trace.initial.plan.state as any).state.path, "flow.ready")
+      assert.strictEqual(trace.steps[0]?.plan.done, true)
+      assert.strictEqual(trace.steps[0]?.plan.output, "machine:done")
+
+      yield* verifyManagedExecution({
+        machine,
+        open: Machine.start(machine as any),
+        initial: traceBoundary(trace, 0),
+        steps: traceSteps(trace),
+        label: "automatic start"
+      })
+      const encoded = yield* Machine.encodeSnapshot(machine as any, trace.initial.plan.state as any)
+      const decoded = yield* Machine.decodeSnapshot(machine as any, encoded)
+      yield* verifyManagedExecution({
+        machine,
+        open: Machine.resume(machine as any, decoded),
+        initial: traceBoundary(trace, 0),
+        steps: traceSteps(trace),
+        label: "automatic resume"
+      })
+    }))
+
+  it.effect("preserves raised-event, action, and planned emission order", () =>
+    Effect.gen(function*() {
+      class Idle extends Schema.TaggedClass<Idle>("DifferentialIdle")("Idle", {}) {}
+      class Working extends Schema.TaggedClass<Working>("DifferentialWorking")("Working", {}) {}
+      class Finished extends Schema.TaggedClass<Finished>("DifferentialFinished")("Finished", {}) {}
+      class Begin extends Schema.TaggedClass<Begin>("DifferentialBegin")("Begin", {}) {}
+      class RaisedOne extends Schema.TaggedClass<RaisedOne>("DifferentialRaisedOne")("RaisedOne", {}) {}
+      class RaisedTwo extends Schema.TaggedClass<RaisedTwo>("DifferentialRaisedTwo")("RaisedTwo", {}) {}
+      class Notice extends Schema.TaggedClass<Notice>("DifferentialNotice")("Notice", { label: Schema.String }) {}
+
+      const actions = yield* Ref.make<ReadonlyArray<string>>([])
+      const record = (label: string) => Machine.action(Ref.update(actions, (labels) => [...labels, label]))
+      const states = Machine.defineStates({
+        Idle,
+        Working,
+        Finished: { schema: Finished, type: "final", output: Schema.String }
+      })
+      const machine = Machine.make({
+        states: states.states,
+        events: [Begin],
+        internalEvents: [RaisedOne, RaisedTwo],
+        emits: [Notice],
+        initial: () => states.initial.Idle(new Idle({}))
+      }).handle({
+        Idle: {
+          entry: ({ emit }) => Effect.andThen(record("entry:idle"), emit(new Notice({ label: "initial" }))),
+          on: {
+            Begin: Effect.fn(function*({ emit, raise, target }) {
+              yield* record("transition:begin")
+              yield* emit(new Notice({ label: "transition" }))
+              yield* raise(new RaisedOne({}))
+              return target.full.Working(new Working({}))
+            })
+          }
+        },
+        Working: {
+          entry: Effect.fn(function*({ emit, raise }) {
+            yield* record("entry:working")
+            yield* emit(new Notice({ label: "entry" }))
+            yield* raise(new RaisedTwo({}))
+          }),
+          on: {
+            RaisedOne: Effect.fn(function*({ emit }) {
+              yield* record("raised:one")
+              yield* emit(new Notice({ label: "raised-one" }))
+            }),
+            RaisedTwo: Effect.fn(function*({ emit, target }) {
+              yield* record("raised:two")
+              yield* emit(new Notice({ label: "raised-two" }))
+              return target.full.Finished(new Finished({}))
+            })
+          }
+        },
+        Finished: {
+          entry: ({ emit }) => Effect.andThen(record("entry:finished"), emit(new Notice({ label: "finished" }))),
+          output: () => "complete"
+        }
+      })
+
+      const initial = yield* Machine.planInitial(machine)
+      assert.deepStrictEqual(initial.emittedEvents.map(({ label }) => label), ["initial"])
+      assert.deepStrictEqual(yield* Ref.get(actions), [])
+      const planned = yield* Machine.plan(machine, initial.state, new Begin({}))
+      assert.deepStrictEqual(
+        planned.microsteps.map(({ event }) => event._tag),
+        ["Begin", "RaisedOne", "RaisedTwo"]
+      )
+      assert.deepStrictEqual(planned.emittedEvents.map(({ label }) => label), [
+        "transition",
+        "entry",
+        "raised-one",
+        "raised-two",
+        "finished"
+      ])
+
+      const actor = yield* Machine.start(machine)
+      assert.deepStrictEqual(yield* Ref.get(actions), ["entry:idle"])
+      yield* actor.send(new Begin({}))
+      assert.strictEqual(yield* actor.join, "complete")
+      assert.deepStrictEqual(yield* Ref.get(actions), [
+        "entry:idle",
+        "transition:begin",
+        "entry:working",
+        "raised:one",
+        "raised:two",
+        "entry:finished"
+      ])
+      assert.deepStrictEqual(
+        yield* Machine.encodeSnapshot(machine, (yield* actor.snapshot).state),
+        yield* Machine.encodeSnapshot(machine, planned.next)
+      )
+
+      yield* Ref.set(actions, [])
+      const resumed = yield* Machine.resume(machine, initial.state)
+      assert.deepStrictEqual(yield* Ref.get(actions), [], "resume must not replay initial entry actions")
+      yield* resumed.send(new Begin({}))
+      assert.strictEqual(yield* resumed.join, "complete")
+      assert.deepStrictEqual(yield* Ref.get(actions), [
+        "transition:begin",
+        "entry:working",
+        "raised:one",
+        "raised:two",
+        "entry:finished"
+      ])
+    }))
+
+  it.effect("retains the last published state when a planned action fails", () =>
+    Effect.gen(function*() {
+      class Idle extends Schema.TaggedClass<Idle>("DifferentialFailureIdle")("Idle", {}) {}
+      class Finished extends Schema.TaggedClass<Finished>("DifferentialFailureFinished")("Finished", {}) {}
+      class Go extends Schema.TaggedClass<Go>("DifferentialFailureGo")("Go", {}) {}
+      class Notice extends Schema.TaggedClass<Notice>("DifferentialFailureNotice")("Notice", {}) {}
+      class ActionFailure extends Data.TaggedError("ActionFailure")<{}> {}
+
+      const actions = yield* Ref.make<ReadonlyArray<string>>([])
+      const states = Machine.defineStates({ Idle, Finished })
+      const machine = Machine.make({
+        states: states.states,
+        events: [Go],
+        emits: [Notice],
+        initial: () => states.initial.Idle(new Idle({}))
+      }).handle({
+        Idle: {
+          on: {
+            Go: Effect.fn(function*({ emit, target }) {
+              yield* Machine.action(Ref.update(actions, (labels) => [...labels, "before"]))
+              yield* Machine.action(Effect.fail(new ActionFailure()))
+              yield* Machine.action(Ref.update(actions, (labels) => [...labels, "after"]))
+              yield* emit(new Notice({}))
+              return target.full.Finished(new Finished({}))
+            })
+          }
+        },
+        Finished: {}
+      })
+      const initial = yield* Machine.planInitial(machine)
+      const planned = yield* Machine.plan(machine, initial.state, new Go({}))
+      assert.deepStrictEqual(planned.next, states.initial.Finished(new Finished({})))
+      assert.strictEqual(planned.actions.length, 3)
+      assert.strictEqual(planned.emittedEvents.length, 1)
+
+      const actor = yield* Machine.start(machine)
+      const failure = yield* actor.changes.pipe(
+        Stream.filter((snapshot) => snapshot.status === "error"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.map((snapshots) => Array.from(snapshots)[0]!),
+        Effect.forkChild({ startImmediately: true })
+      )
+      yield* actor.send(new Go({}))
+      const snapshot = yield* Fiber.join(failure)
+      assert.strictEqual(snapshot.status, "error")
+      if (snapshot.status === "error") {
+        assert.deepStrictEqual(snapshot.state, initial.state)
+        assert.instanceOf(snapshot.cause.reasons.find(Cause.isFailReason)?.error, ActionFailure)
+      }
+      assert.deepStrictEqual(yield* Ref.get(actions), ["before"])
+      assert.deepStrictEqual(yield* actor.snapshot, snapshot)
+    }))
+
+  it.effect("does not publish for an unhandled event before the next handled event", () =>
+    Effect.gen(function*() {
+      class Idle extends Schema.TaggedClass<Idle>("DifferentialNoopIdle")("Idle", {}) {}
+      class Active extends Schema.TaggedClass<Active>("DifferentialNoopActive")("Active", {}) {}
+      class Ignore extends Schema.TaggedClass<Ignore>("DifferentialIgnore")("Ignore", {}) {}
+      class Go extends Schema.TaggedClass<Go>("DifferentialGo")("Go", {}) {}
+      const states = Machine.defineStates({ Idle, Active })
+      const machine = Machine.make({
+        states: states.states,
+        events: [Ignore, Go],
+        initial: () => states.initial.Idle(new Idle({}))
+      }).handle({
+        Idle: { on: { Go: () => states.initial.Active(new Active({})) } },
+        Active: {}
+      })
+      const initial = yield* Machine.planInitial(machine)
+      const ignored = yield* Machine.plan(machine, initial.state, new Ignore({}))
+      const handled = yield* Machine.plan(machine, ignored.next, new Go({}))
+      assert.deepStrictEqual(ignored.microsteps, [])
+
+      const actor = yield* Machine.start(machine)
+      const publications = yield* actor.changes.pipe(
+        Stream.runCollect,
+        Effect.forkChild({ startImmediately: true })
+      )
+      const active = yield* actor.changes.pipe(
+        Stream.filter((snapshot) => snapshot.status === "active" && snapshot.state.path === "Active"),
+        Stream.take(1),
+        Stream.runDrain,
+        Effect.forkChild({ startImmediately: true })
+      )
+      yield* actor.send(new Ignore({}))
+      yield* actor.send(new Go({}))
+      yield* Fiber.join(active)
+      yield* actor.stop
+
+      const observed = Array.from(yield* Fiber.join(publications))
+      assert.deepStrictEqual(observed.map(({ status }) => status), ["active", "active", "stopped"])
+      assert.deepStrictEqual(observed[0]!.state, initial.state)
+      assert.deepStrictEqual(observed[1]!.state, handled.next)
+    }))
+})

--- a/test/MachineSnapshotCodecAdversarial.test.ts
+++ b/test/MachineSnapshotCodecAdversarial.test.ts
@@ -1,0 +1,504 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Cause, Effect, Exit, Option, Schema } from "effect"
+import { FastCheck } from "effect/testing"
+import { Machine } from "../src/index.js"
+
+class Root extends Schema.TaggedClass<Root>("CodecRoot")("CodecRoot", {
+  id: Schema.NonEmptyString
+}) {}
+class Left extends Schema.TaggedClass<Left>("CodecLeft")("CodecLeft", {}) {}
+class LeftWorking extends Schema.TaggedClass<LeftWorking>("CodecLeftWorking")("CodecLeftWorking", {
+  task: Schema.NonEmptyString
+}) {}
+class LeftDone extends Schema.TaggedClass<LeftDone>("CodecLeftDone")("CodecLeftDone", {}) {}
+class Right extends Schema.TaggedClass<Right>("CodecRight")("CodecRight", {}) {}
+class RightWorking extends Schema.TaggedClass<RightWorking>("CodecRightWorking")("CodecRightWorking", {
+  enabled: Schema.Boolean
+}) {}
+class RightDone extends Schema.TaggedClass<RightDone>("CodecRightDone")("CodecRightDone", {}) {}
+
+const TopologyStates = Machine.defineStates({
+  Root: {
+    schema: Root,
+    type: "parallel",
+    states: {
+      left: {
+        schema: Left,
+        initial: "working",
+        states: {
+          working: LeftWorking,
+          done: {
+            schema: LeftDone,
+            type: "final",
+            output: Schema.NumberFromString
+          }
+        }
+      },
+      right: {
+        schema: Right,
+        initial: "working",
+        states: {
+          working: RightWorking,
+          done: {
+            schema: RightDone,
+            type: "final",
+            output: Schema.Boolean
+          }
+        }
+      }
+    }
+  }
+})
+
+const topologyMachine = Machine.make({
+  id: "codec-topology",
+  states: TopologyStates.states,
+  events: [],
+  initial: () => topologyActive()
+})
+
+const topologyActive = () =>
+  TopologyStates.initial.Root(new Root({ id: "root-1" }), (root) =>
+    root
+      .left(new Left({}), (left) => left.working(new LeftWorking({ task: "left-1" })))
+      .right(new Right({}), (right) => right.working(new RightWorking({ enabled: true }))))
+
+const topologyFinal = () =>
+  ({
+    path: "Root",
+    value: new Root({ id: "root-1" }),
+    states: {
+      left: {
+        path: "Root.left",
+        value: new Left({}),
+        state: { path: "Root.left.done", value: new LeftDone({}) }
+      },
+      right: {
+        path: "Root.right",
+        value: new Right({}),
+        state: { path: "Root.right.done", value: new RightDone({}) }
+      }
+    },
+    completed: [
+      { path: "Root.left.done", output: 7 },
+      { path: "Root.right.done", output: true }
+    ]
+  }) as Machine.Machine.Snapshot<typeof TopologyStates.states>
+
+class Workspace extends Schema.TaggedClass<Workspace>("CodecWorkspace")("CodecWorkspace", {
+  revision: Schema.Number
+}) {}
+class Editor extends Schema.TaggedClass<Editor>("CodecEditor")("CodecEditor", {
+  document: Schema.NonEmptyString
+}) {}
+class Editing extends Schema.TaggedClass<Editing>("CodecEditing")("CodecEditing", {
+  contents: Schema.String
+}) {}
+class Preview extends Schema.TaggedClass<Preview>("CodecPreview")("CodecPreview", {
+  page: Schema.Number
+}) {}
+class Outside extends Schema.TaggedClass<Outside>("CodecOutside")("CodecOutside", {}) {}
+
+const HistoryStates = Machine.defineStates({
+  Workspace: {
+    schema: Workspace,
+    initial: "Editor",
+    states: {
+      Editor: {
+        schema: Editor,
+        initial: "editing",
+        states: {
+          editing: Editing,
+          preview: Preview
+        }
+      },
+      recent: { type: "history" },
+      exact: { type: "history", history: "deep" }
+    }
+  },
+  Outside
+})
+
+const historyMachine = Machine.make({
+  id: "codec-history",
+  states: HistoryStates.states,
+  events: [],
+  initial: () => HistoryStates.initial.Outside(new Outside({}))
+})
+
+const historySnapshot = () =>
+  ({
+    ...HistoryStates.initial.Outside(new Outside({})),
+    history: {
+      "Workspace.recent": {
+        mode: "shallow" as const,
+        active: ["Workspace", "Workspace.Editor"],
+        values: {
+          Workspace: new Workspace({ revision: 3 }),
+          "Workspace.Editor": new Editor({ document: "doc-1" })
+        }
+      },
+      "Workspace.exact": {
+        mode: "deep" as const,
+        active: ["Workspace", "Workspace.Editor", "Workspace.Editor.editing"],
+        values: {
+          Workspace: new Workspace({ revision: 3 }),
+          "Workspace.Editor": new Editor({ document: "doc-1" }),
+          "Workspace.Editor.editing": new Editing({ contents: "hello" })
+        }
+      }
+    }
+  }) as Machine.Machine.Snapshot<typeof HistoryStates.states>
+
+const expectEncodeFailure = Effect.fnUntraced(function*(snapshot: unknown, boundary?: string) {
+  const error = yield* Machine.encodeSnapshot(
+    topologyMachine,
+    snapshot as Machine.Machine.Snapshot<typeof TopologyStates.states>
+  ).pipe(Effect.flip)
+  assert.instanceOf(error, Machine.MachineSchemaEncodeError)
+  if (boundary !== undefined) assert.strictEqual(error.boundary, boundary)
+})
+
+const expectDecodeFailure = Effect.fnUntraced(function*(
+  decoding: Effect.Effect<unknown, Machine.MachineSchemaDecodeError>,
+  boundary?: string
+) {
+  const error = yield* decoding.pipe(Effect.flip)
+  assert.instanceOf(error, Machine.MachineSchemaDecodeError)
+  if (boundary !== undefined) assert.strictEqual(error.boundary, boundary)
+})
+
+describe("snapshot codec adversarial boundaries", () => {
+  it.effect.prop(
+    "turns arbitrary JSON-shaped boundary input into values or typed failures, never defects",
+    { input: FastCheck.jsonValue() },
+    ({ input }) =>
+      Effect.gen(function*() {
+        const encodeExit = yield* Effect.exit(Machine.encodeSnapshot(topologyMachine, input as any))
+        const decodeExit = yield* Effect.exit(Machine.decodeSnapshot(topologyMachine, input))
+        const exits: ReadonlyArray<Exit.Exit<unknown, unknown>> = [encodeExit, decodeExit]
+
+        for (const exit of exits) {
+          if (Exit.isSuccess(exit)) continue
+          assert.strictEqual(Cause.hasDies(exit.cause), false)
+          const error = Cause.findErrorOption(exit.cause)
+          assert(Option.isSome(error))
+          assert.ok(
+            error.value instanceof Machine.MachineSchemaEncodeError ||
+              error.value instanceof Machine.MachineSchemaDecodeError
+          )
+        }
+      }),
+    { fastCheck: { numRuns: 100, seed: 83_117 } }
+  )
+
+  it.effect("round-trips active parallel and completed final configurations through JSON", () =>
+    Effect.gen(function*() {
+      for (const snapshot of [topologyActive(), topologyFinal()]) {
+        const encoded = yield* Machine.encodeSnapshot(topologyMachine, snapshot)
+        const decoded = yield* Machine.decodeSnapshot(topologyMachine, JSON.parse(JSON.stringify(encoded)))
+        assert.deepStrictEqual(decoded, snapshot)
+      }
+
+      const encodedFinal = yield* Machine.encodeSnapshot(topologyMachine, topologyFinal())
+      assert.deepStrictEqual(encodedFinal.completed, [
+        { path: "Root.left.done", output: "7" },
+        { path: "Root.right.done", output: true }
+      ])
+    }))
+
+  it.effect("round-trips shallow and deep history records through JSON", () =>
+    Effect.gen(function*() {
+      const snapshot = historySnapshot()
+      const encoded = yield* Machine.encodeSnapshot(historyMachine, snapshot)
+      const decoded = yield* Machine.decodeSnapshot(historyMachine, JSON.parse(JSON.stringify(encoded)))
+
+      assert.deepStrictEqual(decoded, snapshot)
+      assert.instanceOf(decoded.history?.["Workspace.recent"]?.values.Workspace, Workspace)
+      assert.instanceOf(decoded.history?.["Workspace.exact"]?.values["Workspace.Editor.editing"], Editing)
+    }))
+
+  it.effect("resumes a transported stable boundary without running a newly added automatic transition", () =>
+    Effect.gen(function*() {
+      class Before extends Schema.TaggedClass<Before>("CodecAutomaticBefore")("CodecAutomaticBefore", {}) {}
+      class Boundary extends Schema.TaggedClass<Boundary>("CodecAutomaticBoundary")("CodecAutomaticBoundary", {}) {}
+      class After extends Schema.TaggedClass<After>("CodecAutomaticAfter")("CodecAutomaticAfter", {}) {}
+      const states = Machine.defineStates({ Before, Boundary, After })
+      const original = Machine.make({
+        id: "codec-automatic-original",
+        states: states.states,
+        events: [],
+        initial: () => states.initial.Before(new Before({}))
+      }).handle({
+        Before: { always: ({ target }) => target.full.Boundary(new Boundary({})) },
+        Boundary: {},
+        After: {}
+      })
+      const changed = Machine.make({
+        id: "codec-automatic-changed",
+        states: states.states,
+        events: [],
+        initial: () => states.initial.Before(new Before({}))
+      }).handle({
+        Before: {},
+        Boundary: { always: ({ target }) => target.full.After(new After({})) },
+        After: {}
+      })
+
+      const stable = (yield* Machine.planInitial(original)).state
+      assert.strictEqual(stable.path, "Boundary")
+      const transported = JSON.parse(JSON.stringify(yield* Machine.encodeSnapshot(original, stable)))
+      const decoded = yield* Machine.decodeSnapshot(changed, transported)
+      const resumed = yield* Machine.resume(changed, decoded)
+
+      assert.strictEqual((yield* resumed.state).path, "Boundary")
+      yield* Effect.yieldNow
+      assert.strictEqual((yield* resumed.state).path, "Boundary")
+      yield* resumed.stop
+    }))
+
+  it.effect("rejects malformed logical topology before encoding", () =>
+    Effect.gen(function*() {
+      const valid = topologyActive()
+      const malformed: ReadonlyArray<unknown> = [
+        { path: "Missing", value: {} },
+        { ...valid, states: { left: valid.states.left } },
+        {
+          ...valid,
+          states: {
+            ...valid.states,
+            left: { ...valid.states.left, state: valid.states.right.state }
+          }
+        },
+        {
+          ...valid,
+          states: {
+            ...valid.states,
+            left: { ...valid.states.left, value: { _tag: "CodecLeft" } },
+            right: { ...valid.states.right, value: { _tag: "CodecRight", unexpected: true } }
+          }
+        }
+      ]
+
+      for (const snapshot of malformed) {
+        yield* expectEncodeFailure(snapshot)
+      }
+    }))
+
+  it.effect("rejects unknown, duplicate, missing, extra, and impossible encoded configurations", () =>
+    Effect.gen(function*() {
+      const encoded = yield* Machine.encodeSnapshot(topologyMachine, topologyActive())
+      const mutations: Array<unknown> = []
+
+      const unknown = structuredClone(encoded) as any
+      unknown.active[2].path = "Root.left.missing"
+      mutations.push(unknown)
+
+      const duplicate = structuredClone(encoded) as any
+      duplicate.active.push(structuredClone(duplicate.active[2]))
+      mutations.push(duplicate)
+
+      const missingRegion = structuredClone(encoded) as any
+      missingRegion.active = missingRegion.active.filter((entry: any) => !entry.path.startsWith("Root.right"))
+      mutations.push(missingRegion)
+
+      const extraCompoundBranch = structuredClone(encoded) as any
+      extraCompoundBranch.active.push({ path: "Root.left.done", value: { _tag: "CodecLeftDone" } })
+      mutations.push(extraCompoundBranch)
+
+      const impossibleAncestry = structuredClone(encoded) as any
+      impossibleAncestry.active = impossibleAncestry.active.filter((entry: any) => entry.path !== "Root.left")
+      mutations.push(impossibleAncestry)
+
+      for (const mutation of mutations) {
+        yield* expectDecodeFailure(Machine.decodeSnapshot(topologyMachine, mutation), "configuration")
+      }
+    }))
+
+  it.effect("rejects invalid and corrupt completion entries", () =>
+    Effect.gen(function*() {
+      const encoded = yield* Machine.encodeSnapshot(topologyMachine, topologyFinal())
+      const mutations: Array<unknown> = []
+
+      const unknown = structuredClone(encoded) as any
+      unknown.completed[0].path = "Root.left.missing"
+      mutations.push(unknown)
+
+      const duplicate = structuredClone(encoded) as any
+      duplicate.completed.push(structuredClone(duplicate.completed[0]))
+      mutations.push(duplicate)
+
+      const wrongOutput = structuredClone(encoded) as any
+      wrongOutput.completed[0].output = null
+      mutations.push(wrongOutput)
+
+      const activeNotFinal = yield* Machine.encodeSnapshot(topologyMachine, topologyActive())
+      ;(activeNotFinal as any).completed = [{ path: "Root.left.working", output: undefined }]
+      mutations.push(activeNotFinal)
+
+      const inactiveFinal = yield* Machine.encodeSnapshot(topologyMachine, topologyActive())
+      ;(inactiveFinal as any).completed = [{ path: "Root.left.done", output: "1" }]
+      mutations.push(inactiveFinal)
+
+      for (const mutation of mutations) {
+        yield* expectDecodeFailure(Machine.decodeSnapshot(topologyMachine, mutation))
+      }
+    }))
+
+  it.effect("rejects invalid logical completion entries before encoding", () =>
+    Effect.gen(function*() {
+      const final = topologyFinal()
+      const active = topologyActive()
+      const malformed: ReadonlyArray<unknown> = [
+        { ...final, completed: [...(final.completed ?? []), final.completed?.[0]] },
+        { ...final, completed: [{ path: "Root.left.missing", output: 1 }] },
+        { ...active, completed: [{ path: "Root.left.working", output: undefined }] },
+        { ...final, completed: [{ path: "Root.left.done", output: null }] }
+      ]
+
+      for (const snapshot of malformed) {
+        yield* expectEncodeFailure(snapshot)
+      }
+    }))
+
+  it.effect("rejects schema failures on both sides of the codec", () =>
+    Effect.gen(function*() {
+      const logical = topologyActive()
+      const invalidLogical = {
+        ...logical,
+        states: {
+          ...logical.states,
+          left: {
+            ...logical.states.left,
+            state: {
+              ...logical.states.left.state,
+              value: { _tag: "CodecLeftWorking", task: "" }
+            }
+          }
+        }
+      }
+      yield* expectEncodeFailure(invalidLogical, "state")
+
+      const encoded = yield* Machine.encodeSnapshot(topologyMachine, logical)
+      const invalidEncoded = structuredClone(encoded) as any
+      invalidEncoded.active.find((entry: any) => entry.path === "Root.left.working").value.task = ""
+      yield* expectDecodeFailure(Machine.decodeSnapshot(topologyMachine, invalidEncoded), "state")
+    }))
+
+  it.effect("rejects corrupt history paths, modes, values, and control records", () =>
+    Effect.gen(function*() {
+      const encoded = yield* Machine.encodeSnapshot(historyMachine, historySnapshot())
+      const mutations: Array<unknown> = []
+
+      const unknownRecord = structuredClone(encoded) as any
+      unknownRecord.history["Workspace.missing"] = unknownRecord.history["Workspace.exact"]
+      mutations.push(unknownRecord)
+
+      const wrongMode = structuredClone(encoded) as any
+      wrongMode.history["Workspace.exact"].mode = "shallow"
+      mutations.push(wrongMode)
+
+      const duplicatePath = structuredClone(encoded) as any
+      duplicatePath.history["Workspace.exact"].active.push("Workspace.Editor")
+      mutations.push(duplicatePath)
+
+      const missingOwner = structuredClone(encoded) as any
+      missingOwner.history["Workspace.exact"].active = missingOwner.history["Workspace.exact"].active.filter(
+        (path: string) => path !== "Workspace"
+      )
+      delete missingOwner.history["Workspace.exact"].values.Workspace
+      mutations.push(missingOwner)
+
+      const extraValue = structuredClone(encoded) as any
+      extraValue.history["Workspace.exact"].values["Workspace.Editor.preview"] = {
+        _tag: "CodecPreview",
+        page: 1
+      }
+      mutations.push(extraValue)
+
+      const invalidValue = structuredClone(encoded) as any
+      invalidValue.history["Workspace.exact"].values["Workspace.Editor.editing"].contents = 1
+      mutations.push(invalidValue)
+
+      const incompleteCompound = structuredClone(encoded) as any
+      incompleteCompound.history["Workspace.exact"].active = ["Workspace", "Workspace.Editor"]
+      delete incompleteCompound.history["Workspace.exact"].values["Workspace.Editor.editing"]
+      mutations.push(incompleteCompound)
+
+      const shallowWithDeepDescendant = structuredClone(encoded) as any
+      shallowWithDeepDescendant.history["Workspace.recent"].active.push("Workspace.Editor.editing")
+      shallowWithDeepDescendant.history["Workspace.recent"].values["Workspace.Editor.editing"] = {
+        _tag: "CodecEditing",
+        contents: "hello"
+      }
+      mutations.push(shallowWithDeepDescendant)
+
+      const conflictingCompoundChildren = structuredClone(encoded) as any
+      conflictingCompoundChildren.history["Workspace.exact"].active.push("Workspace.Editor.preview")
+      conflictingCompoundChildren.history["Workspace.exact"].values["Workspace.Editor.preview"] = {
+        _tag: "CodecPreview",
+        page: 1
+      }
+      mutations.push(conflictingCompoundChildren)
+
+      const outsideOwner = structuredClone(encoded) as any
+      outsideOwner.history["Workspace.exact"].active.push("Outside")
+      outsideOwner.history["Workspace.exact"].values.Outside = { _tag: "CodecOutside" }
+      mutations.push(outsideOwner)
+
+      for (const mutation of mutations) {
+        yield* expectDecodeFailure(Machine.decodeSnapshot(historyMachine, mutation), "history")
+      }
+    }))
+
+  it.effect("rejects corrupt logical history before encoding", () =>
+    Effect.gen(function*() {
+      const snapshot = historySnapshot()
+      const invalid: ReadonlyArray<unknown> = [
+        {
+          ...snapshot,
+          history: {
+            ...snapshot.history,
+            "Workspace.exact": {
+              ...snapshot.history?.["Workspace.exact"],
+              mode: "shallow"
+            }
+          }
+        },
+        {
+          ...snapshot,
+          history: {
+            ...snapshot.history,
+            "Workspace.exact": {
+              ...snapshot.history?.["Workspace.exact"],
+              active: [...snapshot.history!["Workspace.exact"]!.active, "Workspace.Editor.preview"],
+              values: {
+                ...snapshot.history!["Workspace.exact"]!.values,
+                "Workspace.Editor.preview": new Preview({ page: 1 })
+              }
+            }
+          }
+        },
+        {
+          ...snapshot,
+          history: {
+            ...snapshot.history,
+            "Workspace.exact": {
+              ...snapshot.history?.["Workspace.exact"],
+              active: [...snapshot.history!["Workspace.exact"]!.active, "Outside"],
+              values: {
+                ...snapshot.history!["Workspace.exact"]!.values,
+                Outside: new Outside({})
+              }
+            }
+          }
+        }
+      ]
+
+      for (const malformed of invalid) {
+        const error = yield* Machine.encodeSnapshot(historyMachine, malformed as any).pipe(Effect.flip)
+        assert.instanceOf(error, Machine.MachineSchemaEncodeError)
+        assert.strictEqual(error.boundary, "history")
+      }
+    }))
+})

--- a/test/MachineStateDefinition.test.ts
+++ b/test/MachineStateDefinition.test.ts
@@ -1,0 +1,247 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Schema } from "effect"
+import { Machine } from "../src/index.js"
+
+class Root extends Schema.TaggedClass<Root>("Root")("Root", {}) {}
+class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", {}) {}
+class Done extends Schema.TaggedClass<Done>("Done")("Done", {}) {}
+
+interface OpaqueState {
+  readonly _tag: "OpaqueState"
+  readonly value: number
+}
+
+const OpaqueState = Schema.declare<OpaqueState>((input): input is OpaqueState =>
+  typeof input === "object" && input !== null && "_tag" in input && input._tag === "OpaqueState" &&
+  "value" in input && typeof input.value === "number"
+)
+
+const expectDefinitionError = (
+  run: () => unknown,
+  boundary: "Machine.defineStates" | "Machine.make",
+  path: string,
+  detail: string
+): void => {
+  let failure: unknown
+  try {
+    run()
+  } catch (error) {
+    failure = error
+  }
+  assert.instanceOf(failure, Error)
+  assert.include(failure.message, `${boundary} invalid state definition at "${path}"`)
+  assert.include(failure.message, detail)
+}
+
+const makeFromUnknownStates = (states: unknown): unknown =>
+  Machine.make({
+    states: states as Machine.Machine.StateSchemas,
+    events: [],
+    initial: (): never => {
+      throw new Error("unreachable")
+    }
+  })
+
+describe("exact state-definition runtime validation", () => {
+  it("recognizes Effect schemas before inspecting config properties", () => {
+    const AnnotatedIdle = Idle.annotate({
+      title: "Idle",
+      arbitrarySchemaAnnotation: { owner: "machine-team" }
+    })
+    const states = Machine.defineStates({ Idle: AnnotatedIdle })
+    const machine = Machine.make({
+      states: states.states,
+      events: [],
+      initial: () => states.initial.Idle(new Idle({}))
+    })
+
+    assert.strictEqual(Machine.stateNodes(machine)[0]?.path, "Idle")
+
+    const prototypeNamed = Machine.defineStates({ constructor: Idle, toString: Done })
+    assert.deepStrictEqual(prototypeNamed.initial.constructor(new Idle({})), {
+      path: "constructor",
+      value: new Idle({})
+    })
+  })
+
+  it("accepts an opaque declaration whose Type satisfies TaggedSchema", () => {
+    const states = Machine.defineStates({ Opaque: OpaqueState })
+    const machine = Machine.make({
+      states: states.states,
+      events: [],
+      initial: () => states.initial.Opaque({ _tag: "OpaqueState", value: 1 })
+    })
+
+    assert.strictEqual(Machine.stateNodes(machine)[0]?.path, "Opaque")
+  })
+
+  it("rejects schemas whose decoded type does not have a required PropertyKey _tag", () => {
+    const UntaggedStruct = Schema.Struct({ value: Schema.String })
+
+    for (const schema of [Schema.String, UntaggedStruct]) {
+      for (const [node, path] of [[schema, "Invalid"], [{ schema }, "Invalid.schema"]] as const) {
+        expectDefinitionError(
+          () => Machine.defineStates({ Invalid: node } as unknown as Machine.Machine.StateSchemas),
+          "Machine.defineStates",
+          path,
+          "required PropertyKey _tag"
+        )
+        expectDefinitionError(
+          () => makeFromUnknownStates({ Invalid: node }),
+          "Machine.make",
+          path,
+          "required PropertyKey _tag"
+        )
+      }
+    }
+  })
+
+  it("rejects unknown properties for every state kind with the complete nested path", () => {
+    const invalidTrees: ReadonlyArray<readonly [unknown, string, string]> = [
+      [{ Idle: { schema: Idle, unknown: true } }, "Idle", "atomic states"],
+      [{ Done: { schema: Done, type: "final", unknown: true } }, "Done", "final states"],
+      [{ Root: { schema: Root, initial: "Idle", states: { Idle }, unknown: true } }, "Root", "compound states"],
+      [{ Root: { schema: Root, type: "parallel", states: { Idle }, unknown: true } }, "Root", "parallel states"],
+      [
+        {
+          Root: {
+            schema: Root,
+            initial: "Idle",
+            states: { Idle, History: { type: "history", unknown: true } }
+          }
+        },
+        "Root.History",
+        "history states"
+      ],
+      [
+        {
+          Root: {
+            schema: Root,
+            initial: "Idle",
+            states: { Idle, Choice: { type: "choice", unknown: true } }
+          }
+        },
+        "Root.Choice",
+        "choice states"
+      ]
+    ]
+
+    for (const [states, path, detail] of invalidTrees) {
+      expectDefinitionError(
+        () => Machine.defineStates(states as Machine.Machine.StateSchemas),
+        "Machine.defineStates",
+        path,
+        detail
+      )
+    }
+
+    expectDefinitionError(
+      () =>
+        makeFromUnknownStates({
+          Root: {
+            schema: Root,
+            initial: "Idle",
+            states: { Idle: { schema: Idle, nestedUnknown: true } }
+          }
+        }),
+      "Machine.make",
+      "Root.Idle",
+      "nestedUnknown"
+    )
+  })
+
+  it("rejects invalid state keys recursively, including symbol and __proto__ keys", () => {
+    const symbolKey = Symbol("state")
+    const symbolTree = { Idle } as Record<PropertyKey, unknown>
+    symbolTree[symbolKey] = Idle
+
+    const protoTree = Object.create(null) as Record<PropertyKey, unknown>
+    Object.defineProperty(protoTree, "__proto__", { enumerable: true, value: Idle })
+    const implicitProtoTree = { __proto__: { injected: Idle }, Idle }
+
+    const invalidTrees: ReadonlyArray<readonly [unknown, string, string]> = [
+      [{ "": Idle }, "<empty>", "cannot be empty"],
+      [{ "bad.path": Idle }, "bad.path", "cannot contain"],
+      [{ 0: Idle }, "0", "numeric forms"],
+      [{ "01": Idle }, "01", "numeric forms"],
+      [{ "-1": Idle }, "-1", "numeric forms"],
+      [{ "1e3": Idle }, "1e3", "numeric forms"],
+      [{ "0x10": Idle }, "0x10", "numeric forms"],
+      [{ " 1": Idle }, " 1", "numeric forms"],
+      [{ "1 ": Idle }, "1 ", "numeric forms"],
+      [{ " ": Idle }, " ", "numeric forms"],
+      [{ "\t": Idle }, "\t", "numeric forms"],
+      [symbolTree, "[Symbol(state)]", "not symbols"],
+      [protoTree, "__proto__", "not allowed"],
+      [implicitProtoTree, "__proto__", "implicit"],
+      [
+        {
+          Root: {
+            schema: Root,
+            initial: "bad.path",
+            states: { "bad.path": Idle }
+          }
+        },
+        "Root.bad.path",
+        "cannot contain"
+      ]
+    ]
+
+    for (const [states, path, detail] of invalidTrees) {
+      expectDefinitionError(
+        () => Machine.defineStates(states as Machine.Machine.StateSchemas),
+        "Machine.defineStates",
+        path,
+        detail
+      )
+    }
+
+    expectDefinitionError(
+      () => makeFromUnknownStates({ 12: Idle }),
+      "Machine.make",
+      "12",
+      "numeric forms"
+    )
+  })
+
+  it("rejects unknown or non-string pseudo-state annotations", () => {
+    expectDefinitionError(
+      () =>
+        Machine.defineStates({
+          Root: {
+            schema: Root,
+            initial: "Idle",
+            states: {
+              Idle,
+              Choice: {
+                type: "choice",
+                annotations: { executable: true }
+              } as never
+            }
+          }
+        }),
+      "Machine.defineStates",
+      "Root.Choice.annotations",
+      "executable"
+    )
+    expectDefinitionError(
+      () =>
+        Machine.defineStates({
+          Root: {
+            schema: Root,
+            initial: "Idle",
+            states: {
+              Idle,
+              History: {
+                type: "history",
+                annotations: { title: 1 }
+              } as never
+            }
+          }
+        }),
+      "Machine.defineStates",
+      "Root.History.annotations.title",
+      "must be strings"
+    )
+  })
+})

--- a/test/MachineTestCoverage.test.ts
+++ b/test/MachineTestCoverage.test.ts
@@ -127,8 +127,18 @@ const parallelModel: MachineTest.FiniteModel = {
   initial: "workflow",
   events: ["Left", "Right"],
   transitions: [
-    { source: "workflow.left.idle", event: "Left", target: "workflow.left.done", reenter: false },
-    { source: "workflow.right.idle", event: "Right", target: "workflow.right.done", reenter: false }
+    {
+      source: "workflow.left.idle",
+      trigger: { type: "event", event: "Left" },
+      target: "workflow.left.done",
+      reenter: false
+    },
+    {
+      source: "workflow.right.idle",
+      trigger: { type: "event", event: "Right" },
+      target: "workflow.right.done",
+      reenter: false
+    }
   ]
 }
 
@@ -150,10 +160,10 @@ const historyModel: MachineTest.FiniteModel = {
   initial: "owner",
   events: ["Next", "Leave", "Resume"],
   transitions: [
-    { source: "owner.a", event: "Next", target: "owner.b", reenter: false },
-    { source: "owner.a", event: "Leave", target: "outside", reenter: false },
-    { source: "owner.b", event: "Leave", target: "outside", reenter: false },
-    { source: "outside", event: "Resume", target: "owner.exact", reenter: false }
+    { source: "owner.a", trigger: { type: "event", event: "Next" }, target: "owner.b", reenter: false },
+    { source: "owner.a", trigger: { type: "event", event: "Leave" }, target: "outside", reenter: false },
+    { source: "owner.b", trigger: { type: "event", event: "Leave" }, target: "outside", reenter: false },
+    { source: "outside", trigger: { type: "event", event: "Resume" }, target: "owner.exact", reenter: false }
   ]
 }
 

--- a/test/MachineTestFiniteModel.test.ts
+++ b/test/MachineTestFiniteModel.test.ts
@@ -66,6 +66,7 @@ const assertValid = (
 
   const states = flatten(model)
   const byPath = new Map(states.map((state) => [state.path, state]))
+  const stateOrder = new Map(states.map((state, index) => [state.path, index]))
   assert.strictEqual(byPath.size, states.length)
   for (const state of states) {
     assert.ok(Object.isFrozen(state.node))
@@ -103,8 +104,15 @@ const assertValid = (
       source !== undefined && source.node._tag !== "Final" && source.node._tag !== "History" &&
         source.node._tag !== "Choice"
     )
-    assert.ok(model.events.includes(transition.event))
-    const registration = `${transition.source}\u0000${transition.event}`
+    if (transition.trigger.type === "event") assert.ok(model.events.includes(transition.trigger.event))
+    else {
+      assert.ok(transition.target !== undefined)
+      assert.strictEqual("reenter" in transition, false)
+      assert.ok(stateOrder.get(transition.target!)! > stateOrder.get(transition.source)!)
+      if (transition.trigger.type === "always") assert.strictEqual(source.node._tag, "Atomic")
+      else assert.ok(source.node._tag === "Compound" || source.node._tag === "Parallel")
+    }
+    const registration = `${transition.source}\u0000${JSON.stringify(transition.trigger)}`
     assert.ok(!registrations.has(registration))
     registrations.add(registration)
     if (transition.target !== undefined) {
@@ -136,7 +144,7 @@ const assertValid = (
 
 const canonicalTransition = (transition: Machine.Machine.TransitionDefinition) => ({
   source: transition.source,
-  event: transition.trigger.type === "event" ? transition.trigger.event : transition.trigger.type,
+  trigger: transition.trigger,
   reenter: transition.reenter,
   targets: transition.targets.type === "declared" ? transition.targets.paths : undefined
 })
@@ -162,7 +170,8 @@ describe("MachineTest finite models", () => {
       choiceInitialWitnesses: true,
       structurallyValid: true,
       shrinkPreservesValidity: true,
-      eventlessTransitions: false
+      eventlessTransitions: true,
+      acyclicAutomaticTransitions: true
     })
     const samples = FastCheck.sample(generated.arbitrary, { numRuns: 250, seed: 10_241 })
     for (const model of samples) {
@@ -178,6 +187,12 @@ describe("MachineTest finite models", () => {
     }
     assert.ok(samples.some((model) => flatten(model).some(({ node }) => node._tag === "Parallel")))
     assert.ok(samples.some((model) => flatten(model).some(({ node }) => node._tag === "History")))
+    assert.ok(samples.some((model) => model.transitions.some(({ trigger }) => trigger.type === "always")))
+    assert.ok(samples.some((model) => model.transitions.some(({ trigger }) => trigger.type === "done")))
+    assert.ok(samples.some((model) =>
+      model.transitions.some(({ trigger }) => trigger.type === "event") &&
+      model.transitions.some(({ trigger }) => trigger.type !== "event")
+    ))
     assert.ok(samples.some((model) => flatten(model).filter(({ node }) => node._tag === "History").length > 1))
     assert.ok(
       samples.some((model) =>
@@ -185,6 +200,44 @@ describe("MachineTest finite models", () => {
       )
     )
   })
+
+  it.effect("generates firing event-to-always and event-to-completion chains", () =>
+    Effect.gen(function*() {
+      const samples = FastCheck.sample(generated.arbitrary, { numRuns: 2_000, seed: 12_773 })
+      const witnesses = new Map<"always" | "done", {
+        readonly event: string
+        readonly model: MachineTest.FiniteModel
+      }>()
+
+      for (const model of samples) {
+        for (const eventTag of model.events) {
+          const reference = MachineTest.interpretModel(model, [eventTag])
+          const triggers = reference.steps[0]?.microsteps.flatMap((microstep) =>
+            microstep.transitions.map(({ trigger }) => trigger.type)
+          ) ?? []
+          if (triggers[0] !== "event") {
+            continue
+          }
+          if (triggers.includes("always") && !witnesses.has("always")) {
+            witnesses.set("always", { event: eventTag, model })
+          }
+          if (triggers.includes("done") && !witnesses.has("done")) {
+            witnesses.set("done", { event: eventTag, model })
+          }
+        }
+        if (witnesses.size === 2) {
+          break
+        }
+      }
+
+      assert.ok(witnesses.has("always"), "generated models must exercise an event -> always chain")
+      assert.ok(witnesses.has("done"), "generated models must exercise an event -> completion chain")
+      for (const witness of witnesses.values()) {
+        const machine = MachineTest.compileModel(witness.model)
+        const trace = yield* MachineTest.run(machine, { events: [{ _tag: witness.event }] })
+        yield* MachineTest.verifyModel(witness.model, trace)
+      }
+    }))
 
   it.effect("replays exact generated root and nested value-mutation/capture/restore scenarios", () =>
     Effect.gen(function*() {
@@ -252,15 +305,15 @@ describe("MachineTest finite models", () => {
       )
 
       const actualTransitions = Machine.transitionDefinitions(machine)
-        .filter(({ trigger }) => trigger.type === "event")
+        .filter(({ trigger }) => trigger.type !== "choice")
         .map(canonicalTransition)
       assert.strictEqual(actualTransitions.length, model.transitions.length)
       for (let index = 0; index < model.transitions.length; index++) {
         const expected = model.transitions[index]!
         const actual = actualTransitions[index]!
         assert.strictEqual(actual.source, expected.source)
-        assert.strictEqual(actual.event, expected.event)
-        assert.strictEqual(actual.reenter, expected.reenter)
+        assert.deepStrictEqual(actual.trigger, expected.trigger)
+        assert.strictEqual(actual.reenter, "reenter" in expected ? expected.reenter : false)
         if (expected.target === undefined) {
           assert.strictEqual(actual.targets, undefined)
         } else {
@@ -315,7 +368,12 @@ describe("MachineTest finite models", () => {
         ],
         initial: "right",
         events: ["Switch"],
-        transitions: [{ source: "right.idle", event: "Switch", target: "left", reenter: true }]
+        transitions: [{
+          source: "right.idle",
+          trigger: { type: "event", event: "Switch" },
+          target: "left",
+          reenter: true
+        }]
       }
       const machine = MachineTest.compileModel(model)
       const trace = yield* MachineTest.run(machine, { events: [{ _tag: "Switch" }] })
@@ -376,7 +434,11 @@ describe("MachineTest finite models", () => {
       transitions: []
     }
     assert.throws(
-      () => MachineTest.compileModel({ ...base, transitions: [{ source: "missing", event: "Go", reenter: false }] }),
+      () =>
+        MachineTest.compileModel({
+          ...base,
+          transitions: [{ source: "missing", trigger: { type: "event", event: "Go" }, reenter: false }]
+        }),
       /invalid transition source/
     )
     assert.throws(
@@ -384,8 +446,8 @@ describe("MachineTest finite models", () => {
         MachineTest.compileModel({
           ...base,
           transitions: [
-            { source: "idle", event: "Go", reenter: false },
-            { source: "idle", event: "Go", target: "idle", reenter: true }
+            { source: "idle", trigger: { type: "event", event: "Go" }, reenter: false },
+            { source: "idle", trigger: { type: "event", event: "Go" }, target: "idle", reenter: true }
           ]
         }),
       /duplicate transition/
@@ -417,6 +479,40 @@ describe("MachineTest finite models", () => {
           transitions: []
         }),
       /unknown initial child/
+    )
+
+    assert.throws(
+      () =>
+        MachineTest.compileModel({
+          ...base,
+          transitions: [{
+            source: "idle",
+            trigger: { type: "always" },
+            reenter: false
+          }]
+        } as unknown as MachineTest.FiniteModel),
+      /event-only reenter option/
+    )
+
+    assert.throws(
+      () =>
+        MachineTest.compileModel({
+          roots: [{
+            _tag: "Compound",
+            key: "root",
+            value: 0,
+            initial: "idle",
+            states: [{ _tag: "Atomic", key: "idle", value: 1 }]
+          }],
+          initial: "root",
+          events: ["Unused"],
+          transitions: [{
+            source: "root",
+            trigger: { type: "done" },
+            reenter: false
+          }]
+        } as unknown as MachineTest.FiniteModel),
+      /event-only reenter option/
     )
   })
 
@@ -467,13 +563,18 @@ describe("MachineTest finite models", () => {
         transitions: [
           {
             source: mutationSource,
-            event: "Mutate",
+            trigger: { type: "event", event: "Mutate" },
             target: mutationSource,
             targetValue: 100,
             reenter: false
           },
-          { source: "root.work.phase.idle", event: "Leave", target: "outside", reenter: false },
-          { source: "outside", event: "Leave", target: history, reenter: false }
+          {
+            source: "root.work.phase.idle",
+            trigger: { type: "event", event: "Leave" },
+            target: "outside",
+            reenter: false
+          },
+          { source: "outside", trigger: { type: "event", event: "Leave" }, target: history, reenter: false }
         ],
         historyScenarios: [scenario]
       }

--- a/test/MachineTestReferenceModel.test.ts
+++ b/test/MachineTestReferenceModel.test.ts
@@ -28,6 +28,166 @@ const snapshotAtPath = (snapshot: unknown, path: string): unknown => {
 }
 
 describe("MachineTest finite-model reference interpreter", () => {
+  it.effect("stabilizes acyclic always and completion transitions in semantic order", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [{
+          _tag: "Compound",
+          key: "flow",
+          value: 0,
+          initial: "idle",
+          states: [
+            { _tag: "Atomic", key: "idle", value: 1 },
+            {
+              _tag: "Compound",
+              key: "work",
+              value: 2,
+              initial: "finished",
+              states: [{ _tag: "Final", key: "finished", value: 3, output: "work:finished" }]
+            },
+            { _tag: "Atomic", key: "archived", value: 4 }
+          ]
+        }],
+        initial: "flow",
+        events: ["Tick"],
+        transitions: [
+          { source: "flow.idle", trigger: { type: "always" }, target: "flow.work" },
+          // Completion has priority over an `always` transition registered on
+          // the same newly completed state.
+          { source: "flow.work", trigger: { type: "always" }, target: "flow.idle" },
+          { source: "flow.work", trigger: { type: "done" }, target: "flow.archived" }
+        ]
+      }
+
+      const reference = MachineTest.interpretModel(model, [])
+      assert.deepStrictEqual(
+        reference.initial.microsteps.flatMap((microstep) => microstep.transitions.map(({ trigger }) => trigger)),
+        [{ type: "always" }, { type: "done" }]
+      )
+      assert.deepStrictEqual(reference.initial.state.activePaths, ["flow", "flow.archived"])
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("stabilizes event transitions through always transitions", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [
+          { _tag: "Atomic", key: "idle", value: 0 },
+          { _tag: "Atomic", key: "working", value: 1 },
+          { _tag: "Atomic", key: "ready", value: 2 }
+        ],
+        initial: "idle",
+        events: ["Start"],
+        transitions: [
+          { source: "idle", trigger: { type: "event", event: "Start" }, target: "working", reenter: false },
+          { source: "working", trigger: { type: "always" }, target: "ready" }
+        ]
+      }
+      const reference = MachineTest.interpretModel(model, ["Start"])
+      assert.deepStrictEqual(
+        reference.steps[0]?.microsteps.flatMap((microstep) => microstep.transitions.map(({ trigger }) => trigger)),
+        [{ type: "event", event: "Start" }, { type: "always" }]
+      )
+      assert.deepStrictEqual(reference.final.activePaths, ["ready"])
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Start")] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("recognizes completion again after exiting and reentering the same completed path", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [{
+          _tag: "Compound",
+          key: "root",
+          value: 0,
+          initial: "job",
+          states: [{
+            _tag: "Compound",
+            key: "job",
+            value: 1,
+            initial: "done",
+            states: [{ _tag: "Final", key: "done", value: 2, output: "job:done" }]
+          }]
+        }],
+        initial: "root",
+        events: ["Reset"],
+        transitions: [
+          // This targetless completion consumes the completion generation
+          // without changing the retained completion metadata.
+          { source: "root.job", trigger: { type: "done" } },
+          { source: "root.job", trigger: { type: "event", event: "Reset" }, target: "root.job", reenter: true }
+        ]
+      }
+
+      const reference = MachineTest.interpretModel(model, ["Reset"])
+      assert.deepStrictEqual(
+        reference.initial.microsteps.map((microstep) => microstep.transitions[0]?.trigger.type),
+        ["done"]
+      )
+      assert.deepStrictEqual(
+        reference.steps[0]?.microsteps.map((microstep) => microstep.transitions[0]?.trigger.type),
+        ["event", "done"]
+      )
+      assert.deepStrictEqual(reference.initial.state.completions, reference.steps[0]?.after.completions)
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Reset")] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("fails bounded planning for separate always and completion cycles", () =>
+    Effect.gen(function*() {
+      const always: MachineTest.FiniteModel = {
+        roots: [
+          { _tag: "Atomic", key: "left", value: 0 },
+          { _tag: "Atomic", key: "right", value: 1 }
+        ],
+        initial: "left",
+        events: ["Tick"],
+        transitions: [
+          { source: "left", trigger: { type: "always" }, target: "right" },
+          { source: "right", trigger: { type: "always" }, target: "left" }
+        ]
+      }
+      const completion: MachineTest.FiniteModel = {
+        roots: [
+          {
+            _tag: "Compound",
+            key: "left",
+            value: 0,
+            initial: "done",
+            states: [{ _tag: "Final", key: "done", value: 1, output: "left:done" }]
+          },
+          {
+            _tag: "Compound",
+            key: "right",
+            value: 2,
+            initial: "done",
+            states: [{ _tag: "Final", key: "done", value: 3, output: "right:done" }]
+          }
+        ],
+        initial: "left",
+        events: ["Tick"],
+        transitions: [
+          { source: "left", trigger: { type: "done" }, target: "right" },
+          { source: "right", trigger: { type: "done" }, target: "left" }
+        ]
+      }
+
+      for (const model of [always, completion]) {
+        // `compileModel` deliberately erases the generated machine to `Any`;
+        // planning readiness is established by the compiler for this fixture.
+        const error = yield* Machine.planInitial(MachineTest.compileModel(model) as any).pipe(Effect.flip)
+        assert.instanceOf(error, Machine.InfiniteTransitionError)
+        assert.strictEqual(error.maxIterations, 1000)
+      }
+    }))
+
   const parallelWorkflow = (
     transitions: ReadonlyArray<MachineTest.FiniteTransition>
   ): MachineTest.FiniteModel => ({
@@ -69,10 +229,30 @@ describe("MachineTest finite-model reference interpreter", () => {
   })
 
   const completionTransitions: ReadonlyArray<MachineTest.FiniteTransition> = [
-    { source: "workflow.left.idle", event: "Both", target: "workflow.left.done", reenter: false },
-    { source: "workflow.right.idle", event: "Both", target: "workflow.right.done", reenter: false },
-    { source: "workflow.left.idle", event: "Left", target: "workflow.left.done", reenter: false },
-    { source: "workflow.right.idle", event: "Right", target: "workflow.right.done", reenter: false }
+    {
+      source: "workflow.left.idle",
+      trigger: { type: "event", event: "Both" },
+      target: "workflow.left.done",
+      reenter: false
+    },
+    {
+      source: "workflow.right.idle",
+      trigger: { type: "event", event: "Both" },
+      target: "workflow.right.done",
+      reenter: false
+    },
+    {
+      source: "workflow.left.idle",
+      trigger: { type: "event", event: "Left" },
+      target: "workflow.left.done",
+      reenter: false
+    },
+    {
+      source: "workflow.right.idle",
+      trigger: { type: "event", event: "Right" },
+      target: "workflow.right.done",
+      reenter: false
+    }
   ]
 
   const idleParallelRegions = (offset: number): ReadonlyArray<MachineTest.FiniteState> => [
@@ -109,6 +289,76 @@ describe("MachineTest finite-model reference interpreter", () => {
 
       const machine = MachineTest.compileModel(model)
       const trace = yield* MachineTest.run(machine, { events: [event("Both")] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("propagates parallel completion into its completion transition", () =>
+    Effect.gen(function*() {
+      const model = parallelWorkflow([
+        ...completionTransitions,
+        { source: "workflow", trigger: { type: "done" }, target: "failed" }
+      ])
+      const reference = MachineTest.interpretModel(model, ["Both"])
+
+      assert.deepStrictEqual(
+        reference.steps[0]!.microsteps.map((microstep) =>
+          microstep.transitions.map(({ source, trigger }) => ({ source, trigger }))
+        ),
+        [
+          [
+            { source: "workflow.left.idle", trigger: { type: "event", event: "Both" } },
+            { source: "workflow.right.idle", trigger: { type: "event", event: "Both" } }
+          ],
+          [{ source: "workflow", trigger: { type: "done" } }]
+        ]
+      )
+      assert.deepStrictEqual(reference.final.activePaths, ["failed"])
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Both")] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
+  it.effect("enters a choice from an always transition without a second trigger representation", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [{
+          _tag: "Compound",
+          key: "flow",
+          value: 0,
+          initial: "idle",
+          states: [
+            { _tag: "Atomic", key: "idle", value: 1 },
+            {
+              _tag: "Choice",
+              key: "route",
+              targets: ["flow.ready"],
+              selected: "flow.ready"
+            },
+            { _tag: "Atomic", key: "ready", value: 2 }
+          ]
+        }],
+        initial: "flow",
+        events: ["Unused"],
+        transitions: [{
+          source: "flow.idle",
+          trigger: { type: "always" },
+          target: "flow.route"
+        }]
+      }
+      const reference = MachineTest.interpretModel(model, [])
+
+      assert.deepStrictEqual(
+        reference.initial.microsteps[0]!.transitions.map(({ source, trigger }) => ({ source, trigger })),
+        [
+          { source: "flow.idle", trigger: { type: "always" } },
+          { source: "flow.route", trigger: { type: "choice" } }
+        ]
+      )
+      assert.deepStrictEqual(reference.final.activePaths, ["flow", "flow.ready"])
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [] })
       yield* MachineTest.verifyModel(model, trace)
     }))
 
@@ -149,7 +399,12 @@ describe("MachineTest finite-model reference interpreter", () => {
         ],
         initial: "idle",
         events: ["Start"],
-        transitions: [{ source: "idle", event: "Start", target: "workflow", reenter: false }]
+        transitions: [{
+          source: "idle",
+          trigger: { type: "event", event: "Start" },
+          target: "workflow",
+          reenter: false
+        }]
       }
       const reference = MachineTest.interpretModel(model, ["Start"])
 
@@ -171,8 +426,13 @@ describe("MachineTest finite-model reference interpreter", () => {
   it.effect("lets a child transition preempt an enabled parallel ancestor", () =>
     Effect.gen(function*() {
       const model = parallelWorkflow([
-        { source: "workflow", event: "Abort", target: "failed", reenter: false },
-        { source: "workflow.left.idle", event: "Abort", target: "workflow.left.done", reenter: false }
+        { source: "workflow", trigger: { type: "event", event: "Abort" }, target: "failed", reenter: false },
+        {
+          source: "workflow.left.idle",
+          trigger: { type: "event", event: "Abort" },
+          target: "workflow.left.done",
+          reenter: false
+        }
       ])
       const reference = MachineTest.interpretModel(model, ["Abort"])
       assert.deepStrictEqual(reference.steps[0]!.microsteps[0]!.transitions.map(({ source }) => source), [
@@ -194,8 +454,13 @@ describe("MachineTest finite-model reference interpreter", () => {
   it.effect("uses source document order for conflicting cross-root targets", () =>
     Effect.gen(function*() {
       const model = parallelWorkflow([
-        { source: "workflow.left.idle", event: "Abort", target: "failed", reenter: false },
-        { source: "workflow.right.idle", event: "Abort", target: "cancelled", reenter: false }
+        { source: "workflow.left.idle", trigger: { type: "event", event: "Abort" }, target: "failed", reenter: false },
+        {
+          source: "workflow.right.idle",
+          trigger: { type: "event", event: "Abort" },
+          target: "cancelled",
+          reenter: false
+        }
       ])
       const reference = MachineTest.interpretModel(model, ["Abort"])
       assert.deepStrictEqual(reference.steps[0]!.microsteps[0]!.transitions.map(({ source }) => source), [
@@ -261,7 +526,12 @@ describe("MachineTest finite-model reference interpreter", () => {
         }],
         initial: "app",
         events: ["Enter"],
-        transitions: [{ source: "app.idle", event: "Enter", target: "app.work", reenter: false }]
+        transitions: [{
+          source: "app.idle",
+          trigger: { type: "event", event: "Enter" },
+          target: "app.work",
+          reenter: false
+        }]
       }
 
       const reference = MachineTest.interpretModel(model, ["Enter"])
@@ -307,7 +577,12 @@ describe("MachineTest finite-model reference interpreter", () => {
         }],
         initial: "app",
         events: ["Enter"],
-        transitions: [{ source: "app.idle", event: "Enter", target: "app.running", reenter: false }]
+        transitions: [{
+          source: "app.idle",
+          trigger: { type: "event", event: "Enter" },
+          target: "app.running",
+          reenter: false
+        }]
       }
 
       const reference = MachineTest.interpretModel(model, ["Enter"])
@@ -377,7 +652,7 @@ describe("MachineTest finite-model reference interpreter", () => {
         events: ["Advance"],
         transitions: [{
           source: "app.work.left.idle",
-          event: "Advance",
+          trigger: { type: "event", event: "Advance" },
           target: "app.work.left.running",
           reenter: false
         }]
@@ -446,25 +721,25 @@ describe("MachineTest finite-model reference interpreter", () => {
         transitions: [
           {
             source: "app.work.left.idle",
-            event: "Move",
+            trigger: { type: "event", event: "Move" },
             target: "app.work.left.alternate",
             reenter: false
           },
           {
             source: "app.work.right.idle",
-            event: "Move",
+            trigger: { type: "event", event: "Move" },
             target: "app.work.right.alternate",
             reenter: false
           },
           {
             source: "app.work.left.alternate",
-            event: "ResetParallel",
+            trigger: { type: "event", event: "ResetParallel" },
             target: "app.work",
             reenter: false
           },
           {
             source: "app.work.left.alternate",
-            event: "ResetCompound",
+            trigger: { type: "event", event: "ResetCompound" },
             target: "app",
             reenter: false
           }
@@ -508,7 +783,7 @@ describe("MachineTest finite-model reference interpreter", () => {
         ],
         initial: "idle",
         events: ["Enter"],
-        transitions: [{ source: "idle", event: "Enter", target: "work", reenter: false }]
+        transitions: [{ source: "idle", trigger: { type: "event", event: "Enter" }, target: "work", reenter: false }]
       }
 
       const reference = MachineTest.interpretModel(model, ["Enter"])
@@ -550,8 +825,13 @@ describe("MachineTest finite-model reference interpreter", () => {
       assert.include(fields(droppedError), "microstep.transitions")
 
       const ancestorModel = parallelWorkflow([
-        { source: "workflow", event: "Abort", target: "failed", reenter: false },
-        { source: "workflow.left.idle", event: "Abort", target: "workflow.left.done", reenter: false }
+        { source: "workflow", trigger: { type: "event", event: "Abort" }, target: "failed", reenter: false },
+        {
+          source: "workflow.left.idle",
+          trigger: { type: "event", event: "Abort" },
+          target: "workflow.left.done",
+          reenter: false
+        }
       ])
       const ancestorMachine = MachineTest.compileModel(ancestorModel)
       const ancestor = yield* MachineTest.run(ancestorMachine, { events: [event("Abort")] })
@@ -574,12 +854,22 @@ describe("MachineTest finite-model reference interpreter", () => {
       assert.include(fields(ancestorError), "microstep.transitions")
 
       const conflictModel = parallelWorkflow([
-        { source: "workflow.left.idle", event: "Abort", target: "failed", reenter: false },
-        { source: "workflow.right.idle", event: "Abort", target: "cancelled", reenter: false }
+        { source: "workflow.left.idle", trigger: { type: "event", event: "Abort" }, target: "failed", reenter: false },
+        {
+          source: "workflow.right.idle",
+          trigger: { type: "event", event: "Abort" },
+          target: "cancelled",
+          reenter: false
+        }
       ])
       const reversedModel = parallelWorkflow([
-        { source: "workflow.left.idle", event: "Abort", target: "cancelled", reenter: false },
-        { source: "workflow.right.idle", event: "Abort", target: "failed", reenter: false }
+        {
+          source: "workflow.left.idle",
+          trigger: { type: "event", event: "Abort" },
+          target: "cancelled",
+          reenter: false
+        },
+        { source: "workflow.right.idle", trigger: { type: "event", event: "Abort" }, target: "failed", reenter: false }
       ])
       const reversedMachine = MachineTest.compileModel(reversedModel)
       const reversed = yield* MachineTest.run(reversedMachine, { events: [event("Abort")] })
@@ -721,7 +1011,7 @@ describe("MachineTest finite-model reference interpreter", () => {
         events: ["Start"],
         transitions: [{
           source: "workflow.idle",
-          event: "Start",
+          trigger: { type: "event", event: "Start" },
           target: "workflow.running",
           reenter: false
         }]
@@ -800,6 +1090,50 @@ describe("MachineTest finite-model reference interpreter", () => {
       yield* MachineTest.verifyModel(model, trace)
     }))
 
+  it.effect("propagates nested completion through a completion transition to the parent final", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [{
+          _tag: "Compound",
+          key: "job",
+          value: 0,
+          initial: "phase",
+          states: [
+            {
+              _tag: "Compound",
+              key: "phase",
+              value: 1,
+              initial: "done",
+              states: [{ _tag: "Final", key: "done", value: 2, output: "phase:done" }]
+            },
+            { _tag: "Final", key: "done", value: 3, output: "job:done" }
+          ]
+        }],
+        initial: "job",
+        events: ["Unused"],
+        transitions: [{
+          source: "job.phase",
+          trigger: { type: "done" },
+          target: "job.done"
+        }]
+      }
+      const reference = MachineTest.interpretModel(model, [])
+
+      assert.deepStrictEqual(
+        reference.initial.microsteps.flatMap((microstep) => microstep.transitions.map(({ trigger }) => trigger)),
+        [{ type: "done" }]
+      )
+      assert.deepStrictEqual(reference.final.completions, [
+        { path: "job.done", output: "job:done" },
+        { path: "job", output: "job:done" }
+      ])
+      assert.strictEqual(reference.final.status, "done")
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
   it.effect("models targetless steps, broadened reentry, and cross-root lifecycle order", () =>
     Effect.gen(function*() {
       const model: MachineTest.FiniteModel = {
@@ -828,9 +1162,9 @@ describe("MachineTest finite-model reference interpreter", () => {
         initial: "left",
         events: ["Noop", "Reenter", "Switch"],
         transitions: [
-          { source: "left.branch.leaf", event: "Noop", reenter: false },
-          { source: "left.branch", event: "Reenter", target: "left.branch", reenter: true },
-          { source: "left.branch.leaf", event: "Switch", target: "right", reenter: false }
+          { source: "left.branch.leaf", trigger: { type: "event", event: "Noop" }, reenter: false },
+          { source: "left.branch", trigger: { type: "event", event: "Reenter" }, target: "left.branch", reenter: true },
+          { source: "left.branch.leaf", trigger: { type: "event", event: "Switch" }, target: "right", reenter: false }
         ]
       }
 
@@ -894,8 +1228,8 @@ describe("MachineTest finite-model reference interpreter", () => {
         initial: "root",
         events: ["Go"],
         transitions: [
-          { source: "root.branch", event: "Go", target: "root.other", reenter: false },
-          { source: "root.branch.leaf", event: "Go", target: "root.other", reenter: false }
+          { source: "root.branch", trigger: { type: "event", event: "Go" }, target: "root.other", reenter: false },
+          { source: "root.branch.leaf", trigger: { type: "event", event: "Go" }, target: "root.other", reenter: false }
         ]
       }
       const machine = MachineTest.compileModel(model)
@@ -988,7 +1322,7 @@ describe("MachineTest finite-model reference interpreter", () => {
         ],
         initial: "idle",
         events: ["Start"],
-        transitions: [{ source: "idle", event: "Start", target: "ready", reenter: false }]
+        transitions: [{ source: "idle", trigger: { type: "event", event: "Start" }, target: "ready", reenter: false }]
       }
       const machine = MachineTest.compileModel(model)
       const trace = yield* MachineTest.run(machine, { events: [event("Start")] })
@@ -1046,13 +1380,59 @@ describe("MachineTest finite-model reference interpreter", () => {
     initial,
     events: ["Advance", "Reset", "Leave", "Resume"],
     transitions: [
-      { source: "workspace.editor.writing", event: "Advance", target: "workspace.editor.preview", reenter: false },
-      { source: "workspace.editor.writing", event: "Leave", target: "outside", reenter: false },
-      { source: "workspace.editor.preview", event: "Reset", target: "workspace.editor.writing", reenter: false },
-      { source: "workspace.editor.preview", event: "Leave", target: "outside", reenter: false },
-      { source: "outside", event: "Resume", target: "workspace.recent", reenter: false }
+      {
+        source: "workspace.editor.writing",
+        trigger: { type: "event", event: "Advance" },
+        target: "workspace.editor.preview",
+        reenter: false
+      },
+      {
+        source: "workspace.editor.writing",
+        trigger: { type: "event", event: "Leave" },
+        target: "outside",
+        reenter: false
+      },
+      {
+        source: "workspace.editor.preview",
+        trigger: { type: "event", event: "Reset" },
+        target: "workspace.editor.writing",
+        reenter: false
+      },
+      {
+        source: "workspace.editor.preview",
+        trigger: { type: "event", event: "Leave" },
+        target: "outside",
+        reenter: false
+      },
+      { source: "outside", trigger: { type: "event", event: "Resume" }, target: "workspace.recent", reenter: false }
     ]
   })
+
+  it.effect("uses a history fallback entered by an always transition", () =>
+    Effect.gen(function*() {
+      const base = compoundHistoryModel("deep", "outside")
+      const model: MachineTest.FiniteModel = {
+        ...base,
+        transitions: [{
+          source: "outside",
+          trigger: { type: "always" },
+          target: "workspace.recent"
+        }]
+      }
+      const reference = MachineTest.interpretModel(model, [])
+
+      assert.deepStrictEqual(reference.final.activePaths, [
+        "workspace",
+        "workspace.editor",
+        "workspace.editor.writing"
+      ])
+      assert.deepStrictEqual(reference.final.history, {})
+      assert.deepStrictEqual(reference.initial.microsteps[0]!.transitions[0]!.trigger, { type: "always" })
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
 
   it.effect("uses fallback only before capture, then deep history overwrites and reuses its register", () =>
     Effect.gen(function*() {
@@ -1148,11 +1528,26 @@ describe("MachineTest finite-model reference interpreter", () => {
     initial: "workspace",
     events: ["Advance", "Leave", "ResumeShallow", "ResumeDeep"],
     transitions: [
-      { source: "workspace", event: "Leave", target: "outside", reenter: false },
-      { source: "workspace.editor.idle", event: "Advance", target: "workspace.editor.active", reenter: false },
-      { source: "workspace.sidebar.closed", event: "Advance", target: "workspace.sidebar.open", reenter: false },
-      { source: "outside", event: "ResumeShallow", target: "workspace.recent", reenter: false },
-      { source: "outside", event: "ResumeDeep", target: "workspace.exact", reenter: false }
+      { source: "workspace", trigger: { type: "event", event: "Leave" }, target: "outside", reenter: false },
+      {
+        source: "workspace.editor.idle",
+        trigger: { type: "event", event: "Advance" },
+        target: "workspace.editor.active",
+        reenter: false
+      },
+      {
+        source: "workspace.sidebar.closed",
+        trigger: { type: "event", event: "Advance" },
+        target: "workspace.sidebar.open",
+        reenter: false
+      },
+      {
+        source: "outside",
+        trigger: { type: "event", event: "ResumeShallow" },
+        target: "workspace.recent",
+        reenter: false
+      },
+      { source: "outside", trigger: { type: "event", event: "ResumeDeep" }, target: "workspace.exact", reenter: false }
     ]
   })
 
@@ -1233,14 +1628,24 @@ describe("MachineTest finite-model reference interpreter", () => {
         initial: "workspace",
         events: ["Advance", "Restore"],
         transitions: [
-          { source: "workspace.editor.writing", event: "Advance", target: "workspace.editor.preview", reenter: false },
+          {
+            source: "workspace.editor.writing",
+            trigger: { type: "event", event: "Advance" },
+            target: "workspace.editor.preview",
+            reenter: false
+          },
           {
             source: "workspace.sidebar.open",
-            event: "Restore",
+            trigger: { type: "event", event: "Restore" },
             target: "workspace.editor.exact",
             reenter: true
           },
-          { source: "workspace.sidebar.closed", event: "Advance", target: "workspace.sidebar.open", reenter: false }
+          {
+            source: "workspace.sidebar.closed",
+            trigger: { type: "event", event: "Advance" },
+            target: "workspace.sidebar.open",
+            reenter: false
+          }
         ]
       }
       const events = ["Advance", "Restore"]
@@ -1330,17 +1735,32 @@ describe("MachineTest finite-model reference interpreter", () => {
     initial,
     events: ["Advance", "Mutate", "Leave", "Resume"],
     transitions: [
-      { source: "workspace", event: "Leave", target: "outside", reenter: false },
+      { source: "workspace", trigger: { type: "event", event: "Leave" }, target: "outside", reenter: false },
       {
         source: "workspace.editor.writing",
-        event: "Mutate",
+        trigger: { type: "event", event: "Mutate" },
         target: "workspace.editor.writing",
         targetValue: 42,
         reenter: false
       },
-      { source: "workspace.editor.writing", event: "Advance", target: "workspace.editor.preview", reenter: false },
-      { source: "workspace.sidebar.closed", event: "Advance", target: "workspace.sidebar.open", reenter: false },
-      { source: "outside", event: "Resume", target: "workspace.editor.exact", reenter: false }
+      {
+        source: "workspace.editor.writing",
+        trigger: { type: "event", event: "Advance" },
+        target: "workspace.editor.preview",
+        reenter: false
+      },
+      {
+        source: "workspace.sidebar.closed",
+        trigger: { type: "event", event: "Advance" },
+        target: "workspace.sidebar.open",
+        reenter: false
+      },
+      {
+        source: "outside",
+        trigger: { type: "event", event: "Resume" },
+        target: "workspace.editor.exact",
+        reenter: false
+      }
     ]
   })
 

--- a/test/MachineTotality.test.ts
+++ b/test/MachineTotality.test.ts
@@ -28,14 +28,29 @@ const generatedCases = generatedModels.arbitrary.chain((model) =>
 )
 
 const generatedResumeCases = generatedCases.map((generated) => {
-  const reference = MachineTest.interpretModel(generated.model, generated.events)
+  // Automatic-transition restoration has focused witnesses in the finite
+  // reference-model suite. Keep this broad continuation property on
+  // deterministic state-changing event targets (plus complete generated
+  // history scenarios), where a runtime publication is an honest delivery
+  // barrier for every suffix event.
+  const model: MachineTest.FiniteModel = {
+    ...generated.model,
+    transitions: (generated.model.historyScenarios?.length ?? 0) > 0
+      ? generated.model.transitions
+      : generated.model.transitions.filter((transition) =>
+        transition.trigger.type === "event" && transition.target !== undefined && "reenter" in transition &&
+        !transition.reenter && transition.target !== transition.source
+      )
+  }
+  const reference = MachineTest.interpretModel(model, generated.events)
   let lastObservable = -1
   for (let index = 0; index < reference.steps.length; index++) {
-    if (reference.steps[index]!.microsteps.length > 0) lastObservable = index
+    if (reference.steps[index]!.microsteps.some(({ changed }) => changed)) lastObservable = index
   }
   const events = lastObservable < 0 ? [] : generated.events.slice(0, lastObservable + 1)
   return {
     ...generated,
+    model,
     events,
     boundary: Math.min(generated.boundary, events.length)
   }
@@ -121,10 +136,14 @@ const deliverAndObserve = Effect.fn(function*(
   machine: any,
   ref: Machine.MachineRef<any, any, any, any>,
   event: { readonly _tag: string },
-  planned: { readonly next: unknown; readonly microsteps: ReadonlyArray<unknown> },
+  planned: {
+    readonly next: unknown
+    readonly microsteps: ReadonlyArray<{ readonly changed: boolean }>
+    readonly done: boolean
+  },
   index: number
 ) {
-  if (planned.microsteps.length === 0) {
+  if (!planned.microsteps.some(({ changed }) => changed)) {
     const sendExit = yield* Effect.exit(ref.send(event))
     assertNoUnexpectedDefect(`post-resume send ${index}`, sendExit)
     return planned.next
@@ -133,8 +152,10 @@ const deliverAndObserve = Effect.fn(function*(
   const expected = yield* encodeWithoutDefect(machine, planned.next, `post-resume expected ${index}`)
   const observed = yield* waitForSnapshot(
     ref,
-    (snapshot) => snapshot.status === "error" || isDeepStrictEqual(snapshot.state, planned.next)
-  ).pipe(Effect.forkChild)
+    (snapshot) =>
+      snapshot.status === "error" ||
+      (isDeepStrictEqual(snapshot.state, planned.next) && (!planned.done || snapshot.status === "done"))
+  ).pipe(Effect.forkChild({ startImmediately: true }))
   const sendExit = yield* Effect.exit(ref.send(event))
   assertNoUnexpectedDefect(`post-resume send ${index}`, sendExit)
   const published = yield* Fiber.join(observed)

--- a/test/support/activityLifecycleModel.ts
+++ b/test/support/activityLifecycleModel.ts
@@ -1,0 +1,175 @@
+import { Cause, Data, Deferred, Effect, Exit, Queue, Ref } from "effect"
+import { FastCheck } from "effect/testing"
+import { Machine } from "../../src/index.js"
+
+export type ActivityOutcome = "succeeded" | "cancelled" | "failed"
+
+export type ActivityRecord =
+  | { readonly _tag: "Started"; readonly owner: string; readonly epoch: number }
+  | { readonly _tag: "Exited"; readonly owner: string; readonly epoch: number; readonly outcome: ActivityOutcome }
+
+export interface StartedActivity {
+  readonly owner: string
+  readonly epoch: number
+  readonly release: Deferred.Deferred<void>
+}
+
+export class ActivityFailure extends Data.TaggedError("ActivityFailure")<{
+  readonly owner: string
+  readonly epoch: number
+}> {}
+
+export type ActivityBehavior =
+  | { readonly _tag: "Blocked" }
+  | { readonly _tag: "Failure" }
+  | { readonly _tag: "StaleOnCancel"; readonly event: (epoch: number) => unknown }
+
+type ActivityState = { readonly epoch: number; readonly release: Deferred.Deferred<void> }
+
+export interface ActivityProbe {
+  readonly logic: (
+    owner: string,
+    behavior: ActivityBehavior
+  ) => Machine.Logic<ActivityState, never, ActivityFailure, never, void>
+  readonly immediate: <Event>(
+    owner: string,
+    event: (epoch: number) => Event
+  ) => Machine.Logic<ActivityState, never, ActivityFailure, never, Event>
+  readonly takeStarted: Effect.Effect<StartedActivity>
+  readonly records: Effect.Effect<ReadonlyArray<ActivityRecord>>
+}
+
+const outcomeOf = (exit: Exit.Exit<unknown, unknown>): ActivityOutcome => {
+  if (Exit.isSuccess(exit)) return "succeeded"
+  return exit.cause.reasons.some(Cause.isInterruptReason) ? "cancelled" : "failed"
+}
+
+export const makeActivityProbe: Effect.Effect<ActivityProbe> = Effect.gen(function*() {
+  const nextEpoch = yield* Ref.make(0)
+  const records = yield* Ref.make<ReadonlyArray<ActivityRecord>>([])
+  const started = yield* Queue.unbounded<StartedActivity>()
+  const append = (record: ActivityRecord) => Ref.update(records, (current) => [...current, record])
+  const initial = (owner: string) =>
+    Effect.gen(function*() {
+      const epoch = yield* Ref.updateAndGet(nextEpoch, (current) => current + 1)
+      const release = yield* Deferred.make<void>()
+      yield* append({ _tag: "Started", owner, epoch })
+      yield* Queue.offer(started, { owner, epoch, release })
+      return { epoch, release }
+    })
+  const recordExit = <A, E>(
+    owner: string,
+    state: Effect.Effect<{ readonly epoch: number }, never, never>,
+    exit: Exit.Exit<A, E>
+  ) =>
+    state.pipe(
+      Effect.flatMap(({ epoch }) => append({ _tag: "Exited", owner, epoch, outcome: outcomeOf(exit) }))
+    )
+  const immediate = <Event>(
+    owner: string,
+    event: (epoch: number) => Event
+  ): Machine.Logic<ActivityState, never, ActivityFailure, never, Event> =>
+    Machine.logic<ActivityState, never, Event, ActivityFailure>({
+      initial: () => initial(owner),
+      run: ({ state }) =>
+        state.pipe(
+          Effect.map(({ epoch }) => event(epoch)),
+          Effect.onExit((exit) => recordExit(owner, state, exit))
+        )
+    })
+
+  return {
+    logic: (owner, behavior) =>
+      Machine.logic<ActivityState, never, void, ActivityFailure>({
+        initial: () => initial(owner),
+        run: ({ sendParent, state }) =>
+          state.pipe(
+            Effect.flatMap(({ epoch, release }) => {
+              switch (behavior._tag) {
+                case "Blocked":
+                  return Effect.never.pipe(Effect.asVoid)
+                case "Failure":
+                  return Deferred.await(release).pipe(
+                    Effect.andThen(Effect.fail(new ActivityFailure({ owner, epoch })))
+                  )
+                case "StaleOnCancel":
+                  return Effect.never.pipe(
+                    Effect.onInterrupt(() =>
+                      sendParent(behavior.event(epoch)).pipe(
+                        Effect.catchTag("StoppedError", () => Effect.void)
+                      )
+                    ),
+                    Effect.asVoid
+                  )
+              }
+            }),
+            Effect.onExit((exit) => recordExit(owner, state, exit))
+          )
+      }),
+    immediate,
+    takeStarted: Queue.take(started),
+    records: Ref.get(records)
+  }
+})
+
+export type LifecycleCommand = "enter" | "leave" | "restart"
+
+export interface LifecycleExpectation {
+  readonly starts: number
+  readonly cancellations: number
+}
+
+export const lifecycleCommandSamples = (options?: {
+  readonly numRuns?: number
+  readonly seed?: number
+  readonly maxCommands?: number
+}): ReadonlyArray<ReadonlyArray<LifecycleCommand>> =>
+  FastCheck.sample(
+    FastCheck.array(
+      FastCheck.constantFrom<LifecycleCommand>("enter", "leave", "restart"),
+      { minLength: 1, maxLength: options?.maxCommands ?? 24 }
+    ),
+    { numRuns: options?.numRuns ?? 40, seed: options?.seed ?? 82_419 }
+  )
+
+export const expectedLifecycle = (commands: ReadonlyArray<LifecycleCommand>): LifecycleExpectation => {
+  let active = false
+  let starts = 0
+  let cancellations = 0
+  for (const command of commands) {
+    switch (command) {
+      case "enter":
+        if (!active) {
+          active = true
+          starts++
+        }
+        break
+      case "leave":
+        if (active) {
+          active = false
+          cancellations++
+        }
+        break
+      case "restart":
+        if (active) {
+          cancellations++
+          starts++
+        }
+        break
+    }
+  }
+  if (active) cancellations++
+  return { starts, cancellations }
+}
+
+export const countRecords = (
+  records: ReadonlyArray<ActivityRecord>,
+  kind: "starts" | ActivityOutcome,
+  owner?: string
+): number =>
+  records.filter((record) => {
+    if (owner !== undefined && record.owner !== owner) return false
+    return kind === "starts"
+      ? record._tag === "Started"
+      : record._tag === "Exited" && record.outcome === kind
+  }).length

--- a/test/support/machineRuntimeDifferential.ts
+++ b/test/support/machineRuntimeDifferential.ts
@@ -1,0 +1,145 @@
+import { assert } from "@effect/vitest"
+import { Effect, Fiber, Stream } from "effect"
+import { isDeepStrictEqual } from "node:util"
+import { Machine } from "../../src/index.js"
+import { MachineTest } from "../../src/testing.js"
+
+export type DifferentialStep = {
+  readonly event: { readonly _tag: string }
+  readonly plan: {
+    readonly next: unknown
+    readonly microsteps: ReadonlyArray<unknown>
+    readonly done: boolean
+    readonly output: unknown
+  }
+}
+
+export type DifferentialBoundary = {
+  readonly state: unknown
+  readonly done: boolean
+  readonly output: unknown
+}
+
+const encoded = (machine: Machine.Machine.Any, state: unknown) => Machine.encodeSnapshot(machine as any, state as any)
+
+const assertRuntimeSnapshot = Effect.fn(function*(
+  machine: Machine.Machine.Any,
+  actual: Machine.RuntimeSnapshot<unknown, unknown, unknown>,
+  expected: DifferentialBoundary,
+  label: string
+) {
+  assert.notStrictEqual(actual.status, "error", `${label} unexpectedly failed`)
+  assert.notStrictEqual(actual.status, "stopped", `${label} unexpectedly stopped`)
+  if (actual.status === "error" || actual.status === "stopped") return
+  assert.strictEqual(actual.status, expected.done ? "done" : "active", `${label} status`)
+  assert.deepStrictEqual(yield* encoded(machine, actual.state), yield* encoded(machine, expected.state), label)
+  if (actual.status === "done") assert.deepStrictEqual(actual.output, expected.output, `${label} output`)
+})
+
+const waitForBoundary = (
+  ref: Machine.MachineRef<any, any, any, any>,
+  expected: DifferentialBoundary
+) =>
+  ref.changes.pipe(
+    // SubscriptionRef streams expose the current value first. Drop it so this
+    // fiber acknowledges the publication caused by the event being sent.
+    Stream.drop(1),
+    Stream.filter((snapshot) =>
+      snapshot.status === "error" ||
+      (isDeepStrictEqual(snapshot.state, expected.state) && snapshot.status === (expected.done ? "done" : "active"))
+    ),
+    Stream.take(1),
+    Stream.runCollect,
+    Effect.map((snapshots) => Array.from(snapshots)[0]!)
+  )
+
+/**
+ * Drives a managed machine from a supplied start or resume operation and
+ * compares every runtime publication with an already-computed pure plan.
+ */
+export const verifyManagedExecution = Effect.fn(function*(options: {
+  readonly machine: Machine.Machine.Any
+  readonly open: Effect.Effect<Machine.MachineRef<any, any, any, any>, unknown, never>
+  readonly initial: DifferentialBoundary
+  readonly steps: ReadonlyArray<DifferentialStep>
+  readonly label: string
+}) {
+  const ref = yield* options.open
+  const publications = yield* ref.changes.pipe(
+    Stream.runCollect,
+    Effect.forkChild({ startImmediately: true })
+  )
+  const initial = yield* ref.snapshot
+  yield* assertRuntimeSnapshot(options.machine, initial, options.initial, `${options.label} initial`)
+
+  const expectedPublications: Array<DifferentialBoundary> = [options.initial]
+  for (let index = 0; index < options.steps.length; index++) {
+    const step = options.steps[index]!
+    const publishes = step.plan.microsteps.length > 0
+    const expected = {
+      state: step.plan.next,
+      done: step.plan.done,
+      output: step.plan.output
+    }
+    const observed = publishes
+      ? yield* waitForBoundary(ref, expected).pipe(Effect.forkChild({ startImmediately: true }))
+      : undefined
+
+    yield* ref.send(step.event)
+    if (observed !== undefined) {
+      const snapshot = yield* Fiber.join(observed)
+      yield* assertRuntimeSnapshot(options.machine, snapshot, expected, `${options.label} event ${index}`)
+    }
+    if (publishes) {
+      // A terminal event first publishes the newly active state, then the
+      // managed process publishes its terminal status for that same state.
+      if (step.plan.done) {
+        expectedPublications.push({ state: step.plan.next, done: false, output: undefined })
+      }
+      expectedPublications.push(expected)
+    }
+    if (step.plan.done) break
+  }
+
+  const final = yield* ref.snapshot
+  const expectedFinal = expectedPublications[expectedPublications.length - 1]!
+  yield* assertRuntimeSnapshot(options.machine, final, expectedFinal, `${options.label} final`)
+  yield* ref.stop
+
+  const actualPublications = Array.from(yield* Fiber.join(publications)).filter(({ status }) => status !== "stopped")
+  assert.strictEqual(
+    actualPublications.length,
+    expectedPublications.length,
+    `${options.label} publication count; events without microsteps must not publish`
+  )
+  for (let index = 0; index < expectedPublications.length; index++) {
+    yield* assertRuntimeSnapshot(
+      options.machine,
+      actualPublications[index]!,
+      expectedPublications[index]!,
+      `${options.label} publication ${index}`
+    )
+  }
+})
+
+export const traceBoundary = (
+  trace: MachineTest.Trace<Machine.Machine.Any>,
+  boundary: number
+): DifferentialBoundary =>
+  boundary === 0
+    ? {
+      state: trace.initial.plan.state,
+      done: trace.initial.plan.done,
+      output: trace.initial.plan.output
+    }
+    : {
+      state: trace.steps[boundary - 1]!.plan.next,
+      done: trace.steps[boundary - 1]!.plan.done,
+      output: trace.steps[boundary - 1]!.plan.output
+    }
+
+export const traceSteps = (
+  trace: MachineTest.Trace<Machine.Machine.Any>,
+  from = 0
+): ReadonlyArray<DifferentialStep> =>
+  trace.steps.slice(from).map(({ event, plan }) => ({ event: event as { readonly _tag: string }, plan }))

--- a/typetest/MachineEventByTag.tst.ts
+++ b/typetest/MachineEventByTag.tst.ts
@@ -1,0 +1,64 @@
+import { Schema } from "effect"
+import { describe, expect, it } from "tstyche"
+import { Machine } from "../src/index.js"
+
+describe("Machine.EventByTag", () => {
+  class Idle extends Schema.TaggedClass<Idle>("EventByTagIdle")("EventByTagIdle", {}) {}
+  class Single extends Schema.TaggedClass<Single>("Single")("Single", {
+    value: Schema.Number
+  }) {}
+
+  const FiniteUnion = Schema.Struct({
+    _tag: Schema.Union([Schema.Literal("Alpha"), Schema.Literal("Beta")]),
+    payload: Schema.String,
+    count: Schema.Number
+  })
+
+  it("narrows each member of a finite tag union and preserves its payload", () => {
+    type Alpha = Machine.Machine.EventByTag<readonly [typeof FiniteUnion], "Alpha">
+    type Beta = Machine.Machine.EventByTag<readonly [typeof FiniteUnion], "Beta">
+
+    expect<Alpha>().type.toBe<{
+      readonly _tag: "Alpha"
+      readonly payload: string
+      readonly count: number
+    }>()
+    expect<Beta>().type.toBe<{
+      readonly _tag: "Beta"
+      readonly payload: string
+      readonly count: number
+    }>()
+  })
+
+  it("narrows handler contexts for every finite tag", () => {
+    const states = Machine.defineStates({ Idle })
+    Machine.make({
+      states: states.states,
+      events: [FiniteUnion],
+      initial: () => states.initial.Idle(new Idle({}))
+    }).handle({
+      Idle: {
+        on: {
+          Alpha: ({ event }) => {
+            expect(event).type.toBe<{
+              readonly _tag: "Alpha"
+              readonly payload: string
+              readonly count: number
+            }>()
+          },
+          Beta: ({ event }) => {
+            expect(event).type.toBe<{
+              readonly _tag: "Beta"
+              readonly payload: string
+              readonly count: number
+            }>()
+          }
+        }
+      }
+    })
+  })
+
+  it("preserves ordinary tagged-class event types", () => {
+    expect<Machine.Machine.EventByTag<readonly [typeof Single], "Single">>().type.toBe<Single>()
+  })
+})

--- a/typetest/MachineInspection.tst.ts
+++ b/typetest/MachineInspection.tst.ts
@@ -32,8 +32,107 @@ describe("Machine inspection", () => {
   })
 
   it("preserves state paths for structural inspection", () => {
-    expect(Machine.stateNodes(machine)[0]!.path).type.toBe<"root" | "root.idle" | "root.recent">()
+    const nodes = Machine.stateNodes(machine)
+    expect(nodes[0]!.path).type.toBe<"root" | "root.idle" | "root.recent">()
+    expect(nodes.find((node) => node.type === "history")!.path).type.toBe<"root.recent">()
+    expect(nodes.find((node) => node.type === "history")!.parent).type.toBe<"root" | "root.idle">()
+    expect(nodes.find((node) => node.type === "atomic")!.path).type.toBe<"root" | "root.idle">()
     expect(Machine.configuration(machine, initial)[0]!.path).type.toBe<"root" | "root.idle">()
+  })
+
+  it("narrows every compiled state-node property from its type", () => {
+    const inspect = (node: Machine.Machine.StateNode<"state">) => {
+      switch (node.type) {
+        case "atomic":
+          expect(node.schema).type.toBe<Machine.Machine.TaggedSchema>()
+          expect(node.output).type.toBe<undefined>()
+          expect(node.history).type.toBe<undefined>()
+          expect(node.children).type.toBe<readonly []>()
+          expect(node.initial).type.toBe<undefined>()
+          expect(node.parent).type.toBe<"state" | undefined>()
+          break
+        case "compound":
+          expect(node.schema).type.toBe<Machine.Machine.TaggedSchema>()
+          expect(node.output).type.toBe<undefined>()
+          expect(node.history).type.toBe<undefined>()
+          expect(node.children).type.toBe<ReadonlyArray<"state">>()
+          expect(node.initial).type.toBe<"state">()
+          expect(node.parent).type.toBe<"state" | undefined>()
+          break
+        case "parallel":
+          expect(node.schema).type.toBe<Machine.Machine.TaggedSchema>()
+          expect(node.output).type.toBe<Schema.Top | undefined>()
+          expect(node.history).type.toBe<undefined>()
+          expect(node.children).type.toBe<ReadonlyArray<"state">>()
+          expect(node.initial).type.toBe<undefined>()
+          expect(node.parent).type.toBe<"state" | undefined>()
+          break
+        case "final":
+          expect(node.schema).type.toBe<Machine.Machine.TaggedSchema>()
+          expect(node.output).type.toBe<Schema.Top | undefined>()
+          expect(node.history).type.toBe<undefined>()
+          expect(node.children).type.toBe<readonly []>()
+          expect(node.initial).type.toBe<undefined>()
+          expect(node.parent).type.toBe<"state" | undefined>()
+          break
+        case "history":
+          expect(node.schema).type.toBe<undefined>()
+          expect(node.output).type.toBe<undefined>()
+          expect(node.history).type.toBe<"shallow" | "deep">()
+          expect(node.children).type.toBe<readonly []>()
+          expect(node.initial).type.toBe<undefined>()
+          expect(node.parent).type.toBe<"state">()
+          break
+        case "choice":
+          expect(node.schema).type.toBe<undefined>()
+          expect(node.output).type.toBe<undefined>()
+          expect(node.history).type.toBe<undefined>()
+          expect(node.children).type.toBe<readonly []>()
+          expect(node.initial).type.toBe<undefined>()
+          expect(node.parent).type.toBe<"state">()
+          break
+        default:
+          expect(node).type.toBe<never>()
+      }
+    }
+
+    expect(inspect).type.toBe<(node: Machine.Machine.StateNode<"state">) => void>()
+  })
+
+  it("keeps choice initial paths while configuration remains active-only", () => {
+    const ChoiceStates = Machine.defineStates({
+      Flow: {
+        schema: Root,
+        initial: "Routing",
+        states: {
+          Routing: { type: "choice" },
+          Ready: Idle
+        }
+      }
+    })
+    const choiceMachine = Machine.make({
+      states: ChoiceStates.states,
+      events: [],
+      initial: () => ChoiceStates.initial.Flow(new Root({}), (flow) => flow.Routing())
+    })
+    const flow = Machine.stateNodes(choiceMachine).find((node) => node.type === "compound")!
+    const routing = Machine.stateNodes(choiceMachine).find((node) => node.type === "choice")!
+
+    expect(flow.path).type.toBe<"Flow" | "Flow.Ready">()
+    expect(flow.initial).type.toBe<"Flow" | "Flow.Ready" | "Flow.Routing">()
+    expect<"Flow.Routing">().type.toBeAssignableTo<typeof flow.initial>()
+    expect(routing.path).type.toBe<"Flow.Routing">()
+    expect(routing.parent).type.toBe<"Flow" | "Flow.Ready">()
+
+    const settled: Machine.Machine.Snapshot<typeof ChoiceStates.states> = {
+      path: "Flow",
+      value: new Root({}),
+      state: { path: "Flow.Ready", value: new Idle({}) }
+    }
+    const configuration = Machine.configuration(choiceMachine, settled)
+    expect<(typeof configuration)[number]["path"]>().type.toBe<"Flow" | "Flow.Ready">()
+    expect<(typeof configuration)[number]["type"]>().type.toBe<"atomic" | "compound" | "parallel" | "final">()
+    expect<Extract<(typeof configuration)[number], { readonly type: "history" | "choice" }>>().type.toBe<never>()
   })
 
   it("preserves source paths and event tags for transition inspection", () => {

--- a/typetest/MachineReadiness.tst.ts
+++ b/typetest/MachineReadiness.tst.ts
@@ -1,0 +1,218 @@
+import { Effect, Schema } from "effect"
+import { describe, expect, it } from "tstyche"
+import { ClusterMachine } from "../src/cluster.js"
+import { Machine } from "../src/index.js"
+import { AtomMachine } from "../src/reactivity.js"
+import { MachineTest } from "../src/testing.js"
+
+class Ready extends Schema.TaggedClass<Ready>("Ready")("Ready", {}) {}
+class Flow extends Schema.TaggedClass<Flow>("Flow")("Flow", {}) {}
+class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", {}) {}
+class Done extends Schema.TaggedClass<Done>("Done")("Done", { value: Schema.String }) {}
+class Tick extends Schema.TaggedClass<Tick>("Tick")("Tick", {}) {}
+
+const choiceStates = Machine.defineStates({
+  Ready,
+  Flow: {
+    schema: Flow,
+    initial: "Route",
+    states: {
+      Route: { type: "choice" },
+      Idle
+    }
+  }
+})
+
+const choiceIncomplete = Machine.make({
+  states: choiceStates.states,
+  events: [Tick],
+  initial: () => choiceStates.initial.Ready(new Ready({}))
+})
+const choiceSnapshot = choiceStates.initial.Ready(new Ready({}))
+
+const historyStates = Machine.defineStates({
+  Ready,
+  Flow: {
+    schema: Flow,
+    initial: "Idle",
+    states: {
+      Idle,
+      recent: { type: "history", history: "deep" }
+    }
+  }
+})
+
+const historyIncomplete = Machine.make({
+  states: historyStates.states,
+  events: [Tick],
+  initial: () => historyStates.initial.Ready(new Ready({}))
+})
+const historySnapshot = historyStates.initial.Ready(new Ready({}))
+
+const outputStates = Machine.defineStates({
+  Ready,
+  Done: {
+    schema: Done,
+    type: "final",
+    output: Schema.String
+  }
+})
+
+const outputIncomplete = Machine.make({
+  states: outputStates.states,
+  events: [Tick],
+  initial: () => outputStates.initial.Ready(new Ready({}))
+})
+const outputSnapshot = outputStates.initial.Ready(new Ready({}))
+
+const bound = null as unknown as AtomMachine.Bound<never>
+
+describe("executable machine readiness", () => {
+  it("rejects an unimplemented choice at every planning and execution boundary", () => {
+    expect(Machine.planInitial).type.not.toBeCallableWith(choiceIncomplete)
+    expect(Machine.plan).type.not.toBeCallableWith(choiceIncomplete, choiceSnapshot, new Tick({}))
+    expect(Machine.start).type.not.toBeCallableWith(choiceIncomplete)
+    expect(Machine.resume).type.not.toBeCallableWith(choiceIncomplete, choiceSnapshot)
+    expect(Machine.invokeMachine).type.not.toBeCallableWith({
+      child: Machine.child("choice", choiceIncomplete)
+    })
+    expect(MachineTest.run).type.not.toBeCallableWith(choiceIncomplete, { events: [] })
+    expect(AtomMachine.make).type.not.toBeCallableWith(choiceIncomplete)
+    expect(AtomMachine.resume).type.not.toBeCallableWith(choiceIncomplete, choiceSnapshot)
+    expect(bound.make).type.not.toBeCallableWith(choiceIncomplete)
+    expect(bound.resume).type.not.toBeCallableWith(choiceIncomplete, choiceSnapshot)
+    expect(ClusterMachine.make).type.not.toBeCallableWith("Choice", choiceIncomplete, { version: "1" })
+  })
+
+  it("rejects an unimplemented history default at every planning and execution boundary", () => {
+    expect(Machine.planInitial).type.not.toBeCallableWith(historyIncomplete)
+    expect(Machine.plan).type.not.toBeCallableWith(historyIncomplete, historySnapshot, new Tick({}))
+    expect(Machine.start).type.not.toBeCallableWith(historyIncomplete)
+    expect(Machine.resume).type.not.toBeCallableWith(historyIncomplete, historySnapshot)
+    expect(Machine.invokeMachine).type.not.toBeCallableWith({
+      child: Machine.child("history", historyIncomplete)
+    })
+    expect(MachineTest.run).type.not.toBeCallableWith(historyIncomplete, { events: [] })
+    expect(AtomMachine.make).type.not.toBeCallableWith(historyIncomplete)
+    expect(AtomMachine.resume).type.not.toBeCallableWith(historyIncomplete, historySnapshot)
+    expect(bound.make).type.not.toBeCallableWith(historyIncomplete)
+    expect(bound.resume).type.not.toBeCallableWith(historyIncomplete, historySnapshot)
+    expect(ClusterMachine.make).type.not.toBeCallableWith("History", historyIncomplete, { version: "1" })
+  })
+
+  it("rejects an unimplemented output at every planning and execution boundary", () => {
+    expect(Machine.planInitial).type.not.toBeCallableWith(outputIncomplete)
+    expect(Machine.plan).type.not.toBeCallableWith(outputIncomplete, outputSnapshot, new Tick({}))
+    expect(Machine.start).type.not.toBeCallableWith(outputIncomplete)
+    expect(Machine.resume).type.not.toBeCallableWith(outputIncomplete, outputSnapshot)
+    expect(Machine.invokeMachine).type.not.toBeCallableWith({
+      child: Machine.child("output", outputIncomplete),
+      onDone: () => undefined
+    })
+    expect(MachineTest.run).type.not.toBeCallableWith(outputIncomplete, { events: [] })
+    expect(AtomMachine.make).type.not.toBeCallableWith(outputIncomplete)
+    expect(AtomMachine.resume).type.not.toBeCallableWith(outputIncomplete, outputSnapshot)
+    expect(bound.make).type.not.toBeCallableWith(outputIncomplete)
+    expect(bound.resume).type.not.toBeCallableWith(outputIncomplete, outputSnapshot)
+    expect(ClusterMachine.make).type.not.toBeCallableWith("Output", outputIncomplete, { version: "1" })
+  })
+
+  it("accepts a complete machine and preserves its exact channels through every adapter", () => {
+    const completeStates = Machine.defineStates({
+      Ready,
+      Flow: {
+        schema: Flow,
+        initial: "Route",
+        states: {
+          Route: { type: "choice" },
+          Idle,
+          recent: { type: "history", history: "deep" },
+          Done: {
+            schema: Done,
+            type: "final",
+            output: Schema.String
+          }
+        }
+      }
+    })
+    const complete = Machine.make({
+      states: completeStates.states,
+      events: [Tick],
+      initial: () => completeStates.initial.Ready(new Ready({}))
+    }).handle({
+      Flow: {
+        history: {
+          recent: {
+            default: ({ target }) =>
+              target.Flow(
+                new Flow({}),
+                (flow) => flow.Idle(new Idle({}))
+              )
+          }
+        },
+        states: {
+          Route: {
+            choice: {
+              targets: ["Flow.Idle"],
+              transition: ({ target }) => target.local.Idle(new Idle({}))
+            }
+          },
+          Done: {
+            output: ({ state }) => state.value
+          }
+        }
+      }
+    })
+    const completeSnapshot = completeStates.initial.Ready(new Ready({}))
+
+    const plannedInitial = Machine.planInitial(complete)
+    const planned = Machine.plan(complete, completeSnapshot, new Tick({}))
+    const started = Machine.start(complete)
+    const resumed = Machine.resume(complete, completeSnapshot)
+    const invocation = Machine.invokeMachine({
+      child: Machine.child("complete", complete),
+      onDone: () => undefined
+    })
+    const trace = MachineTest.run(complete, { events: [new Tick({})] })
+    const atom = AtomMachine.make(complete)
+    const resumedAtom = AtomMachine.resume(complete, completeSnapshot)
+    const boundAtom = bound.make(complete)
+    const boundResumedAtom = bound.resume(complete, completeSnapshot)
+    const cluster = ClusterMachine.make("Complete", complete, { version: "1" })
+
+    type AtomChannels<A> = A extends AtomMachine.MachineAtom<infer State, infer Event, any, infer Output, any> ?
+      readonly [State, Event, Output]
+      : never
+
+    expect<Machine.Machine.UnhandledStates<typeof complete>>().type.toBe<"Ready" | "Flow.Idle">()
+    expect<Machine.Machine.Output<typeof complete>>().type.toBe<string>()
+    expect<Machine.Machine.InputEvent<typeof complete>>().type.toBe<Tick>()
+    expect<Effect.Success<typeof plannedInitial>["state"]>().type.toBe<
+      Machine.Machine.Snapshot<typeof completeStates.states>
+    >()
+    expect<Effect.Success<typeof planned>["next"]>().type.toBe<
+      Machine.Machine.Snapshot<typeof completeStates.states>
+    >()
+    expect<Effect.Success<typeof started>["send"]>().type.toBe<
+      (event: Tick) => Effect.Effect<void, Machine.StoppedError>
+    >()
+    expect<Effect.Success<typeof resumed>["send"]>().type.toBe<
+      (event: Tick) => Effect.Effect<void, Machine.StoppedError>
+    >()
+    expect(invocation).type.toBeAssignableTo<Machine.Machine.AnyInvokeConfig>()
+    expect<Effect.Success<typeof trace>>().type.toBe<MachineTest.Trace<typeof complete>>()
+    expect<AtomChannels<typeof atom>>().type.toBe<
+      readonly [Machine.Machine.Snapshot<typeof completeStates.states>, Tick, string]
+    >()
+    expect<AtomChannels<typeof resumedAtom>>().type.toBe<
+      readonly [Machine.Machine.Snapshot<typeof completeStates.states>, Tick, string]
+    >()
+    expect<AtomChannels<typeof boundAtom>>().type.toBe<
+      readonly [Machine.Machine.Snapshot<typeof completeStates.states>, Tick, string]
+    >()
+    expect<AtomChannels<typeof boundResumedAtom>>().type.toBe<
+      readonly [Machine.Machine.Snapshot<typeof completeStates.states>, Tick, string]
+    >()
+    expect(cluster.machine).type.toBe<typeof complete>()
+  })
+})

--- a/typetest/MachineStateDefinition.tst.ts
+++ b/typetest/MachineStateDefinition.tst.ts
@@ -1,0 +1,134 @@
+import { Schema } from "effect"
+import { describe, expect, it } from "tstyche"
+import { Machine } from "../src/index.js"
+
+class Root extends Schema.TaggedClass<Root>("Root")("Root", {}) {}
+class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", {}) {}
+class Done extends Schema.TaggedClass<Done>("Done")("Done", {}) {}
+
+describe("exact state definitions", () => {
+  it("accepts the exact property grammar and preserves schema objects as atomic nodes", () => {
+    const AnnotatedIdle = Idle.annotate({
+      title: "Idle",
+      arbitrarySchemaAnnotation: { owner: "machine-team" }
+    })
+    const states = Machine.defineStates({
+      Atomic: { schema: Idle, type: "active" },
+      SchemaAtomic: AnnotatedIdle,
+      Final: { schema: Done, type: "final", output: Schema.String },
+      Compound: {
+        schema: Root,
+        initial: "Idle",
+        states: {
+          Idle,
+          Choice: { type: "choice", annotations: { title: "Route" } },
+          History: { type: "history", history: "deep", annotations: { description: "Resume" } }
+        }
+      },
+      Parallel: {
+        schema: Root,
+        type: "parallel",
+        output: Schema.String,
+        states: { Region: Idle }
+      }
+    })
+
+    expect<Machine.Machine.StateNodeIdentifier<typeof states.states>>().type.toBe<
+      | "Atomic"
+      | "SchemaAtomic"
+      | "Final"
+      | "Compound"
+      | "Compound.Idle"
+      | "Compound.Choice"
+      | "Compound.History"
+      | "Parallel"
+      | "Parallel.Region"
+    >()
+  })
+
+  it("rejects unknown properties for every state kind, including nested nodes", () => {
+    expect(Machine.defineStates).type.not.toBeCallableWith({
+      Idle: { schema: Idle, unknown: true }
+    })
+    expect(Machine.defineStates).type.not.toBeCallableWith({
+      Done: { schema: Done, type: "final", unknown: true }
+    })
+    expect(Machine.defineStates).type.not.toBeCallableWith({
+      Root: { schema: Root, initial: "Idle", states: { Idle }, unknown: true }
+    })
+    expect(Machine.defineStates).type.not.toBeCallableWith({
+      Root: { schema: Root, type: "parallel", states: { Idle }, unknown: true }
+    })
+    expect(Machine.defineStates).type.not.toBeCallableWith({
+      Root: {
+        schema: Root,
+        initial: "Idle",
+        states: {
+          Idle,
+          History: { type: "history", unknown: true },
+          Choice: { type: "choice", unknown: true }
+        }
+      }
+    })
+    expect(Machine.make).type.not.toBeCallableWith({
+      states: {
+        Root: {
+          schema: Root,
+          initial: "Idle",
+          states: { Idle: { schema: Idle, nestedUnknown: true } }
+        }
+      },
+      events: [],
+      initial: (): never => {
+        throw new Error("unreachable")
+      }
+    })
+  })
+
+  it("rejects empty, dotted, numeric-form, symbol, and __proto__ keys recursively", () => {
+    const symbolKey = Symbol("state")
+
+    expect(Machine.defineStates).type.not.toBeCallableWith({ "": Idle })
+    expect(Machine.defineStates).type.not.toBeCallableWith({ "bad.path": Idle })
+    expect(Machine.defineStates).type.not.toBeCallableWith({ 0: Idle })
+    expect(Machine.defineStates).type.not.toBeCallableWith({ "01": Idle })
+    expect(Machine.defineStates).type.not.toBeCallableWith({ "-1": Idle })
+    expect(Machine.defineStates).type.not.toBeCallableWith({ "1e3": Idle })
+    expect(Machine.defineStates).type.not.toBeCallableWith({ "0x10": Idle })
+    expect(Machine.defineStates).type.not.toBeCallableWith({ " 1": Idle })
+    expect(Machine.defineStates).type.not.toBeCallableWith({ "1 ": Idle })
+    expect(Machine.defineStates).type.not.toBeCallableWith({ " ": Idle })
+    expect(Machine.defineStates).type.not.toBeCallableWith({ "\t": Idle })
+    expect(Machine.defineStates).type.not.toBeCallableWith({ [symbolKey]: Idle })
+    expect(Machine.defineStates).type.not.toBeCallableWith({ __proto__: Idle })
+    expect(Machine.defineStates).type.not.toBeCallableWith({
+      Root: {
+        schema: Root,
+        initial: "bad.path",
+        states: { "bad.path": Idle }
+      }
+    })
+
+    type InvalidKey = Machine.Machine.ValidateStateSchemas<{
+      readonly Root: {
+        readonly schema: typeof Root
+        readonly initial: "bad.path"
+        readonly states: { readonly "bad.path": typeof Idle }
+      }
+    }>
+    expect<InvalidKey["Root"]["states"]["bad.path"]["path"]>().type.toBe<"Root.bad.path">()
+    expect<InvalidKey["Root"]["states"]["bad.path"]["details"]>().type.toBe<"bad.path">()
+
+    type InvalidProperty = Machine.Machine.ValidateStateSchemas<{
+      readonly Root: {
+        readonly schema: typeof Root
+        readonly initial: "Idle"
+        readonly states: {
+          readonly Idle: { readonly schema: typeof Idle; readonly nestedUnknown: true }
+        }
+      }
+    }>
+    expect<InvalidProperty["Root"]["states"]["Idle"]["path"]>().type.toBe<"Root.Idle">()
+    expect<InvalidProperty["Root"]["states"]["Idle"]["details"]>().type.toBe<"nestedUnknown">()
+  })
+})

--- a/typetest/MachineTestFiniteModel.tst.ts
+++ b/typetest/MachineTestFiniteModel.tst.ts
@@ -4,6 +4,25 @@ import { Machine } from "../src/index.js"
 import { MachineTest } from "../src/testing.js"
 
 describe("MachineTest finite models", () => {
+  it("uses one discriminated trigger representation", () => {
+    expect<MachineTest.FiniteTransition["trigger"]>().type.toBe<MachineTest.FiniteTransitionTrigger>()
+    expect<MachineTest.FiniteTransitionTrigger>().type.toBe<
+      | { readonly type: "event"; readonly event: string }
+      | { readonly type: "always" }
+      | { readonly type: "done" }
+    >()
+    expect<Extract<MachineTest.FiniteTransition, { readonly trigger: { readonly type: "event" } }>>()
+      .type.toBe<MachineTest.FiniteEventTransition>()
+    expect<Exclude<MachineTest.FiniteTransition, { readonly trigger: { readonly type: "event" } }>>()
+      .type.toBe<MachineTest.FiniteAutomaticTransition>()
+    expect<keyof MachineTest.FiniteEventTransition>().type.toBe<
+      "source" | "trigger" | "target" | "targetValue" | "reenter"
+    >()
+    expect<keyof MachineTest.FiniteAutomaticTransition>().type.toBe<
+      "source" | "trigger" | "target" | "targetValue"
+    >()
+  })
+
   const generated = MachineTest.finiteModels({
     maxRoots: 2,
     maxDepth: 3,
@@ -24,7 +43,8 @@ describe("MachineTest finite models", () => {
     expect(generated.diagnostics.guarantees.historyLeaveResumeSequences).type.toBe<true>()
     expect(generated.diagnostics.guarantees.historyValueScenarios).type.toBe<true>()
     expect(generated.diagnostics.guarantees.structurallyValid).type.toBe<true>()
-    expect(generated.diagnostics.guarantees.eventlessTransitions).type.toBe<false>()
+    expect(generated.diagnostics.guarantees.eventlessTransitions).type.toBe<true>()
+    expect(generated.diagnostics.guarantees.acyclicAutomaticTransitions).type.toBe<true>()
   })
 
   it("models atomic, final, compound, and parallel nodes", () => {
@@ -54,7 +74,7 @@ describe("MachineTest finite models", () => {
       roots: [{ _tag: "Atomic", key: "idle", value: 0 }],
       initial: "idle",
       events: ["Tick"],
-      transitions: [{ source: "idle", event: "Tick", target: "idle", reenter: false }]
+      transitions: [{ source: "idle", trigger: { type: "event", event: "Tick" }, target: "idle", reenter: false }]
     }
     const machine = MachineTest.compileModel(model)
     expect(machine).type.toBe<Machine.Machine.Any>()
@@ -100,7 +120,12 @@ describe("MachineTest finite models", () => {
       }],
       initial: "root",
       events: ["Restore"],
-      transitions: [{ source: "root.idle", event: "Restore", target: "root.recent", reenter: true }]
+      transitions: [{
+        source: "root.idle",
+        trigger: { type: "event", event: "Restore" },
+        target: "root.recent",
+        reenter: true
+      }]
     }
     expect(model.roots[0]).type.toBe<MachineTest.FiniteState | undefined>()
   })

--- a/typetest/MachineTestReferenceModel.tst.ts
+++ b/typetest/MachineTestReferenceModel.tst.ts
@@ -7,7 +7,7 @@ describe("MachineTest finite-model reference interpreter", () => {
     roots: [{ _tag: "Atomic", key: "idle", value: 0 }],
     initial: "idle",
     events: ["Tick"],
-    transitions: [{ source: "idle", event: "Tick", reenter: false }]
+    transitions: [{ source: "idle", trigger: { type: "event", event: "Tick" }, reenter: false }]
   }
   const reference = MachineTest.interpretModel(model, ["Tick"])
 


### PR DESCRIPTION
## Summary

- Fix supervisor-owned machine terminalization so initialization and runtime `self.stop` cannot deadlock, while preserving exactly-once cleanup and terminal publication across stop, completion, and failure races.
- Strengthen public type safety with consistent executable-machine readiness, finite-union event narrowing, exact state-definition validation, and discriminated compiled state-node inspection.
- Expand `MachineTest` finite models from event-only transitions to canonical `event | always | done` triggers, including independent stabilization, completion, cycle, resume, generated-model, and managed-runtime differential verification.
- Add adversarial snapshot-codec, activity-lifecycle, process-lifecycle, and compiler-instantiation regression coverage.

`MachineTest.FiniteTransition` now migrates from `{ source, event, ... }` to `{ source, trigger: { type: "event", event }, ... }`; automatic transitions use `{ type: "always" }` or `{ type: "done" }`.

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (not applicable; no examples changed)
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed
