### PR TITLE
Add runtime performance benchmarks

### DIFF
--- a/.changeset/fast-machines-benchmark.md
+++ b/.changeset/fast-machines-benchmark.md
@@ -2,4 +2,4 @@
 "@typeonce/effect-machine": patch
 ---
 
-Add a local runtime benchmark command that measures pure planning, end-to-end event drainage, machine lifecycle throughput, and idle-machine memory growth against the compiled package, XState 5, and the published XState 6 alpha.
+Add local and pull request runtime benchmark reporting for pure planning, end-to-end event drainage, machine lifecycle throughput, and idle-machine memory growth against the compiled package, XState 5, and the published XState 6 alpha.

--- a/.changeset/fast-machines-benchmark.md
+++ b/.changeset/fast-machines-benchmark.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Add a local runtime benchmark command that measures pure planning, end-to-end event drainage, machine lifecycle throughput, and idle-machine memory growth against the compiled package, XState 5, and the published XState 6 alpha.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,8 +12,9 @@
 - [ ] `pnpm check`
 - [ ] Relevant example checks, when examples changed
 - [ ] Reviewed the automated type-performance report, when the public TypeScript API or inference changed
+- [ ] Reviewed the automated runtime-performance report, when runtime behavior changed
 
 <!--
-The type-performance workflow posts and updates the base-versus-PR comparison automatically.
+The type- and runtime-performance workflows post and update their base-versus-PR comparisons automatically.
 Do not copy a manually measured table into this description.
 -->

--- a/.github/workflows/runtime-performance-comment.yml
+++ b/.github/workflows/runtime-performance-comment.yml
@@ -1,0 +1,102 @@
+name: Runtime performance comment
+
+on:
+  workflow_run:
+    workflows: [Runtime performance]
+    types: [completed]
+
+concurrency:
+  group: runtime-performance-comment-${{ github.event.workflow_run.head_repository.id }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out trusted reporting code
+        uses: actions/checkout@v7
+
+      - name: Download performance report
+        uses: actions/download-artifact@v8
+        with:
+          name: runtime-performance-report
+          path: report
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Render report from validated benchmark data
+        run: >-
+          node scripts/compare-runtime-performance.mjs
+          report/base
+          report/head
+          > "$RUNNER_TEMP/report.md"
+
+      - name: Create or update pull request comment
+        uses: actions/github-script@v9
+        env:
+          REPORT_PATH: ${{ runner.temp }}/report.md
+        with:
+          script: |
+            const fs = require("node:fs")
+            const marker = "<!-- effect-machine-runtime-performance -->"
+            const report = fs.readFileSync(process.env.REPORT_PATH, "utf8")
+
+            if (Buffer.byteLength(report, "utf8") > 60_000) {
+              core.setFailed("Runtime-performance report exceeds the safe comment size")
+              return
+            }
+
+            const run = context.payload.workflow_run
+            let pull = run.pull_requests?.[0]
+
+            if (pull === undefined) {
+              try {
+                const associated = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  ...context.repo,
+                  commit_sha: run.head_sha
+                })
+                pull = associated.data.find((candidate) =>
+                  candidate.base.repo.full_name === `${context.repo.owner}/${context.repo.repo}`
+                )
+              } catch (error) {
+                core.warning(`Unable to look up a pull request for ${run.head_sha}: ${error.message}`)
+              }
+            }
+
+            if (pull === undefined) {
+              core.notice("No pull request is associated with this workflow run")
+              return
+            }
+
+            const body = `${marker}\n${report}`
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: pull.number,
+              per_page: 100
+            })
+            const previous = comments.find((comment) =>
+              comment.user?.type === "Bot" && comment.body?.startsWith(marker)
+            )
+
+            if (previous === undefined) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: pull.number,
+                body
+              })
+            } else {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: previous.id,
+                body
+              })
+            }

--- a/.github/workflows/runtime-performance.yml
+++ b/.github/workflows/runtime-performance.yml
@@ -1,0 +1,96 @@
+name: Runtime performance
+
+on:
+  pull_request:
+
+concurrency:
+  group: runtime-performance-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  runtime-performance:
+    name: runtime-performance
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out base
+        uses: actions/checkout@v7
+        with:
+          path: base
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Check out pull request
+        uses: actions/checkout@v7
+        with:
+          path: head
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: pnpm/action-setup@v6
+        with:
+          package_json_file: head/package.json
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: |
+            base/pnpm-lock.yaml
+            head/pnpm-lock.yaml
+
+      - name: Install and build pull request
+        run: |
+          pnpm --dir head install --frozen-lockfile
+          pnpm --dir head build
+
+      - name: Install and build base when benchmarkable
+        if: ${{ hashFiles('base/scripts/runtime-performance.mjs') != '' }}
+        run: |
+          pnpm --dir base install --frozen-lockfile
+          pnpm --dir base build
+
+      - name: Measure base and pull request
+        shell: bash
+        run: |
+          set -euo pipefail
+          reports="$RUNNER_TEMP/runtime-performance"
+          mkdir -p "$reports/base" "$reports/head"
+
+          measure() {
+            local checkout="$1"
+            local output="$2"
+            (
+              cd "$checkout"
+              node --expose-gc scripts/runtime-performance.mjs --json
+            ) > "$output"
+          }
+
+          if [[ -f base/scripts/runtime-performance.mjs ]]; then
+            measure base "$reports/base/1.json"
+            measure head "$reports/head/1.json"
+            measure head "$reports/head/2.json"
+            measure base "$reports/base/2.json"
+            measure base "$reports/base/3.json"
+            measure head "$reports/head/3.json"
+          else
+            measure head "$reports/head/1.json"
+            measure head "$reports/head/2.json"
+            measure head "$reports/head/3.json"
+          fi
+
+          node head/scripts/compare-runtime-performance.mjs \
+            "$reports/base" \
+            "$reports/head" \
+            > "$RUNNER_TEMP/runtime-performance-report.md"
+          cat "$RUNNER_TEMP/runtime-performance-report.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report for the comment workflow
+        uses: actions/upload-artifact@v7
+        with:
+          name: runtime-performance-report
+          path: ${{ runner.temp }}/runtime-performance
+          if-no-files-found: error
+          retention-days: 7

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:types": "tstyche",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "perf:types": "pnpm build && node scripts/type-performance.mjs",
+    "perf:runtime": "pnpm build && node --expose-gc scripts/runtime-performance.mjs",
     "format": "dprint fmt",
     "format:check": "dprint check",
     "test:consumer": "node scripts/test-consumer.mjs",
@@ -68,9 +69,12 @@
     "@types/node": "25.7.0",
     "dprint": "0.55.2",
     "effect": "4.0.0-beta.102",
+    "tinybench": "2.9.0",
     "tstyche": "7.2.1",
     "typescript": "6.0.3",
-    "vitest": "4.1.10"
+    "vitest": "4.1.10",
+    "xstate-v5": "npm:xstate@5.32.5",
+    "xstate-v6": "npm:xstate@6.0.0-alpha.27"
   },
   "packageManager": "pnpm@10.17.1",
   "engines": {

--- a/perf/runtime/README.md
+++ b/perf/runtime/README.md
@@ -1,0 +1,75 @@
+# Runtime performance
+
+Run the local runtime benchmark suite against the compiled package and the
+pinned XState comparison versions:
+
+```sh
+pnpm perf:runtime
+```
+
+The command reports:
+
+- pure `Machine.plan` counter-transition throughput;
+- end-to-end useful-increment throughput for a burst sent to one running machine;
+- machine start-and-stop throughput;
+- idle heap and resident-memory growth at 100, 500, and 1,000 live machines.
+
+The comparison dependencies use package aliases, so XState 5 and 6 can be
+loaded by the same process:
+
+- `xstate-v5`: `xstate@5.32.5`, the stable v5 baseline;
+- `xstate-v6`: `xstate@6.0.0-alpha.27`, the latest published v6 alpha available
+  when the harness was added.
+
+All implementations use the same flat counter topology, immutable events, and
+terminal fence. The XState adapter uses `assign` in v5 and the v6 transition
+function API because `assign` is not exported by that alpha.
+
+The burst benchmark reports useful counter increments per second. It enqueues
+one final fence event after all counter events and awaits the machine's terminal
+output, so the measured duration also amortizes that fence and terminal
+cleanup. This measures complete queue drainage, not only the enqueue time
+returned by `MachineRef.send`.
+
+Results are informational. Compare runs on the same machine while it is idle,
+using the same Node.js and dependency versions. Tinybench warms each scenario
+before collecting samples, and the memory measurements force garbage
+collection before every observation. Each implementation's memory curve runs
+in a fresh child process so garbage from one library cannot distort another
+library's baseline.
+
+These scenarios compare observable work, not identical internals. Effect
+Machine plans through an `Effect`, validates schema-backed state and events,
+and its running machine provisions Effect queues, fibers, synchronization,
+change publication, and child/invoke lifecycle machinery. XState's counter is
+a smaller synchronous actor. Treat the comparison as an application-level
+cost baseline, not a claim that the libraries provide the same runtime
+guarantees.
+
+The fitted heap slope is the primary idle-capacity metric. Resident memory is
+reported as a raw diagnostic because V8 and the operating-system allocator can
+reuse already committed pages. The capacity-per-GiB value is a linear estimate
+that excludes shared process overhead; it is not a run-until-OOM limit.
+
+Use a shorter smoke run while changing the harness:
+
+```sh
+pnpm perf:runtime -- --quick
+```
+
+Display the complete versioned report as JSON, or write a machine-readable JSON
+file alongside the terminal report:
+
+```sh
+pnpm perf:runtime -- --json
+pnpm perf:runtime -- --output runtime-performance.json
+```
+
+Prefer `--output` for scripts: pnpm and the preceding build may add their own
+lines to standard output before `--json` is printed.
+
+The implementation lives in `scripts/runtime-performance.mjs`; the Effect
+Machine fixture is in `perf/runtime/counter.mjs`, and the comparison adapter is
+in `perf/runtime/xstate.mjs`. Add new scenarios only when every implementation
+performs equivalent observable work and the result is consumed and checked so
+the JavaScript engine cannot discard it.

--- a/perf/runtime/README.md
+++ b/perf/runtime/README.md
@@ -68,6 +68,13 @@ pnpm perf:runtime -- --output runtime-performance.json
 Prefer `--output` for scripts: pnpm and the preceding build may add their own
 lines to standard output before `--json` is printed.
 
+Pull requests run the suite three times for both the base and pull request
+revisions on the same GitHub-hosted runner. The workflow publishes the median
+of those process-level results to the job summary and a sticky pull request
+comment. The benchmark workflow has read-only repository access; a separate
+trusted `workflow_run` workflow validates the uploaded JSON before receiving
+permission to update the comment.
+
 The implementation lives in `scripts/runtime-performance.mjs`; the Effect
 Machine fixture is in `perf/runtime/counter.mjs`, and the comparison adapter is
 in `perf/runtime/xstate.mjs`. Add new scenarios only when every implementation

--- a/perf/runtime/counter.mjs
+++ b/perf/runtime/counter.mjs
@@ -1,0 +1,119 @@
+import { Effect, Schema } from "effect"
+import { Machine } from "../../dist/index.js"
+
+const CounterState = Schema.TaggedUnion({
+  Count: {
+    value: Schema.Number
+  },
+  Done: {
+    value: Schema.Number
+  }
+})
+
+const CounterEvent = Schema.TaggedUnion({
+  Increment: {},
+  Finish: {}
+})
+
+const CounterStates = Machine.defineStates({
+  Count: CounterState.cases.Count,
+  Done: {
+    schema: CounterState.cases.Done,
+    type: "final",
+    output: Schema.Number
+  }
+})
+
+export const counterMachine = Machine.make({
+  id: "RuntimeBenchmarkCounter",
+  states: CounterStates.states,
+  events: [CounterEvent.cases.Increment, CounterEvent.cases.Finish],
+  initial: () => CounterStates.initial.Count(CounterState.cases.Count.make({ value: 0 }))
+}).handle({
+  Count: {
+    on: {
+      Increment: ({ state, target }) =>
+        target.full.Count(CounterState.cases.Count.make({ value: state.value + 1 })),
+      Finish: ({ state, target }) => target.full.Done(CounterState.cases.Done.make({ value: state.value }))
+    }
+  },
+  Done: {
+    output: ({ state }) => state.value
+  }
+})
+
+export const incrementEvent = CounterEvent.cases.Increment.make({})
+const finishEvent = CounterEvent.cases.Finish.make({})
+
+export const initialCounterSnapshot = Effect.runSync(
+  Machine.planInitial(counterMachine).pipe(Effect.map((planned) => planned.state))
+)
+
+export const counterValue = (snapshot) => snapshot.value.value
+
+export const planCounterBatch = (size) => {
+  return Effect.runSync(
+    Effect.gen(function*() {
+      let snapshot = initialCounterSnapshot
+      for (let index = 0; index < size; index += 1) {
+        snapshot = (yield* Machine.plan(counterMachine, snapshot, incrementEvent)).next
+      }
+      return counterValue(snapshot)
+    })
+  )
+}
+
+export const startCounter = () => Effect.runPromise(Machine.start(counterMachine))
+
+export const stopCounter = (ref) => Effect.runPromise(ref.stop)
+
+export const runCounterBurst = (ref, size) =>
+  Effect.runPromise(
+    Effect.gen(function*() {
+      for (let index = 0; index < size; index += 1) {
+        yield* ref.send(incrementEvent)
+      }
+      yield* ref.send(finishEvent)
+      return yield* ref.join
+    })
+  )
+
+export const startCounters = (count) =>
+  Effect.runPromise(
+    Effect.forEach(
+      Array.from({ length: count }),
+      () => Machine.start(counterMachine),
+      { concurrency: 1 }
+    )
+  )
+
+export const stopCounters = (refs) =>
+  Effect.runPromise(
+    Effect.forEach(refs, (ref) => ref.stop, {
+      concurrency: "unbounded",
+      discard: true
+    })
+  )
+
+export const effectMachineAdapter = {
+  implementation: "effect-machine",
+  label: "Effect Machine",
+  version: undefined,
+  async: true,
+  planCounterBatch,
+  runCounterBurst,
+  runLifecycle: async () => {
+    const ref = await startCounter()
+    try {
+      if (!ref.sessionId.startsWith("machine:")) {
+        throw new Error(`Lifecycle benchmark produced invalid session id ${ref.sessionId}`)
+      }
+    } finally {
+      await stopCounter(ref)
+    }
+  },
+  startCounter,
+  startCounters,
+  stopCounter,
+  stopCounters
+}

--- a/perf/runtime/implementations.mjs
+++ b/perf/runtime/implementations.mjs
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs"
+import * as XStateV5 from "xstate-v5"
+import * as XStateV6 from "xstate-v6"
+import { effectMachineAdapter } from "./counter.mjs"
+import { makeXStateAdapter } from "./xstate.mjs"
+
+const readPackageVersion = (path) => JSON.parse(readFileSync(path, "utf8")).version
+
+export const packageVersions = {
+  effectMachine: readPackageVersion(new URL("../../package.json", import.meta.url)),
+  effect: readPackageVersion(new URL("../../node_modules/effect/package.json", import.meta.url)),
+  tinybench: readPackageVersion(new URL("../../node_modules/tinybench/package.json", import.meta.url)),
+  xstateV5: readPackageVersion(new URL("../../node_modules/xstate-v5/package.json", import.meta.url)),
+  xstateV6: readPackageVersion(new URL("../../node_modules/xstate-v6/package.json", import.meta.url))
+}
+
+export const implementations = [
+  { ...effectMachineAdapter, version: packageVersions.effectMachine },
+  makeXStateAdapter({
+    implementation: "xstate-v5",
+    label: "XState 5",
+    version: packageVersions.xstateV5,
+    xstate: XStateV5
+  }),
+  makeXStateAdapter({
+    implementation: "xstate-v6",
+    label: "XState 6 alpha",
+    version: packageVersions.xstateV6,
+    xstate: XStateV6
+  })
+]

--- a/perf/runtime/memory-worker.mjs
+++ b/perf/runtime/memory-worker.mjs
@@ -1,0 +1,74 @@
+import process from "node:process"
+import { setImmediate as yieldToEventLoop } from "node:timers/promises"
+import { implementations } from "./implementations.mjs"
+
+if (typeof globalThis.gc !== "function") {
+  throw new Error("Runtime memory benchmarks require Node.js with --expose-gc")
+}
+
+const implementationId = process.argv[2]
+const counts = JSON.parse(process.argv[3] ?? "[]")
+const implementation = implementations.find((candidate) => candidate.implementation === implementationId)
+
+if (implementation === undefined) {
+  throw new Error(`Unknown runtime benchmark implementation: ${implementationId}`)
+}
+
+const collectGarbage = async () => {
+  for (let index = 0; index < 3; index += 1) {
+    globalThis.gc()
+    await yieldToEventLoop()
+  }
+}
+
+const linearSlope = (points, value) => {
+  const withBaseline = [{ machines: 0, [value]: 0 }, ...points]
+  const meanX = withBaseline.reduce((total, point) => total + point.machines, 0) / withBaseline.length
+  const meanY = withBaseline.reduce((total, point) => total + point[value], 0) / withBaseline.length
+  let numerator = 0
+  let denominator = 0
+  for (const point of withBaseline) {
+    numerator += (point.machines - meanX) * (point[value] - meanY)
+    denominator += (point.machines - meanX) ** 2
+  }
+  return numerator / denominator
+}
+
+// Trigger implementation-specific lazy initialization before taking the baseline.
+const warmup = await implementation.startCounter()
+await implementation.stopCounter(warmup)
+await collectGarbage()
+
+const baseline = process.memoryUsage()
+const points = []
+const refs = []
+
+try {
+  for (const count of counts) {
+    refs.push(...await implementation.startCounters(count - refs.length))
+    await collectGarbage()
+    const usage = process.memoryUsage()
+    points.push({
+      machines: count,
+      heapUsedBytes: usage.heapUsed,
+      heapDeltaBytes: usage.heapUsed - baseline.heapUsed,
+      rssBytes: usage.rss,
+      rssDeltaBytes: usage.rss - baseline.rss
+    })
+  }
+} finally {
+  await implementation.stopCounters(refs)
+  await collectGarbage()
+}
+
+process.stdout.write(JSON.stringify({
+  implementation: implementation.implementation,
+  implementationLabel: implementation.label,
+  implementationVersion: implementation.version,
+  baseline: {
+    heapUsedBytes: baseline.heapUsed,
+    rssBytes: baseline.rss
+  },
+  points,
+  heapBytesPerIdleMachine: linearSlope(points, "heapDeltaBytes")
+}))

--- a/perf/runtime/xstate.mjs
+++ b/perf/runtime/xstate.mjs
@@ -1,0 +1,94 @@
+const incrementEvent = Object.freeze({ type: "Increment" })
+const finishEvent = Object.freeze({ type: "Finish" })
+
+export const makeXStateAdapter = (options) => {
+  const { implementation, label, version, xstate } = options
+  const increment = typeof xstate.assign === "function"
+    ? {
+      actions: xstate.assign({
+        value: ({ context }) => context.value + 1
+      })
+    }
+    : ({ context }) => ({
+      context: { value: context.value + 1 }
+    })
+
+  const machine = xstate.createMachine({
+    id: `RuntimeBenchmarkCounter-${implementation}`,
+    context: { value: 0 },
+    initial: "counting",
+    states: {
+      counting: {
+        on: {
+          Increment: increment,
+          Finish: { target: "done" }
+        }
+      },
+      done: { type: "final" }
+    }
+  })
+  const initialSnapshot = xstate.initialTransition(machine)[0]
+
+  const planCounterBatch = (size) => {
+    let snapshot = initialSnapshot
+    for (let index = 0; index < size; index += 1) {
+      snapshot = xstate.transition(machine, snapshot, incrementEvent)[0]
+    }
+    return snapshot.context.value
+  }
+
+  const startCounter = () => xstate.createActor(machine).start()
+  const stopCounter = (actor) => actor.stop()
+
+  const runCounterBurst = (actor, size) => {
+    for (let index = 0; index < size; index += 1) {
+      actor.send(incrementEvent)
+    }
+    actor.send(finishEvent)
+    const snapshot = actor.getSnapshot()
+    if (snapshot.status !== "done") {
+      throw new Error(`${label} terminal fence produced status ${snapshot.status}`)
+    }
+    return snapshot.context.value
+  }
+
+  const runLifecycle = () => {
+    const actor = startCounter()
+    try {
+      const snapshot = actor.getSnapshot()
+      if (snapshot.status !== "active" || snapshot.context.value !== 0) {
+        throw new Error(`${label} lifecycle benchmark produced an invalid initial snapshot`)
+      }
+    } finally {
+      stopCounter(actor)
+    }
+  }
+
+  const startCounters = (count) => {
+    const actors = []
+    for (let index = 0; index < count; index += 1) {
+      actors.push(startCounter())
+    }
+    return actors
+  }
+
+  const stopCounters = (actors) => {
+    for (const actor of actors) {
+      stopCounter(actor)
+    }
+  }
+
+  return {
+    implementation,
+    label,
+    version,
+    async: false,
+    planCounterBatch,
+    runCounterBurst,
+    runLifecycle,
+    startCounter,
+    startCounters,
+    stopCounter,
+    stopCounters
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       effect:
         specifier: 4.0.0-beta.102
         version: 4.0.0-beta.102
+      tinybench:
+        specifier: 2.9.0
+        version: 2.9.0
       tstyche:
         specifier: 7.2.1
         version: 7.2.1(typescript@6.0.3)
@@ -36,6 +39,12 @@ importers:
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@types/node@25.7.0)(vite@8.1.5(@types/node@25.7.0)(yaml@2.9.0))
+      xstate-v5:
+        specifier: npm:xstate@5.32.5
+        version: xstate@5.32.5
+      xstate-v6:
+        specifier: npm:xstate@6.0.0-alpha.27
+        version: xstate@6.0.0-alpha.27
 
 packages:
 
@@ -1021,6 +1030,13 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  xstate@5.32.5:
+    resolution: {integrity: sha512-ULazi1oe6wGrXl0Frb6otSlkm5HLifbbVTkMk5kkSKqz4TkxJaVpnl6jOJwKeid3ORPxYyZQgNLUSYX9q65SIA==}
+
+  xstate@6.0.0-alpha.27:
+    resolution: {integrity: sha512-gpJrSoIBWE2jguo8kNGQulNdWNPtzi4nhDvzOKh9VP3M+UHc7ISFqvLRpO2xmGjW5pvpv1sE0beK8rJ2cGFJMQ==}
+    hasBin: true
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -1908,5 +1924,9 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  xstate@5.32.5: {}
+
+  xstate@6.0.0-alpha.27: {}
 
   yaml@2.9.0: {}

--- a/scripts/compare-runtime-performance.mjs
+++ b/scripts/compare-runtime-performance.mjs
@@ -1,0 +1,310 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
+import { join } from "node:path"
+
+const [baseDirectory, pullRequestDirectory] = process.argv.slice(2)
+
+if (baseDirectory === undefined || pullRequestDirectory === undefined) {
+  throw new Error(
+    "Usage: node scripts/compare-runtime-performance.mjs <base-report-directory> <pr-report-directory>"
+  )
+}
+
+const isBoundedNumber = (value) => Number.isFinite(value) && Math.abs(value) <= 1_000_000_000_000_000
+const isShortString = (value, maximum) => typeof value === "string" && value.length > 0 && value.length <= maximum
+
+const validateReport = (report, path) => {
+  if (
+    report?.schemaVersion !== 2 ||
+    typeof report.environment !== "object" ||
+    report.environment === null ||
+    typeof report.configuration !== "object" ||
+    report.configuration === null ||
+    !Array.isArray(report.benchmarks) ||
+    !Array.isArray(report.memory)
+  ) {
+    throw new Error(`Unsupported runtime-performance report: ${path}`)
+  }
+  if (
+    !isShortString(report.environment.node, 40) ||
+    !isShortString(report.environment.architecture, 40) ||
+    !isShortString(report.environment.cpu, 200) ||
+    report.benchmarks.length > 100 ||
+    report.memory.length > 20
+  ) {
+    throw new Error(`Invalid runtime-performance metadata: ${path}`)
+  }
+
+  const benchmarkKeys = new Set()
+  for (const benchmark of report.benchmarks) {
+    const key = `${benchmark.implementation}\u0000${benchmark.id}`
+    if (
+      !isShortString(benchmark.implementation, 100) ||
+      !isShortString(benchmark.implementationLabel, 200) ||
+      !isShortString(benchmark.implementationVersion, 100) ||
+      !isShortString(benchmark.id, 100) ||
+      !isShortString(benchmark.label, 200) ||
+      !isShortString(benchmark.unit, 100) ||
+      !isBoundedNumber(benchmark.medianThroughput) ||
+      benchmark.medianThroughput < 0 ||
+      !isBoundedNumber(benchmark.relativeMarginOfError) ||
+      benchmark.relativeMarginOfError < 0 ||
+      benchmarkKeys.has(key)
+    ) {
+      throw new Error(`Invalid runtime-performance benchmark: ${path}`)
+    }
+    benchmarkKeys.add(key)
+  }
+
+  const memoryKeys = new Set()
+  for (const measurement of report.memory) {
+    if (
+      !isShortString(measurement.implementation, 100) ||
+      !isShortString(measurement.implementationLabel, 200) ||
+      !isShortString(measurement.implementationVersion, 100) ||
+      !isBoundedNumber(measurement.heapBytesPerIdleMachine) ||
+      measurement.heapBytesPerIdleMachine < 0 ||
+      !Array.isArray(measurement.points) ||
+      measurement.points.length > 20 ||
+      memoryKeys.has(measurement.implementation)
+    ) {
+      throw new Error(`Invalid runtime-performance memory measurement: ${path}`)
+    }
+    for (const point of measurement.points) {
+      if (
+        !Number.isSafeInteger(point.machines) ||
+        point.machines < 0 ||
+        !isBoundedNumber(point.heapDeltaBytes) ||
+        !isBoundedNumber(point.rssDeltaBytes)
+      ) {
+        throw new Error(`Invalid runtime-performance memory point: ${path}`)
+      }
+    }
+    memoryKeys.add(measurement.implementation)
+  }
+}
+
+const readReports = (directory, required) => {
+  if (!existsSync(directory)) {
+    if (required) {
+      throw new Error(`Runtime-performance report directory does not exist: ${directory}`)
+    }
+    return []
+  }
+
+  const entries = readdirSync(directory)
+    .filter((entry) => entry.endsWith(".json"))
+    .sort()
+  if (entries.length === 0) {
+    if (required) {
+      throw new Error(`Runtime-performance report directory is empty: ${directory}`)
+    }
+    return []
+  }
+  if (entries.length > 5) {
+    throw new Error(`Too many runtime-performance reports in ${directory}`)
+  }
+
+  return entries.map((entry) => {
+    const path = join(directory, entry)
+    if (!statSync(path).isFile() || statSync(path).size > 500_000) {
+      throw new Error(`Invalid runtime-performance report file: ${path}`)
+    }
+    const report = JSON.parse(readFileSync(path, "utf8"))
+    validateReport(report, path)
+    return report
+  })
+}
+
+const median = (values) => {
+  const sorted = [...values].sort((left, right) => left - right)
+  const middle = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle]
+}
+
+const assertConsistentRuns = (reports, label) => {
+  const first = reports[0]
+  const configuration = JSON.stringify(first.configuration)
+  const benchmarkKeys = first.benchmarks.map((benchmark) =>
+    `${benchmark.implementation}\u0000${benchmark.id}\u0000${benchmark.unit}`
+  ).sort().join("\u0001")
+  const memoryKeys = first.memory.map((measurement) => measurement.implementation).sort().join("\u0001")
+
+  for (const report of reports.slice(1)) {
+    if (
+      JSON.stringify(report.configuration) !== configuration ||
+      report.environment.node !== first.environment.node ||
+      report.environment.architecture !== first.environment.architecture ||
+      report.environment.cpu !== first.environment.cpu ||
+      report.benchmarks.map((benchmark) =>
+        `${benchmark.implementation}\u0000${benchmark.id}\u0000${benchmark.unit}`
+      ).sort().join("\u0001") !== benchmarkKeys ||
+      report.memory.map((measurement) => measurement.implementation).sort().join("\u0001") !== memoryKeys
+    ) {
+      throw new Error(`Inconsistent ${label} runtime-performance reports`)
+    }
+  }
+}
+
+const aggregate = (reports, label) => {
+  assertConsistentRuns(reports, label)
+  const first = reports[0]
+  return {
+    runCount: reports.length,
+    environment: first.environment,
+    configuration: first.configuration,
+    benchmarks: first.benchmarks.map((benchmark) => {
+      const matches = reports.map((report) =>
+        report.benchmarks.find((candidate) =>
+          candidate.implementation === benchmark.implementation && candidate.id === benchmark.id
+        )
+      )
+      return {
+        ...benchmark,
+        medianThroughput: median(matches.map((match) => match.medianThroughput)),
+        relativeMarginOfError: median(matches.map((match) => match.relativeMarginOfError))
+      }
+    }),
+    memory: first.memory.map((measurement) => ({
+      ...measurement,
+      heapBytesPerIdleMachine: median(
+        reports.map((report) =>
+          report.memory.find((candidate) => candidate.implementation === measurement.implementation)
+            .heapBytesPerIdleMachine
+        )
+      )
+    }))
+  }
+}
+
+const baseReports = readReports(baseDirectory, false)
+const pullRequestReports = readReports(pullRequestDirectory, true)
+const base = baseReports.length === 0 ? undefined : aggregate(baseReports, "base")
+const pullRequest = aggregate(pullRequestReports, "pull request")
+
+const integer = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 })
+const decimal = new Intl.NumberFormat("en-US", { minimumFractionDigits: 1, maximumFractionDigits: 1 })
+const escapeCell = (value) => String(value).replaceAll("|", "\\|").replaceAll("\n", " ")
+const code = (value) => `\`${String(value).replaceAll("`", "\\`")}\``
+const formatThroughput = (value, unit) => `${integer.format(value)} ${escapeCell(unit)}`
+const formatHeap = (value) => `${decimal.format(value / 1_024)} KiB`
+const formatDifference = (before, after) => {
+  const difference = after - before
+  const sign = difference > 0 ? "+" : ""
+  const percentage = before === 0 ? undefined : difference / before * 100
+  return percentage === undefined
+    ? `${sign}${integer.format(difference)}`
+    : `${sign}${decimal.format(percentage)}%`
+}
+
+const implementations = [...new Map(
+  pullRequest.benchmarks.map((benchmark) => [benchmark.implementation, {
+    id: benchmark.implementation,
+    label: benchmark.implementationLabel,
+    version: benchmark.implementationVersion
+  }])
+).values()]
+const scenarios = [...new Map(
+  pullRequest.benchmarks.map((benchmark) => [benchmark.id, {
+    id: benchmark.id,
+    label: benchmark.label,
+    unit: benchmark.unit
+  }])
+).values()]
+
+const lines = [
+  "## Runtime performance",
+  "",
+  `Median of ${pullRequest.runCount} independent benchmark processes on ${code(pullRequest.environment.cpu)} with Node ${code(pullRequest.environment.node)}.`,
+  "",
+  "### Pull request baseline",
+  "",
+  `| Scenario | ${implementations.map((implementation) => escapeCell(implementation.label)).join(" | ")} |`,
+  `| --- | ${implementations.map(() => "---:").join(" | ")} |`
+]
+
+for (const scenario of scenarios) {
+  lines.push(
+    `| ${escapeCell(scenario.label)} | ${implementations.map((implementation) => {
+      const benchmark = pullRequest.benchmarks.find((candidate) =>
+        candidate.implementation === implementation.id && candidate.id === scenario.id
+      )
+      return benchmark === undefined ? "—" : formatThroughput(benchmark.medianThroughput, benchmark.unit)
+    }).join(" | ")} |`
+  )
+}
+
+lines.push(
+  "",
+  "| Idle memory | Heap per machine |",
+  "| --- | ---: |"
+)
+for (const implementation of implementations) {
+  const measurement = pullRequest.memory.find((candidate) => candidate.implementation === implementation.id)
+  lines.push(
+    `| ${escapeCell(implementation.label)} | ${measurement === undefined ? "—" : formatHeap(measurement.heapBytesPerIdleMachine)} |`
+  )
+}
+
+if (base === undefined) {
+  lines.push(
+    "",
+    "The base revision does not contain the runtime benchmark harness, so this bootstrapping PR reports the pull request baseline without a base comparison."
+  )
+} else if (JSON.stringify(base.configuration) !== JSON.stringify(pullRequest.configuration)) {
+  lines.push(
+    "",
+    "Base and pull request use different benchmark configurations, so their results are not compared."
+  )
+} else {
+  const baseEffect = new Map(
+    base.benchmarks
+      .filter((benchmark) => benchmark.implementation === "effect-machine")
+      .map((benchmark) => [benchmark.id, benchmark])
+  )
+  const pullRequestEffect = new Map(
+    pullRequest.benchmarks
+      .filter((benchmark) => benchmark.implementation === "effect-machine")
+      .map((benchmark) => [benchmark.id, benchmark])
+  )
+  lines.push(
+    "",
+    "### Effect Machine change from base",
+    "",
+    "| Metric | Base | PR | Difference |",
+    "| --- | ---: | ---: | ---: |"
+  )
+  for (const scenario of scenarios) {
+    const before = baseEffect.get(scenario.id)
+    const after = pullRequestEffect.get(scenario.id)
+    if (before !== undefined && after !== undefined && before.unit === after.unit) {
+      lines.push(
+        `| ${escapeCell(scenario.label)} | ${formatThroughput(before.medianThroughput, before.unit)} | ${formatThroughput(after.medianThroughput, after.unit)} | ${formatDifference(before.medianThroughput, after.medianThroughput)} |`
+      )
+    }
+  }
+  const beforeMemory = base.memory.find((measurement) => measurement.implementation === "effect-machine")
+  const afterMemory = pullRequest.memory.find((measurement) => measurement.implementation === "effect-machine")
+  if (beforeMemory !== undefined && afterMemory !== undefined) {
+    lines.push(
+      `| Idle heap per machine | ${formatHeap(beforeMemory.heapBytesPerIdleMachine)} | ${formatHeap(afterMemory.heapBytesPerIdleMachine)} | ${formatDifference(beforeMemory.heapBytesPerIdleMachine, afterMemory.heapBytesPerIdleMachine)} |`
+    )
+  }
+}
+
+lines.push(
+  "",
+  "<details>",
+  "<summary>Versions and interpretation</summary>",
+  "",
+  ...implementations.map((implementation) =>
+    `- ${escapeCell(implementation.label)}: ${code(implementation.version)}`
+  ),
+  "",
+  "Higher throughput is better; lower idle heap is better. Runtime measurements on shared GitHub-hosted hardware remain informational, so small differences should be confirmed across multiple workflow runs.",
+  "",
+  "</details>"
+)
+
+console.log(lines.join("\n"))

--- a/scripts/runtime-performance.mjs
+++ b/scripts/runtime-performance.mjs
@@ -1,0 +1,299 @@
+import { execFileSync } from "node:child_process"
+import { writeFileSync } from "node:fs"
+import { cpus, freemem, platform, release, totalmem } from "node:os"
+import { resolve } from "node:path"
+import process from "node:process"
+import { fileURLToPath } from "node:url"
+import { Bench } from "tinybench"
+import { implementations, packageVersions } from "../perf/runtime/implementations.mjs"
+const sourceRevision = (() => {
+  try {
+    return {
+      commit: execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+      dirty: execFileSync("git", ["status", "--porcelain", "--untracked-files=no"], {
+        encoding: "utf8"
+      }).trim().length > 0
+    }
+  } catch {
+    return { commit: null, dirty: null }
+  }
+})()
+
+const options = {
+  json: false,
+  output: undefined,
+  quick: false
+}
+
+for (let index = 2; index < process.argv.length; index += 1) {
+  const argument = process.argv[index]
+  if (argument === "--") {
+    continue
+  } else if (argument === "--json") {
+    options.json = true
+  } else if (argument === "--quick") {
+    options.quick = true
+  } else if (argument === "--output") {
+    const output = process.argv[index + 1]
+    if (output === undefined) {
+      throw new Error("--output requires a file path")
+    }
+    options.output = resolve(output)
+    index += 1
+  } else {
+    throw new Error(`Unknown argument: ${argument}`)
+  }
+}
+
+if (typeof globalThis.gc !== "function") {
+  throw new Error("Runtime benchmarks require Node.js with --expose-gc")
+}
+
+const configuration = options.quick
+  ? {
+    timeMilliseconds: 100,
+    warmupTimeMilliseconds: 25,
+    minimumIterations: 2,
+    minimumWarmupIterations: 1,
+    planningBatchSize: 25,
+    burstBatchSize: 25,
+    memoryCounts: [25, 100]
+  }
+  : {
+    timeMilliseconds: 1_000,
+    warmupTimeMilliseconds: 250,
+    minimumIterations: 10,
+    minimumWarmupIterations: 5,
+    planningBatchSize: 100,
+    burstBatchSize: 250,
+    memoryCounts: [100, 500, 1_000]
+  }
+
+const bench = new Bench({
+  time: configuration.timeMilliseconds,
+  warmupTime: configuration.warmupTimeMilliseconds,
+  iterations: configuration.minimumIterations,
+  warmupIterations: configuration.minimumWarmupIterations,
+  throws: true
+})
+const benchmarkDefinitions = new Map()
+const activeBurstRefs = new Map()
+
+for (const implementation of implementations) {
+  const metadata = {
+    implementation: implementation.implementation,
+    implementationLabel: implementation.label,
+    implementationVersion: implementation.version
+  }
+  const planningTask = `${implementation.implementation}:plan-counter`
+  benchmarkDefinitions.set(planningTask, {
+    ...metadata,
+    id: "plan-counter",
+    label: "Plan counter transitions",
+    unit: "transitions/s",
+    operationsPerIteration: configuration.planningBatchSize
+  })
+  bench.add(planningTask, () => {
+    const value = implementation.planCounterBatch(configuration.planningBatchSize)
+    if (value !== configuration.planningBatchSize) {
+      throw new Error(
+        `${implementation.label} planning benchmark produced ${value}, expected ${configuration.planningBatchSize}`
+      )
+    }
+  })
+
+  const burstTask = `${implementation.implementation}:runtime-burst`
+  benchmarkDefinitions.set(burstTask, {
+    ...metadata,
+    id: "runtime-burst",
+    label: "Drain burst with terminal fence",
+    unit: "increments/s",
+    operationsPerIteration: configuration.burstBatchSize,
+    fenceEventsPerIteration: 1
+  })
+  const runBurst = implementation.async
+    ? async () => {
+      const value = await implementation.runCounterBurst(
+        activeBurstRefs.get(implementation.implementation),
+        configuration.burstBatchSize
+      )
+      if (value !== configuration.burstBatchSize) {
+        throw new Error(
+          `${implementation.label} runtime benchmark produced ${value}, expected ${configuration.burstBatchSize}`
+        )
+      }
+    }
+    : () => {
+      const value = implementation.runCounterBurst(
+        activeBurstRefs.get(implementation.implementation),
+        configuration.burstBatchSize
+      )
+      if (value !== configuration.burstBatchSize) {
+        throw new Error(
+          `${implementation.label} runtime benchmark produced ${value}, expected ${configuration.burstBatchSize}`
+        )
+      }
+    }
+  bench.add(burstTask, runBurst, {
+    beforeEach: async () => {
+      activeBurstRefs.set(implementation.implementation, await implementation.startCounter())
+    },
+    afterEach: async () => {
+      const ref = activeBurstRefs.get(implementation.implementation)
+      await implementation.stopCounter(ref)
+      activeBurstRefs.delete(implementation.implementation)
+    }
+  })
+
+  const lifecycleTask = `${implementation.implementation}:start-stop`
+  benchmarkDefinitions.set(lifecycleTask, {
+    ...metadata,
+    id: "start-stop",
+    label: "Start and stop a machine",
+    unit: "machines/s",
+    operationsPerIteration: 1
+  })
+  bench.add(
+    lifecycleTask,
+    implementation.async
+      ? async () => {
+        await implementation.runLifecycle()
+      }
+      : () => implementation.runLifecycle()
+  )
+}
+
+try {
+  await bench.warmup()
+  await bench.run()
+} finally {
+  for (const implementation of implementations) {
+    const ref = activeBurstRefs.get(implementation.implementation)
+    if (ref !== undefined) {
+      await implementation.stopCounter(ref)
+      activeBurstRefs.delete(implementation.implementation)
+    }
+  }
+}
+
+const percentile = (samples, quantile) =>
+  samples[Math.max(0, Math.ceil(samples.length * quantile) - 1)]
+
+const benchmarks = bench.tasks.map((task) => {
+  const definition = benchmarkDefinitions.get(task.name)
+  const result = task.result
+  if (definition === undefined || result === undefined) {
+    throw new Error(`Missing benchmark result for ${task.name}`)
+  }
+  if (result.error !== undefined) {
+    throw result.error
+  }
+  const operations = definition.operationsPerIteration
+  const medianBatchMilliseconds = percentile(result.samples, 0.5)
+  return {
+    ...definition,
+    medianThroughput: operations * 1_000 / medianBatchMilliseconds,
+    meanThroughput: result.hz * operations,
+    meanNanosecondsPerOperation: result.mean * 1_000_000 / operations,
+    medianBatchMilliseconds,
+    p95BatchMilliseconds: percentile(result.samples, 0.95),
+    p99BatchMilliseconds: result.p99,
+    relativeMarginOfError: result.rme,
+    sampleCount: result.samples.length
+  }
+})
+
+const memoryWorker = fileURLToPath(new URL("../perf/runtime/memory-worker.mjs", import.meta.url))
+const memory = implementations.map((implementation) =>
+  JSON.parse(
+    execFileSync(
+      process.execPath,
+      ["--expose-gc", memoryWorker, implementation.implementation, JSON.stringify(configuration.memoryCounts)],
+      { encoding: "utf8" }
+    )
+  )
+)
+
+const cpu = cpus()[0]
+const report = {
+  schemaVersion: 2,
+  generatedAt: new Date().toISOString(),
+  source: sourceRevision,
+  environment: {
+    node: process.version,
+    platform: platform(),
+    release: release(),
+    architecture: process.arch,
+    cpu: cpu?.model ?? "unknown",
+    logicalCpuCount: cpus().length,
+    totalMemoryBytes: totalmem(),
+    freeMemoryBytes: freemem(),
+    packages: packageVersions
+  },
+  configuration,
+  benchmarks,
+  memory
+}
+
+const json = `${JSON.stringify(report, null, 2)}\n`
+if (options.output !== undefined) {
+  writeFileSync(options.output, json, "utf8")
+}
+
+if (options.json) {
+  process.stdout.write(json)
+} else {
+  const integer = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 })
+  const decimal = new Intl.NumberFormat("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+  const bytes = new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 })
+  const formatBytes = (value) => `${bytes.format(value / 1_024)} KiB`
+  const formatDuration = (nanoseconds) =>
+    nanoseconds >= 1_000_000
+      ? `${decimal.format(nanoseconds / 1_000_000)} ms`
+      : nanoseconds >= 1_000
+      ? `${decimal.format(nanoseconds / 1_000)} µs`
+      : `${decimal.format(nanoseconds)} ns`
+
+  console.log(`Runtime performance (${process.version}, ${cpu?.model ?? "unknown"})\n`)
+  console.table(
+    benchmarks.map((result) => ({
+      Implementation: `${result.implementationLabel} ${result.implementationVersion}`,
+      Scenario: result.label,
+      "Median throughput": `${integer.format(result.medianThroughput)} ${result.unit}`,
+      "Mean/op": formatDuration(result.meanNanosecondsPerOperation),
+      "p95 batch": `${decimal.format(result.p95BatchMilliseconds)} ms`,
+      Margin: `±${decimal.format(result.relativeMarginOfError)}%`,
+      Samples: integer.format(result.sampleCount)
+    }))
+  )
+
+  console.log("\nIdle machine memory after forced GC\n")
+  console.table(
+    memory.flatMap((result) =>
+      result.points.map((point) => ({
+        Implementation: `${result.implementationLabel} ${result.implementationVersion}`,
+        Machines: integer.format(point.machines),
+        "Heap delta": formatBytes(point.heapDeltaBytes),
+        "Heap/machine": formatBytes(point.heapDeltaBytes / point.machines),
+        "RSS delta": formatBytes(point.rssDeltaBytes)
+      }))
+    )
+  )
+  for (const result of memory) {
+    console.log(
+      `${result.implementationLabel} heap slope: ${formatBytes(result.heapBytesPerIdleMachine)} per idle machine`
+    )
+    if (Number.isFinite(result.heapBytesPerIdleMachine) && result.heapBytesPerIdleMachine > 0) {
+      console.log(
+        `${result.implementationLabel} estimated idle capacity per GiB: ${integer.format(1_073_741_824 / result.heapBytesPerIdleMachine)} machines`
+      )
+    } else {
+      console.log(`${result.implementationLabel} estimated idle capacity per GiB: unavailable`)
+    }
+  }
+  console.log("RSS is an allocator-sensitive diagnostic; heap slope is the primary memory metric.")
+  if (options.output !== undefined) {
+    console.log(`\nJSON report written to ${options.output}`)
+  }
+  console.log("\nResults are informational. Compare runs made on the same machine and runtime configuration.")
+}


### PR DESCRIPTION
## Summary

- add repeatable local runtime benchmarks for planning, event drainage, lifecycle, and idle memory
- compare the compiled library with pinned XState 5 and XState 6 alpha baselines
- produce human-readable output and versioned JSON reports for future automation
- run base and pull request benchmarks three times on the same GitHub-hosted runner
- publish the median results through a read-only benchmark workflow and a separate trusted sticky-comment workflow

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] `pnpm perf:types`
- [ ] Relevant example checks, when examples changed — not applicable
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed — no public API change
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed — bootstrap job and artifact passed; sticky comments activate after the trusted workflow lands on `main`

<!--
The type-performance workflow posts and updates the base-versus-PR comparison automatically.
Do not copy a manually measured table into this description.
-->
