### PR TITLE
Reduce planner allocation overhead

### DIFF
--- a/.changeset/faster-planners-rest.md
+++ b/.changeset/faster-planners-rest.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Reduce runtime planner allocation overhead by reusing compiled schema decoders and state topology paths, deferring effect service allocation until it is needed, and avoiding unused snapshots.

--- a/src/internal/machineModel.ts
+++ b/src/internal/machineModel.ts
@@ -698,6 +698,22 @@ interface MachineProtocolSchemas {
   readonly emit: Schema.Top
 }
 
+type BoundaryDecoder = (value: unknown) => Effect.Effect<unknown, Schema.SchemaError, unknown>
+
+const boundaryDecoderCache = new WeakMap<object, BoundaryDecoder>()
+const pathToRootCache = new WeakMap<Machine.StateNodes, Map<string, ReadonlyArray<string>>>()
+
+const getBoundaryDecoder = (schema: Schema.Top): BoundaryDecoder => {
+  const key = schema as object
+  const cached = boundaryDecoderCache.get(key)
+  if (cached !== undefined) {
+    return cached
+  }
+  const decoder = Schema.decodeUnknownEffect(Schema.toType(schema)) as BoundaryDecoder
+  boundaryDecoderCache.set(key, decoder)
+  return decoder
+}
+
 const MachineProtocolTypeId = Symbol.for("effect/Machine/protocol")
 
 const getProtocolSchemas = (machine: Machine.Any): MachineProtocolSchemas => {
@@ -734,7 +750,7 @@ export const decodeBoundary = <A>(
   value: unknown,
   options: DecodeBoundaryOptions
 ): Effect.Effect<A, MachineSchemaDecodeError> =>
-  Schema.decodeUnknownEffect(Schema.toType(schema))(value).pipe(
+  getBoundaryDecoder(schema)(value).pipe(
     Effect.mapError((cause) =>
       new MachineSchemaDecodeError({
         machineId: machine.id,
@@ -829,12 +845,22 @@ export const isPathInSubtree = (path: string, ancestor: string): boolean =>
   path === ancestor || isDescendantOf(path, ancestor)
 
 export const getPathToRoot = (machine: Machine.Any, path: string): ReadonlyArray<string> => {
+  let pathsByLeaf = pathToRootCache.get(machine.stateNodes)
+  if (pathsByLeaf === undefined) {
+    pathsByLeaf = new Map()
+    pathToRootCache.set(machine.stateNodes, pathsByLeaf)
+  }
+  const cached = pathsByLeaf.get(path)
+  if (cached !== undefined) {
+    return cached
+  }
   const paths: Array<string> = []
   let current: string | undefined = path
   while (current !== undefined) {
     paths.unshift(current)
     current = getNode(machine, current).parent
   }
+  pathsByLeaf.set(path, paths)
   return paths
 }
 

--- a/src/internal/machinePlanner.ts
+++ b/src/internal/machinePlanner.ts
@@ -269,14 +269,24 @@ const collectStateAction = Effect.fnUntraced(function*<Context, Event, E, R>(
   handler: ((context: Context) => Machine.StateActionResult<E, R>) | undefined,
   context: Context
 ) {
-  const deferredActions = yield* makeDeferredActions
-  const deferredRaisedEvents = yield* makeDeferredRaisedEvents
-  if (handler !== undefined) {
-    const result = handler(context)
-    if (Effect.isEffect(result)) {
-      yield* provideDeferredServices(result, machine, deferredActions, deferredRaisedEvents)
+  if (handler === undefined) {
+    return {
+      actions: [] as ReadonlyArray<DeferredAction<E, R>>,
+      raisedEvents: [] as ReadonlyArray<Event>,
+      emittedEvents: [] as ReadonlyArray<unknown>
     }
   }
+  const result = handler(context)
+  if (!Effect.isEffect(result)) {
+    return {
+      actions: [] as ReadonlyArray<DeferredAction<E, R>>,
+      raisedEvents: [] as ReadonlyArray<Event>,
+      emittedEvents: [] as ReadonlyArray<unknown>
+    }
+  }
+  const deferredActions = yield* makeDeferredActions
+  const deferredRaisedEvents = yield* makeDeferredRaisedEvents
+  yield* provideDeferredServices(result, machine, deferredActions, deferredRaisedEvents)
   const actions = yield* deferredActions.read
   const raisedEvents = yield* deferredRaisedEvents.read
   const emittedEvents = yield* deferredRaisedEvents.readEmitted
@@ -298,12 +308,18 @@ const collectTransition = Effect.fnUntraced(function*<
   transition: TransitionHandler<States, E, R, Context>,
   context: Context
 ) {
+  const result = transition(context)
+  if (!Effect.isEffect(result)) {
+    return {
+      state: result,
+      actions: [] as ReadonlyArray<DeferredAction<E, R>>,
+      raisedEvents: [] as ReadonlyArray<Event>,
+      emittedEvents: [] as ReadonlyArray<unknown>
+    }
+  }
   const deferredActions = yield* makeDeferredActions
   const deferredRaisedEvents = yield* makeDeferredRaisedEvents
-  const result = transition(context)
-  const state = Effect.isEffect(result)
-    ? yield* provideDeferredServices(result, machine, deferredActions, deferredRaisedEvents)
-    : result
+  const state = yield* provideDeferredServices(result, machine, deferredActions, deferredRaisedEvents)
   const actions = yield* deferredActions.read
   const raisedEvents = yield* deferredRaisedEvents.read
   const emittedEvents = yield* deferredRaisedEvents.readEmitted
@@ -320,12 +336,18 @@ const collectStateInitializer = Effect.fnUntraced(function*(
   handler: (context: any) => unknown,
   context: any
 ) {
+  const result = handler(context)
+  if (!Effect.isEffect(result)) {
+    return {
+      value: result,
+      actions: [] as ReadonlyArray<DeferredAction>,
+      raisedEvents: [] as ReadonlyArray<unknown>,
+      emittedEvents: [] as ReadonlyArray<unknown>
+    }
+  }
   const deferredActions = yield* makeDeferredActions
   const deferredRaisedEvents = yield* makeDeferredRaisedEvents
-  const result = handler(context)
-  const value = Effect.isEffect(result)
-    ? yield* provideDeferredServices(result, machine, deferredActions, deferredRaisedEvents)
-    : result
+  const value = yield* provideDeferredServices(result, machine, deferredActions, deferredRaisedEvents)
   return {
     value,
     actions: yield* deferredActions.read,
@@ -2123,7 +2145,6 @@ const macrostep: <
   event: Machine.EventOf<Events>
 ) {
   const configuration = yield* normalizeConfigurationEffect<States>(machine, state)
-  const snapshot = snapshotFromConfiguration<States>(machine, configuration)
   const decodedEvent = yield* decodeEvent<Events>(machine, event)
   if (isActiveFinalConfiguration(machine, configuration)) {
     const completed = yield* completeConfigurationEffect(machine, configuration, decodedEvent)
@@ -2150,7 +2171,7 @@ const macrostep: <
   )
   if (selections.length === 0) {
     return {
-      next: snapshot,
+      next: snapshotFromConfiguration<States>(machine, configuration),
       actions: [],
       emittedEvents: [],
       microsteps: [],


### PR DESCRIPTION
## Summary

- cache schema boundary decoders and state-to-root topology paths with `WeakMap` ownership
- avoid allocating deferred Effect services for synchronous handlers
- materialize unchanged snapshots only on the unhandled-transition path
- preserve the public API and state-machine execution semantics

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (no examples changed)
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed (no public type changes; local `pnpm perf:types` passed)
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed

The local three-run median comparison against the merged `main` benchmark baseline showed a substantial improvement in planning and runtime throughput, with effectively unchanged idle-machine heap usage. The automated base-versus-PR report confirms the same direction on GitHub's runner: planning improved 38.5%, burst throughput improved 35.7%, start/stop improved 12.0%, and idle heap changed by -0.2%.
