### PR TITLE
Add conditional transition eligibility

### DIFF
--- a/.changeset/tidy-machines-delegate.md
+++ b/.changeset/tidy-machines-delegate.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Add typed `when` predicates to object-form event transitions. A false predicate rejects the child transition and continues normal hierarchical selection at ancestor states, while a selected transition returning `undefined` remains targetless and consumes the event. Conditional edges are exposed through machine inspection without evaluating predicates.

--- a/README.md
+++ b/README.md
@@ -428,6 +428,59 @@ runtime state later. `snapshot` is intentionally absent from entry, exit,
 invoke, and choice contexts. In particular, startup and chained choices may run
 before a complete stable snapshot containing their pseudo-source exists.
 
+### Conditional ancestor fallback
+
+Use ordinary TypeScript control flow when one selected handler owns the whole
+decision:
+
+```ts
+const handlers = {
+  on: {
+    Submit: ({ state, target }) =>
+      state.valid
+        ? target.local.Submitting.from()
+        : target.local.Invalid.from()
+  }
+}
+```
+
+An object-form event transition may instead declare `when` when a rejected
+child transition must let normal hierarchical selection continue at its
+ancestors:
+
+```ts
+Workspace: {
+  on: {
+    Close: ({ target }) => target.full.Closed.from()
+  },
+  states: {
+    Editing: {
+      on: {
+        Close: {
+          when: ({ state }) => state.dirty,
+          targets: ["Workspace.ConfirmClose"],
+          transition: ({ target }) => target.local.ConfirmClose.from()
+        }
+      }
+    }
+  }
+}
+```
+
+When `Editing` is dirty, its conditional transition intercepts `Close`. When it
+is clean, `when` returns `false`, the child transition is not selected, and the
+`Workspace` handler closes normally. By contrast, a selected transition whose
+`transition` returns `undefined` is targetless and still consumes the event.
+
+`when` receives only `state`, `parent`, `parents`, `event`, and the captured
+`snapshot`; it cannot target, raise, emit, stage actions, or access the managed
+runtime. It may return a boolean or an Effect producing a boolean. Treat that
+Effect as an observationally pure eligibility check: perform external work in
+the selected transition through `Machine.action`. `targets` remains optional,
+but declaring it makes the conditional edge visible to inspection and
+visualization. `Machine.transitionDefinitions` marks these edges with
+`conditional: true` without evaluating the predicate.
+
 Effect Schema annotations are the metadata source for active states. Annotate
 the schema itself; `Machine.stateNodes` exposes the resolved annotation map:
 
@@ -636,9 +689,11 @@ restoration.
 
 ## Current limits
 
-Declarative first-class guards are not part of the current API. Ordinary
-TypeScript conditions implement guards. Use `Machine.after` for a cancellable
-state-scoped delayed event.
+The library intentionally does not include general guard registries,
+combinators, or guarded transition arrays. Use ordinary TypeScript conditions
+for decisions local to one handler, choice states for explicit transient
+routing, and `when` only for conditional hierarchical fallback. Use
+`Machine.after` for a cancellable state-scoped delayed event.
 
 ## Guidance for agents and contributors
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -65,6 +65,9 @@ class methods or nominal class identity.
   transport boundary.
 - Return snapshots or typed target-builder results from transitions. Do not
   return raw decoded state values.
+- Use ordinary `if`/`else` inside a transition for decisions owned by that
+  handler. Use object-form `when` only when `false` must reject the child
+  transition and continue hierarchical selection at an ancestor.
 - Effects returned by handlers are planning Effects. Wrap external effects in
   `Machine.action`.
 - Put data on the narrowest state where it is valid. Put data shared by sibling
@@ -444,6 +447,39 @@ Submit: ({ target }) => Machine.action(writeAuditLog, target.local.Saving(new Sa
 `Machine.action(effect, next)` stages the same action and returns `next`, which
 is convenient when the transition does not otherwise need an Effect generator.
 
+### Conditional hierarchical selection
+
+Do not introduce `when` merely to replace ordinary control flow:
+
+```ts
+// Preferred: this handler owns both outcomes.
+Submit: ({ state, target }) =>
+  state.valid ? target.local.Ready.from() : target.local.Invalid.from()
+```
+
+Use `when` only when a nested state conditionally intercepts an event that an
+ancestor otherwise handles:
+
+```ts
+Editing: {
+  on: {
+    Close: {
+      when: ({ state }) => state.dirty,
+      targets: ["Workspace.ConfirmClose"],
+      transition: ({ target }) => target.local.ConfirmClose.from()
+    }
+  }
+}
+```
+
+`false` means this transition is ineligible, so selection continues toward the
+root. Once selected, returning `undefined` still means a targetless transition
+that consumes the event. A `when` predicate sees only read-only state, parent,
+parents, event, and snapshot data. It may use an Effect to read services, but it
+must be observationally pure; actions, emissions, raised events, and runtime
+operations belong in `transition`. Use a choice state instead when one
+already-selected transition needs explicit multi-destination routing.
+
 The managed runtime executes staged actions before publishing the planned
 state. If an action fails, it retains the previous state and suppresses planned
 emissions.
@@ -801,9 +837,10 @@ compiler resource or instantiation limits.
 
 The current API does not include:
 
-- declarative first-class guards;
+- guard registries, guard combinators, or guarded transition arrays;
 - a complete inspectable graph for arbitrary transition Effects.
 
-Use ordinary TypeScript conditions for guards and `Machine.after` for
-state-scoped timers. Do not invent undocumented state-node properties such as
-`guard`.
+Use ordinary TypeScript conditions for local decisions, `when` for conditional
+ancestor fallback, and `Machine.after` for state-scoped timers. Do not invent
+undocumented properties such as `guard` or add `when` to `always`, `onDone`, or
+choice transitions.

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -104,9 +104,10 @@ type IsAny<A> = 0 extends (1 & A) ? true : false
  *
  * **Gotchas**
  *
- * Declarative first-class guards are not part of the current API. Conditional
- * behavior can be expressed in typed handlers with ordinary TypeScript control
- * flow. Use `after` for cancellable state-scoped delayed events.
+ * Use ordinary TypeScript control flow for decisions owned by one handler.
+ * Object-form event transitions accept `when` only for the distinct case where
+ * a rejected child transition must let hierarchical selection continue at its
+ * ancestors. Use `after` for cancellable state-scoped delayed events.
  *
  * @category models
  * @since 4.0.0
@@ -2538,6 +2539,8 @@ export declare namespace Machine {
     readonly source: SourcePath
     readonly trigger: TransitionTrigger<EventTag>
     readonly reenter: boolean
+    /** Present when selection evaluates a `when` predicate before retaining this transition. */
+    readonly conditional?: true
     readonly targets: TransitionTargets<TargetPath>
   }
 
@@ -3620,6 +3623,39 @@ export declare namespace Machine {
   }
 
   /**
+   * Read-only context passed to an event transition's `when` predicate.
+   *
+   * A predicate only decides whether its transition participates in
+   * hierarchical selection. It cannot construct targets, stage actions, raise
+   * or emit events, or access the managed runtime. Returning `false` continues
+   * selection at ancestor states.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export type TransitionWhenContext<
+    States extends StateSchemas,
+    Events extends ReadonlyArray<TaggedSchema>,
+    StateId extends StateIdentifier<States>,
+    EventTag extends TagOf<Events[number]>
+  > = Pick<
+    HandlerContext<States, Events, readonly [], StateId, EventTag, never, never>,
+    "state" | "parent" | "parents" | "snapshot" | "event"
+  >
+
+  /** Predicate evaluated before an event transition is selected. */
+  export type TransitionWhen<
+    States extends StateSchemas,
+    Events extends ReadonlyArray<TaggedSchema>,
+    StateId extends StateIdentifier<States>,
+    EventTag extends TagOf<Events[number]>,
+    E,
+    R
+  > = (
+    context: TransitionWhenContext<States, Events, StateId, EventTag>
+  ) => boolean | Effect.Effect<boolean, E, R>
+
+  /**
    * Context passed to an entry or exit state handler.
    *
    * @category models
@@ -3987,6 +4023,14 @@ export declare namespace Machine {
       keyof On
     ]
     : never
+  /** Extracts the return values from event-transition eligibility predicates. */
+  export type EventWhenReturn<Config> = Config extends { readonly on?: infer On } ? {
+      readonly [EventTag in keyof On]: NonNullable<On[EventTag]> extends {
+        readonly when?: infer When
+      } ? NonNullable<When> extends (...args: any) => infer Ret ? Ret : never
+        : never
+    }[keyof On]
+    : never
   /**
    * Extracts the invoke config or configs from a state config.
    *
@@ -4124,6 +4168,7 @@ export declare namespace Machine {
    */
   export type ConfigServices<Config> =
     | Effect.Services<EventHandlerReturn<Config>>
+    | Effect.Services<EventWhenReturn<Config>>
     | Effect.Services<AlwaysReturn<Config>>
     | Effect.Services<DoneReturn<Config>>
     | Effect.Services<StateActionReturn<Config, "entry">>
@@ -4302,6 +4347,13 @@ export declare namespace Machine {
         ) => HandlerResult<States, any, any>)
         | {
           readonly reenter?: boolean
+          /**
+           * Makes this transition eligible for selection. Returning `false`
+           * continues normal hierarchical selection at ancestor states. Use
+           * ordinary control flow inside `transition` for decisions owned by
+           * this handler.
+           */
+          readonly when?: TransitionWhen<States, Events, StateId, EventTag, any, any>
           /**
            * Upper bound of state or history paths this handler may target.
            * Returning `void` is always permitted. Declaring a parent state also
@@ -4738,6 +4790,21 @@ export declare namespace Machine {
     }
     : unknown
 
+  type HandlerDirectWhenValidation<
+    StateId extends string,
+    Config,
+    Trigger extends "always" | "onDone",
+    Transition = Config extends { readonly [Key in Trigger]?: infer Value } ? NonNullable<Value> : never
+  > = Trigger extends keyof Config ? "when" extends keyof Transition ? {
+        readonly [Key in Trigger]: HandlerValidationError<
+          "Transition conditions are only supported for event handlers",
+          StateId,
+          Trigger
+        >
+      }
+    : unknown
+    : unknown
+
   type HandlerChildrenValidation<
     Node,
     Prefix extends string,
@@ -4811,6 +4878,8 @@ export declare namespace Machine {
         & HandlerOnTargetValidation<StateId, Config>
         & HandlerDirectTargetValidation<StateId, Config, "always">
         & HandlerDirectTargetValidation<StateId, Config, "onDone">
+        & HandlerDirectWhenValidation<StateId, Config, "always">
+        & HandlerDirectWhenValidation<StateId, Config, "onDone">
         & HandlerInvokeOutputValidation<Events, StateId, Config>
         & HandlerInvokeEmitsValidation<Events, StateId, Config>
         & HandlerInvokeSnapshotValidation<Events, StateId, Config>
@@ -4989,6 +5058,7 @@ export declare namespace Machine {
 
   type HandlerConfigError<Config> =
     | Effect.Error<EventHandlerReturn<Config>>
+    | Effect.Error<EventWhenReturn<Config>>
     | Effect.Error<AlwaysReturn<Config>>
     | Effect.Error<DoneReturn<Config>>
     | Effect.Error<StateActionReturn<Config, "entry">>
@@ -5147,6 +5217,7 @@ export declare namespace Machine {
       | ((context: HandlerContext<States, Events, Emits, StateId, EventTag, E, R>) => HandlerResult<States, E, R>)
       | {
         readonly reenter?: boolean
+        readonly when?: TransitionWhen<States, Events, StateId, EventTag, E, R>
         /** Statically declared upper bound of possible target paths. */
         readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
         readonly transition: (
@@ -5273,6 +5344,27 @@ const validateTransitionTargets = (
   }
 }
 
+const validateTransitionWhen = (
+  path: string,
+  trigger: PropertyKey,
+  transition: unknown,
+  allowed: boolean
+): void => {
+  if (typeof transition !== "object" || transition === null || !hasProperty(transition, "when")) {
+    return
+  }
+  if (!allowed) {
+    throw new Error(
+      `Machine transition for state "${path}" on "${String(trigger)}" cannot declare when`
+    )
+  }
+  if (typeof transition.when !== "function") {
+    throw new Error(
+      `Machine expected transition condition for state "${path}" on "${String(trigger)}" to be a function`
+    )
+  }
+}
+
 const flattenHandlers = (
   handlers: Record<PropertyKey, Machine.AnyStateConfig>,
   stateNodes: Machine.StateNodes,
@@ -5293,12 +5385,17 @@ const flattenHandlers = (
     const on = stateConfig.on
     if (typeof on === "object" && on !== null) {
       for (const event of Reflect.ownKeys(on)) {
-        validateTransitionTargets(stateNodes, path, event, (on as Record<PropertyKey, unknown>)[event])
+        const transition = (on as Record<PropertyKey, unknown>)[event]
+        validateTransitionTargets(stateNodes, path, event, transition)
+        validateTransitionWhen(path, event, transition, true)
       }
     }
     validateTransitionTargets(stateNodes, path, "always", stateConfig.always)
     validateTransitionTargets(stateNodes, path, "done", stateConfig.onDone)
     validateTransitionTargets(stateNodes, path, "choice", stateConfig.choice)
+    validateTransitionWhen(path, "always", stateConfig.always, false)
+    validateTransitionWhen(path, "done", stateConfig.onDone, false)
+    validateTransitionWhen(path, "choice", stateConfig.choice, false)
     const node = stateNodes.byPath.get(path)
     if (node?.type === "choice") {
       if (
@@ -6785,7 +6882,8 @@ export const stateNodes = <M extends Machine.Any>(
  * are followed by eventless and completion handlers. This function does not
  * execute handlers. Object-form event, eventless, and completion handlers with
  * a `targets` declaration expose those possible paths; handlers without one
- * remain dynamic.
+ * remain dynamic. Conditional event transitions are marked without evaluating
+ * their `when` predicate.
  *
  * @category getters
  * @since 4.0.0
@@ -6858,7 +6956,11 @@ export const configuration = <M extends Machine.Any>(
 }
 
 /**
- * Returns the event tags handled by the current state snapshot.
+ * Returns the potential event tags handled by the current state snapshot.
+ *
+ * Conditional transitions are included without evaluating their `when`
+ * predicates because this getter receives neither an event value nor Effect
+ * services.
  *
  * @category getters
  * @since 4.0.0

--- a/src/MachineTest.ts
+++ b/src/MachineTest.ts
@@ -852,6 +852,7 @@ export interface TransitionCoverageItem<
   readonly source: SourcePath
   readonly trigger: Machine.Machine.TransitionTrigger<EventTag>
   readonly reenter: boolean
+  readonly conditional?: true
   readonly targets: Machine.Machine.TransitionTargets<TargetPath>
 }
 
@@ -1126,6 +1127,7 @@ export const coverage = <M extends AnyMachine>(
       source: definition.source,
       trigger: definition.trigger,
       reenter: definition.reenter,
+      ...(definition.conditional === true ? { conditional: true as const } : {}),
       targets: definition.targets
     })
   )

--- a/src/internal/machineModel.ts
+++ b/src/internal/machineModel.ts
@@ -568,6 +568,9 @@ export const transitionDefinitions = (
         source: node.path,
         trigger: { type: "event", event },
         reenter: typeof handler === "object" && handler !== null && handler.reenter === true,
+        ...(typeof handler === "object" && handler !== null && typeof handler.when === "function"
+          ? { conditional: true as const }
+          : {}),
         targets: transitionTargets(handler)
       })
     }
@@ -735,7 +738,7 @@ export const decodeBoundary = <A>(
   options: DecodeBoundaryOptions
 ): Effect.Effect<A, MachineSchemaDecodeError> =>
   Schema.decodeUnknownEffect(Schema.toType(schema))(value).pipe(
-    Effect.mapError((cause) =>
+    Effect.mapError((cause: Schema.SchemaError) =>
       new MachineSchemaDecodeError({
         machineId: machine.id,
         boundary: options.boundary,

--- a/src/internal/machinePlanner.ts
+++ b/src/internal/machinePlanner.ts
@@ -239,12 +239,14 @@ type EventTransition<States extends Machine.StateSchemas, E, R, Context> =
   | TransitionHandler<States, E, R, Context>
   | {
     readonly reenter?: boolean
+    readonly when?: (context: any) => boolean | Effect.Effect<boolean, E, R>
     readonly targets?: ReadonlyArray<string>
     readonly transition: TransitionHandler<States, E, R, Context>
   }
 
 type MicrostepTransition<States extends Machine.StateSchemas, E, R, Context> = {
   readonly reenter: boolean
+  readonly when: ((context: any) => boolean | Effect.Effect<boolean, E, R>) | undefined
   readonly targets: ReadonlyArray<string> | undefined
   readonly transition: TransitionHandler<States, E, R, Context>
 }
@@ -256,9 +258,10 @@ const normalizeTransition = <States extends Machine.StateSchemas, E, R, Context>
     return undefined
   }
   return typeof transition === "function"
-    ? { reenter: false, targets: undefined, transition }
+    ? { reenter: false, when: undefined, targets: undefined, transition }
     : {
       reenter: transition.reenter === true,
+      when: transition.when,
       targets: transition.targets,
       transition: transition.transition
     }
@@ -694,6 +697,25 @@ const makeTransitionContext = <
   target: machine.makeTargetBuilder(path as StateId)
 })
 
+const makeTransitionWhenContext = <
+  const States extends Machine.StateSchemas,
+  const Events extends ReadonlyArray<Machine.TaggedSchema>,
+  StateId extends Machine.StateIdentifier<States>,
+  EventTag extends Machine.TagOf<Events[number]>
+>(
+  machine: Machine.Any,
+  configuration: ActiveConfiguration,
+  path: string,
+  event: Machine.EventByTag<Events, EventTag>,
+  snapshot: Machine.Snapshot<States>
+): Machine.TransitionWhenContext<States, Events, StateId, EventTag> => ({
+  state: getActiveValue(configuration, path) as Machine.StateByIdentifier<States, StateId>,
+  parent: getParentValue(machine, configuration, path) as Machine.ParentStateValue<States, StateId>,
+  parents: getParentValues(machine, configuration, path) as Machine.ParentStateValues<States, StateId>,
+  event,
+  snapshot
+})
+
 const makeDoneContext = <
   const States extends Machine.StateSchemas,
   const Events extends ReadonlyArray<Machine.TaggedSchema>,
@@ -886,7 +908,7 @@ const selectDoneTransitions = <
   return selected
 }
 
-const selectEventTransitions = <
+const selectEventTransitions = Effect.fnUntraced(function*<
   const States extends Machine.StateSchemas,
   const Events extends ReadonlyArray<Machine.TaggedSchema>,
   const Emits extends ReadonlyArray<Machine.TaggedSchema>,
@@ -896,14 +918,7 @@ const selectEventTransitions = <
   machine: Machine.Any,
   configuration: ActiveConfiguration,
   event: Machine.EventByTag<Events, Machine.TagOf<Events[number]>>
-): ReadonlyArray<
-  SelectedTransition<
-    States,
-    E,
-    R,
-    Machine.HandlerContext<States, Events, Emits, Machine.StateIdentifier<States>, Machine.TagOf<Events[number]>, E, R>
-  >
-> => {
+) {
   const selected: Array<
     SelectedTransition<
       States,
@@ -921,12 +936,51 @@ const selectEventTransitions = <
     >
   > = []
   const selectedSources = new Set<string>()
+  const eligibility = new Map<string, boolean>()
   let snapshot: Machine.Snapshot<States> | undefined
   const capturedSnapshot = () => snapshot ??= snapshotFromConfiguration<States>(machine, configuration)
   for (const leaf of getActiveLeafPaths(machine, configuration)) {
     for (const path of getLeafCandidatePaths(machine, leaf)) {
-      const transition = normalizeTransition(machine.handlers[path]?.on?.[event._tag])
+      const transition = normalizeTransition<
+        States,
+        E,
+        R,
+        Machine.HandlerContext<
+          States,
+          Events,
+          Emits,
+          Machine.StateIdentifier<States>,
+          Machine.TagOf<Events[number]>,
+          E,
+          R
+        >
+      >(machine.handlers[path]?.on?.[event._tag] as any)
       if (transition !== undefined) {
+        let eligible = eligibility.get(path)
+        if (eligible === undefined) {
+          if (transition.when === undefined) {
+            eligible = true
+          } else {
+            const result = transition.when(
+              makeTransitionWhenContext<
+                States,
+                Events,
+                Machine.StateIdentifier<States>,
+                Machine.TagOf<Events[number]>
+              >(machine, configuration, path, event, capturedSnapshot())
+            )
+            eligible = Effect.isEffect(result) ? yield* result : result
+            if (typeof eligible !== "boolean") {
+              throw new Error(
+                `Machine transition condition for state "${path}" on "${String(event._tag)}" must return a boolean`
+              )
+            }
+          }
+          eligibility.set(path, eligible)
+        }
+        if (!eligible) {
+          continue
+        }
         if (!selectedSources.has(path)) {
           selectedSources.add(path)
           selected.push({
@@ -961,7 +1015,7 @@ const selectEventTransitions = <
     }
   }
   return selected
-}
+})
 
 const getTargetNodePath = <const States extends Machine.StateSchemas>(
   target:
@@ -2051,7 +2105,7 @@ const settle: <
     // internal queue, so decoding it again here only repeats schema work.
     const raisedEvent = raisedEventValue
     currentEvent = raisedEvent
-    const raisedSelections = selectEventTransitions<States, Events, Emits, E, R>(
+    const raisedSelections = yield* selectEventTransitions<States, Events, Emits, E, R>(
       machine,
       currentState,
       raisedEvent as Machine.EventByTag<Events, Machine.TagOf<Events[number]>>
@@ -2143,7 +2197,7 @@ const macrostep: <
     }
   }
 
-  const selections = selectEventTransitions<States, Events, Emits, E, R>(
+  const selections = yield* selectEventTransitions<States, Events, Emits, E, R>(
     machine,
     configuration,
     decodedEvent as Machine.EventByTag<Events, Machine.TagOf<Events[number]>>

--- a/test/MachineWhen.test.ts
+++ b/test/MachineWhen.test.ts
@@ -1,0 +1,187 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Context, Effect, Schema } from "effect"
+import { FastCheck } from "effect/testing"
+import { Machine } from "../src/index.js"
+
+class Workspace extends Schema.TaggedClass<Workspace>("WhenWorkspace")("WhenWorkspace", {}) {}
+class Editing extends Schema.TaggedClass<Editing>("WhenEditing")("WhenEditing", {
+  dirty: Schema.Boolean
+}) {}
+class ConfirmClose extends Schema.TaggedClass<ConfirmClose>("WhenConfirmClose")("WhenConfirmClose", {}) {}
+class Closed extends Schema.TaggedClass<Closed>("WhenClosed")("WhenClosed", {}) {}
+class Close extends Schema.TaggedClass<Close>("WhenClose")("Close", {}) {}
+class BlockClose extends Schema.TaggedClass<BlockClose>("WhenBlockClose")("BlockClose", {}) {}
+
+const States = Machine.defineStates({
+  Workspace: {
+    schema: Workspace,
+    initial: "Editing",
+    states: {
+      Editing,
+      ConfirmClose
+    }
+  },
+  Closed
+})
+
+const snapshot = (dirty: boolean) =>
+  States.initial.Workspace(
+    new Workspace({}),
+    (workspace) => workspace.Editing(new Editing({ dirty }))
+  )
+
+const machine = Machine.make({
+  states: States.states,
+  events: [Close, BlockClose],
+  initial: () => snapshot(false)
+}).handle({
+  Workspace: {
+    on: {
+      Close: ({ target }) => target.full.Closed(new Closed({})),
+      BlockClose: ({ target }) => target.full.Closed(new Closed({}))
+    },
+    states: {
+      Editing: {
+        on: {
+          Close: {
+            when: ({ state }) => state.dirty,
+            targets: ["Workspace.ConfirmClose"],
+            transition: ({ target }) => target.local.ConfirmClose(new ConfirmClose({}))
+          },
+          BlockClose: {
+            when: ({ state }) => state.dirty,
+            targets: [],
+            transition: () => undefined
+          }
+        }
+      }
+    }
+  }
+})
+
+describe("Machine transition conditions", () => {
+  it.effect.prop(
+    "selects the child when true and otherwise continues at its ancestor",
+    { dirty: FastCheck.boolean() },
+    ({ dirty }) =>
+      Effect.gen(function*() {
+        const planned = yield* Machine.plan(machine, snapshot(dirty), new Close({}))
+        assert.strictEqual(planned.microsteps[0]?.transitions[0]?.source, dirty ? "Workspace.Editing" : "Workspace")
+        assert.strictEqual(
+          planned.next.path === "Closed" ? "Closed" : planned.next.state.path,
+          dirty ? "Workspace.ConfirmClose" : "Closed"
+        )
+      }),
+    { fastCheck: { numRuns: 100, seed: 84_031 } }
+  )
+
+  it.effect("keeps a selected targetless child transition distinct from a rejected condition", () =>
+    Effect.gen(function*() {
+      const consumed = yield* Machine.plan(machine, snapshot(true), new BlockClose({}))
+      assert.strictEqual(consumed.next.path, "Workspace")
+      if (consumed.next.path === "Workspace") {
+        assert.strictEqual(consumed.next.state.path, "Workspace.Editing")
+      }
+      assert.deepStrictEqual(consumed.microsteps[0]?.transitions, [{
+        source: "Workspace.Editing",
+        trigger: { type: "event", event: "BlockClose" },
+        reenter: false,
+        target: undefined,
+        resolvedTarget: undefined
+      }])
+
+      const delegated = yield* Machine.plan(machine, snapshot(false), new BlockClose({}))
+      assert.strictEqual(delegated.next.path, "Closed")
+      assert.strictEqual(delegated.microsteps[0]?.transitions[0]?.source, "Workspace")
+    }))
+
+  it.effect("evaluates an Effect condition and preserves its service requirement", () => {
+    class MayIntercept extends Context.Service<MayIntercept, boolean>()("test/MachineWhen/MayIntercept") {}
+    const effectful = Machine.make({
+      states: States.states,
+      events: [Close],
+      initial: () => snapshot(true)
+    }).handle({
+      Workspace: {
+        on: {
+          Close: ({ target }) => target.full.Closed(new Closed({}))
+        },
+        states: {
+          Editing: {
+            on: {
+              Close: {
+                when: () =>
+                  Effect.gen(function*() {
+                    return yield* MayIntercept
+                  }),
+                transition: ({ target }) => target.local.ConfirmClose(new ConfirmClose({}))
+              }
+            }
+          }
+        }
+      }
+    })
+
+    return Effect.gen(function*() {
+      const intercepted = yield* Machine.plan(effectful, snapshot(true), new Close({})).pipe(
+        Effect.provideService(MayIntercept, true)
+      )
+      assert.strictEqual(intercepted.next.path, "Workspace")
+      if (intercepted.next.path === "Workspace") {
+        assert.strictEqual(intercepted.next.state.path, "Workspace.ConfirmClose")
+      }
+
+      const delegated = yield* Machine.plan(effectful, snapshot(true), new Close({})).pipe(
+        Effect.provideService(MayIntercept, false)
+      )
+      assert.strictEqual(delegated.next.path, "Closed")
+    })
+  })
+
+  it("reports conditional transitions without evaluating them", () => {
+    assert.deepStrictEqual(
+      Machine.transitionDefinitions(machine).filter(({ conditional }) => conditional === true),
+      [
+        {
+          source: "Workspace.Editing",
+          trigger: { type: "event", event: "Close" },
+          reenter: false,
+          conditional: true,
+          targets: { type: "declared", paths: ["Workspace.ConfirmClose"] }
+        },
+        {
+          source: "Workspace.Editing",
+          trigger: { type: "event", event: "BlockClose" },
+          reenter: false,
+          conditional: true,
+          targets: { type: "declared", paths: [] }
+        }
+      ]
+    )
+  })
+
+  it("rejects malformed conditions at the handler boundary", () => {
+    assert.throws(
+      () =>
+        Machine.make({
+          states: States.states,
+          events: [Close],
+          initial: () => snapshot(false)
+        }).handle({
+          Workspace: {
+            states: {
+              Editing: {
+                on: {
+                  Close: {
+                    when: "not-a-function",
+                    transition: () => undefined
+                  }
+                }
+              }
+            }
+          }
+        } as any),
+      /expected transition condition.*to be a function/
+    )
+  })
+})

--- a/test/visualization/text.ts
+++ b/test/visualization/text.ts
@@ -32,6 +32,7 @@ interface TransitionDefinition {
       readonly type: "choice"
     }
   readonly reenter: boolean
+  readonly conditional?: true
   readonly targets:
     | {
       readonly type: "dynamic"
@@ -110,7 +111,9 @@ const triggerLabels = (definitions: ReadonlyArray<TransitionDefinition>): Readon
   const events = definitions.flatMap((definition) =>
     definition.trigger.type === "event" ?
       [
-        `${String(definition.trigger.event)}${definition.reenter ? " [reenter]" : ""}${targets(definition)}`
+        `${String(definition.trigger.event)}${definition.conditional ? " [when]" : ""}${
+          definition.reenter ? " [reenter]" : ""
+        }${targets(definition)}`
       ]
       : []
   )

--- a/typetest/MachineWhen.tst.ts
+++ b/typetest/MachineWhen.tst.ts
@@ -1,0 +1,152 @@
+import { Context, Data, Effect, Schema } from "effect"
+import { describe, expect, it } from "tstyche"
+import { Machine } from "../src/index.js"
+
+class Workspace extends Schema.TaggedClass<Workspace>("WhenTypeWorkspace")("Workspace", {}) {}
+class Editing extends Schema.TaggedClass<Editing>("WhenTypeEditing")("Editing", {
+  dirty: Schema.Boolean
+}) {}
+class ConfirmClose extends Schema.TaggedClass<ConfirmClose>("WhenTypeConfirmClose")("ConfirmClose", {}) {}
+class Closed extends Schema.TaggedClass<Closed>("WhenTypeClosed")("Closed", {}) {}
+class Close extends Schema.TaggedClass<Close>("WhenTypeClose")("Close", {}) {}
+
+const States = Machine.defineStates({
+  Workspace: {
+    schema: Workspace,
+    initial: "Editing",
+    states: {
+      Editing,
+      ConfirmClose
+    }
+  },
+  Closed
+})
+
+const base = Machine.make({
+  states: States.states,
+  events: [Close],
+  initial: () =>
+    States.initial.Workspace(
+      new Workspace({}),
+      (workspace) => workspace.Editing(new Editing({ dirty: false }))
+    )
+})
+
+describe("Machine transition conditions", () => {
+  it("exposes a read-only eligibility context and typed transition context", () => {
+    const complete = base.handle({
+      Workspace: {
+        states: {
+          Editing: {
+            on: {
+              Close: {
+                when: (context) => {
+                  expect(context.state).type.toBe<Editing>()
+                  expect(context.parent).type.toBe<Workspace>()
+                  expect(context.parents.Workspace).type.toBe<Workspace>()
+                  expect(context.event).type.toBe<Close>()
+                  expect(context.snapshot).type.toBe<Machine.Machine.Snapshot<typeof States.states>>()
+                  expect(context).type.not.toHaveProperty("target")
+                  expect(context).type.not.toHaveProperty("runtime")
+                  expect(context).type.not.toHaveProperty("raise")
+                  expect(context).type.not.toHaveProperty("emit")
+                  return context.state.dirty
+                },
+                transition: ({ target }) => target.local.ConfirmClose(new ConfirmClose({}))
+              }
+            }
+          }
+        }
+      }
+    })
+
+    expect(Machine.plan).type.toBeCallableWith(
+      complete,
+      States.initial.Workspace(
+        new Workspace({}),
+        (workspace) => workspace.Editing(new Editing({ dirty: false }))
+      ),
+      new Close({})
+    )
+  })
+
+  it("preserves Effect errors and services contributed by when", () => {
+    class Eligibility extends Context.Service<Eligibility, boolean>()("types/when/Eligibility") {}
+    class EligibilityError extends Data.TaggedError("EligibilityError")<{}> {}
+    const complete = base.handle({
+      Workspace: {
+        states: {
+          Editing: {
+            on: {
+              Close: {
+                when: Effect.fn(function*() {
+                  const eligible = yield* Eligibility
+                  if (Math.random() > 2) return yield* new EligibilityError()
+                  return eligible
+                }),
+                transition: ({ target }) => target.local.ConfirmClose(new ConfirmClose({}))
+              }
+            }
+          }
+        }
+      }
+    })
+
+    expect<Machine.Machine.Error<typeof complete>>().type.toBe<EligibilityError>()
+    expect<Machine.Machine.Services<typeof complete>>().type.toBe<Eligibility>()
+  })
+
+  it("rejects non-boolean predicates and keeps when event-only", () => {
+    expect(base.handle).type.not.toBeCallableWith({
+      Workspace: {
+        states: {
+          Editing: {
+            on: {
+              Close: {
+                when: () => "yes",
+                transition: () => undefined
+              }
+            }
+          }
+        }
+      }
+    })
+
+    expect(base.handle).type.not.toBeCallableWith({
+      Workspace: {
+        always: {
+          when: () => true,
+          transition: () => undefined
+        }
+      }
+    })
+
+    expect(base.handle).type.not.toBeCallableWith({
+      Workspace: {
+        onDone: {
+          when: () => true,
+          transition: () => undefined
+        }
+      }
+    })
+  })
+
+  it("keeps declared-target validation for conditional transitions", () => {
+    const target = base.makeTargetBuilder("Workspace.Editing")
+    expect(base.handle).type.not.toBeCallableWith({
+      Workspace: {
+        states: {
+          Editing: {
+            on: {
+              Close: {
+                when: () => true,
+                targets: ["Closed"],
+                transition: () => target.local.ConfirmClose(new ConfirmClose({}))
+              }
+            }
+          }
+        }
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- add typed `when` predicates to object-form event transitions so an ineligible child transition delegates normal selection to its ancestors
- keep eligibility Effect-native while restricting its context to read-only state, parent, parents, event, and snapshot data
- expose conditional edges to inspection, visualization, and transition coverage without evaluating predicates
- document the narrow intended use for humans and agents, including when ordinary control flow or choice states remain preferable
- add property-based runtime coverage and compile-time API/inference coverage

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [ ] Relevant example checks, when examples changed
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed (`pnpm perf:types` passed locally; CI comparison pending)
- [ ] Reviewed the automated runtime-performance report, when runtime behavior changed (CI comparison pending)
