### PR TITLE
Reduce managed runtime overhead

### DIFF
--- a/.changeset/lean-runtimes-rest.md
+++ b/.changeset/lean-runtimes-rest.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Reduce managed runtime memory and lifecycle overhead by removing redundant process coordination state, reusing the live runtime service, and allocating invoke management only for machines with invoke definitions.

--- a/src/internal/machineProcess.ts
+++ b/src/internal/machineProcess.ts
@@ -60,6 +60,20 @@ const getInvokes = (
   return Array.isArray(invokes) ? invokes as ReadonlyArray<AnyInvokeConfig> : [invokes as AnyInvokeConfig]
 }
 
+const invokeCapabilityCache = new WeakMap<Machine.Any, boolean>()
+
+const hasInvokeCapability = (machine: Machine.Any): boolean => {
+  const cached = invokeCapabilityCache.get(machine)
+  if (cached !== undefined) {
+    return cached
+  }
+  const hasInvokes = Object.values(
+    machine.handlers as Record<string, Machine.AnyStateConfig>
+  ).some((config) => config.invoke !== undefined)
+  invokeCapabilityCache.set(machine, hasInvokes)
+  return hasInvokes
+}
+
 const makeProcessLogic: <
   const States extends Machine.StateSchemas,
   const Events extends ReadonlyArray<Machine.TaggedSchema>,
@@ -107,8 +121,9 @@ const makeProcessLogic: <
 >(
   machine: Machine<States, Events, Input, UnhandledStates, E, R, InitialE, InitialR, FinalStates, Output, Emits>,
   entry: ProcessEntry<States, Input>
-) =>
-  ({
+) => {
+  const hasInvokes = hasInvokeCapability(machine)
+  return ({
     initial: (scope) =>
       internalRuntime.provideMachineRuntime(
         Effect.gen(function*() {
@@ -142,6 +157,47 @@ const makeProcessLogic: <
               initialState,
               internalPlanner.InitialEvent
             )
+          }
+
+          const liveRuntime = internalPlanner.makeLiveRuntime<Machine.EventOf<Events>, Machine.EmitOf<Emits>>(
+            machine,
+            context
+          )
+
+          if (!hasInvokes) {
+            yield* Effect.whileLoop({
+              while: () => terminal === undefined,
+              body: () =>
+                Effect.gen(function*() {
+                  const event = yield* receive
+                  const current = yield* state
+                  const planned = yield* internalPlanner.plan(machine, current, event)
+                  if (planned.microsteps.length === 0) {
+                    return yield* Effect.yieldNow
+                  }
+
+                  yield* internalPlanner.runActions(planned.actions, liveRuntime)
+                  yield* setState(planned.next)
+                  yield* internalPlanner.runEmittedEvents(
+                    planned.emittedEvents as ReadonlyArray<Machine.EmitOf<Emits>>,
+                    liveRuntime
+                  )
+
+                  if (planned.done) {
+                    terminal = { output: planned.output }
+                  } else {
+                    yield* Effect.yieldNow
+                  }
+                }),
+              step: () => undefined
+            })
+
+            if (terminal === undefined) {
+              return yield* Effect.die(
+                new Error("Machine process stopped receiving events before reaching a terminal configuration")
+              )
+            }
+            return terminal.output
           }
 
           const invokeSessions = yield* Ref.make<HashMap.HashMap<string, InvokeSession>>(
@@ -366,18 +422,14 @@ const makeProcessLogic: <
                     }
                   }
 
-                  const runtime = internalPlanner.makeLiveRuntime<Machine.EventOf<Events>, Machine.EmitOf<Emits>>(
-                    machine,
-                    context
-                  )
-                  yield* internalPlanner.runActions(planned.actions, runtime)
+                  yield* internalPlanner.runActions(planned.actions, liveRuntime)
                   if (changed) {
                     yield* stopInvokes(exitPaths)
                   }
                   yield* setState(planned.next)
                   yield* internalPlanner.runEmittedEvents(
                     planned.emittedEvents as ReadonlyArray<Machine.EmitOf<Emits>>,
-                    runtime
+                    liveRuntime
                   )
 
                   if (planned.done) {
@@ -425,6 +477,7 @@ const makeProcessLogic: <
     | StartupError
     | StoppedError
   >
+}
 
 export const toProcessLogic: <
   const States extends Machine.StateSchemas,

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -69,6 +69,7 @@ export type RuntimeSnapshot<State, Error = never, Output = never> =
 interface VersionedSnapshot<State, Error, Output> {
   readonly revision: number
   readonly snapshot: RuntimeSnapshot<State, Error, Output>
+  readonly terminalizing: boolean
 }
 
 export type RuntimeOutcome<State, Error = never, Output = never> =
@@ -253,25 +254,19 @@ export const watch = <State, Event, Error = never, Output = never>(
   )
 
 interface ProcessRuntime {
-  readonly close: (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<void>
   readonly nextSessionId: Effect.Effect<string>
-  readonly rootScope: Scope.Closeable
 }
 
-const makeProcessRuntime: Effect.Effect<ProcessRuntime> = Effect.gen(function*() {
+const makeProcessRuntime: Effect.Effect<ProcessRuntime> = Effect.sync(() => {
   let sessionIdCounter = 0
-  const rootScope = yield* Scope.make("parallel")
   return {
-    close: (exit) => Scope.close(rootScope, exit),
-    nextSessionId: Effect.sync(() => `machine:${sessionIdCounter++}`),
-    rootScope
+    nextSessionId: Effect.sync(() => `machine:${sessionIdCounter++}`)
   }
 })
 
 interface StartInternalOptions {
   readonly detached?: boolean
   readonly fiberScope?: Scope.Scope
-  readonly finalizer?: (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<void>
   readonly id?: string
   readonly onReady?: (ref: MachineRef<any, any, any, any>) => Effect.Effect<void>
   readonly onStop?: Effect.Effect<void>
@@ -309,12 +304,8 @@ const startInternal: <
   })
   const childrenScope = yield* Scope.make("parallel")
   const childRegistry = yield* SubscriptionRef.make<ChildRegistry>({ revision: 0, children: HashMap.empty() })
-  const currentChildrenScope = yield* SynchronizedRef.make<Scope.Closeable>(childrenScope)
 
-  const closeChildren = <A, E>(exit: Exit.Exit<A, E>): Effect.Effect<void> =>
-    SynchronizedRef.get(currentChildrenScope).pipe(
-      Effect.flatMap((scope) => Scope.close(scope, exit))
-    )
+  const closeChildren = <A, E>(exit: Exit.Exit<A, E>): Effect.Effect<void> => Scope.close(childrenScope, exit)
 
   const cleanupStartupFailure = <A, E>(exit: Exit.Exit<A, E>): Effect.Effect<void> =>
     Exit.isFailure(exit)
@@ -322,9 +313,6 @@ const startInternal: <
         Effect.ensuring(Deferred.succeed(terminalized, void 0))
       )
       : Effect.void
-
-  const finalize = (exit: Exit.Exit<unknown, unknown>): Effect.Effect<void> =>
-    options.finalizer === undefined ? Effect.void : options.finalizer(exit)
 
   const cleanup = options.onStop ?? Effect.void
 
@@ -479,18 +467,14 @@ const startInternal: <
     Exclude<ChildRequirements, Scope.Scope>
   > {
     if (spawnOptions?.id === undefined) {
-      return SynchronizedRef.get(currentChildrenScope).pipe(
-        Effect.flatMap((childrenScope) =>
-          Effect.acquireRelease(
-            startInternal(logic, {
-              fiberScope: childrenScope,
-              parent: self as MachineRef<unknown, unknown, unknown, unknown>,
-              runtime: options.runtime
-            }),
-            (child) => child.stop
-          ).pipe(Scope.provide(childrenScope))
-        )
-      ) as Effect.Effect<
+      return Effect.acquireRelease(
+        startInternal(logic, {
+          fiberScope: childrenScope,
+          parent: self as MachineRef<unknown, unknown, unknown, unknown>,
+          runtime: options.runtime
+        }),
+        (child) => child.stop
+      ).pipe(Scope.provide(childrenScope)) as Effect.Effect<
         MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>,
         ChildInitialError,
         Exclude<ChildRequirements, Scope.Scope>
@@ -498,38 +482,34 @@ const startInternal: <
     }
 
     const childId = spawnOptions.id
-    return SynchronizedRef.get(currentChildrenScope).pipe(
-      Effect.flatMap((childrenScope) =>
-        Effect.acquireRelease(
-          Effect.gen(function*() {
-            const token = Symbol()
-            yield* reserveChildId(childId, token)
-            const child = yield* startInternal(logic, {
-              fiberScope: childrenScope,
-              id: childId,
-              onReady: (child) =>
-                registerStartedChild(
-                  childId,
-                  token,
-                  child,
-                  spawnOptions.descriptor
-                ).pipe(Effect.asVoid),
-              onStop: unregisterChild(childId, token),
-              parent: self as ProcessAddress<unknown>,
-              runtime: options.runtime
-            }).pipe(
-              Effect.onExit((exit) =>
-                Exit.isFailure(exit)
-                  ? unregisterChild(childId, token)
-                  : Effect.void
-              )
-            )
-            return child
-          }),
-          (child) => child.stop
-        ).pipe(Scope.provide(childrenScope))
-      )
-    ) as Effect.Effect<
+    return Effect.acquireRelease(
+      Effect.gen(function*() {
+        const token = Symbol()
+        yield* reserveChildId(childId, token)
+        const child = yield* startInternal(logic, {
+          fiberScope: childrenScope,
+          id: childId,
+          onReady: (child) =>
+            registerStartedChild(
+              childId,
+              token,
+              child,
+              spawnOptions.descriptor
+            ).pipe(Effect.asVoid),
+          onStop: unregisterChild(childId, token),
+          parent: self as ProcessAddress<unknown>,
+          runtime: options.runtime
+        }).pipe(
+          Effect.onExit((exit) =>
+            Exit.isFailure(exit)
+              ? unregisterChild(childId, token)
+              : Effect.void
+          )
+        )
+        return child
+      }),
+      (child) => child.stop
+    ).pipe(Scope.provide(childrenScope)) as Effect.Effect<
       MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>,
       ChildAlreadyExistsError | ChildInitialError,
       Exclude<ChildRequirements, Scope.Scope>
@@ -575,12 +555,12 @@ const startInternal: <
   )
   const current = yield* SynchronizedRef.make<VersionedSnapshot<State, Error, Output>>({
     revision: 0,
+    terminalizing: false,
     snapshot: {
       status: "active",
       state: initial
     }
   })
-  const terminalizing = yield* Ref.make(false)
   const publishSnapshot = (
     snapshot: VersionedSnapshot<State, Error, Output>
   ): Effect.Effect<VersionedSnapshot<State, Error, Output>> =>
@@ -625,25 +605,22 @@ const startInternal: <
     SynchronizedRef.modifyEffect(
       current,
       (current) =>
-        Ref.get(terminalizing).pipe(
-          Effect.flatMap((isTerminalizing) =>
-            isTerminalizing
-              ? Effect.succeed([undefined, current] as const)
-              : Effect.map(
-                f(current.snapshot),
-                (next) => {
-                  if (next === undefined) {
-                    return [undefined, current] as const
-                  }
-                  const versioned = {
-                    revision: current.revision + 1,
-                    snapshot: next
-                  }
-                  return [versioned, versioned] as const
-                }
-              )
+        current.terminalizing
+          ? Effect.succeed([undefined, current] as const)
+          : Effect.map(
+            f(current.snapshot),
+            (next) => {
+              if (next === undefined) {
+                return [undefined, current] as const
+              }
+              const versioned = {
+                revision: current.revision + 1,
+                snapshot: next,
+                terminalizing: false
+              }
+              return [versioned, versioned] as const
+            }
           )
-        )
     ).pipe(
       Effect.flatMap((versioned) => versioned === undefined ? Effect.succeed(undefined) : publishIfCurrent(versioned)),
       Effect.map((published) => published?.snapshot)
@@ -654,25 +631,21 @@ const startInternal: <
       snapshot: Extract<RuntimeSnapshot<State, Error, Output>, { readonly status: "active" }>
     ) => RuntimeSnapshot<State, Error, Output>
   ): Effect.Effect<RuntimeSnapshot<State, Error, Output> | undefined> =>
-    SynchronizedRef.modifyEffect(
+    SynchronizedRef.modify(
       current,
-      (current) =>
-        Ref.get(terminalizing).pipe(
-          Effect.flatMap((isTerminalizing): Effect.Effect<SnapshotModification> => {
-            if (isTerminalizing || current.snapshot.status !== "active") {
-              return Effect.succeed([undefined, current] as SnapshotModification)
-            }
-            return Ref.set(terminalizing, true).pipe(
-              Effect.as([
-                {
-                  revision: current.revision + 1,
-                  snapshot: f(current.snapshot)
-                },
-                current
-              ] as SnapshotModification)
-            )
-          })
-        )
+      (current): SnapshotModification => {
+        if (current.terminalizing || current.snapshot.status !== "active") {
+          return [undefined, current]
+        }
+        return [
+          {
+            revision: current.revision + 1,
+            snapshot: f(current.snapshot),
+            terminalizing: true
+          },
+          { ...current, terminalizing: true }
+        ]
+      }
     ).pipe(Effect.map((versioned) => versioned?.snapshot))
 
   const setAndPublishSnapshot = (
@@ -680,7 +653,8 @@ const startInternal: <
   ): Effect.Effect<void> =>
     SynchronizedRef.updateAndGet(current, (current) => ({
       revision: current.revision + 1,
-      snapshot
+      snapshot,
+      terminalizing: true
     })).pipe(
       Effect.flatMap(publishSnapshot),
       Effect.flatMap(completeIfTerminal),
@@ -709,7 +683,6 @@ const startInternal: <
         Effect.andThen(closeChildren(exit)),
         Effect.andThen(setAndPublishSnapshot(snapshot)),
         Effect.andThen(cleanup),
-        Effect.andThen(finalize(exit)),
         Effect.andThen(completeDone),
         Effect.ensuring(Deferred.succeed(terminalized, void 0))
       )
@@ -950,14 +923,12 @@ export const startProcess: <
     options === undefined
       ? {
         detached: true,
-        finalizer: runtime.close,
         runtime
       }
       : {
         ...options,
         detached: true,
-        finalizer: runtime.close,
         runtime
       }
-  ).pipe(Effect.onExit((exit) => Exit.isFailure(exit) ? runtime.close(exit) : Effect.void))
+  )
 })


### PR DESCRIPTION
## Summary

- skip invoke-registry allocation and invoke-management closures for machines without invoke definitions
- reuse one live runtime service for the lifetime of a running machine
- remove an unused root scope and a synchronized wrapper around the immutable child scope
- consolidate terminalization state into the already synchronized runtime snapshot

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (no examples changed)
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed (no public type changes; local `pnpm perf:types` passed)
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed

Local repeated-process measurements against merged `main` reduced idle heap per machine by 13.8%. An interleaved A/B run kept burst throughput effectively flat while improving start/stop throughput by 20.8%. The automated CI comparison confirms the result: idle heap improved 13.9%, start/stop throughput improved 35.2%, burst throughput improved 4.1%, and planning remained flat at +0.3%. The 181 machine runtime tests also passed three additional consecutive stress runs.
