### PR TITLE
Allocate child runtime resources lazily

### DIFF
--- a/.changeset/lazy-children-rest.md
+++ b/.changeset/lazy-children-rest.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Allocate child process scopes and observable child registries only when a machine uses child-management capabilities.

--- a/.github/workflows/runtime-performance.yml
+++ b/.github/workflows/runtime-performance.yml
@@ -14,7 +14,7 @@ jobs:
   runtime-performance:
     name: runtime-performance
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Check out base
         uses: actions/checkout@v7
@@ -46,8 +46,7 @@ jobs:
           pnpm --dir head install --frozen-lockfile
           pnpm --dir head build
 
-      - name: Install and build base when benchmarkable
-        if: ${{ hashFiles('base/scripts/runtime-performance.mjs') != '' }}
+      - name: Install and build base
         run: |
           pnpm --dir base install --frozen-lockfile
           pnpm --dir base build
@@ -57,6 +56,7 @@ jobs:
         run: |
           set -euo pipefail
           reports="$RUNNER_TEMP/runtime-performance"
+          harness="$GITHUB_WORKSPACE/head/scripts/runtime-performance.mjs"
           mkdir -p "$reports/base" "$reports/head"
 
           measure() {
@@ -64,22 +64,20 @@ jobs:
             local output="$2"
             (
               cd "$checkout"
-              node --expose-gc scripts/runtime-performance.mjs --json
+              EFFECT_MACHINE_BENCHMARK_ROOT="$PWD" node --expose-gc "$harness" --json
             ) > "$output"
           }
 
-          if [[ -f base/scripts/runtime-performance.mjs ]]; then
-            measure base "$reports/base/1.json"
-            measure head "$reports/head/1.json"
-            measure head "$reports/head/2.json"
-            measure base "$reports/base/2.json"
-            measure base "$reports/base/3.json"
-            measure head "$reports/head/3.json"
-          else
-            measure head "$reports/head/1.json"
-            measure head "$reports/head/2.json"
-            measure head "$reports/head/3.json"
-          fi
+          measure base "$reports/base/1.json"
+          measure head "$reports/head/1.json"
+          measure head "$reports/head/2.json"
+          measure base "$reports/base/2.json"
+          measure base "$reports/base/3.json"
+          measure head "$reports/head/3.json"
+          measure head "$reports/head/4.json"
+          measure base "$reports/base/4.json"
+          measure base "$reports/base/5.json"
+          measure head "$reports/head/5.json"
 
           node head/scripts/compare-runtime-performance.mjs \
             "$reports/base" \

--- a/perf/runtime/README.md
+++ b/perf/runtime/README.md
@@ -11,8 +11,12 @@ The command reports:
 
 - pure `Machine.plan` counter-transition throughput;
 - end-to-end useful-increment throughput for a burst sent to one running machine;
+- the same running burst while a consumer drains every published snapshot;
+- repeated child lookup and delivery to one running child;
 - machine start-and-stop throughput;
-- idle heap and resident-memory growth at 100, 500, and 1,000 live machines.
+- parent-with-child start-and-stop throughput;
+- heap and resident-memory growth for both idle machines and idle parents with
+  one child, at 100, 500, and 1,000 live units.
 
 The comparison dependencies use package aliases, so XState 5 and 6 can be
 loaded by the same process:
@@ -68,12 +72,15 @@ pnpm perf:runtime -- --output runtime-performance.json
 Prefer `--output` for scripts: pnpm and the preceding build may add their own
 lines to standard output before `--json` is printed.
 
-Pull requests run the suite three times for both the base and pull request
-revisions on the same GitHub-hosted runner. The workflow publishes the median
-of those process-level results to the job summary and a sticky pull request
-comment. The benchmark workflow has read-only repository access; a separate
-trusted `workflow_run` workflow validates the uploaded JSON before receiving
-permission to update the comment.
+Pull requests run the pull request's benchmark harness five times against both
+the base and pull request library revisions on the same GitHub-hosted runner.
+Using one harness revision means a newly added scenario can compare both
+implementations immediately. The runs are interleaved to reduce time-dependent
+machine drift. The workflow publishes the process-level median and its median
+absolute deviation to the job summary and a sticky pull request comment. The
+benchmark workflow has read-only repository access; a separate trusted
+`workflow_run` workflow validates the uploaded JSON before receiving permission
+to update the comment.
 
 The implementation lives in `scripts/runtime-performance.mjs`; the Effect
 Machine fixture is in `perf/runtime/counter.mjs`, and the comparison adapter is

--- a/perf/runtime/counter.mjs
+++ b/perf/runtime/counter.mjs
@@ -1,5 +1,17 @@
-import { Effect, Schema } from "effect"
-import { Machine } from "../../dist/index.js"
+import { readFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const implementationRoot = resolve(
+  process.env.EFFECT_MACHINE_BENCHMARK_ROOT ?? fileURLToPath(new URL("../..", import.meta.url))
+)
+const implementationRequire = createRequire(pathToFileURL(join(implementationRoot, "package.json")))
+const effectPackagePath = implementationRequire.resolve("effect/package.json")
+const effectPackage = JSON.parse(readFileSync(effectPackagePath, "utf8"))
+const effect = await import(pathToFileURL(resolve(dirname(effectPackagePath), effectPackage.exports["."])).href)
+const { Machine } = await import(pathToFileURL(join(implementationRoot, "dist/index.js")).href)
+const { Effect, Fiber, Option, Schema, Stream } = effect
 
 const CounterState = Schema.TaggedUnion({
   Count: {
@@ -42,6 +54,20 @@ export const counterMachine = Machine.make({
   }
 })
 
+const ParentState = Schema.TaggedUnion({ Active: {} })
+const ParentStates = Machine.defineStates({ Active: ParentState.cases.Active })
+const CounterChild = Machine.child("counter", counterMachine)
+const counterParentMachine = Machine.make({
+  id: "RuntimeBenchmarkCounterParent",
+  states: ParentStates.states,
+  events: [],
+  initial: () => ParentStates.initial.Active(ParentState.cases.Active.make({}))
+}).handle({
+  Active: {
+    invoke: Machine.invokeMachine({ child: CounterChild })
+  }
+})
+
 export const incrementEvent = CounterEvent.cases.Increment.make({})
 const finishEvent = CounterEvent.cases.Finish.make({})
 
@@ -66,6 +92,76 @@ export const planCounterBatch = (size) => {
 export const startCounter = () => Effect.runPromise(Machine.start(counterMachine))
 
 export const stopCounter = (ref) => Effect.runPromise(ref.stop)
+
+export const startObservedCounter = () =>
+  Effect.runPromise(
+    Effect.gen(function*() {
+      const ref = yield* Machine.start(counterMachine)
+      const observer = yield* ref.changes.pipe(Stream.runDrain, Effect.forkDetach)
+      yield* Effect.yieldNow
+      return { ref, observer }
+    })
+  )
+
+export const stopObservedCounter = ({ ref, observer }) =>
+  Effect.runPromise(
+    ref.stop.pipe(Effect.ensuring(Fiber.interrupt(observer)))
+  )
+
+export const runObservedCounterBurst = ({ ref, observer }, size) =>
+  Effect.runPromise(
+    Effect.gen(function*() {
+      for (let index = 0; index < size; index += 1) {
+        yield* ref.send(incrementEvent)
+      }
+      yield* ref.send(finishEvent)
+      const value = yield* ref.join
+      yield* Fiber.join(observer)
+      return value
+    })
+  )
+
+const waitForCounterChild = (parent) =>
+  Effect.gen(function*() {
+    for (let attempt = 0; attempt < 1_000; attempt += 1) {
+      const child = yield* parent.child(CounterChild)
+      if (Option.isSome(child)) {
+        return child.value
+      }
+      yield* Effect.yieldNow
+    }
+    return yield* Effect.dieMessage("Effect Machine child did not become ready")
+  })
+
+export const startChildCounter = () =>
+  Effect.runPromise(
+    Effect.gen(function*() {
+      const parent = yield* Machine.start(counterParentMachine)
+      yield* waitForCounterChild(parent)
+      return parent
+    })
+  )
+
+export const stopChildCounter = (parent) => Effect.runPromise(parent.stop)
+
+export const runChildCounterBurst = (parent, size) =>
+  Effect.runPromise(
+    Effect.gen(function*() {
+      for (let index = 0; index < size; index += 1) {
+        const child = yield* parent.child(CounterChild)
+        if (Option.isNone(child)) {
+          return yield* Effect.dieMessage("Effect Machine child disappeared during the benchmark")
+        }
+        yield* child.value.send(incrementEvent)
+      }
+      const child = yield* parent.child(CounterChild)
+      if (Option.isNone(child)) {
+        return yield* Effect.dieMessage("Effect Machine child disappeared before the terminal fence")
+      }
+      yield* child.value.send(finishEvent)
+      return yield* child.value.join
+    })
+  )
 
 export const runCounterBurst = (ref, size) =>
   Effect.runPromise(
@@ -95,6 +191,22 @@ export const stopCounters = (refs) =>
     })
   )
 
+export const startChildCounters = (count) =>
+  Effect.runPromise(
+    Effect.forEach(
+      Array.from({ length: count }),
+      () =>
+        Effect.gen(function*() {
+          const parent = yield* Machine.start(counterParentMachine)
+          yield* waitForCounterChild(parent)
+          return parent
+        }),
+      { concurrency: 1 }
+    )
+  )
+
+export const stopChildCounters = stopCounters
+
 export const effectMachineAdapter = {
   implementation: "effect-machine",
   label: "Effect Machine",
@@ -102,6 +214,8 @@ export const effectMachineAdapter = {
   async: true,
   planCounterBatch,
   runCounterBurst,
+  runObservedCounterBurst,
+  runChildCounterBurst,
   runLifecycle: async () => {
     const ref = await startCounter()
     try {
@@ -112,8 +226,24 @@ export const effectMachineAdapter = {
       await stopCounter(ref)
     }
   },
+  runChildLifecycle: async () => {
+    const parent = await startChildCounter()
+    try {
+      if (!parent.sessionId.startsWith("machine:")) {
+        throw new Error(`Child lifecycle benchmark produced invalid session id ${parent.sessionId}`)
+      }
+    } finally {
+      await stopChildCounter(parent)
+    }
+  },
   startCounter,
+  startObservedCounter,
+  startChildCounter,
   startCounters,
+  startChildCounters,
   stopCounter,
+  stopChildCounter,
+  stopChildCounters,
+  stopObservedCounter,
   stopCounters
 }

--- a/perf/runtime/implementations.mjs
+++ b/perf/runtime/implementations.mjs
@@ -1,14 +1,19 @@
 import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
 import * as XStateV5 from "xstate-v5"
 import * as XStateV6 from "xstate-v6"
 import { effectMachineAdapter } from "./counter.mjs"
 import { makeXStateAdapter } from "./xstate.mjs"
 
 const readPackageVersion = (path) => JSON.parse(readFileSync(path, "utf8")).version
+const implementationRoot = resolve(
+  process.env.EFFECT_MACHINE_BENCHMARK_ROOT ?? fileURLToPath(new URL("../..", import.meta.url))
+)
 
 export const packageVersions = {
-  effectMachine: readPackageVersion(new URL("../../package.json", import.meta.url)),
-  effect: readPackageVersion(new URL("../../node_modules/effect/package.json", import.meta.url)),
+  effectMachine: readPackageVersion(resolve(implementationRoot, "package.json")),
+  effect: readPackageVersion(resolve(implementationRoot, "node_modules/effect/package.json")),
   tinybench: readPackageVersion(new URL("../../node_modules/tinybench/package.json", import.meta.url)),
   xstateV5: readPackageVersion(new URL("../../node_modules/xstate-v5/package.json", import.meta.url)),
   xstateV6: readPackageVersion(new URL("../../node_modules/xstate-v6/package.json", import.meta.url))

--- a/perf/runtime/memory-worker.mjs
+++ b/perf/runtime/memory-worker.mjs
@@ -8,10 +8,31 @@ if (typeof globalThis.gc !== "function") {
 
 const implementationId = process.argv[2]
 const counts = JSON.parse(process.argv[3] ?? "[]")
+const profileId = process.argv[4] ?? "idle"
 const implementation = implementations.find((candidate) => candidate.implementation === implementationId)
 
 if (implementation === undefined) {
   throw new Error(`Unknown runtime benchmark implementation: ${implementationId}`)
+}
+
+const profile = profileId === "idle"
+  ? {
+    id: "idle",
+    label: "Idle machine",
+    start: implementation.startCounters,
+    stop: implementation.stopCounters
+  }
+  : profileId === "parent-with-child"
+  ? {
+    id: "parent-with-child",
+    label: "Idle parent with one child",
+    start: implementation.startChildCounters,
+    stop: implementation.stopChildCounters
+  }
+  : undefined
+
+if (profile === undefined) {
+  throw new Error(`Unknown runtime memory profile: ${profileId}`)
 }
 
 const collectGarbage = async () => {
@@ -35,8 +56,8 @@ const linearSlope = (points, value) => {
 }
 
 // Trigger implementation-specific lazy initialization before taking the baseline.
-const warmup = await implementation.startCounter()
-await implementation.stopCounter(warmup)
+const warmup = await profile.start(1)
+await profile.stop(warmup)
 await collectGarbage()
 
 const baseline = process.memoryUsage()
@@ -45,7 +66,7 @@ const refs = []
 
 try {
   for (const count of counts) {
-    refs.push(...await implementation.startCounters(count - refs.length))
+    refs.push(...await profile.start(count - refs.length))
     await collectGarbage()
     const usage = process.memoryUsage()
     points.push({
@@ -57,7 +78,7 @@ try {
     })
   }
 } finally {
-  await implementation.stopCounters(refs)
+  await profile.stop(refs)
   await collectGarbage()
 }
 
@@ -65,6 +86,8 @@ process.stdout.write(JSON.stringify({
   implementation: implementation.implementation,
   implementationLabel: implementation.label,
   implementationVersion: implementation.version,
+  id: profile.id,
+  label: profile.label,
   baseline: {
     heapUsedBytes: baseline.heapUsed,
     rssBytes: baseline.rss

--- a/perf/runtime/xstate.mjs
+++ b/perf/runtime/xstate.mjs
@@ -27,6 +27,18 @@ export const makeXStateAdapter = (options) => {
       done: { type: "final" }
     }
   })
+  const parentMachine = xstate.createMachine({
+    id: `RuntimeBenchmarkCounterParent-${implementation}`,
+    initial: "active",
+    states: {
+      active: {
+        invoke: {
+          id: "counter",
+          src: machine
+        }
+      }
+    }
+  })
   const initialSnapshot = xstate.initialTransition(machine)[0]
 
   const planCounterBatch = (size) => {
@@ -40,6 +52,37 @@ export const makeXStateAdapter = (options) => {
   const startCounter = () => xstate.createActor(machine).start()
   const stopCounter = (actor) => actor.stop()
 
+  const startObservedCounter = () => {
+    const actor = xstate.createActor(machine)
+    let observed
+    let complete
+    const completion = new Promise((resolve) => {
+      complete = resolve
+    })
+    const subscription = actor.subscribe({
+      next: (snapshot) => {
+        observed = snapshot
+      },
+      complete
+    })
+    actor.start()
+    return { actor, completion, getObserved: () => observed, subscription }
+  }
+  const stopObservedCounter = ({ actor, subscription }) => {
+    actor.stop()
+    subscription.unsubscribe()
+  }
+
+  const startChildCounter = () => {
+    const parent = xstate.createActor(parentMachine).start()
+    if (parent.getSnapshot().children.counter === undefined) {
+      parent.stop()
+      throw new Error(`${label} child did not become ready`)
+    }
+    return parent
+  }
+  const stopChildCounter = (parent) => parent.stop()
+
   const runCounterBurst = (actor, size) => {
     for (let index = 0; index < size; index += 1) {
       actor.send(incrementEvent)
@@ -48,6 +91,39 @@ export const makeXStateAdapter = (options) => {
     const snapshot = actor.getSnapshot()
     if (snapshot.status !== "done") {
       throw new Error(`${label} terminal fence produced status ${snapshot.status}`)
+    }
+    return snapshot.context.value
+  }
+
+  const runObservedCounterBurst = async ({ actor, completion, getObserved }, size) => {
+    for (let index = 0; index < size; index += 1) {
+      actor.send(incrementEvent)
+    }
+    actor.send(finishEvent)
+    await completion
+    const snapshot = getObserved()
+    if (snapshot?.status !== "done") {
+      throw new Error(`${label} observed terminal fence produced status ${snapshot?.status}`)
+    }
+    return snapshot.context.value
+  }
+
+  const runChildCounterBurst = (parent, size) => {
+    for (let index = 0; index < size; index += 1) {
+      const child = parent.getSnapshot().children.counter
+      if (child === undefined) {
+        throw new Error(`${label} child disappeared during the benchmark`)
+      }
+      child.send(incrementEvent)
+    }
+    const child = parent.getSnapshot().children.counter
+    if (child === undefined) {
+      throw new Error(`${label} child disappeared before the terminal fence`)
+    }
+    child.send(finishEvent)
+    const snapshot = child.getSnapshot()
+    if (snapshot.status !== "done") {
+      throw new Error(`${label} child terminal fence produced status ${snapshot.status}`)
     }
     return snapshot.context.value
   }
@@ -61,6 +137,18 @@ export const makeXStateAdapter = (options) => {
       }
     } finally {
       stopCounter(actor)
+    }
+  }
+
+  const runChildLifecycle = () => {
+    const parent = startChildCounter()
+    try {
+      const child = parent.getSnapshot().children.counter
+      if (child === undefined || child.getSnapshot().status !== "active") {
+        throw new Error(`${label} child lifecycle benchmark produced an invalid initial snapshot`)
+      }
+    } finally {
+      stopChildCounter(parent)
     }
   }
 
@@ -78,6 +166,16 @@ export const makeXStateAdapter = (options) => {
     }
   }
 
+  const startChildCounters = (count) => {
+    const actors = []
+    for (let index = 0; index < count; index += 1) {
+      actors.push(startChildCounter())
+    }
+    return actors
+  }
+
+  const stopChildCounters = stopCounters
+
   return {
     implementation,
     label,
@@ -85,10 +183,19 @@ export const makeXStateAdapter = (options) => {
     async: false,
     planCounterBatch,
     runCounterBurst,
+    runChildCounterBurst,
+    runChildLifecycle,
     runLifecycle,
+    runObservedCounterBurst,
     startCounter,
+    startChildCounter,
     startCounters,
+    startChildCounters,
+    startObservedCounter,
     stopCounter,
-    stopCounters
+    stopChildCounter,
+    stopChildCounters,
+    stopCounters,
+    stopObservedCounter
   }
 }

--- a/scripts/compare-runtime-performance.mjs
+++ b/scripts/compare-runtime-performance.mjs
@@ -79,6 +79,37 @@ const validateReport = (report, path) => {
         throw new Error(`Invalid runtime-performance memory point: ${path}`)
       }
     }
+    if (measurement.profiles !== undefined) {
+      if (!Array.isArray(measurement.profiles) || measurement.profiles.length === 0 || measurement.profiles.length > 10) {
+        throw new Error(`Invalid runtime-performance memory profiles: ${path}`)
+      }
+      const profileIds = new Set()
+      for (const profile of measurement.profiles) {
+        if (
+          profile.implementation !== measurement.implementation ||
+          !isShortString(profile.id, 100) ||
+          !isShortString(profile.label, 200) ||
+          !isBoundedNumber(profile.heapBytesPerIdleMachine) ||
+          profile.heapBytesPerIdleMachine < 0 ||
+          !Array.isArray(profile.points) ||
+          profile.points.length > 20 ||
+          profileIds.has(profile.id)
+        ) {
+          throw new Error(`Invalid runtime-performance memory profile: ${path}`)
+        }
+        for (const point of profile.points) {
+          if (
+            !Number.isSafeInteger(point.machines) ||
+            point.machines < 0 ||
+            !isBoundedNumber(point.heapDeltaBytes) ||
+            !isBoundedNumber(point.rssDeltaBytes)
+          ) {
+            throw new Error(`Invalid runtime-performance memory profile point: ${path}`)
+          }
+        }
+        profileIds.add(profile.id)
+      }
+    }
     memoryKeys.add(measurement.implementation)
   }
 }
@@ -123,6 +154,11 @@ const median = (values) => {
     : sorted[middle]
 }
 
+const relativeMedianAbsoluteDeviation = (values) => {
+  const center = median(values)
+  return center === 0 ? 0 : median(values.map((value) => Math.abs(value - center))) / center * 100
+}
+
 const assertConsistentRuns = (reports, label) => {
   const first = reports[0]
   const configuration = JSON.stringify(first.configuration)
@@ -130,6 +166,9 @@ const assertConsistentRuns = (reports, label) => {
     `${benchmark.implementation}\u0000${benchmark.id}\u0000${benchmark.unit}`
   ).sort().join("\u0001")
   const memoryKeys = first.memory.map((measurement) => measurement.implementation).sort().join("\u0001")
+  const memoryProfileKeys = first.memory.flatMap((measurement) =>
+    (measurement.profiles ?? []).map((profile) => `${measurement.implementation}\u0000${profile.id}`)
+  ).sort().join("\u0001")
 
   for (const report of reports.slice(1)) {
     if (
@@ -141,6 +180,9 @@ const assertConsistentRuns = (reports, label) => {
         `${benchmark.implementation}\u0000${benchmark.id}\u0000${benchmark.unit}`
       ).sort().join("\u0001") !== benchmarkKeys ||
       report.memory.map((measurement) => measurement.implementation).sort().join("\u0001") !== memoryKeys
+      || report.memory.flatMap((measurement) =>
+        (measurement.profiles ?? []).map((profile) => `${measurement.implementation}\u0000${profile.id}`)
+      ).sort().join("\u0001") !== memoryProfileKeys
     ) {
       throw new Error(`Inconsistent ${label} runtime-performance reports`)
     }
@@ -160,21 +202,36 @@ const aggregate = (reports, label) => {
           candidate.implementation === benchmark.implementation && candidate.id === benchmark.id
         )
       )
+      const throughputs = matches.map((match) => match.medianThroughput)
       return {
         ...benchmark,
-        medianThroughput: median(matches.map((match) => match.medianThroughput)),
+        medianThroughput: median(throughputs),
+        processRelativeMad: relativeMedianAbsoluteDeviation(throughputs),
         relativeMarginOfError: median(matches.map((match) => match.relativeMarginOfError))
       }
     }),
-    memory: first.memory.map((measurement) => ({
-      ...measurement,
-      heapBytesPerIdleMachine: median(
-        reports.map((report) =>
-          report.memory.find((candidate) => candidate.implementation === measurement.implementation)
-            .heapBytesPerIdleMachine
-        )
+    memory: first.memory.map((measurement) => {
+      const matches = reports.map((report) =>
+        report.memory.find((candidate) => candidate.implementation === measurement.implementation)
       )
-    }))
+      const heapSlopes = matches.map((match) => match.heapBytesPerIdleMachine)
+      return {
+        ...measurement,
+        heapBytesPerIdleMachine: median(heapSlopes),
+        processRelativeMad: relativeMedianAbsoluteDeviation(heapSlopes),
+        profiles: measurement.profiles?.map((profile) => {
+          const profileMatches = matches.map((match) =>
+            match.profiles.find((candidate) => candidate.id === profile.id)
+          )
+          const profileHeapSlopes = profileMatches.map((match) => match.heapBytesPerIdleMachine)
+          return {
+            ...profile,
+            heapBytesPerIdleMachine: median(profileHeapSlopes),
+            processRelativeMad: relativeMedianAbsoluteDeviation(profileHeapSlopes)
+          }
+        })
+      }
+    })
   }
 }
 
@@ -189,6 +246,7 @@ const escapeCell = (value) => String(value).replaceAll("|", "\\|").replaceAll("\
 const code = (value) => `\`${String(value).replaceAll("`", "\\`")}\``
 const formatThroughput = (value, unit) => `${integer.format(value)} ${escapeCell(unit)}`
 const formatHeap = (value) => `${decimal.format(value / 1_024)} KiB`
+const formatVariability = (value) => `${decimal.format(value)}% MAD`
 const formatDifference = (before, after) => {
   const difference = after - before
   const sign = difference > 0 ? "+" : ""
@@ -235,15 +293,19 @@ for (const scenario of scenarios) {
   )
 }
 
+const memoryProfiles = pullRequest.memory[0]?.profiles ?? []
 lines.push(
   "",
-  "| Idle memory | Heap per machine |",
-  "| --- | ---: |"
+  `| Memory profile | ${implementations.map((implementation) => escapeCell(implementation.label)).join(" | ")} |`,
+  `| --- | ${implementations.map(() => "---:").join(" | ")} |`
 )
-for (const implementation of implementations) {
-  const measurement = pullRequest.memory.find((candidate) => candidate.implementation === implementation.id)
+for (const profile of memoryProfiles) {
   lines.push(
-    `| ${escapeCell(implementation.label)} | ${measurement === undefined ? "—" : formatHeap(measurement.heapBytesPerIdleMachine)} |`
+    `| ${escapeCell(profile.label)} | ${implementations.map((implementation) => {
+      const measurement = pullRequest.memory.find((candidate) => candidate.implementation === implementation.id)
+      const implementationProfile = measurement?.profiles?.find((candidate) => candidate.id === profile.id)
+      return implementationProfile === undefined ? "—" : formatHeap(implementationProfile.heapBytesPerIdleMachine)
+    }).join(" | ")} |`
   )
 }
 
@@ -272,24 +334,29 @@ if (base === undefined) {
     "",
     "### Effect Machine change from base",
     "",
-    "| Metric | Base | PR | Difference |",
-    "| --- | ---: | ---: | ---: |"
+    "| Metric | Base | Base variability | PR | PR variability | Difference |",
+    "| --- | ---: | ---: | ---: | ---: | ---: |"
   )
   for (const scenario of scenarios) {
     const before = baseEffect.get(scenario.id)
     const after = pullRequestEffect.get(scenario.id)
     if (before !== undefined && after !== undefined && before.unit === after.unit) {
       lines.push(
-        `| ${escapeCell(scenario.label)} | ${formatThroughput(before.medianThroughput, before.unit)} | ${formatThroughput(after.medianThroughput, after.unit)} | ${formatDifference(before.medianThroughput, after.medianThroughput)} |`
+        `| ${escapeCell(scenario.label)} | ${formatThroughput(before.medianThroughput, before.unit)} | ${formatVariability(before.processRelativeMad)} | ${formatThroughput(after.medianThroughput, after.unit)} | ${formatVariability(after.processRelativeMad)} | ${formatDifference(before.medianThroughput, after.medianThroughput)} |`
       )
     }
   }
   const beforeMemory = base.memory.find((measurement) => measurement.implementation === "effect-machine")
   const afterMemory = pullRequest.memory.find((measurement) => measurement.implementation === "effect-machine")
   if (beforeMemory !== undefined && afterMemory !== undefined) {
-    lines.push(
-      `| Idle heap per machine | ${formatHeap(beforeMemory.heapBytesPerIdleMachine)} | ${formatHeap(afterMemory.heapBytesPerIdleMachine)} | ${formatDifference(beforeMemory.heapBytesPerIdleMachine, afterMemory.heapBytesPerIdleMachine)} |`
-    )
+    for (const beforeProfile of beforeMemory.profiles ?? []) {
+      const afterProfile = afterMemory.profiles?.find((candidate) => candidate.id === beforeProfile.id)
+      if (afterProfile !== undefined) {
+        lines.push(
+          `| ${escapeCell(beforeProfile.label)} heap per unit | ${formatHeap(beforeProfile.heapBytesPerIdleMachine)} | ${formatVariability(beforeProfile.processRelativeMad)} | ${formatHeap(afterProfile.heapBytesPerIdleMachine)} | ${formatVariability(afterProfile.processRelativeMad)} | ${formatDifference(beforeProfile.heapBytesPerIdleMachine, afterProfile.heapBytesPerIdleMachine)} |`
+        )
+      }
+    }
   }
 }
 
@@ -302,7 +369,7 @@ lines.push(
     `- ${escapeCell(implementation.label)}: ${code(implementation.version)}`
   ),
   "",
-  "Higher throughput is better; lower idle heap is better. Runtime measurements on shared GitHub-hosted hardware remain informational, so small differences should be confirmed across multiple workflow runs.",
+  "Higher throughput is better; lower heap is better. Variability is the median absolute deviation across independent processes, relative to their median. Runtime measurements on shared GitHub-hosted hardware remain informational, so small differences should be confirmed across multiple workflow runs.",
   "",
   "</details>"
 )

--- a/scripts/runtime-performance.mjs
+++ b/scripts/runtime-performance.mjs
@@ -57,6 +57,7 @@ const configuration = options.quick
     minimumWarmupIterations: 1,
     planningBatchSize: 25,
     burstBatchSize: 25,
+    childBatchSize: 10,
     memoryCounts: [25, 100]
   }
   : {
@@ -66,6 +67,7 @@ const configuration = options.quick
     minimumWarmupIterations: 5,
     planningBatchSize: 100,
     burstBatchSize: 250,
+    childBatchSize: 100,
     memoryCounts: [100, 500, 1_000]
   }
 
@@ -78,6 +80,8 @@ const bench = new Bench({
 })
 const benchmarkDefinitions = new Map()
 const activeBurstRefs = new Map()
+const activeChildRefs = new Map()
+const activeObservedRefs = new Map()
 
 for (const implementation of implementations) {
   const metadata = {
@@ -145,6 +149,79 @@ for (const implementation of implementations) {
     }
   })
 
+  const observedBurstTask = `${implementation.implementation}:observed-runtime-burst`
+  benchmarkDefinitions.set(observedBurstTask, {
+    ...metadata,
+    id: "observed-runtime-burst",
+    label: "Drain burst with a change observer",
+    unit: "increments/s",
+    operationsPerIteration: configuration.burstBatchSize,
+    fenceEventsPerIteration: 1
+  })
+  bench.add(observedBurstTask, async () => {
+    const value = await implementation.runObservedCounterBurst(
+      activeObservedRefs.get(implementation.implementation),
+      configuration.burstBatchSize
+    )
+    if (value !== configuration.burstBatchSize) {
+      throw new Error(
+        `${implementation.label} observed runtime benchmark produced ${value}, expected ${configuration.burstBatchSize}`
+      )
+    }
+  }, {
+    beforeEach: async () => {
+      activeObservedRefs.set(implementation.implementation, await implementation.startObservedCounter())
+    },
+    afterEach: async () => {
+      const ref = activeObservedRefs.get(implementation.implementation)
+      await implementation.stopObservedCounter(ref)
+      activeObservedRefs.delete(implementation.implementation)
+    }
+  })
+
+  const childBurstTask = `${implementation.implementation}:child-runtime-burst`
+  benchmarkDefinitions.set(childBurstTask, {
+    ...metadata,
+    id: "child-runtime-burst",
+    label: "Lookup and send to one child",
+    unit: "increments/s",
+    operationsPerIteration: configuration.childBatchSize,
+    fenceEventsPerIteration: 1
+  })
+  const runChildBurst = implementation.async
+    ? async () => {
+      const value = await implementation.runChildCounterBurst(
+        activeChildRefs.get(implementation.implementation),
+        configuration.childBatchSize
+      )
+      if (value !== configuration.childBatchSize) {
+        throw new Error(
+          `${implementation.label} child runtime benchmark produced ${value}, expected ${configuration.childBatchSize}`
+        )
+      }
+    }
+    : () => {
+      const value = implementation.runChildCounterBurst(
+        activeChildRefs.get(implementation.implementation),
+        configuration.childBatchSize
+      )
+      if (value !== configuration.childBatchSize) {
+        throw new Error(
+          `${implementation.label} child runtime benchmark produced ${value}, expected ${configuration.childBatchSize}`
+        )
+      }
+    }
+  bench.add(childBurstTask, runChildBurst, {
+    beforeEach: async () => {
+      activeChildRefs.set(implementation.implementation, await implementation.startChildCounter())
+    },
+    afterEach: async () => {
+      const ref = activeChildRefs.get(implementation.implementation)
+      await implementation.stopChildCounter(ref)
+      activeChildRefs.delete(implementation.implementation)
+    }
+  })
+
   const lifecycleTask = `${implementation.implementation}:start-stop`
   benchmarkDefinitions.set(lifecycleTask, {
     ...metadata,
@@ -161,6 +238,23 @@ for (const implementation of implementations) {
       }
       : () => implementation.runLifecycle()
   )
+
+  const childLifecycleTask = `${implementation.implementation}:child-start-stop`
+  benchmarkDefinitions.set(childLifecycleTask, {
+    ...metadata,
+    id: "child-start-stop",
+    label: "Start and stop a parent with one child",
+    unit: "families/s",
+    operationsPerIteration: 1
+  })
+  bench.add(
+    childLifecycleTask,
+    implementation.async
+      ? async () => {
+        await implementation.runChildLifecycle()
+      }
+      : () => implementation.runChildLifecycle()
+  )
 }
 
 try {
@@ -172,6 +266,16 @@ try {
     if (ref !== undefined) {
       await implementation.stopCounter(ref)
       activeBurstRefs.delete(implementation.implementation)
+    }
+    const childRef = activeChildRefs.get(implementation.implementation)
+    if (childRef !== undefined) {
+      await implementation.stopChildCounter(childRef)
+      activeChildRefs.delete(implementation.implementation)
+    }
+    const observedRef = activeObservedRefs.get(implementation.implementation)
+    if (observedRef !== undefined) {
+      await implementation.stopObservedCounter(observedRef)
+      activeObservedRefs.delete(implementation.implementation)
     }
   }
 }
@@ -204,15 +308,25 @@ const benchmarks = bench.tasks.map((task) => {
 })
 
 const memoryWorker = fileURLToPath(new URL("../perf/runtime/memory-worker.mjs", import.meta.url))
-const memory = implementations.map((implementation) =>
-  JSON.parse(
-    execFileSync(
-      process.execPath,
-      ["--expose-gc", memoryWorker, implementation.implementation, JSON.stringify(configuration.memoryCounts)],
-      { encoding: "utf8" }
+const memoryProfileIds = ["idle", "parent-with-child"]
+const memory = implementations.map((implementation) => {
+  const profiles = memoryProfileIds.map((profileId) =>
+    JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          "--expose-gc",
+          memoryWorker,
+          implementation.implementation,
+          JSON.stringify(configuration.memoryCounts),
+          profileId
+        ],
+        { encoding: "utf8" }
+      )
     )
   )
-)
+  return { ...profiles[0], profiles }
+})
 
 const cpu = cpus()[0]
 const report = {
@@ -267,28 +381,33 @@ if (options.json) {
     }))
   )
 
-  console.log("\nIdle machine memory after forced GC\n")
+  console.log("\nRuntime memory after forced GC\n")
   console.table(
     memory.flatMap((result) =>
-      result.points.map((point) => ({
-        Implementation: `${result.implementationLabel} ${result.implementationVersion}`,
-        Machines: integer.format(point.machines),
-        "Heap delta": formatBytes(point.heapDeltaBytes),
-        "Heap/machine": formatBytes(point.heapDeltaBytes / point.machines),
-        "RSS delta": formatBytes(point.rssDeltaBytes)
-      }))
+      result.profiles.flatMap((profile) =>
+        profile.points.map((point) => ({
+          Implementation: `${result.implementationLabel} ${result.implementationVersion}`,
+          Profile: profile.label,
+          Units: integer.format(point.machines),
+          "Heap delta": formatBytes(point.heapDeltaBytes),
+          "Heap/unit": formatBytes(point.heapDeltaBytes / point.machines),
+          "RSS delta": formatBytes(point.rssDeltaBytes)
+        }))
+      )
     )
   )
   for (const result of memory) {
-    console.log(
-      `${result.implementationLabel} heap slope: ${formatBytes(result.heapBytesPerIdleMachine)} per idle machine`
-    )
-    if (Number.isFinite(result.heapBytesPerIdleMachine) && result.heapBytesPerIdleMachine > 0) {
+    for (const profile of result.profiles) {
       console.log(
-        `${result.implementationLabel} estimated idle capacity per GiB: ${integer.format(1_073_741_824 / result.heapBytesPerIdleMachine)} machines`
+        `${result.implementationLabel} ${profile.label.toLowerCase()} heap slope: ${formatBytes(profile.heapBytesPerIdleMachine)} per unit`
       )
-    } else {
-      console.log(`${result.implementationLabel} estimated idle capacity per GiB: unavailable`)
+      if (profile.id === "idle" && Number.isFinite(profile.heapBytesPerIdleMachine) && profile.heapBytesPerIdleMachine > 0) {
+        console.log(
+          `${result.implementationLabel} estimated idle capacity per GiB: ${integer.format(1_073_741_824 / profile.heapBytesPerIdleMachine)} machines`
+        )
+      } else if (profile.id === "idle") {
+        console.log(`${result.implementationLabel} estimated idle capacity per GiB: unavailable`)
+      }
     }
   }
   console.log("RSS is an allocator-sensitive diagnostic; heap slope is the primary memory metric.")

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -46,6 +46,16 @@ interface ChildRegistry {
   readonly children: HashMap.HashMap<string, ChildEntry>
 }
 
+interface ChildResources {
+  readonly scope: Scope.Closeable
+  readonly registry: SubscriptionRef.SubscriptionRef<ChildRegistry>
+}
+
+interface ChildResourcesState {
+  readonly closed: boolean
+  readonly resources: ChildResources | undefined
+}
+
 export type RuntimeSnapshot<State, Error = never, Output = never> =
   | {
     readonly status: "active"
@@ -302,10 +312,37 @@ const startInternal: <
   const changes = yield* PubSub.unbounded<Take.Take<VersionedSnapshot<State, Error, Output>>>({
     replay: 1
   })
-  const childrenScope = yield* Scope.make("parallel")
-  const childRegistry = yield* SubscriptionRef.make<ChildRegistry>({ revision: 0, children: HashMap.empty() })
+  const childResourcesState = yield* SynchronizedRef.make<ChildResourcesState>({
+    closed: false,
+    resources: undefined
+  })
 
-  const closeChildren = <A, E>(exit: Exit.Exit<A, E>): Effect.Effect<void> => Scope.close(childrenScope, exit)
+  const getOrCreateChildResources: Effect.Effect<ChildResources | undefined> = SynchronizedRef.modifyEffect(
+    childResourcesState,
+    (state) => {
+      if (state.resources !== undefined || state.closed) {
+        return Effect.succeed([state.resources, state] as const)
+      }
+      return Effect.all({
+        scope: Scope.make("parallel"),
+        registry: SubscriptionRef.make<ChildRegistry>({ revision: 0, children: HashMap.empty() })
+      }).pipe(
+        Effect.map((resources) => [resources, { closed: false, resources }] as const)
+      )
+    }
+  )
+
+  const getExistingChildResources: Effect.Effect<ChildResources | undefined> = SynchronizedRef.get(
+    childResourcesState
+  ).pipe(Effect.map((state) => state.resources))
+
+  const closeChildren = <A, E>(exit: Exit.Exit<A, E>): Effect.Effect<void> =>
+    SynchronizedRef.modify(childResourcesState, (state) =>
+      state.closed
+        ? [undefined, state] as const
+        : [state.resources, { ...state, closed: true }] as const).pipe(
+        Effect.flatMap((resources) => resources === undefined ? Effect.void : Scope.close(resources.scope, exit))
+      )
 
   const cleanupStartupFailure = <A, E>(exit: Exit.Exit<A, E>): Effect.Effect<void> =>
     Exit.isFailure(exit)
@@ -317,49 +354,55 @@ const startInternal: <
   const cleanup = options.onStop ?? Effect.void
 
   const reserveChildId = (
+    registry: SubscriptionRef.SubscriptionRef<ChildRegistry>,
     id: string,
     token: symbol
   ): Effect.Effect<void, ChildAlreadyExistsError> =>
-    SubscriptionRef.modifyEffect(childRegistry, (registry) =>
-      HashMap.has(registry.children, id)
+    SubscriptionRef.modifyEffect(registry, (current) =>
+      HashMap.has(current.children, id)
         ? Effect.fail(new ChildAlreadyExistsError({ id }))
         : Effect.succeed(
           [undefined, {
-            revision: registry.revision,
-            children: HashMap.set(registry.children, id, { _tag: "Starting", token })
+            revision: current.revision,
+            children: HashMap.set(current.children, id, { _tag: "Starting", token })
           }] as const
         ))
 
-  const unregisterChild = (id: string, token: symbol): Effect.Effect<void> =>
-    SubscriptionRef.modify(childRegistry, (registry) => {
-      const entry = HashMap.get(registry.children, id)
+  const unregisterChild = (
+    registry: SubscriptionRef.SubscriptionRef<ChildRegistry>,
+    id: string,
+    token: symbol
+  ): Effect.Effect<void> =>
+    SubscriptionRef.modify(registry, (current) => {
+      const entry = HashMap.get(current.children, id)
       if (Option.isNone(entry) || entry.value.token !== token) {
-        return [undefined, registry] as const
+        return [undefined, current] as const
       }
       const next = {
-        revision: registry.revision + 1,
-        children: HashMap.remove(registry.children, id)
+        revision: current.revision + 1,
+        children: HashMap.remove(current.children, id)
       }
       return [next, next] as const
     }).pipe(Effect.asVoid)
 
   const registerStartedChild = (
+    registry: SubscriptionRef.SubscriptionRef<ChildRegistry>,
     id: string,
     token: symbol,
     ref: MachineRef<any, any, any, any>,
     descriptor: ChildDescriptor | undefined
   ): Effect.Effect<boolean> =>
     SubscriptionRef.modify<ChildRegistry, boolean>(
-      childRegistry,
-      (registry) => {
-        const entry = HashMap.get(registry.children, id)
+      registry,
+      (current) => {
+        const entry = HashMap.get(current.children, id)
         if (Option.isNone(entry) || entry.value._tag !== "Starting" || entry.value.token !== token) {
-          return [false, registry] as const
+          return [false, current] as const
         }
         const next = {
-          revision: registry.revision + 1,
+          revision: current.revision + 1,
           children: HashMap.set(
-            HashMap.remove(registry.children, id),
+            HashMap.remove(current.children, id),
             id,
             { _tag: "Started", token, descriptor, ref }
           )
@@ -382,14 +425,18 @@ const startInternal: <
     child: ChildSelector
   ): Effect.Effect<Option.Option<MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>>> => {
     const id = typeof child === "string" ? child : child.id
-    return (
-      SubscriptionRef.get(childRegistry).pipe(
-        Effect.map((registry) => {
-          const entry = HashMap.get(registry.children, id)
-          return Option.isSome(entry) && matchesChildSelector(entry.value, child)
-            ? Option.some(entry.value.ref as MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>)
-            : Option.none()
-        })
+    return getExistingChildResources.pipe(
+      Effect.flatMap((resources) =>
+        resources === undefined
+          ? Effect.succeed(Option.none())
+          : SubscriptionRef.get(resources.registry).pipe(
+            Effect.map((registry) => {
+              const entry = HashMap.get(registry.children, id)
+              return Option.isSome(entry) && matchesChildSelector(entry.value, child)
+                ? Option.some(entry.value.ref as MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>)
+                : Option.none()
+            })
+          )
       )
     )
   }
@@ -398,38 +445,56 @@ const startInternal: <
     child: ChildSelector
   ): Stream.Stream<Option.Option<MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>>> => {
     const id = typeof child === "string" ? child : child.id
-    return SubscriptionRef.changes(childRegistry).pipe(
-      Stream.map((registry) => {
-        const entry = HashMap.get(registry.children, id)
-        return Option.isSome(entry) && matchesChildSelector(entry.value, child)
-          ? Option.some(entry.value.ref as MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>)
-          : Option.none()
-      })
+    return Stream.unwrap(
+      getOrCreateChildResources.pipe(
+        Effect.map((resources) =>
+          resources === undefined
+            ? Stream.succeed(Option.none()).pipe(Stream.concat(Stream.never))
+            : SubscriptionRef.changes(resources.registry).pipe(
+              Stream.map((registry) => {
+                const entry = HashMap.get(registry.children, id)
+                return Option.isSome(entry) && matchesChildSelector(entry.value, child)
+                  ? Option.some(entry.value.ref as MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>)
+                  : Option.none()
+              })
+            )
+        )
+      )
     )
   }
 
   const sendTo = (child: ChildSelector, event: unknown): Effect.Effect<void, StoppedError> => {
     const id = typeof child === "string" ? child : child.id
-    return (
-      SubscriptionRef.get(childRegistry).pipe(
-        Effect.flatMap((registry) => {
-          const entry = HashMap.get(registry.children, id)
-          return Option.isSome(entry) && matchesChildSelector(entry.value, child)
-            ? entry.value.ref.send(event)
-            : Effect.void
-        })
+    return getExistingChildResources.pipe(
+      Effect.flatMap((resources) =>
+        resources === undefined
+          ? Effect.void
+          : SubscriptionRef.get(resources.registry).pipe(
+            Effect.flatMap((registry) => {
+              const entry = HashMap.get(registry.children, id)
+              return Option.isSome(entry) && matchesChildSelector(entry.value, child)
+                ? entry.value.ref.send(event)
+                : Effect.void
+            })
+          )
       )
     )
   }
 
   const stopChild = (child: ChildSelector): Effect.Effect<void> => {
     const id = typeof child === "string" ? child : child.id
-    return (
-      SubscriptionRef.get(childRegistry).pipe(
-        Effect.flatMap((registry) => {
-          const entry = HashMap.get(registry.children, id)
-          return Option.isSome(entry) && matchesChildSelector(entry.value, child) ? entry.value.ref.stop : Effect.void
-        })
+    return getExistingChildResources.pipe(
+      Effect.flatMap((resources) =>
+        resources === undefined
+          ? Effect.void
+          : SubscriptionRef.get(resources.registry).pipe(
+            Effect.flatMap((registry) => {
+              const entry = HashMap.get(registry.children, id)
+              return Option.isSome(entry) && matchesChildSelector(entry.value, child)
+                ? entry.value.ref.stop
+                : Effect.void
+            })
+          )
       )
     )
   }
@@ -467,14 +532,20 @@ const startInternal: <
     Exclude<ChildRequirements, Scope.Scope>
   > {
     if (spawnOptions?.id === undefined) {
-      return Effect.acquireRelease(
-        startInternal(logic, {
-          fiberScope: childrenScope,
-          parent: self as MachineRef<unknown, unknown, unknown, unknown>,
-          runtime: options.runtime
-        }),
-        (child) => child.stop
-      ).pipe(Scope.provide(childrenScope)) as Effect.Effect<
+      return getOrCreateChildResources.pipe(
+        Effect.flatMap((resources) =>
+          resources === undefined
+            ? Effect.interrupt
+            : Effect.acquireRelease(
+              startInternal(logic, {
+                fiberScope: resources.scope,
+                parent: self as MachineRef<unknown, unknown, unknown, unknown>,
+                runtime: options.runtime
+              }),
+              (child) => child.stop
+            ).pipe(Scope.provide(resources.scope))
+        )
+      ) as Effect.Effect<
         MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>,
         ChildInitialError,
         Exclude<ChildRequirements, Scope.Scope>
@@ -482,34 +553,41 @@ const startInternal: <
     }
 
     const childId = spawnOptions.id
-    return Effect.acquireRelease(
-      Effect.gen(function*() {
-        const token = Symbol()
-        yield* reserveChildId(childId, token)
-        const child = yield* startInternal(logic, {
-          fiberScope: childrenScope,
-          id: childId,
-          onReady: (child) =>
-            registerStartedChild(
-              childId,
-              token,
-              child,
-              spawnOptions.descriptor
-            ).pipe(Effect.asVoid),
-          onStop: unregisterChild(childId, token),
-          parent: self as ProcessAddress<unknown>,
-          runtime: options.runtime
-        }).pipe(
-          Effect.onExit((exit) =>
-            Exit.isFailure(exit)
-              ? unregisterChild(childId, token)
-              : Effect.void
-          )
-        )
-        return child
-      }),
-      (child) => child.stop
-    ).pipe(Scope.provide(childrenScope)) as Effect.Effect<
+    return getOrCreateChildResources.pipe(
+      Effect.flatMap((resources) =>
+        resources === undefined
+          ? Effect.interrupt
+          : Effect.acquireRelease(
+            Effect.gen(function*() {
+              const token = Symbol()
+              yield* reserveChildId(resources.registry, childId, token)
+              const child = yield* startInternal(logic, {
+                fiberScope: resources.scope,
+                id: childId,
+                onReady: (child) =>
+                  registerStartedChild(
+                    resources.registry,
+                    childId,
+                    token,
+                    child,
+                    spawnOptions.descriptor
+                  ).pipe(Effect.asVoid),
+                onStop: unregisterChild(resources.registry, childId, token),
+                parent: self as ProcessAddress<unknown>,
+                runtime: options.runtime
+              }).pipe(
+                Effect.onExit((exit) =>
+                  Exit.isFailure(exit)
+                    ? unregisterChild(resources.registry, childId, token)
+                    : Effect.void
+                )
+              )
+              return child
+            }),
+            (child) => child.stop
+          ).pipe(Scope.provide(resources.scope))
+      )
+    ) as Effect.Effect<
       MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>,
       ChildAlreadyExistsError | ChildInitialError,
       Exclude<ChildRequirements, Scope.Scope>


### PR DESCRIPTION
## Summary

- create the child scope and observable child registry only when child-management capabilities are first used
- serialize first allocation against process shutdown with one synchronized lifecycle state
- preserve immediate child lookup, race-free child change observation, dynamic spawning, and child cleanup
- avoid holding the lifecycle lock while closing child scopes so child finalizers can unregister safely
- run one benchmark harness against both revisions with five interleaved processes and process-level variability
- measure observed bursts, child lookup/delivery, parent-child lifecycle, and parent-with-child memory for Effect Machine and both XState baselines

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (no examples changed)
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed (no public type changes; local `pnpm perf:types` passed)
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed

`pnpm check` and `pnpm perf:types` pass. The 181 machine runtime tests also passed five additional consecutive stress runs before the benchmark expansion.

The final local A/B used the PR harness for both revisions and the CI ordering: five interleaved full processes per revision. Relative process variability is reported as median absolute deviation.

- ordinary planning: +0.1% (base 1.4% MAD, PR 2.0% MAD)
- unobserved burst: +1.1% (base 0.9% MAD, PR 0.9% MAD)
- observed burst: +1.7% (base 1.1% MAD, PR 0.5% MAD)
- child lookup and delivery: +0.4% (base 0.8% MAD, PR 0.3% MAD)
- no-child start/stop: +2.5% (base 1.2% MAD, PR 0.7% MAD)
- parent-with-child start/stop: -2.6% (base 0.9% MAD, PR 0.4% MAD)
- idle machine heap: 25.8 KiB to 25.1 KiB (-2.7%)
- idle parent-with-child heap: 74.5 KiB to 75.2 KiB (+1.0%)

An earlier independent five-process pass measured the same memory changes, child lookup/delivery at -1.0%, and parent-with-child lifecycle at -3.6%. The combined result identifies a narrow tradeoff: machines that never use child capabilities save 2.7% idle heap and start slightly faster; machines that create a child pay about 1% more combined heap and 2.6-3.6% during family allocation/teardown, while steady-state child lookup and delivery remain flat.

The GitHub runner reproduced the result across five processes: planning +1.3%, unobserved burst +2.2%, observed burst +0.9%, child lookup/delivery -0.0%, no-child start/stop +3.0%, parent-with-child start/stop -1.5%, idle heap -2.7%, and parent-with-child heap +1.0%. All required checks pass.
