### PR TITLE
Reuse configurations while draining event batches

### DIFF
--- a/.changeset/calm-machines-batch.md
+++ b/.changeset/calm-machines-batch.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Reuse the validated statechart configuration while draining queued event batches, avoiding repeated snapshot normalization without retaining the cache while a machine is idle. Canonicalize history snapshot paths in machine document order so batched and public planning produce identical snapshots.

--- a/src/internal/machineModel.ts
+++ b/src/internal/machineModel.ts
@@ -215,6 +215,7 @@ const historyFromSnapshotEffect = Effect.fnUntraced(function*(
 })
 
 const historyToSnapshot = (
+  machine: Machine.Any,
   history: ReadonlyMap<string, HistoryRecord>
 ): Readonly<
   Record<string, {
@@ -229,10 +230,11 @@ const historyToSnapshot = (
     readonly values: Readonly<Record<string, unknown>>
   }> = {}
   for (const [path, record] of history) {
+    const active = Array.from(record.active).sort((left, right) => compareDocumentOrder(machine, left, right))
     entries[path] = {
       mode: record.mode,
-      active: Array.from(record.active),
-      values: Object.fromEntries(record.values)
+      active,
+      values: Object.fromEntries(active.map((path) => [path, record.values.get(path)]))
     }
   }
   return entries
@@ -1009,7 +1011,7 @@ export const snapshotFromConfiguration = <const States extends Machine.StateSche
     }).completed = completed
   }
   if (configuration.history.size > 0) {
-    Object.assign(snapshot, { history: historyToSnapshot(configuration.history) })
+    Object.assign(snapshot, { history: historyToSnapshot(machine, configuration.history) })
   }
   return snapshot
 }
@@ -1024,7 +1026,7 @@ export const snapshotFromConfigurationAtPath = <const States extends Machine.Sta
 ): Machine.SnapshotByIdentifier<States, Machine.StateIdentifier<States>> => {
   const snapshot = snapshotFromPath<States>(machine, configuration, path)
   if (configuration.history.size > 0) {
-    Object.assign(snapshot, { history: historyToSnapshot(configuration.history) })
+    Object.assign(snapshot, { history: historyToSnapshot(machine, configuration.history) })
   }
   return snapshot
 }

--- a/src/internal/machinePlanner.ts
+++ b/src/internal/machinePlanner.ts
@@ -2107,6 +2107,121 @@ const settle: <
     : { ...result, done: false, output: undefined }
 })
 
+const macrostepConfiguration: <
+  const States extends Machine.StateSchemas,
+  const Events extends ReadonlyArray<Machine.TaggedSchema>,
+  const Emits extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+  const Input extends Schema.Top = typeof Schema.Void,
+  UnhandledStates extends Machine.StateIdentifier<States> = Machine.StateIdentifier<States>,
+  E = never,
+  R = never,
+  InitialE = never,
+  InitialR = never,
+  FinalStates extends Machine.StateIdentifier<States> = never,
+  Output = never
+>(
+  machine: Machine<States, Events, Input, UnhandledStates, E, R, InitialE, InitialR, FinalStates, Output, Emits>,
+  configuration: ActiveConfiguration,
+  event: Machine.EventOf<Events>
+) => Effect.Effect<
+  MacrostepPlan<ActiveConfiguration, Machine.EventOf<Events>, E, R, Output>,
+  E | InfiniteTransitionError | MachineSchemaDecodeError,
+  R
+> = Effect.fnUntraced(function*<
+  const States extends Machine.StateSchemas,
+  const Events extends ReadonlyArray<Machine.TaggedSchema>,
+  const Emits extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+  const Input extends Schema.Top = typeof Schema.Void,
+  UnhandledStates extends Machine.StateIdentifier<States> = Machine.StateIdentifier<States>,
+  E = never,
+  R = never,
+  InitialE = never,
+  InitialR = never,
+  FinalStates extends Machine.StateIdentifier<States> = never,
+  Output = never
+>(
+  machine: Machine<States, Events, Input, UnhandledStates, E, R, InitialE, InitialR, FinalStates, Output, Emits>,
+  configuration: ActiveConfiguration,
+  event: Machine.EventOf<Events>
+) {
+  const decodedEvent = yield* decodeEvent<Events>(machine, event)
+  if (isActiveFinalConfiguration(machine, configuration)) {
+    const completed = yield* completeConfigurationEffect(machine, configuration, decodedEvent)
+    const root = getRootPath(machine, completed.configuration)
+    if (!completed.configuration.outputs.has(root)) {
+      return yield* Effect.die(
+        new Error("Machine reached a terminal configuration without a completed root output")
+      )
+    }
+    return {
+      next: completed.configuration,
+      actions: [],
+      emittedEvents: [],
+      microsteps: [],
+      done: true,
+      output: completed.configuration.outputs.get(root) as Output
+    }
+  }
+
+  const selections = selectEventTransitions<States, Events, Emits, E, R>(
+    machine,
+    configuration,
+    decodedEvent as Machine.EventByTag<Events, Machine.TagOf<Events[number]>>
+  )
+  if (selections.length === 0) {
+    return {
+      next: configuration,
+      actions: [],
+      emittedEvents: [],
+      microsteps: [],
+      done: false,
+      output: undefined
+    }
+  }
+  const step = yield* microstep(
+    machine,
+    configuration,
+    decodedEvent,
+    selections
+  )
+  const actions = [...step.actions]
+  const raisedEvents = [...step.raisedEvents]
+  const emittedEvents = [...step.emittedEvents]
+  const microsteps = [step]
+  return yield* settle(machine, step.next, decodedEvent, actions, raisedEvents, emittedEvents, microsteps)
+})
+
+const snapshotMacrostep = <
+  const States extends Machine.StateSchemas,
+  Event,
+  E,
+  R,
+  Output
+>(
+  machine: Machine.Any,
+  settled: MacrostepPlan<ActiveConfiguration, Event, E, R, Output>
+): MacrostepPlan<Machine.Snapshot<States>, Event, E, R, Output> => {
+  const planned = {
+    next: snapshotFromConfiguration<States>(machine, settled.next),
+    actions: settled.actions,
+    emittedEvents: settled.emittedEvents,
+    microsteps: settled.microsteps.map((step) => ({
+      next: snapshotFromConfiguration<States>(machine, step.next),
+      event: step.event,
+      transitions: step.transitions,
+      actions: step.actions,
+      raisedEvents: step.raisedEvents,
+      emittedEvents: step.emittedEvents,
+      exitPaths: step.exitPaths,
+      entryPaths: step.entryPaths,
+      changed: step.changed
+    }))
+  }
+  return settled.done
+    ? { ...planned, done: true, output: settled.output }
+    : { ...planned, done: false, output: undefined }
+}
+
 const macrostep: <
   const States extends Machine.StateSchemas,
   const Events extends ReadonlyArray<Machine.TaggedSchema>,
@@ -2145,73 +2260,13 @@ const macrostep: <
   event: Machine.EventOf<Events>
 ) {
   const configuration = yield* normalizeConfigurationEffect<States>(machine, state)
-  const decodedEvent = yield* decodeEvent<Events>(machine, event)
-  if (isActiveFinalConfiguration(machine, configuration)) {
-    const completed = yield* completeConfigurationEffect(machine, configuration, decodedEvent)
-    const root = getRootPath(machine, completed.configuration)
-    if (!completed.configuration.outputs.has(root)) {
-      return yield* Effect.die(
-        new Error("Machine reached a terminal configuration without a completed root output")
-      )
-    }
-    return {
-      next: snapshotFromConfiguration<States>(machine, completed.configuration),
-      actions: [],
-      emittedEvents: [],
-      microsteps: [],
-      done: true,
-      output: completed.configuration.outputs.get(root) as Output
-    }
-  }
-
-  const selections = selectEventTransitions<States, Events, Emits, E, R>(
-    machine,
-    configuration,
-    decodedEvent as Machine.EventByTag<Events, Machine.TagOf<Events[number]>>
-  )
-  if (selections.length === 0) {
-    return {
-      next: snapshotFromConfiguration<States>(machine, configuration),
-      actions: [],
-      emittedEvents: [],
-      microsteps: [],
-      done: false,
-      output: undefined
-    }
-  }
-  const step = yield* microstep(
-    machine,
-    configuration,
-    decodedEvent,
-    selections
-  )
-  const actions = [...step.actions]
-  const raisedEvents = [...step.raisedEvents]
-  const emittedEvents = [...step.emittedEvents]
-  const microsteps = [step]
-  const settled = yield* settle(machine, step.next, decodedEvent, actions, raisedEvents, emittedEvents, microsteps)
-  const planned = {
-    next: snapshotFromConfiguration<States>(machine, settled.next),
-    actions: settled.actions,
-    emittedEvents: settled.emittedEvents,
-    microsteps: settled.microsteps.map((step) => ({
-      next: snapshotFromConfiguration<States>(machine, step.next),
-      event: step.event,
-      transitions: step.transitions,
-      actions: step.actions,
-      raisedEvents: step.raisedEvents,
-      emittedEvents: step.emittedEvents,
-      exitPaths: step.exitPaths,
-      entryPaths: step.entryPaths,
-      changed: step.changed
-    }))
-  }
-  return settled.done
-    ? { ...planned, done: true, output: settled.output }
-    : { ...planned, done: false, output: undefined }
+  const settled = yield* macrostepConfiguration(machine, configuration, event)
+  return snapshotMacrostep<States, Machine.EventOf<Events>, E, R, Output>(machine, settled)
 })
 
 export const plan = macrostep
+
+export const planConfiguration = macrostepConfiguration
 
 const actionUnsafe = Effect.fnUntraced(function*<E, R>(
   effect: Effect.Effect<void, E, R>

--- a/src/internal/machineProcess.ts
+++ b/src/internal/machineProcess.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as HashMap from "effect/HashMap"
 import * as Option from "effect/Option"
+import * as Queue from "effect/Queue"
 import * as Ref from "effect/Ref"
 import type * as Schema from "effect/Schema"
 import * as Scope from "effect/Scope"
@@ -147,14 +148,14 @@ const makeProcessLogic: <
     run: (context) =>
       internalRuntime.provideMachineRuntime(
         Effect.gen(function*() {
-          const { receive, state, setState } = context
+          const { mailbox, receive, state, setState } = context
           let terminal: { readonly output: Output } | undefined
 
-          const initialState = yield* state
-          if (internalPlanner.isFinalState(machine, initialState)) {
+          let current = yield* state
+          if (internalPlanner.isFinalState(machine, current)) {
             return yield* internalPlanner.getFinalOutputEffect<States, Events, Output>(
               machine,
-              initialState,
+              current,
               internalPlanner.InitialEvent
             )
           }
@@ -165,26 +166,46 @@ const makeProcessLogic: <
           )
 
           if (!hasInvokes) {
+            // A queued batch is produced entirely by this worker, so its
+            // configuration is already validated. Drop both caches before
+            // blocking again so idle machines retain only the public snapshot.
+            let configuration: Model.ActiveConfiguration | undefined
+            let pendingEvent: Option.Option<Machine.EventOf<Events>> = Option.none()
+            let pollEvent: Effect.Effect<Option.Option<Machine.EventOf<Events>>> | undefined
             yield* Effect.whileLoop({
               while: () => terminal === undefined,
               body: () =>
                 Effect.gen(function*() {
-                  const event = yield* receive
-                  const current = yield* state
-                  const planned = yield* internalPlanner.plan(machine, current, event)
-                  if (planned.microsteps.length === 0) {
-                    return
+                  const event = Option.isSome(pendingEvent) ? pendingEvent.value : yield* receive
+                  pendingEvent = Option.none()
+                  const planned = yield* internalPlanner.planConfiguration(
+                    machine,
+                    configuration ?? (yield* Model.normalizeConfigurationEffect(machine, current)),
+                    event
+                  )
+                  configuration = planned.next
+
+                  if (planned.microsteps.length > 0) {
+                    const next = Model.snapshotFromConfiguration<States>(machine, planned.next)
+                    yield* internalPlanner.runActions(planned.actions, liveRuntime)
+                    yield* setState(next)
+                    current = next
+                    yield* internalPlanner.runEmittedEvents(
+                      planned.emittedEvents as ReadonlyArray<Machine.EmitOf<Emits>>,
+                      liveRuntime
+                    )
+
+                    if (planned.done) {
+                      terminal = { output: planned.output }
+                    }
                   }
 
-                  yield* internalPlanner.runActions(planned.actions, liveRuntime)
-                  yield* setState(planned.next)
-                  yield* internalPlanner.runEmittedEvents(
-                    planned.emittedEvents as ReadonlyArray<Machine.EmitOf<Emits>>,
-                    liveRuntime
-                  )
-
-                  if (planned.done) {
-                    terminal = { output: planned.output }
+                  if (terminal === undefined) {
+                    pendingEvent = yield* (pollEvent ??= Queue.poll(mailbox))
+                    if (Option.isNone(pendingEvent)) {
+                      configuration = undefined
+                      pollEvent = undefined
+                    }
                   }
                 }),
               step: () => undefined
@@ -349,15 +370,14 @@ const makeProcessLogic: <
             yield* startInvokeWatchers(config, child, key, token, scope)
           })
           const startInvokes: (
-            state: Machine.Snapshot<States>,
+            configuration: Model.ActiveConfiguration,
             paths: ReadonlyArray<string>,
             event: Machine.LifecycleEvent<Events>
           ) => Effect.Effect<void, E | MachineSchemaDecodeError, R> = Effect.fnUntraced(function*(
-            state: Machine.Snapshot<States>,
+            configuration: Model.ActiveConfiguration,
             paths: ReadonlyArray<string>,
             event: Machine.LifecycleEvent<Events>
           ) {
-            const configuration = yield* Model.normalizeConfigurationEffect(machine, state)
             yield* Effect.all(
               internalPlanner.sortEntryPaths(machine, paths)
                 .filter((path) => configuration.active.has(path))
@@ -393,51 +413,74 @@ const makeProcessLogic: <
             )
 
           return yield* Effect.gen(function*() {
+            let configuration: Model.ActiveConfiguration | undefined = yield* Model.normalizeConfigurationEffect(
+              machine,
+              current
+            )
             yield* startInvokes(
-              initialState,
-              Model.getInitialEntryPaths(machine, yield* Model.normalizeConfigurationEffect(machine, initialState)),
+              configuration,
+              Model.getInitialEntryPaths(machine, configuration),
               internalPlanner.InitialEvent
             )
+            // As above, keep the normalized configuration only while this
+            // worker can continue draining an already queued batch.
+            configuration = undefined
+            let pendingEvent: Option.Option<Machine.EventOf<Events>> = Option.none()
+            let pollEvent: Effect.Effect<Option.Option<Machine.EventOf<Events>>> | undefined
 
             yield* Effect.whileLoop({
               while: () => terminal === undefined,
               body: () =>
                 Effect.gen(function*() {
-                  const event = yield* receive
-                  const current = yield* state
-                  const planned = yield* internalPlanner.plan(machine, current, event)
-                  if (planned.microsteps.length === 0) {
-                    return
-                  }
-                  const changed = planned.microsteps.some((step) => step.changed)
-                  const exitPaths = planned.microsteps.flatMap((step) => step.exitPaths)
-                  const entryEvents = new Map<string, Machine.LifecycleEvent<Events>>()
-                  for (const step of planned.microsteps) {
-                    if (step.changed) {
-                      for (const path of step.entryPaths) {
-                        entryEvents.set(path, step.event as Machine.LifecycleEvent<Events>)
+                  const event = Option.isSome(pendingEvent) ? pendingEvent.value : yield* receive
+                  pendingEvent = Option.none()
+                  const planned = yield* internalPlanner.planConfiguration(
+                    machine,
+                    configuration ?? (yield* Model.normalizeConfigurationEffect(machine, current)),
+                    event
+                  )
+                  configuration = planned.next
+                  if (planned.microsteps.length > 0) {
+                    const changed = planned.microsteps.some((step) => step.changed)
+                    const exitPaths = planned.microsteps.flatMap((step) => step.exitPaths)
+                    const entryEvents = new Map<string, Machine.LifecycleEvent<Events>>()
+                    for (const step of planned.microsteps) {
+                      if (step.changed) {
+                        for (const path of step.entryPaths) {
+                          entryEvents.set(path, step.event as Machine.LifecycleEvent<Events>)
+                        }
+                      }
+                    }
+
+                    const next = Model.snapshotFromConfiguration<States>(machine, planned.next)
+                    yield* internalPlanner.runActions(planned.actions, liveRuntime)
+                    if (changed) {
+                      yield* stopInvokes(exitPaths)
+                    }
+                    yield* setState(next)
+                    current = next
+                    yield* internalPlanner.runEmittedEvents(
+                      planned.emittedEvents as ReadonlyArray<Machine.EmitOf<Emits>>,
+                      liveRuntime
+                    )
+
+                    if (planned.done) {
+                      terminal = { output: planned.output }
+                      yield* stopAllInvokes(Exit.succeed(planned.output))
+                    } else {
+                      if (changed) {
+                        for (const [path, entryEvent] of entryEvents) {
+                          yield* startInvokes(planned.next, [path], entryEvent)
+                        }
                       }
                     }
                   }
 
-                  yield* internalPlanner.runActions(planned.actions, liveRuntime)
-                  if (changed) {
-                    yield* stopInvokes(exitPaths)
-                  }
-                  yield* setState(planned.next)
-                  yield* internalPlanner.runEmittedEvents(
-                    planned.emittedEvents as ReadonlyArray<Machine.EmitOf<Emits>>,
-                    liveRuntime
-                  )
-
-                  if (planned.done) {
-                    terminal = { output: planned.output }
-                    yield* stopAllInvokes(Exit.succeed(planned.output))
-                  } else {
-                    if (changed) {
-                      for (const [path, entryEvent] of entryEvents) {
-                        yield* startInvokes(planned.next, [path], entryEvent)
-                      }
+                  if (terminal === undefined) {
+                    pendingEvent = yield* (pollEvent ??= Queue.poll(mailbox))
+                    if (Option.isNone(pendingEvent)) {
+                      configuration = undefined
+                      pollEvent = undefined
                     }
                   }
                 }),

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -149,6 +149,7 @@ export interface ProcessScope<Event> {
 
 export interface ProcessContext<State, Event> extends ProcessScope<Event> {
   readonly receive: Effect.Effect<Event>
+  readonly mailbox: Queue.Dequeue<Event>
   readonly state: Effect.Effect<State>
   readonly setState: (state: State) => Effect.Effect<void>
   readonly updateState: <E, R>(
@@ -836,6 +837,7 @@ const startInternal: <
   const context: ProcessContext<State, Event> = {
     ...scope,
     receive: Queue.take(queue),
+    mailbox: queue,
     state: SynchronizedRef.get(current).pipe(Effect.map((current) => current.snapshot.state)),
     setState: setActiveState,
     updateState: (f) =>


### PR DESCRIPTION
## Summary

- Split statechart macrostep planning into an internal normalized-configuration path and the existing public snapshot projection.
- Reuse the validated configuration only while a process drains a contiguous queued event batch, then release it before blocking so idle actors do not retain the cache.
- Preserve validation for every external event and for the first snapshot entering each batch.
- Canonicalize persisted history paths in machine document order so batched execution remains observably identical to public step-by-step planning.

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed

Local validation includes 414 runtime tests, 155 type tests / 788 assertions, strict consumer and package checks, and unchanged type-performance budgets.

The GitHub-hosted five-process benchmark measured +17.1% unobserved burst throughput, +16.8% observed burst throughput, +11.3% child-send throughput, +1.2% lifecycle throughput, and +2.2% parent/child lifecycle throughput. Public planning was -1.4%, within the 2.3% baseline variability. Idle heap changed from 23.5 to 23.9 KiB (+1.6%) and parent/child heap from 73.8 to 73.9 KiB (+0.2%).
