### PR TITLE
Compact invoked child supervision

### DIFF
--- a/.changeset/direct-invokes-report.md
+++ b/.changeset/direct-invokes-report.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Reduce invoked-child memory and lifecycle overhead by delivering terminal outcomes directly through process supervision and allocating a watcher fiber only for invokes that map active child snapshots.

--- a/perf/runtime/README.md
+++ b/perf/runtime/README.md
@@ -17,7 +17,8 @@ The command reports:
 - parent-with-child start-and-stop throughput;
 - heap and resident-memory growth at 100, 500, and 1,000 live units, including
   a raw managed process, an idle statechart, two independent statecharts, a
-  parent with one child, and that relationship with child observation active;
+  parent with one child, that relationship with child-registry observation
+  active, and an invoked child whose active snapshots are observed;
 - lower-bound memory profiles for Effect itself: a suspended fiber, a queue
   with a waiting fiber, and a minimal mailbox/state/completion actor shell.
 
@@ -56,10 +57,11 @@ same runtime guarantees.
 The fitted heap slope is the primary idle-capacity metric. Compare adjacent
 profiles to attribute retained memory: raw process to idle statechart isolates
 statechart machinery, two independent machines to parent-with-child isolates
-relationship bookkeeping, and unobserved to observed parent-child isolates
-observation. The Effect profiles are primitive lower bounds, not feature-equivalent
-competitors. Resident memory is reported as a raw diagnostic because V8 and the
-operating-system allocator can reuse already committed pages. The
+relationship bookkeeping, while the two observed parent-child profiles isolate
+registry and invoked-snapshot observation. The Effect profiles are primitive
+lower bounds, not feature-equivalent competitors. Resident memory is reported
+as a raw diagnostic because V8 and the operating-system allocator can reuse
+already committed pages. The
 capacity-per-GiB value is a linear estimate that excludes shared process
 overhead; it is not a run-until-OOM limit.
 

--- a/perf/runtime/counter.mjs
+++ b/perf/runtime/counter.mjs
@@ -71,6 +71,20 @@ const counterParentMachine = Machine.make({
   }
 })
 
+const counterSnapshotParentMachine = Machine.make({
+  id: "RuntimeBenchmarkSnapshotCounterParent",
+  states: ParentStates.states,
+  events: [],
+  initial: () => ParentStates.initial.Active(ParentState.cases.Active.make({}))
+}).handle({
+  Active: {
+    invoke: Machine.invokeMachine({
+      child: CounterChild,
+      snapshot: () => undefined
+    })
+  }
+})
+
 export const incrementEvent = CounterEvent.cases.Increment.make({})
 const finishEvent = CounterEvent.cases.Finish.make({})
 
@@ -254,6 +268,20 @@ const startObservedChildCounters = (count) =>
     )
   )
 
+const startSnapshotObservedChildCounters = (count) =>
+  Effect.runPromise(
+    Effect.forEach(
+      Array.from({ length: count }),
+      () =>
+        Effect.gen(function*() {
+          const parent = yield* Machine.start(counterSnapshotParentMachine)
+          yield* waitForCounterChild(parent)
+          return parent
+        }),
+      { concurrency: 1 }
+    )
+  )
+
 const stopObservedChildCounters = (units) =>
   Effect.runPromise(
     Effect.forEach(
@@ -327,6 +355,11 @@ export const effectMachineAdapter = {
       label: "Parent with observed child registry",
       start: startObservedChildCounters,
       stop: stopObservedChildCounters
+    },
+    "snapshot-observed-parent-with-child": {
+      label: "Parent with invoked child snapshot watcher",
+      start: startSnapshotObservedChildCounters,
+      stop: stopChildCounters
     }
   }
 }

--- a/src/internal/machineProcess.ts
+++ b/src/internal/machineProcess.ts
@@ -281,10 +281,13 @@ const makeProcessLogic: <
             key: string,
             token: symbol,
             outcome: internalRuntime.RuntimeOutcome<any, any, any>
-          ): Effect.Effect<void> =>
-            isCurrentInvoke(key, token).pipe(
+          ): Effect.Effect<void> => {
+            if (outcome._tag === "Stopped") {
+              return Effect.void
+            }
+            return isCurrentInvoke(key, token).pipe(
               Effect.flatMap((isCurrent) => {
-                if (!isCurrent || outcome._tag === "Stopped") {
+                if (!isCurrent) {
                   return Effect.void
                 }
                 if (outcome._tag === "Done") {
@@ -300,6 +303,7 @@ const makeProcessLogic: <
                 return context.failCause(outcome.cause)
               })
             )
+          }
           const startInvokeSnapshotWatcher = Effect.fnUntraced(function*(
             config: AnyInvokeConfig,
             child: internalRuntime.MachineRef<any, any, any, any>,

--- a/src/internal/machineProcess.ts
+++ b/src/internal/machineProcess.ts
@@ -6,12 +6,12 @@
 
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
+import * as Fiber from "effect/Fiber"
 import * as HashMap from "effect/HashMap"
 import * as Option from "effect/Option"
 import * as Queue from "effect/Queue"
 import * as Ref from "effect/Ref"
 import type * as Schema from "effect/Schema"
-import * as Scope from "effect/Scope"
 import * as Stream from "effect/Stream"
 import type { ActionError, ExecutionServices, Machine, Runtime } from "../Machine.js"
 import { ChildAlreadyExistsError, InfiniteTransitionError, MachineSchemaDecodeError } from "./machineErrors.js"
@@ -34,7 +34,7 @@ type AnyInvokeConfig = Machine.InvokeConfig<any, any, any, any, any, any, any, a
 
 interface InvokeSession {
   readonly token: symbol
-  readonly scope: Scope.Closeable
+  readonly watcher: Fiber.Fiber<void> | undefined
   readonly childId: string
   readonly path: string
 }
@@ -240,10 +240,17 @@ const makeProcessLogic: <
                 return Option.isSome(current) && current.value.token === token
               })
             )
+          const stopInvokeSession = (session: InvokeSession): Effect.Effect<void> =>
+            Effect.all(
+              [
+                ...(session.watcher === undefined ? [] : [Fiber.interrupt(session.watcher)]),
+                context.stopChild(session.childId)
+              ],
+              { discard: true, concurrency: "unbounded" }
+            )
           const removeInvoke = (
             key: string,
-            token: symbol | undefined,
-            exit: Exit.Exit<unknown, unknown>
+            token: symbol | undefined
           ): Effect.Effect<void> =>
             Ref.modify(invokeSessions, (sessions) => {
               const current = HashMap.get(sessions, key)
@@ -254,80 +261,87 @@ const makeProcessLogic: <
               Effect.flatMap((session) =>
                 session === undefined
                   ? Effect.void
-                  : Scope.close(session.scope, exit).pipe(
-                    Effect.andThen(context.stopChild(session.childId))
-                  )
+                  : stopInvokeSession(session)
               )
             )
-          const stopInvoke = (key: string, exit: Exit.Exit<unknown, unknown>): Effect.Effect<void> =>
-            removeInvoke(key, undefined, exit)
-          const stopAllInvokes = (exit: Exit.Exit<unknown, unknown>): Effect.Effect<void> =>
-            Ref.modify(invokeSessions, (sessions) => [HashMap.toEntries(sessions), HashMap.empty()] as const).pipe(
+          const stopInvoke = (key: string): Effect.Effect<void> => removeInvoke(key, undefined)
+          const stopAllInvokes: Effect.Effect<void> = Ref.modify(invokeSessions, (sessions) =>
+            [HashMap.toEntries(sessions), HashMap.empty()] as const).pipe(
               Effect.flatMap((sessions) =>
                 Effect.all(
                   sessions.map(([, session]) =>
-                    Scope.close(session.scope, exit).pipe(
-                      Effect.andThen(context.stopChild(session.childId))
-                    )
+                    stopInvokeSession(session)
                   ),
                   { discard: true, concurrency: "unbounded" }
                 )
               )
             )
-          const startInvokeWatchers = Effect.fnUntraced(function*(
+          const handleInvokeOutcome = (
+            config: AnyInvokeConfig,
+            key: string,
+            token: symbol,
+            outcome: internalRuntime.RuntimeOutcome<any, any, any>
+          ): Effect.Effect<void> =>
+            isCurrentInvoke(key, token).pipe(
+              Effect.flatMap((isCurrent) => {
+                if (!isCurrent || outcome._tag === "Stopped") {
+                  return Effect.void
+                }
+                if (outcome._tag === "Done") {
+                  const mappedEvent = config.onDone === undefined
+                    ? outcome.output
+                    : config.onDone({ id: config.id, output: outcome.output })
+                  return mappedEvent === undefined
+                    ? Effect.void
+                    : context.self.send(mappedEvent as Machine.EventOf<Events>).pipe(
+                      Effect.catchTag("StoppedError", () => Effect.void)
+                    )
+                }
+                return context.failCause(outcome.cause)
+              })
+            )
+          const startInvokeSnapshotWatcher = Effect.fnUntraced(function*(
             config: AnyInvokeConfig,
             child: internalRuntime.MachineRef<any, any, any, any>,
             key: string,
-            token: symbol,
-            scope: Scope.Closeable
+            token: symbol
           ) {
-            if (config.snapshot !== undefined) {
-              const mapSnapshot = config.snapshot
-              yield* child.changes.pipe(
-                Stream.filter((snapshot) => snapshot.status === "active"),
-                Stream.runForEach((snapshot) =>
-                  isCurrentInvoke(key, token).pipe(
-                    Effect.flatMap((isCurrent) => {
-                      if (!isCurrent) {
-                        return Effect.void
-                      }
-                      const mappedEvent = mapSnapshot({ id: config.id, snapshot })
-                      return mappedEvent === undefined
-                        ? Effect.void
-                        : context.self.send(mappedEvent as Machine.EventOf<Events>).pipe(
-                          Effect.catchTag("StoppedError", () => Effect.void)
-                        )
-                    })
-                  )
-                ),
-                Effect.forkIn(scope),
-                Effect.asVoid
-              )
+            if (config.snapshot === undefined) {
+              return
             }
-            yield* internalRuntime.watch(child).pipe(
-              Stream.runForEach((outcome) =>
+            const mapSnapshot = config.snapshot
+            const watcher = yield* child.changes.pipe(
+              Stream.filter((snapshot) => snapshot.status === "active"),
+              Stream.runForEach((snapshot) =>
                 isCurrentInvoke(key, token).pipe(
                   Effect.flatMap((isCurrent) => {
-                    if (!isCurrent || outcome._tag === "Stopped") {
+                    if (!isCurrent) {
                       return Effect.void
                     }
-                    if (outcome._tag === "Done") {
-                      const mappedEvent = config.onDone === undefined
-                        ? outcome.output
-                        : config.onDone({ id: config.id, output: outcome.output })
-                      return mappedEvent === undefined
-                        ? Effect.void
-                        : context.self.send(mappedEvent as Machine.EventOf<Events>).pipe(
-                          Effect.catchTag("StoppedError", () => Effect.void)
-                        )
-                    }
-                    return context.failCause(outcome.cause)
+                    const mappedEvent = mapSnapshot({ id: config.id, snapshot })
+                    return mappedEvent === undefined
+                      ? Effect.void
+                      : context.self.send(mappedEvent as Machine.EventOf<Events>).pipe(
+                        Effect.catchTag("StoppedError", () => Effect.void)
+                      )
                   })
                 )
               ),
-              Effect.forkIn(scope),
-              Effect.asVoid
+              Effect.forkChild
             )
+            const installed = yield* Ref.modify(invokeSessions, (sessions) => {
+              const current = HashMap.get(sessions, key)
+              if (Option.isNone(current) || current.value.token !== token) {
+                return [false, sessions] as const
+              }
+              return [
+                true,
+                HashMap.set(sessions, key, { ...current.value, watcher })
+              ] as const
+            })
+            if (!installed) {
+              yield* Fiber.interrupt(watcher)
+            }
           })
           const startInvoke = Effect.fnUntraced(function*<StateId extends Machine.StateIdentifier<States>>(
             path: StateId,
@@ -337,13 +351,11 @@ const makeProcessLogic: <
             const invokeId = String(config.id)
             const key = makeInvokeSessionKey(path, invokeId)
             const childId = config.address === undefined ? makeInvokeChildId(path, invokeId) : String(config.address)
-            const scope = yield* Scope.make("parallel")
             const reserved = yield* Ref.modify(invokeSessions, (sessions) =>
               HashMap.has(sessions, key)
                 ? [false, sessions] as const
-                : [true, HashMap.set(sessions, key, { token, scope, childId, path })] as const)
+                : [true, HashMap.set(sessions, key, { token, watcher: undefined, childId, path })] as const)
             if (!reserved) {
-              yield* Scope.close(scope, Exit.void)
               return yield* Effect.fail(new ChildAlreadyExistsError({ id: invokeId }))
             }
             const logic = config.src()
@@ -358,24 +370,19 @@ const makeProcessLogic: <
                 initial: (childScope) => logic.initial({ ...childScope, sendParent }),
                 run: (childContext) => logic.run({ ...childContext, sendParent })
               },
-              config.descriptor === undefined
-                ? { id: childId }
-                : { id: childId, descriptor: config.descriptor }
+              {
+                id: childId,
+                ...(config.descriptor === undefined ? undefined : { descriptor: config.descriptor }),
+                onOutcome: (outcome) => handleInvokeOutcome(config, key, token, outcome)
+              }
             ).pipe(
               Effect.onExit((exit) =>
                 Exit.isFailure(exit)
-                  ? Ref.update(invokeSessions, (sessions) => {
-                    const current = HashMap.get(sessions, key)
-                    return Option.isSome(current) && current.value.token === token
-                      ? HashMap.remove(sessions, key)
-                      : sessions
-                  }).pipe(
-                    Effect.andThen(Scope.close(scope, Exit.failCause(exit.cause)))
-                  )
+                  ? removeInvoke(key, token)
                   : Effect.void
               )
             )
-            yield* startInvokeWatchers(config, child, key, token, scope)
+            yield* startInvokeSnapshotWatcher(config, child, key, token)
           })
           const startInvokes: (
             configuration: Model.ActiveConfiguration,
@@ -412,7 +419,7 @@ const makeProcessLogic: <
                   internalPlanner.sortExitPaths(machine, paths).flatMap((path) =>
                     HashMap.toEntries(sessions)
                       .filter(([, session]) => session.path === path)
-                      .map(([key]) => stopInvoke(key, Exit.void))
+                      .map(([key]) => stopInvoke(key))
                   ),
                   { discard: true, concurrency: "unbounded" }
                 )
@@ -481,7 +488,7 @@ const makeProcessLogic: <
 
                     if (planned.done) {
                       terminal = { output: planned.output as Output }
-                      yield* stopAllInvokes(Exit.succeed(planned.output))
+                      yield* stopAllInvokes
                     } else {
                       if (changed) {
                         for (const [path, entryEvent] of entryEvents) {
@@ -509,7 +516,7 @@ const makeProcessLogic: <
             }
             return terminal.output
           }).pipe(
-            Effect.onExit((exit) => stopAllInvokes(exit))
+            Effect.onExit(() => stopAllInvokes)
           )
         }),
         context

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -180,6 +180,9 @@ export interface ProcessSpawn {
     options: {
       readonly id: string
       readonly descriptor?: ChildDescriptor
+      readonly onOutcome?: (
+        outcome: RuntimeOutcome<ChildState, ChildError, ChildOutput>
+      ) => Effect.Effect<void>
     }
   ): Effect.Effect<
     MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>,
@@ -277,6 +280,7 @@ const makeProcessRuntime: Effect.Effect<ProcessRuntime> = Effect.sync(() => {
 interface StartInternalOptions {
   readonly detached?: boolean
   readonly id?: string
+  readonly onOutcome?: (outcome: RuntimeOutcome<any, any, any>) => Effect.Effect<void>
   readonly onReady?: (
     ref: MachineRef<any, any, any, any>,
     requestStop: Effect.Effect<void>
@@ -560,6 +564,9 @@ const startInternal: <
     spawnOptions: {
       readonly id: string
       readonly descriptor?: ChildDescriptor
+      readonly onOutcome?: (
+        outcome: RuntimeOutcome<ChildState, ChildError, ChildOutput>
+      ) => Effect.Effect<void>
     }
   ): Effect.Effect<
     MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>,
@@ -571,6 +578,9 @@ const startInternal: <
     spawnOptions?: {
       readonly id: string
       readonly descriptor?: ChildDescriptor
+      readonly onOutcome?: (
+        outcome: RuntimeOutcome<ChildState, ChildError, ChildOutput>
+      ) => Effect.Effect<void>
     }
   ): Effect.Effect<
     MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>,
@@ -592,6 +602,7 @@ const startInternal: <
             return yield* startInternal(logic, {
               detached: true,
               ...(spawnOptions?.id === undefined ? undefined : { id: spawnOptions.id }),
+              ...(spawnOptions?.onOutcome === undefined ? undefined : { onOutcome: spawnOptions.onOutcome }),
               onReady: (child, requestChildStop) =>
                 Effect.sync(() => {
                   startedChild = child
@@ -794,15 +805,23 @@ const startInternal: <
     snapshot: RuntimeSnapshot<State, Error, Output>,
     exit: Exit.Exit<unknown, unknown>,
     completeDone: Effect.Effect<void>
-  ): Effect.Effect<void> =>
-    Effect.uninterruptible(
+  ): Effect.Effect<void> => {
+    const notifyOutcome = options.onOutcome === undefined
+      ? Effect.void
+      : Effect.suspend(() => options.onOutcome!(classifyOutcome(snapshot)!)).pipe(
+        Effect.exit,
+        Effect.asVoid
+      )
+    return Effect.uninterruptible(
       Queue.shutdown(queue).pipe(
         Effect.andThen(closeChildren(exit)),
         Effect.andThen(setAndPublishSnapshot(snapshot)),
+        Effect.andThen(notifyOutcome),
         Effect.andThen(cleanup),
         Effect.andThen(completeDone)
       )
     )
+  }
 
   const reserveStoppedSnapshot = reserveTerminalSnapshot((snapshot) => ({
     status: "stopped",

--- a/test/MachineProcessLifecycle.test.ts
+++ b/test/MachineProcessLifecycle.test.ts
@@ -371,6 +371,68 @@ describe("machine process lifecycle", () => {
       )
     }))
 
+  it.effect("delivers done, failure, and stopped child outcomes exactly once", () =>
+    Effect.gen(function*() {
+      const parentScope = yield* Deferred.make<MachineRuntime.ProcessScope<never>>()
+      const outcomes = yield* Ref.make<ReadonlyArray<string>>([])
+      const parentLogic: MachineRuntime.ProcessLogic<undefined, never> = {
+        initial: (scope) => Deferred.succeed(parentScope, scope).pipe(Effect.as(undefined)),
+        run: () => Effect.never
+      }
+      const parent = yield* MachineRuntime.startProcess(parentLogic)
+      const scope = yield* Deferred.await(parentScope)
+      const recordOutcome = (id: string) => (outcome: MachineRuntime.RuntimeOutcome<unknown, unknown, unknown>) =>
+        Ref.update(outcomes, (current) => [...current, `${id}:${outcome._tag}`])
+
+      const done = yield* scope.spawn(
+        Machine.logic({ initial: 0, run: () => Effect.succeed("output") }),
+        { id: "done", onOutcome: recordOutcome("done") }
+      )
+      assert.strictEqual(yield* done.join, "output")
+
+      const failed = yield* scope.spawn(
+        Machine.logic({ initial: 0, run: () => Effect.fail("failure") }),
+        { id: "failed", onOutcome: recordOutcome("failed") }
+      )
+      assert.strictEqual(yield* Effect.flip(failed.join), "failure")
+
+      const stopped = yield* scope.spawn(
+        Machine.logic({ initial: 0, run: () => Effect.never }),
+        { id: "stopped", onOutcome: recordOutcome("stopped") }
+      )
+      yield* stopped.stop
+
+      assert.deepStrictEqual(yield* Ref.get(outcomes), [
+        "done:Done",
+        "failed:Failure",
+        "stopped:Stopped"
+      ])
+      yield* parent.stop
+    }))
+
+  it.effect("isolates child terminalization from outcome callback defects", () =>
+    Effect.gen(function*() {
+      const parentScope = yield* Deferred.make<MachineRuntime.ProcessScope<never>>()
+      const parentLogic: MachineRuntime.ProcessLogic<undefined, never> = {
+        initial: (scope) => Deferred.succeed(parentScope, scope).pipe(Effect.as(undefined)),
+        run: () => Effect.never
+      }
+      const parent = yield* MachineRuntime.startProcess(parentLogic)
+      const child = yield* (yield* Deferred.await(parentScope)).spawn(
+        Machine.logic({ initial: 0, run: () => Effect.succeed("output") }),
+        { id: "child", onOutcome: () => Effect.die("callback defect") }
+      )
+
+      assert.strictEqual(yield* child.join, "output")
+      assert.deepStrictEqual(yield* child.snapshot, {
+        status: "done",
+        state: 0,
+        output: "output"
+      })
+      assert.deepStrictEqual(yield* parent.snapshot, { status: "active", state: undefined })
+      yield* parent.stop
+    }))
+
   it.effect("publishes and cleans up exactly once when stop races process completion", () =>
     Effect.gen(function*() {
       const cleanupCount = yield* Ref.make(0)


### PR DESCRIPTION
## Summary

- deliver invoked-child terminal outcomes directly through process supervision
- remove the per-invoke scope and terminal watcher fiber
- retain an explicitly owned watcher only when an invoke maps active child snapshots
- add exact outcome/defect lifecycle coverage and a snapshot-watcher memory profile

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (not applicable)
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed (public API unchanged; local budget passes)
- [ ] Reviewed the automated runtime-performance report, when runtime behavior changed
