### PR TITLE
Compact machine worker loops

### DIFF
--- a/.changeset/compact-idle-workers.md
+++ b/.changeset/compact-idle-workers.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Compact running machine workers into a single generator loop and allocate emitted-event runtime closures only when a machine emits, reducing idle heap and improving event throughput without changing scheduler yield semantics.

--- a/src/internal/machineProcess.ts
+++ b/src/internal/machineProcess.ts
@@ -129,15 +129,16 @@ const makeProcessLogic: <
             return yield* Model.normalizeSnapshotEffect(machine, entry.snapshot)
           }
           const planned = yield* internalPlanner.planInitial(machine, ...entry.args)
-          const runtime = internalPlanner.makeLiveRuntime<Machine.EventOf<Events>, Machine.EmitOf<Emits>>(
-            machine,
-            scope
-          )
           yield* internalPlanner.runCommands(
             planned.commands,
             scope
           )
-          yield* internalPlanner.runEmittedEvents(planned.emittedEvents, runtime)
+          if (planned.emittedEvents.length > 0) {
+            yield* internalPlanner.runEmittedEvents(
+              planned.emittedEvents,
+              internalPlanner.makeLiveRuntime<Machine.EventOf<Events>, Machine.EmitOf<Emits>>(machine, scope)
+            )
+          }
           return planned.state
         }),
         scope
@@ -157,64 +158,60 @@ const makeProcessLogic: <
             )
           }
 
-          const liveRuntime = internalPlanner.makeLiveRuntime<Machine.EventOf<Events>, Machine.EmitOf<Emits>>(
-            machine,
-            context
-          )
-
           if (!hasInvokes) {
             // A queued batch is produced entirely by this worker, so its
             // configuration is already validated. Drop both caches before
             // blocking again so idle machines retain only the public snapshot.
+            // Keeping the loop in this generator avoids a suspended generator
+            // per iteration; every iteration still crosses Effect boundaries,
+            // so the Effect scheduler remains responsible for cooperative yield.
             let configuration: Model.ActiveConfiguration | undefined
             let pendingEvent: Option.Option<Machine.EventOf<Events>> = Option.none()
             let pollEvent: Effect.Effect<Option.Option<Machine.EventOf<Events>>> | undefined
-            yield* Effect.whileLoop({
-              while: () => terminal === undefined,
-              body: () =>
-                Effect.gen(function*() {
-                  const event = Option.isSome(pendingEvent) ? pendingEvent.value : yield* receive
-                  pendingEvent = Option.none()
-                  let planned
-                  try {
-                    planned = internalPlanner.planConfiguration(
-                      machine,
-                      configuration ?? Model.normalizeConfigurationSync(machine, current),
-                      event
-                    )
-                  } catch (error) {
-                    if (error instanceof InfiniteTransitionError || error instanceof MachineSchemaDecodeError) {
-                      return yield* error
-                    }
-                    throw error
-                  }
-                  configuration = planned.next
+            let liveRuntime: Runtime<Machine.EventOf<Events>, Machine.EmitOf<Emits>> | undefined
+            while (terminal === undefined) {
+              const event = Option.isSome(pendingEvent) ? pendingEvent.value : yield* receive
+              pendingEvent = Option.none()
+              let planned
+              try {
+                planned = internalPlanner.planConfiguration(
+                  machine,
+                  configuration ?? Model.normalizeConfigurationSync(machine, current),
+                  event
+                )
+              } catch (error) {
+                if (error instanceof InfiniteTransitionError || error instanceof MachineSchemaDecodeError) {
+                  return yield* error
+                }
+                throw error
+              }
+              configuration = planned.next
 
-                  if (planned.microsteps.length > 0) {
-                    const next = Model.snapshotFromConfiguration<States>(machine, planned.next)
-                    yield* internalPlanner.runCommands(planned.commands, context)
-                    yield* setState(next)
-                    current = next
-                    yield* internalPlanner.runEmittedEvents(
-                      planned.emittedEvents as ReadonlyArray<Machine.EmitOf<Emits>>,
-                      liveRuntime
-                    )
+              if (planned.microsteps.length > 0) {
+                const next = Model.snapshotFromConfiguration<States>(machine, planned.next)
+                yield* internalPlanner.runCommands(planned.commands, context)
+                yield* setState(next)
+                current = next
+                if (planned.emittedEvents.length > 0) {
+                  yield* internalPlanner.runEmittedEvents(
+                    planned.emittedEvents as ReadonlyArray<Machine.EmitOf<Emits>>,
+                    liveRuntime ??= internalPlanner.makeLiveRuntime(machine, context)
+                  )
+                }
 
-                    if (planned.done) {
-                      terminal = { output: planned.output as Output }
-                    }
-                  }
+                if (planned.done) {
+                  terminal = { output: planned.output as Output }
+                }
+              }
 
-                  if (terminal === undefined) {
-                    pendingEvent = yield* (pollEvent ??= Queue.poll(mailbox))
-                    if (Option.isNone(pendingEvent)) {
-                      configuration = undefined
-                      pollEvent = undefined
-                    }
-                  }
-                }),
-              step: () => undefined
-            })
+              if (terminal === undefined) {
+                pendingEvent = yield* (pollEvent ??= Queue.poll(mailbox))
+                if (Option.isNone(pendingEvent)) {
+                  configuration = undefined
+                  pollEvent = undefined
+                }
+              }
+            }
 
             if (terminal === undefined) {
               return yield* Effect.die(
@@ -414,73 +411,71 @@ const makeProcessLogic: <
             configuration = undefined
             let pendingEvent: Option.Option<Machine.EventOf<Events>> = Option.none()
             let pollEvent: Effect.Effect<Option.Option<Machine.EventOf<Events>>> | undefined
+            let liveRuntime: Runtime<Machine.EventOf<Events>, Machine.EmitOf<Emits>> | undefined
 
-            yield* Effect.whileLoop({
-              while: () => terminal === undefined,
-              body: () =>
-                Effect.gen(function*() {
-                  const event = Option.isSome(pendingEvent) ? pendingEvent.value : yield* receive
-                  pendingEvent = Option.none()
-                  let planned
-                  try {
-                    planned = internalPlanner.planConfiguration(
-                      machine,
-                      configuration ?? Model.normalizeConfigurationSync(machine, current),
-                      event
-                    )
-                  } catch (error) {
-                    if (error instanceof InfiniteTransitionError || error instanceof MachineSchemaDecodeError) {
-                      return yield* error
-                    }
-                    throw error
-                  }
-                  configuration = planned.next
-                  if (planned.microsteps.length > 0) {
-                    const changed = planned.microsteps.some((step) => step.changed)
-                    const exitPaths = planned.microsteps.flatMap((step) => step.exitPaths)
-                    const entryEvents = new Map<string, Machine.LifecycleEvent<Events>>()
-                    for (const step of planned.microsteps) {
-                      if (step.changed) {
-                        for (const path of step.entryPaths) {
-                          entryEvents.set(path, step.event as Machine.LifecycleEvent<Events>)
-                        }
-                      }
-                    }
-
-                    const next = Model.snapshotFromConfiguration<States>(machine, planned.next)
-                    yield* internalPlanner.runCommands(planned.commands, context)
-                    if (changed) {
-                      yield* stopInvokes(exitPaths)
-                    }
-                    yield* setState(next)
-                    current = next
-                    yield* internalPlanner.runEmittedEvents(
-                      planned.emittedEvents as ReadonlyArray<Machine.EmitOf<Emits>>,
-                      liveRuntime
-                    )
-
-                    if (planned.done) {
-                      terminal = { output: planned.output as Output }
-                      yield* stopAllInvokes
-                    } else {
-                      if (changed) {
-                        for (const [path, entryEvent] of entryEvents) {
-                          yield* startInvokes(planned.next, [path], entryEvent)
-                        }
-                      }
+            // Match the compact non-invoke loop while retaining state-scoped
+            // child lifecycle work at the same ordered Effect boundaries.
+            while (terminal === undefined) {
+              const event = Option.isSome(pendingEvent) ? pendingEvent.value : yield* receive
+              pendingEvent = Option.none()
+              let planned
+              try {
+                planned = internalPlanner.planConfiguration(
+                  machine,
+                  configuration ?? Model.normalizeConfigurationSync(machine, current),
+                  event
+                )
+              } catch (error) {
+                if (error instanceof InfiniteTransitionError || error instanceof MachineSchemaDecodeError) {
+                  return yield* error
+                }
+                throw error
+              }
+              configuration = planned.next
+              if (planned.microsteps.length > 0) {
+                const changed = planned.microsteps.some((step) => step.changed)
+                const exitPaths = planned.microsteps.flatMap((step) => step.exitPaths)
+                const entryEvents = new Map<string, Machine.LifecycleEvent<Events>>()
+                for (const step of planned.microsteps) {
+                  if (step.changed) {
+                    for (const path of step.entryPaths) {
+                      entryEvents.set(path, step.event as Machine.LifecycleEvent<Events>)
                     }
                   }
+                }
 
-                  if (terminal === undefined) {
-                    pendingEvent = yield* (pollEvent ??= Queue.poll(mailbox))
-                    if (Option.isNone(pendingEvent)) {
-                      configuration = undefined
-                      pollEvent = undefined
-                    }
+                const next = Model.snapshotFromConfiguration<States>(machine, planned.next)
+                yield* internalPlanner.runCommands(planned.commands, context)
+                if (changed) {
+                  yield* stopInvokes(exitPaths)
+                }
+                yield* setState(next)
+                current = next
+                if (planned.emittedEvents.length > 0) {
+                  yield* internalPlanner.runEmittedEvents(
+                    planned.emittedEvents as ReadonlyArray<Machine.EmitOf<Emits>>,
+                    liveRuntime ??= internalPlanner.makeLiveRuntime(machine, context)
+                  )
+                }
+
+                if (planned.done) {
+                  terminal = { output: planned.output as Output }
+                  yield* stopAllInvokes
+                } else if (changed) {
+                  for (const [path, entryEvent] of entryEvents) {
+                    yield* startInvokes(planned.next, [path], entryEvent)
                   }
-                }),
-              step: () => undefined
-            })
+                }
+              }
+
+              if (terminal === undefined) {
+                pendingEvent = yield* (pollEvent ??= Queue.poll(mailbox))
+                if (Option.isNone(pendingEvent)) {
+                  configuration = undefined
+                  pollEvent = undefined
+                }
+              }
+            }
 
             if (terminal === undefined) {
               return yield* Effect.die(


### PR DESCRIPTION
## Summary

- keep each running machine in one generator loop instead of retaining a nested `Effect.whileLoop` body generator and its closures
- preserve all mailbox, state publication, invoke lifecycle, command, and emission ordering boundaries
- allocate and cache the live emitted-event runtime only after a machine actually emits
- continue relying on Effect's scheduler operation budget for cooperative yielding

Heap-retainer analysis attributed approximately 1.5 KiB per idle statechart to the nested loop and eager emission closures. Four order-balanced local process pairs reduced idle heap by 7.2% and parent-family heap by 6.0%, while improving the measured runtime, observed, and child-send hot paths by 17–26%.

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (not applicable)
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed; local budgets are unchanged and no public API changed
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed
