### PR TITLE
Suspend idle compiled machine workers

### DIFF
--- a/.changeset/calm-workers-rest.md
+++ b/.changeset/calm-workers-rest.md
@@ -1,0 +1,8 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Suspend compiled statechart workers while their mailboxes are idle and start an
+on-demand drain when an event arrives. This reduces retained heap for idle
+machines and invoked families without changing event ordering, terminal
+arbitration, or the public machine API.

--- a/perf/runtime/counter.mjs
+++ b/perf/runtime/counter.mjs
@@ -232,7 +232,8 @@ const rawProcessLogic = {
 const rawCompiledProcessLogic = {
   [machineRuntime.compiledProcess]: true,
   initial: () => Effect.succeed(0),
-  run: () => Effect.never
+  run: () => Effect.never,
+  drain: () => Effect.succeed(Option.none())
 }
 
 const startRawProcesses = (count) =>

--- a/src/internal/machineProcess.ts
+++ b/src/internal/machineProcess.ts
@@ -119,6 +119,13 @@ const makeProcessLogic: <
   entry: ProcessEntry<States, Input>
 ) => {
   const hasInvokes = hasInvokeCapability(machine)
+  // A process logic value may be reused for multiple starts. Key retained
+  // invoke state by the stable process address so each running instance owns
+  // its own table even when an invoke wrapper decorates the context object.
+  const invokeSessionsByContext = new WeakMap<object, {
+    readonly sessions: Map<string, InvokeSession>
+    initialized: boolean
+  }>()
   return ({
     [internalRuntime.childlessProcess]: hasInvokes ? undefined : true,
     [internalRuntime.compiledProcess]: true,
@@ -142,6 +149,300 @@ const makeProcessLogic: <
           return planned.state
         }),
         scope
+      ),
+    drain: (context: internalRuntime.ProcessContext<Machine.Snapshot<States>, Machine.EventOf<Events>>) =>
+      internalRuntime.provideMachineRuntime(
+        Effect.gen(function*() {
+          const { mailbox, state, setState } = context
+          let current = yield* state
+          if (internalPlanner.isFinalState(machine, current)) {
+            return Option.some(
+              yield* internalPlanner.getFinalOutputEffect<States, Events, Output>(
+                machine,
+                current,
+                internalPlanner.InitialEvent
+              )
+            )
+          }
+
+          let configuration: Model.ActiveConfiguration | undefined
+          let liveRuntime: Runtime<Machine.EventOf<Events>, Machine.EmitOf<Emits>> | undefined
+
+          let stopAllInvokes: Effect.Effect<void> | undefined
+          let startInvokes:
+            | ((
+              configuration: Model.ActiveConfiguration,
+              paths: ReadonlyArray<string>,
+              event: Machine.LifecycleEvent<Events>
+            ) => Effect.Effect<void, E | MachineSchemaDecodeError, R>)
+            | undefined
+          let stopInvokes: ((paths: ReadonlyArray<string>) => Effect.Effect<void>) | undefined
+
+          if (hasInvokes) {
+            let session = invokeSessionsByContext.get(context.self)
+            if (session === undefined) {
+              session = { sessions: new Map(), initialized: false }
+              invokeSessionsByContext.set(context.self, session)
+            }
+            const invokeSessions = session.sessions
+            const makeInvokeSessionKey = (path: string, id: string): string => `${path.length}:${path}${id}`
+            const makeInvokeChildId = (path: string, id: string): string =>
+              `Machine.invoke:${makeInvokeSessionKey(path, id)}`
+            const isCurrentInvoke = (key: string, token: symbol): Effect.Effect<boolean> =>
+              Effect.sync(() => invokeSessions.get(key)?.token === token)
+            const stopInvokeSession = (session: InvokeSession): Effect.Effect<void> =>
+              context.stopChild(session.childId)
+            const removeInvoke = (
+              key: string,
+              token: symbol | undefined
+            ): Effect.Effect<void> =>
+              Effect.sync(() => {
+                const current = invokeSessions.get(key)
+                if (current === undefined || (token !== undefined && current.token !== token)) {
+                  return undefined
+                }
+                invokeSessions.delete(key)
+                return current
+              }).pipe(
+                Effect.flatMap((session) =>
+                  session === undefined
+                    ? Effect.void
+                    : stopInvokeSession(session)
+                )
+              )
+            const stopInvoke = (key: string): Effect.Effect<void> => removeInvoke(key, undefined)
+            stopAllInvokes = Effect.sync(() => {
+              const sessions = Array.from(invokeSessions.values())
+              invokeSessions.clear()
+              return sessions
+            }).pipe(
+              Effect.flatMap((sessions) =>
+                Effect.all(
+                  sessions.map((session) => stopInvokeSession(session)),
+                  { discard: true, concurrency: "unbounded" }
+                )
+              )
+            )
+            const handleInvokeOutcome = (
+              config: AnyInvokeConfig,
+              key: string,
+              token: symbol,
+              outcome: internalRuntime.RuntimeOutcome<any, any, any>
+            ): Effect.Effect<void> => {
+              if (outcome._tag === "Stopped") {
+                return Effect.void
+              }
+              return isCurrentInvoke(key, token).pipe(
+                Effect.flatMap((isCurrent) => {
+                  if (!isCurrent) {
+                    return Effect.void
+                  }
+                  if (outcome._tag === "Done") {
+                    const mappedEvent = config.onDone === undefined
+                      ? outcome.output
+                      : config.onDone({ id: config.id, output: outcome.output })
+                    return mappedEvent === undefined
+                      ? Effect.void
+                      : context.self.send(mappedEvent as Machine.EventOf<Events>).pipe(
+                        Effect.catchTag("StoppedError", () => Effect.void)
+                      )
+                  }
+                  return context.failCause(outcome.cause)
+                })
+              )
+            }
+            const handleInvokeSnapshot = (
+              config: AnyInvokeConfig,
+              key: string,
+              token: symbol,
+              snapshot: Extract<internalRuntime.RuntimeSnapshot<any, any, any>, { readonly status: "active" }>
+            ): Effect.Effect<void> =>
+              isCurrentInvoke(key, token).pipe(
+                Effect.flatMap((isCurrent) => {
+                  if (!isCurrent || config.snapshot === undefined) {
+                    return Effect.void
+                  }
+                  const mappedEvent = config.snapshot({ id: config.id, snapshot })
+                  return mappedEvent === undefined
+                    ? Effect.void
+                    : context.self.send(mappedEvent as Machine.EventOf<Events>).pipe(
+                      Effect.catchTag("StoppedError", () => Effect.void)
+                    )
+                })
+              )
+            const startInvoke = Effect.fnUntraced(function*<StateId extends Machine.StateIdentifier<States>>(
+              path: StateId,
+              config: AnyInvokeConfig
+            ) {
+              const token = Symbol()
+              const invokeId = String(config.id)
+              const key = makeInvokeSessionKey(path, invokeId)
+              const childId = config.address === undefined ? makeInvokeChildId(path, invokeId) : String(config.address)
+              const reserved = yield* Effect.sync(() => {
+                if (invokeSessions.has(key)) {
+                  return false
+                }
+                invokeSessions.set(key, { token, childId, path })
+                return true
+              })
+              if (!reserved) {
+                return yield* Effect.fail(new ChildAlreadyExistsError({ id: invokeId }))
+              }
+              const logic = config.src()
+              const processLogic = logic as internalRuntime.ProcessLogic<any, any, any, any, any, any>
+              const sendParent = (event: unknown): Effect.Effect<void, StoppedError> =>
+                isCurrentInvoke(key, token).pipe(
+                  Effect.flatMap((isCurrent) =>
+                    isCurrent ? context.self.send(event as Machine.EventOf<Events>) : Effect.void
+                  )
+                )
+              yield* context.spawn(
+                {
+                  ...(processLogic[internalRuntime.childlessProcess] === true
+                    ? { [internalRuntime.childlessProcess]: true as const }
+                    : undefined),
+                  ...(processLogic[internalRuntime.compiledProcess] === true
+                    ? { [internalRuntime.compiledProcess]: true as const }
+                    : undefined),
+                  initial: (childScope) => logic.initial({ ...childScope, sendParent }),
+                  run: (childContext) => logic.run({ ...childContext, sendParent }),
+                  ...(processLogic.drain === undefined ? undefined : {
+                    drain: (childContext: internalRuntime.ProcessContext<any, any>) =>
+                      processLogic.drain!({ ...childContext, sendParent })
+                  })
+                },
+                {
+                  id: childId,
+                  ...(config.descriptor === undefined ? undefined : { descriptor: config.descriptor }),
+                  onOutcome: (outcome) => handleInvokeOutcome(config, key, token, outcome),
+                  ...(config.snapshot === undefined ? undefined : {
+                    [internalRuntime.activeSnapshotObserver]: (snapshot) =>
+                      handleInvokeSnapshot(config, key, token, snapshot)
+                  })
+                }
+              ).pipe(
+                Effect.onExit((exit) =>
+                  Exit.isFailure(exit)
+                    ? removeInvoke(key, token)
+                    : Effect.void
+                )
+              )
+            })
+            startInvokes = Effect.fnUntraced(function*(
+              configuration: Model.ActiveConfiguration,
+              paths: ReadonlyArray<string>,
+              event: Machine.LifecycleEvent<Events>
+            ) {
+              yield* Effect.all(
+                internalPlanner.sortEntryPaths(machine, paths)
+                  .filter((path) => configuration.active.has(path))
+                  .flatMap((path) =>
+                    getInvokes(Model.getStateConfigByPath(machine, path), {
+                      state: Model.getActiveValue(configuration, path),
+                      parent: Model.getParentValue(machine, configuration, path),
+                      parents: Model.getParentValues(machine, configuration, path),
+                      event
+                    }).map((config) =>
+                      startInvoke(
+                        path as Machine.StateIdentifier<States>,
+                        config
+                      ) as Effect.Effect<void, E | MachineSchemaDecodeError, R>
+                    )
+                  ),
+                { discard: true }
+              )
+            })
+            stopInvokes = (paths) =>
+              Effect.sync(() =>
+                internalPlanner.sortExitPaths(machine, paths).flatMap((path) =>
+                  Array.from(invokeSessions.entries())
+                    .filter(([, session]) => session.path === path)
+                    .map(([key]) => key)
+                )
+              ).pipe(
+                Effect.flatMap((keys) =>
+                  Effect.all(
+                    keys.map(stopInvoke),
+                    { discard: true, concurrency: "unbounded" }
+                  )
+                )
+              )
+
+            configuration = Model.normalizeConfigurationSync(machine, current)
+            if (!session.initialized) {
+              yield* startInvokes(
+                configuration,
+                Model.getInitialEntryPaths(machine, configuration),
+                internalPlanner.InitialEvent
+              )
+              session.initialized = true
+            }
+          }
+
+          while (true) {
+            const pending = yield* Queue.poll(mailbox)
+            if (Option.isNone(pending)) {
+              return Option.none<Output>()
+            }
+            const event = pending.value
+            let planned
+            try {
+              planned = internalPlanner.planConfiguration(
+                machine,
+                configuration ?? Model.normalizeConfigurationSync(machine, current),
+                event
+              )
+            } catch (error) {
+              if (error instanceof InfiniteTransitionError || error instanceof MachineSchemaDecodeError) {
+                return yield* error
+              }
+              throw error
+            }
+            configuration = planned.next
+
+            if (planned.microsteps.length > 0) {
+              let changed = false
+              let exitPaths: ReadonlyArray<string> = []
+              let entryEvents: Map<string, Machine.LifecycleEvent<Events>> | undefined
+              if (hasInvokes) {
+                changed = planned.microsteps.some((step) => step.changed)
+                exitPaths = planned.microsteps.flatMap((step) => step.exitPaths)
+                entryEvents = new Map()
+                for (const step of planned.microsteps) {
+                  if (step.changed) {
+                    for (const path of step.entryPaths) {
+                      entryEvents.set(path, step.event as Machine.LifecycleEvent<Events>)
+                    }
+                  }
+                }
+              }
+              const next = Model.snapshotFromConfiguration<States>(machine, planned.next)
+              yield* internalPlanner.runCommands(planned.commands, context)
+              if (changed) {
+                yield* stopInvokes!(exitPaths)
+              }
+              yield* setState(next)
+              current = next
+              if (planned.emittedEvents.length > 0) {
+                yield* internalPlanner.runEmittedEvents(
+                  planned.emittedEvents as ReadonlyArray<Machine.EmitOf<Emits>>,
+                  liveRuntime ??= internalPlanner.makeLiveRuntime(machine, context)
+                )
+              }
+              if (planned.done) {
+                if (stopAllInvokes !== undefined) {
+                  yield* stopAllInvokes
+                }
+                return Option.some(planned.output as Output)
+              } else if (changed) {
+                for (const [path, entryEvent] of entryEvents!) {
+                  yield* startInvokes!(planned.next, [path], entryEvent)
+                }
+              }
+            }
+          }
+        }),
+        context
       ),
     run: (context) =>
       internalRuntime.provideMachineRuntime(
@@ -344,7 +645,11 @@ const makeProcessLogic: <
                   ? { [internalRuntime.compiledProcess]: true as const }
                   : undefined),
                 initial: (childScope) => logic.initial({ ...childScope, sendParent }),
-                run: (childContext) => logic.run({ ...childContext, sendParent })
+                run: (childContext) => logic.run({ ...childContext, sendParent }),
+                ...(processLogic.drain === undefined ? undefined : {
+                  drain: (childContext: internalRuntime.ProcessContext<any, any>) =>
+                    processLogic.drain!({ ...childContext, sendParent })
+                })
               },
               {
                 id: childId,

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -176,6 +176,10 @@ export interface ProcessLogic<
   readonly [compiledProcess]?: true
   initial(scope: ProcessScope<Event>): Effect.Effect<State, InitialError, Requirements>
   run(context: ProcessContext<State, Event>): Effect.Effect<Output, Error, Requirements>
+  /** @internal */
+  readonly drain?: (
+    context: ProcessContext<State, Event>
+  ) => Effect.Effect<Option.Option<Output>, Error, Requirements>
 }
 
 export interface ProcessSpawn {
@@ -1112,10 +1116,9 @@ const startGenericInternal: <
   return ref
 })
 
-// Compiled statecharts have a bounded runtime shape: initialization is already
-// complete and `run` is the generated event loop. That lets one fiber own both
-// event processing and terminal publication without changing the generic
-// `Machine.logic` contract above.
+// Compiled statecharts have a bounded runtime shape. Their optional `drain`
+// protocol lets a fiber own event processing and terminal publication only
+// while work exists; custom process logic keeps the persistent `run` contract.
 const startCompiledInternal: <
   State,
   Event,
@@ -1145,11 +1148,28 @@ const startCompiledInternal: <
   const termination = yield* Deferred.make<ProcessTermination>()
   const done = yield* Deferred.make<Output, Error | StoppedError>()
   const awaitCompletion = Deferred.await(done).pipe(Effect.exit, Effect.asVoid)
+  const onDemand = logic.drain !== undefined
+  const drainServices = onDemand ? yield* Effect.context<Requirements>() : undefined
   let worker: Fiber.Fiber<any, never> | undefined
+  let draining = false
+  let offerRevision = 0
+  let interruptRequested = false
+  let terminationRequested = false
   let requestRuntimeTermination = (requested: ProcessTermination): Effect.Effect<boolean> =>
     Deferred.succeed(termination, requested)
+  let sendEvent = (event: Event): Effect.Effect<void, StoppedError> =>
+    Queue.offer(queue, event).pipe(
+      Effect.flatMap((accepted) => accepted ? Effect.void : Effect.fail(new StoppedError()))
+    )
+  let settleRequestedTermination = (_requested: ProcessTermination): Effect.Effect<void> => Effect.void
   const interruptWorker: Effect.Effect<void> = Effect.suspend(() =>
-    worker === undefined ? Effect.void : Fiber.interrupt(worker)
+    worker === undefined
+      ? onDemand
+        ? Effect.sync(() => {
+          interruptRequested = true
+        })
+        : Effect.void
+      : Fiber.interrupt(worker)
   )
   let initializing = true
   const requestStop = requestRuntimeTermination({ _tag: "Stopped" }).pipe(Effect.asVoid)
@@ -1167,10 +1187,7 @@ const startCompiledInternal: <
       }
       return requestRuntimeTermination({ _tag: "Stopped" }).pipe(Effect.andThen(Effect.interrupt))
     }),
-    send: (event: Event) =>
-      Queue.offer(queue, event).pipe(
-        Effect.flatMap((accepted) => accepted ? Effect.void : Effect.fail(new StoppedError()))
-      )
+    send: (event: Event) => Effect.suspend(() => sendEvent(event))
   }
 
   let {
@@ -1213,8 +1230,8 @@ const startCompiledInternal: <
       } as const
       return requestRuntimeTermination(requested).pipe(
         Effect.flatMap((accepted) =>
-          accepted && worker !== undefined
-            ? Effect.forkDetach(interruptWorker).pipe(Effect.asVoid)
+          accepted
+            ? Effect.forkDetach(settleRequestedTermination(requested)).pipe(Effect.asVoid)
             : Effect.void
         )
       )
@@ -1467,6 +1484,7 @@ const startCompiledInternal: <
           ? reserveTermination(requested).pipe(
             Effect.tap((snapshot) =>
               Effect.sync(() => {
+                terminationRequested = true
                 reservedTerminationSnapshot = snapshot
               })
             ),
@@ -1476,11 +1494,29 @@ const startCompiledInternal: <
       )
     )
 
-  const stop: Effect.Effect<void> = Effect.uninterruptible(
-    requestRuntimeTermination({ _tag: "Stopped" }).pipe(
-      Effect.andThen(interruptWorker),
-      Effect.andThen(awaitCompletion)
+  const finishRequestedTermination = (requested: ProcessTermination): Effect.Effect<void> =>
+    Effect.gen(function*() {
+      const snapshot = reservedTerminationSnapshot ?? (yield* reserveTermination(requested))
+      if (snapshot === undefined) {
+        return yield* awaitCompletion
+      }
+      return yield* completeTermination(requested, snapshot)
+    })
+
+  settleRequestedTermination = (requested) =>
+    Effect.suspend(() =>
+      onDemand && !draining
+        ? finishRequestedTermination(requested)
+        : interruptWorker.pipe(Effect.andThen(awaitCompletion))
     )
+
+  const stop: Effect.Effect<void> = Effect.uninterruptible(
+    Effect.suspend(() => {
+      const requested = { _tag: "Stopped" } as const
+      return requestRuntimeTermination(requested).pipe(
+        Effect.flatMap((accepted) => accepted ? settleRequestedTermination(requested) : awaitCompletion)
+      )
+    })
   )
 
   const context: ProcessContext<State, Event> = {
@@ -1557,6 +1593,96 @@ const startCompiledInternal: <
   }
   if (options.onSnapshot !== undefined) {
     yield* notifyActiveSnapshot(options.onSnapshot, { status: "active", state: initial })
+  }
+
+  if (onDemand) {
+    const drainRuntime: Effect.Effect<void, never, Requirements> = Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function*() {
+        let observedRevision = offerRevision
+        while (true) {
+          const pending = yield* Deferred.poll(termination)
+          if (Option.isSome(pending)) {
+            return yield* finishRequestedTermination(yield* pending.value)
+          }
+
+          const exit = yield* restore(Effect.suspend(() => logic.drain!(context))).pipe(Effect.exit)
+          if (Exit.isFailure(exit)) {
+            const completed: ProcessTermination = { _tag: "Failure", cause: exit.cause }
+            yield* Deferred.succeed(termination, completed)
+            return yield* finishRequestedTermination(yield* Deferred.await(termination))
+          }
+          if (Option.isSome(exit.value)) {
+            const completed: ProcessTermination = { _tag: "Done", output: exit.value.value }
+            yield* Deferred.succeed(termination, completed)
+            return yield* finishRequestedTermination(yield* Deferred.await(termination))
+          }
+
+          const requested = yield* Deferred.poll(termination)
+          if (Option.isSome(requested)) {
+            return yield* finishRequestedTermination(yield* requested.value)
+          }
+
+          const continueDraining = yield* Effect.sync(() => {
+            if (offerRevision !== observedRevision) {
+              observedRevision = offerRevision
+              return true
+            }
+            draining = false
+            worker = undefined
+            return false
+          })
+          if (!continueDraining) {
+            return
+          }
+        }
+      })
+    )
+
+    const providedDrainRuntime = Effect.provideContext(drainRuntime, drainServices!)
+    // Claim ownership before yielding so a concurrent stop can always find or
+    // request interruption of this worker. The yield also keeps `send` as a
+    // mailbox operation: user transition work never runs inline in the sender.
+    const scheduledDrainRuntime = Effect.uninterruptible(
+      Effect.yieldNow.pipe(Effect.andThen(providedDrainRuntime))
+    )
+    const forkDrain = options.detached === true
+      ? Effect.forkDetach(scheduledDrainRuntime, { startImmediately: true })
+      : Effect.forkChild(scheduledDrainRuntime, { startImmediately: true })
+
+    sendEvent = (event) =>
+      Effect.uninterruptible(
+        Effect.suspend(() => {
+          if (!Queue.offerUnsafe(queue, event)) {
+            return Effect.fail(new StoppedError())
+          }
+          offerRevision += 1
+          if (terminationRequested) {
+            return Effect.fail(new StoppedError())
+          }
+          if (draining) {
+            return Effect.void
+          }
+          draining = true
+          return forkDrain.pipe(
+            Effect.flatMap((fiber) =>
+              Effect.sync(() => {
+                worker = fiber
+                if (!interruptRequested) {
+                  return false
+                }
+                interruptRequested = false
+                return true
+              }).pipe(
+                Effect.flatMap((interrupt) => interrupt ? Fiber.interrupt(fiber) : Effect.void)
+              )
+            )
+          )
+        })
+      )
+
+    draining = true
+    yield* providedDrainRuntime
+    return ref
   }
 
   const pendingTermination = yield* Deferred.poll(termination)

--- a/test/MachineProcessLifecycle.test.ts
+++ b/test/MachineProcessLifecycle.test.ts
@@ -1,9 +1,47 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Deferred, Effect, Exit, Fiber, Option, Ref, Stream } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Option, Queue, Ref, Stream } from "effect"
 import { Machine } from "../src/index.js"
 import * as MachineRuntime from "../src/internal/machineRuntime.js"
 
 describe("machine process lifecycle", () => {
+  it.effect("wakes an on-demand compiled process across consecutive idle periods", () =>
+    Effect.gen(function*() {
+      type Event = {
+        readonly value: number
+        readonly processed: Deferred.Deferred<void>
+      }
+      const ref = yield* MachineRuntime.startProcess<number, Event>({
+        [MachineRuntime.childlessProcess]: true,
+        [MachineRuntime.compiledProcess]: true,
+        initial: () => Effect.succeed(0),
+        run: () => Effect.never,
+        drain: (context) =>
+          Effect.gen(function*() {
+            while (true) {
+              const event = yield* Queue.poll(context.mailbox)
+              if (Option.isNone(event)) {
+                return Option.none()
+              }
+              yield* context.setState(event.value.value)
+              yield* Deferred.succeed(event.value.processed, undefined)
+            }
+          })
+      })
+
+      for (let value = 1; value <= 100; value += 1) {
+        const processed = yield* Deferred.make<void>()
+        yield* ref.send({ value, processed })
+        yield* Deferred.await(processed)
+        if (value % 2 === 0) {
+          yield* Effect.yieldNow
+        }
+      }
+
+      assert.strictEqual(yield* ref.state, 100)
+      yield* ref.stop
+      assert.deepStrictEqual(yield* ref.snapshot, { status: "stopped", state: 100 })
+    }))
+
   it.effect("provides empty child operations for childless process logic", () =>
     Effect.gen(function*() {
       const processScope = yield* Deferred.make<MachineRuntime.ProcessScope<never>>()


### PR DESCRIPTION
## Summary

- suspend compiled statechart workers while their mailboxes are idle and start a drain fiber only when work arrives
- preserve single-owner event ordering and terminal arbitration across send, stop, failure, and invoked-child races
- apply the same on-demand kernel to invoked machines and add repeated idle wake-up coverage

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (not applicable)
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed (`pnpm perf:types`; public API unchanged)
- [ ] Reviewed the automated runtime-performance report, when runtime behavior changed

Local three-process comparison: leaf lifecycle +5.2%, parent-child lifecycle +6.3%, leaf heap -25.2%, and parent-child heap -27.9%; event throughput was within -0.2% to +1.7% of base.