### PR TITLE
Compact invoked child ownership

### DIFF
--- a/.changeset/calm-children-invoke.md
+++ b/.changeset/calm-children-invoke.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Reduce the retained memory of invoked machines by running the original child logic with a compact guarded `sendParent` channel instead of allocating a wrapper process for every invocation.

--- a/src/internal/machineProcess.ts
+++ b/src/internal/machineProcess.ts
@@ -70,6 +70,78 @@ const hasInvokeCapability = (machine: Machine.Any): boolean => {
   return hasInvokes
 }
 
+const isCurrentInvoke = (
+  sessions: Map<string, InvokeSession>,
+  key: string,
+  token: symbol
+): Effect.Effect<boolean> => Effect.sync(() => sessions.get(key)?.token === token)
+
+const makeInvokeSendParent = (
+  sessions: Map<string, InvokeSession>,
+  self: internalRuntime.ProcessScope<any>["self"],
+  key: string,
+  token: symbol
+): (event: unknown) => Effect.Effect<void, StoppedError> => {
+  return (event) =>
+    isCurrentInvoke(sessions, key, token).pipe(
+      Effect.flatMap((isCurrent) => isCurrent ? self.send(event) : Effect.void)
+    )
+}
+
+const makeInvokeOutcomeHandler = (
+  sessions: Map<string, InvokeSession>,
+  self: internalRuntime.ProcessScope<any>["self"],
+  failCause: internalRuntime.ProcessScope<any>["failCause"],
+  config: AnyInvokeConfig,
+  key: string,
+  token: symbol
+): (outcome: internalRuntime.RuntimeOutcome<any, any, any>) => Effect.Effect<void> => {
+  return (outcome) => {
+    if (outcome._tag === "Stopped") {
+      return Effect.void
+    }
+    return isCurrentInvoke(sessions, key, token).pipe(
+      Effect.flatMap((isCurrent) => {
+        if (!isCurrent) {
+          return Effect.void
+        }
+        if (outcome._tag === "Done") {
+          const mappedEvent = config.onDone === undefined
+            ? outcome.output
+            : config.onDone({ id: config.id, output: outcome.output })
+          return mappedEvent === undefined
+            ? Effect.void
+            : self.send(mappedEvent).pipe(Effect.catchTag("StoppedError", () => Effect.void))
+        }
+        return failCause(outcome.cause)
+      })
+    )
+  }
+}
+
+const makeInvokeSnapshotHandler = (
+  sessions: Map<string, InvokeSession>,
+  self: internalRuntime.ProcessScope<any>["self"],
+  config: AnyInvokeConfig,
+  key: string,
+  token: symbol
+): (
+  snapshot: Extract<internalRuntime.RuntimeSnapshot<any, any, any>, { readonly status: "active" }>
+) => Effect.Effect<void> => {
+  return (snapshot) =>
+    isCurrentInvoke(sessions, key, token).pipe(
+      Effect.flatMap((isCurrent) => {
+        if (!isCurrent || config.snapshot === undefined) {
+          return Effect.void
+        }
+        const mappedEvent = config.snapshot({ id: config.id, snapshot })
+        return mappedEvent === undefined
+          ? Effect.void
+          : self.send(mappedEvent).pipe(Effect.catchTag("StoppedError", () => Effect.void))
+      })
+    )
+}
+
 const makeProcessLogic: <
   const States extends Machine.StateSchemas,
   const Events extends ReadonlyArray<Machine.TaggedSchema>,
@@ -189,8 +261,6 @@ const makeProcessLogic: <
             const makeInvokeSessionKey = (path: string, id: string): string => `${path.length}:${path}${id}`
             const makeInvokeChildId = (path: string, id: string): string =>
               `Machine.invoke:${makeInvokeSessionKey(path, id)}`
-            const isCurrentInvoke = (key: string, token: symbol): Effect.Effect<boolean> =>
-              Effect.sync(() => invokeSessions.get(key)?.token === token)
             const stopInvokeSession = (session: InvokeSession): Effect.Effect<void> =>
               context.stopChild(session.childId)
             const removeInvoke = (
@@ -224,53 +294,6 @@ const makeProcessLogic: <
                 )
               )
             )
-            const handleInvokeOutcome = (
-              config: AnyInvokeConfig,
-              key: string,
-              token: symbol,
-              outcome: internalRuntime.RuntimeOutcome<any, any, any>
-            ): Effect.Effect<void> => {
-              if (outcome._tag === "Stopped") {
-                return Effect.void
-              }
-              return isCurrentInvoke(key, token).pipe(
-                Effect.flatMap((isCurrent) => {
-                  if (!isCurrent) {
-                    return Effect.void
-                  }
-                  if (outcome._tag === "Done") {
-                    const mappedEvent = config.onDone === undefined
-                      ? outcome.output
-                      : config.onDone({ id: config.id, output: outcome.output })
-                    return mappedEvent === undefined
-                      ? Effect.void
-                      : context.self.send(mappedEvent as Machine.EventOf<Events>).pipe(
-                        Effect.catchTag("StoppedError", () => Effect.void)
-                      )
-                  }
-                  return context.failCause(outcome.cause)
-                })
-              )
-            }
-            const handleInvokeSnapshot = (
-              config: AnyInvokeConfig,
-              key: string,
-              token: symbol,
-              snapshot: Extract<internalRuntime.RuntimeSnapshot<any, any, any>, { readonly status: "active" }>
-            ): Effect.Effect<void> =>
-              isCurrentInvoke(key, token).pipe(
-                Effect.flatMap((isCurrent) => {
-                  if (!isCurrent || config.snapshot === undefined) {
-                    return Effect.void
-                  }
-                  const mappedEvent = config.snapshot({ id: config.id, snapshot })
-                  return mappedEvent === undefined
-                    ? Effect.void
-                    : context.self.send(mappedEvent as Machine.EventOf<Events>).pipe(
-                      Effect.catchTag("StoppedError", () => Effect.void)
-                    )
-                })
-              )
             const startInvoke = Effect.fnUntraced(function*<StateId extends Machine.StateIdentifier<States>>(
               path: StateId,
               config: AnyInvokeConfig
@@ -291,34 +314,29 @@ const makeProcessLogic: <
               }
               const logic = config.src()
               const processLogic = logic as internalRuntime.ProcessLogic<any, any, any, any, any, any>
-              const sendParent = (event: unknown): Effect.Effect<void, StoppedError> =>
-                isCurrentInvoke(key, token).pipe(
-                  Effect.flatMap((isCurrent) =>
-                    isCurrent ? context.self.send(event as Machine.EventOf<Events>) : Effect.void
-                  )
-                )
+              const sendParent = makeInvokeSendParent(invokeSessions, context.self, key, token)
               yield* context.spawn(
-                {
-                  ...(processLogic[internalRuntime.childlessProcess] === true
-                    ? { [internalRuntime.childlessProcess]: true as const }
-                    : undefined),
-                  ...(processLogic[internalRuntime.compiledProcess] === true
-                    ? { [internalRuntime.compiledProcess]: true as const }
-                    : undefined),
-                  initial: (childScope) => logic.initial({ ...childScope, sendParent }),
-                  run: (childContext) => logic.run({ ...childContext, sendParent }),
-                  ...(processLogic.drain === undefined ? undefined : {
-                    drain: (childContext: internalRuntime.ProcessContext<any, any>) =>
-                      processLogic.drain!({ ...childContext, sendParent })
-                  })
-                },
+                processLogic,
                 {
                   id: childId,
                   ...(config.descriptor === undefined ? undefined : { descriptor: config.descriptor }),
-                  onOutcome: (outcome) => handleInvokeOutcome(config, key, token, outcome),
+                  [internalRuntime.sendParentOverride]: sendParent,
+                  onOutcome: makeInvokeOutcomeHandler(
+                    invokeSessions,
+                    context.self,
+                    context.failCause,
+                    config,
+                    key,
+                    token
+                  ),
                   ...(config.snapshot === undefined ? undefined : {
-                    [internalRuntime.activeSnapshotObserver]: (snapshot) =>
-                      handleInvokeSnapshot(config, key, token, snapshot)
+                    [internalRuntime.activeSnapshotObserver]: makeInvokeSnapshotHandler(
+                      invokeSessions,
+                      context.self,
+                      config,
+                      key,
+                      token
+                    )
                   })
                 }
               ).pipe(
@@ -531,8 +549,6 @@ const makeProcessLogic: <
           const makeInvokeSessionKey = (path: string, id: string): string => `${path.length}:${path}${id}`
           const makeInvokeChildId = (path: string, id: string): string =>
             `Machine.invoke:${makeInvokeSessionKey(path, id)}`
-          const isCurrentInvoke = (key: string, token: symbol): Effect.Effect<boolean> =>
-            Effect.sync(() => invokeSessions.get(key)?.token === token)
           const stopInvokeSession = (session: InvokeSession): Effect.Effect<void> => context.stopChild(session.childId)
           const removeInvoke = (
             key: string,
@@ -565,53 +581,6 @@ const makeProcessLogic: <
               )
             )
           )
-          const handleInvokeOutcome = (
-            config: AnyInvokeConfig,
-            key: string,
-            token: symbol,
-            outcome: internalRuntime.RuntimeOutcome<any, any, any>
-          ): Effect.Effect<void> => {
-            if (outcome._tag === "Stopped") {
-              return Effect.void
-            }
-            return isCurrentInvoke(key, token).pipe(
-              Effect.flatMap((isCurrent) => {
-                if (!isCurrent) {
-                  return Effect.void
-                }
-                if (outcome._tag === "Done") {
-                  const mappedEvent = config.onDone === undefined
-                    ? outcome.output
-                    : config.onDone({ id: config.id, output: outcome.output })
-                  return mappedEvent === undefined
-                    ? Effect.void
-                    : context.self.send(mappedEvent as Machine.EventOf<Events>).pipe(
-                      Effect.catchTag("StoppedError", () => Effect.void)
-                    )
-                }
-                return context.failCause(outcome.cause)
-              })
-            )
-          }
-          const handleInvokeSnapshot = (
-            config: AnyInvokeConfig,
-            key: string,
-            token: symbol,
-            snapshot: Extract<internalRuntime.RuntimeSnapshot<any, any, any>, { readonly status: "active" }>
-          ): Effect.Effect<void> =>
-            isCurrentInvoke(key, token).pipe(
-              Effect.flatMap((isCurrent) => {
-                if (!isCurrent || config.snapshot === undefined) {
-                  return Effect.void
-                }
-                const mappedEvent = config.snapshot({ id: config.id, snapshot })
-                return mappedEvent === undefined
-                  ? Effect.void
-                  : context.self.send(mappedEvent as Machine.EventOf<Events>).pipe(
-                    Effect.catchTag("StoppedError", () => Effect.void)
-                  )
-              })
-            )
           const startInvoke = Effect.fnUntraced(function*<StateId extends Machine.StateIdentifier<States>>(
             path: StateId,
             config: AnyInvokeConfig
@@ -632,34 +601,29 @@ const makeProcessLogic: <
             }
             const logic = config.src()
             const processLogic = logic as internalRuntime.ProcessLogic<any, any, any, any, any, any>
-            const sendParent = (event: unknown): Effect.Effect<void, StoppedError> =>
-              isCurrentInvoke(key, token).pipe(
-                Effect.flatMap((isCurrent) =>
-                  isCurrent ? context.self.send(event as Machine.EventOf<Events>) : Effect.void
-                )
-              )
+            const sendParent = makeInvokeSendParent(invokeSessions, context.self, key, token)
             yield* context.spawn(
-              {
-                ...(processLogic[internalRuntime.childlessProcess] === true
-                  ? { [internalRuntime.childlessProcess]: true as const }
-                  : undefined),
-                ...(processLogic[internalRuntime.compiledProcess] === true
-                  ? { [internalRuntime.compiledProcess]: true as const }
-                  : undefined),
-                initial: (childScope) => logic.initial({ ...childScope, sendParent }),
-                run: (childContext) => logic.run({ ...childContext, sendParent }),
-                ...(processLogic.drain === undefined ? undefined : {
-                  drain: (childContext: internalRuntime.ProcessContext<any, any>) =>
-                    processLogic.drain!({ ...childContext, sendParent })
-                })
-              },
+              processLogic,
               {
                 id: childId,
                 ...(config.descriptor === undefined ? undefined : { descriptor: config.descriptor }),
-                onOutcome: (outcome) => handleInvokeOutcome(config, key, token, outcome),
+                [internalRuntime.sendParentOverride]: sendParent,
+                onOutcome: makeInvokeOutcomeHandler(
+                  invokeSessions,
+                  context.self,
+                  context.failCause,
+                  config,
+                  key,
+                  token
+                ),
                 ...(config.snapshot === undefined ? undefined : {
-                  [internalRuntime.activeSnapshotObserver]: (snapshot) =>
-                    handleInvokeSnapshot(config, key, token, snapshot)
+                  [internalRuntime.activeSnapshotObserver]: makeInvokeSnapshotHandler(
+                    invokeSessions,
+                    context.self,
+                    config,
+                    key,
+                    token
+                  )
                 })
               }
             ).pipe(

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -51,6 +51,9 @@ export const childlessProcess: unique symbol = Symbol.for("effect/Machine/childl
 /** @internal */
 export const compiledProcess: unique symbol = Symbol.for("effect/Machine/compiledProcess")
 
+/** @internal */
+export const sendParentOverride: unique symbol = Symbol.for("effect/Machine/sendParentOverride")
+
 interface ChildRegistrySnapshot {
   readonly closed: boolean
   readonly revision: number
@@ -237,6 +240,7 @@ export interface ProcessSpawn {
       readonly [activeSnapshotObserver]?: (
         snapshot: Extract<RuntimeSnapshot<ChildState, ChildError, ChildOutput>, { readonly status: "active" }>
       ) => Effect.Effect<void>
+      readonly [sendParentOverride]?: (event: unknown) => Effect.Effect<void, StoppedError>
     }
   ): Effect.Effect<
     MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>,
@@ -356,6 +360,7 @@ interface StartInternalOptions {
   readonly onStop?: Effect.Effect<void>
   readonly parent?: ProcessAddress<unknown>
   readonly runtime: ProcessRuntime
+  readonly sendParent?: (event: unknown) => Effect.Effect<void, StoppedError>
 }
 
 interface ChildRuntime {
@@ -372,6 +377,7 @@ interface ChildRuntime {
 }
 
 const noChildChanges = Stream.succeed(Option.none()).pipe(Stream.concat(Stream.never))
+const noParentSend = (_event: unknown): Effect.Effect<void, StoppedError> => Effect.void
 
 const childlessRuntime: ChildRuntime = {
   close: () => Effect.void,
@@ -384,7 +390,7 @@ const childlessRuntime: ChildRuntime = {
 
 const makeChildRuntime = (
   self: ProcessAddress<any>,
-  options: StartInternalOptions
+  runtime: ProcessRuntime
 ): Effect.Effect<ChildRuntime> =>
   Effect.sync(() => {
     // Child-registry decisions are synchronous and every access below runs in
@@ -627,6 +633,7 @@ const makeChildRuntime = (
         readonly [activeSnapshotObserver]?: (
           snapshot: Extract<RuntimeSnapshot<ChildState, ChildError, ChildOutput>, { readonly status: "active" }>
         ) => Effect.Effect<void>
+        readonly [sendParentOverride]?: (event: unknown) => Effect.Effect<void, StoppedError>
       }
     ): Effect.Effect<
       MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>,
@@ -644,6 +651,7 @@ const makeChildRuntime = (
         readonly [activeSnapshotObserver]?: (
           snapshot: Extract<RuntimeSnapshot<ChildState, ChildError, ChildOutput>, { readonly status: "active" }>
         ) => Effect.Effect<void>
+        readonly [sendParentOverride]?: (event: unknown) => Effect.Effect<void, StoppedError>
       }
     ): Effect.Effect<
       MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>,
@@ -669,6 +677,9 @@ const makeChildRuntime = (
                 ...(spawnOptions?.[activeSnapshotObserver] === undefined
                   ? undefined
                   : { onSnapshot: spawnOptions[activeSnapshotObserver] }),
+                ...(spawnOptions?.[sendParentOverride] === undefined
+                  ? undefined
+                  : { sendParent: spawnOptions[sendParentOverride] }),
                 onReady: (child, requestChildStop) =>
                   Effect.sync(() => {
                     startedChild = child
@@ -678,7 +689,7 @@ const makeChildRuntime = (
                   ),
                 onStop: unregister(key, token),
                 parent: self,
-                runtime: options.runtime
+                runtime
               }).pipe(
                 Effect.onExit((exit) =>
                   Exit.isFailure(exit)
@@ -721,13 +732,24 @@ const startGenericInternal: <
   logic: ProcessLogic<State, Event, Error, Requirements, Output, InitialError>,
   options: StartInternalOptions
 ) {
+  const {
+    detached,
+    id: requestedId,
+    onOutcome,
+    onReady,
+    onSnapshot,
+    onStop,
+    parent,
+    runtime,
+    sendParent: overrideSendParent
+  } = options
   type ProcessTermination =
     | { readonly _tag: "Stopped" }
     | { readonly _tag: "Done"; readonly output: Output }
     | { readonly _tag: "Failure"; readonly cause: Cause.Cause<Error> }
 
-  const sessionId = yield* options.runtime.nextSessionId
-  const id = options.id ?? sessionId
+  const sessionId = yield* runtime.nextSessionId
+  const id = requestedId ?? sessionId
   const queue = yield* Queue.unbounded<Event>()
   const termination = yield* Deferred.make<ProcessTermination>()
   const done = yield* Deferred.make<Output, Error | StoppedError>()
@@ -769,19 +791,18 @@ const startGenericInternal: <
       sendTo,
       spawn,
       stop: stopChild
-    } = yield* makeChildRuntime(self, options))
+    } = yield* makeChildRuntime(self, runtime))
   }
   const cleanupStartupFailure = <A, E>(exit: Exit.Exit<A, E>): Effect.Effect<void> =>
     Exit.isFailure(exit)
       ? closeChildren(exit)
       : Effect.void
-  const cleanup = options.onStop ?? Effect.void
-  const sendParent = (event: unknown): Effect.Effect<void, StoppedError> =>
-    options.parent === undefined ? Effect.void : options.parent.send(event)
+  const cleanup = onStop ?? Effect.void
+  const sendParent = overrideSendParent ?? (parent === undefined ? noParentSend : parent.send)
 
   const scope: ProcessScope<Event> = {
     self,
-    parent: options.parent,
+    parent,
     spawn,
     sendParent,
     sendTo,
@@ -810,7 +831,7 @@ const startGenericInternal: <
   })
   const publishSnapshot: (
     snapshot: VersionedSnapshot<State, Error, Output>
-  ) => Effect.Effect<VersionedSnapshot<State, Error, Output>> = options.onSnapshot === undefined
+  ) => Effect.Effect<VersionedSnapshot<State, Error, Output>> = onSnapshot === undefined
     ? (snapshot) =>
       snapshot.changes === undefined
         ? Effect.succeed(snapshot)
@@ -822,7 +843,7 @@ const startGenericInternal: <
       const runtimeSnapshot = snapshot.snapshot
       return runtimeSnapshot.status !== "active"
         ? publish
-        : publish.pipe(Effect.tap(() => notifyActiveSnapshot(options.onSnapshot!, runtimeSnapshot)))
+        : publish.pipe(Effect.tap(() => notifyActiveSnapshot(onSnapshot, runtimeSnapshot)))
     }
 
   const completeChanges = (
@@ -943,9 +964,9 @@ const startGenericInternal: <
     exit: Exit.Exit<unknown, unknown>,
     completeDone: Effect.Effect<void>
   ): Effect.Effect<void> => {
-    const notifyOutcome = options.onOutcome === undefined
+    const notifyOutcome = onOutcome === undefined
       ? Effect.void
-      : Effect.suspend(() => options.onOutcome!(classifyOutcome(snapshot)!)).pipe(
+      : Effect.suspend(() => onOutcome(classifyOutcome(snapshot)!)).pipe(
         Effect.exit,
         Effect.asVoid
       )
@@ -1079,11 +1100,11 @@ const startGenericInternal: <
     childChanges
   }
 
-  if (options.onReady !== undefined) {
-    yield* options.onReady(ref, requestStop)
+  if (onReady !== undefined) {
+    yield* onReady(ref, requestStop)
   }
-  if (options.onSnapshot !== undefined) {
-    yield* notifyActiveSnapshot(options.onSnapshot, { status: "active", state: initial })
+  if (onSnapshot !== undefined) {
+    yield* notifyActiveSnapshot(onSnapshot, { status: "active", state: initial })
   }
 
   const reserveTermination = (termination: ProcessTermination) => {
@@ -1112,7 +1133,7 @@ const startGenericInternal: <
   }
 
   const forkRuntime = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-    options.detached === true
+    detached === true
       ? Effect.forkDetach(effect)
       : Effect.forkChild(effect)
 
@@ -1181,13 +1202,24 @@ const startCompiledInternal: <
   logic: ProcessLogic<State, Event, Error, Requirements, Output, InitialError>,
   options: StartInternalOptions
 ) {
+  const {
+    detached,
+    id: requestedId,
+    onOutcome,
+    onReady,
+    onSnapshot,
+    onStop,
+    parent,
+    runtime,
+    sendParent: overrideSendParent
+  } = options
   type ProcessTermination =
     | { readonly _tag: "Stopped" }
     | { readonly _tag: "Done"; readonly output: Output }
     | { readonly _tag: "Failure"; readonly cause: Cause.Cause<Error> }
 
-  const sessionId = yield* options.runtime.nextSessionId
-  const id = options.id ?? sessionId
+  const sessionId = yield* runtime.nextSessionId
+  const id = requestedId ?? sessionId
   const onDemand = logic.drain !== undefined
   const queue = onDemand ? undefined : yield* Queue.unbounded<Event>()
   // An on-demand drain never blocks on mailbox input: send schedules its owner
@@ -1280,19 +1312,18 @@ const startCompiledInternal: <
       sendTo,
       spawn,
       stop: stopChild
-    } = yield* makeChildRuntime(self, options))
+    } = yield* makeChildRuntime(self, runtime))
   }
   const cleanupStartupFailure = <A, E>(exit: Exit.Exit<A, E>): Effect.Effect<void> =>
     Exit.isFailure(exit)
       ? closeChildren(exit)
       : Effect.void
-  const cleanup = options.onStop ?? Effect.void
-  const sendParent = (event: unknown): Effect.Effect<void, StoppedError> =>
-    options.parent === undefined ? Effect.void : options.parent.send(event)
+  const cleanup = onStop ?? Effect.void
+  const sendParent = overrideSendParent ?? (parent === undefined ? noParentSend : parent.send)
 
   const scope: ProcessScope<Event> = {
     self,
-    parent: options.parent,
+    parent,
     spawn,
     sendParent,
     sendTo,
@@ -1335,7 +1366,7 @@ const startCompiledInternal: <
   const getCurrent = Effect.sync(() => MutableRef.get(current))
   const publishSnapshot: (
     snapshot: VersionedSnapshot<State, Error, Output>
-  ) => Effect.Effect<VersionedSnapshot<State, Error, Output>> = options.onSnapshot === undefined
+  ) => Effect.Effect<VersionedSnapshot<State, Error, Output>> = onSnapshot === undefined
     ? (snapshot) =>
       snapshot.changes === undefined
         ? Effect.succeed(snapshot)
@@ -1347,7 +1378,7 @@ const startCompiledInternal: <
       const runtimeSnapshot = snapshot.snapshot
       return runtimeSnapshot.status !== "active"
         ? publish
-        : publish.pipe(Effect.tap(() => notifyActiveSnapshot(options.onSnapshot!, runtimeSnapshot)))
+        : publish.pipe(Effect.tap(() => notifyActiveSnapshot(onSnapshot, runtimeSnapshot)))
     }
 
   const completeChanges = (
@@ -1456,9 +1487,9 @@ const startCompiledInternal: <
     exit: Exit.Exit<unknown, unknown>,
     completeDone: Effect.Effect<void>
   ): Effect.Effect<void> => {
-    const notifyOutcome = options.onOutcome === undefined
+    const notifyOutcome = onOutcome === undefined
       ? Effect.void
-      : Effect.suspend(() => options.onOutcome!(classifyOutcome(snapshot)!)).pipe(
+      : Effect.suspend(() => onOutcome(classifyOutcome(snapshot)!)).pipe(
         Effect.exit,
         Effect.asVoid
       )
@@ -1641,11 +1672,11 @@ const startCompiledInternal: <
     childChanges
   }
 
-  if (options.onReady !== undefined) {
-    yield* options.onReady(ref, requestStop)
+  if (onReady !== undefined) {
+    yield* onReady(ref, requestStop)
   }
-  if (options.onSnapshot !== undefined) {
-    yield* notifyActiveSnapshot(options.onSnapshot, { status: "active", state: initial })
+  if (onSnapshot !== undefined) {
+    yield* notifyActiveSnapshot(onSnapshot, { status: "active", state: initial })
   }
 
   if (onDemand) {
@@ -1696,7 +1727,7 @@ const startCompiledInternal: <
     const scheduledDrainRuntime = Effect.uninterruptible(
       Effect.yieldNow.pipe(Effect.andThen(providedDrainRuntime))
     )
-    const forkDrain = options.detached === true
+    const forkDrain = detached === true
       ? Effect.forkDetach(scheduledDrainRuntime, { startImmediately: true })
       : Effect.forkChild(scheduledDrainRuntime, { startImmediately: true })
 
@@ -1757,7 +1788,7 @@ const startCompiledInternal: <
     })
   )
 
-  worker = yield* (options.detached === true
+  worker = yield* (detached === true
     ? Effect.forkDetach(compiledRuntime, { startImmediately: true })
     : Effect.forkChild(compiledRuntime, { startImmediately: true }))
   return ref

--- a/test/Machine.test.ts
+++ b/test/Machine.test.ts
@@ -4097,6 +4097,93 @@ describe("Machine", () => {
       assert.strictEqual(yield* actor.join, "loaded")
     }))
 
+  it.effect("routes sendParent from an active invoked machine", () =>
+    Effect.gen(function*() {
+      const childStarted = yield* Deferred.make<void>()
+      const machine = Machine.make({
+        states: { Loading, Success: SuccessOutput },
+        events: [RequestSucceeded],
+        initial: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+      }).handle({
+        Loading: {
+          invoke: Machine.invoke({
+            id: "request",
+            src: () =>
+              Machine.logic({
+                initial: undefined,
+                run: ({ sendParent }) =>
+                  Deferred.succeed(childStarted, void 0).pipe(
+                    Effect.andThen(sendParent(new RequestSucceeded({ value: "child" }))),
+                    Effect.andThen(Effect.never)
+                  )
+              })
+          }),
+          on: {
+            RequestSucceeded: ({ event }) => FlatInitial.Success(new Success({ requestId: event.value }))
+          }
+        },
+        Success: {
+          output: ({ state }) => state.requestId
+        }
+      })
+
+      const actor = yield* Machine.start(machine)
+      yield* Deferred.await(childStarted)
+
+      assert.strictEqual(yield* actor.join, "child")
+    }))
+
+  it.effect("drops sendParent from a stale invoked machine finalizer", () =>
+    Effect.gen(function*() {
+      const childStarted = yield* Deferred.make<void>()
+      const machine = Machine.make({
+        states: { Idle, Loading, Success: SuccessOutput },
+        events: [Resolve, RequestSucceeded],
+        initial: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+      }).handle({
+        Idle: {
+          on: {
+            RequestSucceeded: ({ event }) => FlatInitial.Success(new Success({ requestId: event.value }))
+          }
+        },
+        Loading: {
+          invoke: Machine.invoke({
+            id: "request",
+            src: () =>
+              Machine.logic({
+                initial: undefined,
+                run: ({ sendParent }) =>
+                  Deferred.succeed(childStarted, void 0).pipe(
+                    Effect.andThen(Effect.never),
+                    Effect.onInterrupt(() => sendParent(new RequestSucceeded({ value: "stale" })))
+                  )
+              })
+          }),
+          on: {
+            Resolve: () => FlatInitial.Idle(new Idle({ userId: "resolved" }))
+          }
+        },
+        Success: {
+          output: ({ state }) => state.requestId
+        }
+      })
+
+      const actor = yield* Machine.start(machine)
+      yield* Deferred.await(childStarted)
+      yield* sendAndWaitForSnapshot(
+        actor,
+        new Resolve({}),
+        (snapshot) => snapshot.status === "active" && snapshot.state.path === "Idle"
+      )
+      yield* Effect.yieldNow
+
+      assert.deepStrictEqual(yield* actor.snapshot, {
+        status: "active",
+        state: { path: "Idle", value: new Idle({ userId: "resolved" }) }
+      })
+      yield* actor.stop
+    }))
+
   it.effect("invokeEffect maps typed failures without manual Effect recovery", () =>
     Effect.gen(function*() {
       const failure = new InvokeError({ message: "unavailable" })


### PR DESCRIPTION
## Summary

- run invoked machines with their original compiled process logic instead of allocating a wrapper process per invocation
- provide the state-scoped `sendParent` guard through compact internal runtime ownership while preserving stale-session filtering
- keep startup-only hooks out of long-lived runtime option closures
- cover active and stale-finalizer `sendParent` behavior explicitly

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed

Additional local validation:

- `pnpm perf:types`
- three independent full base and candidate memory processes, plus reverse-order throughput controls
- parent/child relationship memory and observed-invoke memory decreased without changing the public API or type inference
