### PR TITLE
Compile machine execution kernel

### DIFF
--- a/.changeset/compiled-machines-execute.md
+++ b/.changeset/compiled-machines-execute.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Compile reusable statechart execution metadata and run eligible flat machines through a synchronous specialized planner inside the compact Effect process kernel. This removes per-event Effect wrappers and repeated topology construction while preserving schema validation, raised-event stabilization, lifecycle ordering, observation, interruption, invoked children, and the public planning and machine APIs.

--- a/src/internal/machinePlanner.ts
+++ b/src/internal/machinePlanner.ts
@@ -67,6 +67,22 @@ interface Collected<Event> {
   readonly emittedEvents: Array<unknown>
 }
 
+const targetBuilderCache = new WeakMap<object, Map<string, unknown>>()
+
+const getTargetBuilder = (machine: Machine.Any, path: string): any => {
+  let byPath = targetBuilderCache.get(machine)
+  if (byPath === undefined) {
+    byPath = new Map()
+    targetBuilderCache.set(machine, byPath)
+  }
+  if (byPath.has(path)) {
+    return byPath.get(path)
+  }
+  const builder = machine.makeTargetBuilder(path as any)
+  byPath.set(path, builder)
+  return builder
+}
+
 const makeCollector = <Event>(machine: Machine.Any): Collected<Event> => {
   const commands: Array<RuntimeCommand> = []
   const raisedEvents: Array<Event> = []
@@ -389,7 +405,7 @@ const resolveHistoryTarget = (
   }
   const collected = collectTransition(machine, fallback, {
     event,
-    target: machine.makeTargetBuilder(target.parent).full,
+    target: getTargetBuilder(machine, target.parent).full,
     parent: target.parent
   })
   if (collected.state === undefined || isHistoryTarget(collected.state) || !isSnapshot(collected.state)) {
@@ -591,7 +607,7 @@ const makeTransitionContext = <
   parents: getParentValues(machine, configuration, path) as Machine.ParentStateValues<States, StateId>,
   event,
   snapshot,
-  target: machine.makeTargetBuilder(path as StateId)
+  target: getTargetBuilder(machine, path)
 })
 
 const makeDoneContext = <
@@ -613,7 +629,7 @@ const makeDoneContext = <
   event,
   output: output as Machine.CompletionOutputByIdentifier<States, StateId>,
   snapshot,
-  target: machine.makeTargetBuilder(path as StateId)
+  target: getTargetBuilder(machine, path)
 })
 
 const collectStateActions = <
@@ -715,7 +731,7 @@ const selectAlwaysTransitions = <
               >,
               event,
               snapshot: capturedSnapshot(),
-              target: machine.makeTargetBuilder(path as Machine.StateIdentifier<States>)
+              target: getTargetBuilder(machine, path)
             }
           })
         }
@@ -1081,7 +1097,7 @@ const resolveChoiceTarget = (
         parent: getParentValue(machine, provisional, node.path),
         parents: getParentValues(machine, provisional, node.path),
         event,
-        target: machine.makeTargetBuilder(node.path as any)
+        target: getTargetBuilder(machine, node.path)
       })
       if (collected.state === undefined) {
         throw new Error(`Machine choice resolver for "${node.path}" must return a target`)
@@ -1928,6 +1944,180 @@ const macrostepConfiguration = <
   const emittedEvents = [...step.emittedEvents]
   const microsteps = [step]
   return settle(machine, step.next, decodedEvent, commands, raisedEvents, emittedEvents, microsteps)
+}
+
+interface FlatExecutionDescriptor {
+  readonly paths: ReadonlySet<string>
+}
+
+const compileFlatExecutionDescriptor = (machine: Machine.Any): FlatExecutionDescriptor | undefined => {
+  const paths = new Set<string>()
+  for (const node of machine.stateNodes.byPath.values() as Iterable<Machine.StateNode>) {
+    if (node.parent !== undefined || (node.type !== "atomic" && node.type !== "final")) {
+      return undefined
+    }
+    const config = machine.handlers[node.path] as Machine.AnyStateConfig | undefined
+    if (
+      config?.entry !== undefined || config?.exit !== undefined || config?.always !== undefined ||
+      config?.onDone !== undefined || config?.invoke !== undefined
+    ) {
+      return undefined
+    }
+    paths.add(node.path)
+  }
+  return paths.size === 0 ? undefined : { paths }
+}
+
+const planFlatConfiguration = (
+  machine: Machine.Any,
+  descriptor: FlatExecutionDescriptor,
+  configuration: ActiveConfiguration,
+  input: unknown
+): MacrostepPlan<ActiveConfiguration, any, any, any, any> => {
+  const decoded = decodeEventSync(machine, input) as { readonly _tag: PropertyKey }
+  if (isActiveFinalConfiguration(machine, configuration)) {
+    const completed = completeConfigurationSync(machine, configuration, decoded)
+    const root = getRootPath(machine, completed.configuration)
+    if (!completed.configuration.outputs.has(root)) {
+      throw new Error("Machine reached a terminal configuration without a completed root output")
+    }
+    return {
+      next: completed.configuration,
+      commands: [],
+      emittedEvents: [],
+      microsteps: [],
+      done: true,
+      output: completed.configuration.outputs.get(root)
+    }
+  }
+
+  let current = configuration
+  let event: any = decoded
+  const pending: Array<any> = []
+  let pendingIndex = 0
+  const commands: Array<RuntimeCommand> = []
+  const emittedEvents: Array<unknown> = []
+  const microsteps: Array<MicrostepPlan<ActiveConfiguration, any, any, any>> = []
+  let iterations = 0
+
+  while (true) {
+    iterations += 1
+    if (iterations > MaxMacrostepIterations) {
+      throw new InfiniteTransitionError({
+        machineId: machine.id,
+        state: String(getLeafPath(machine, current)),
+        maxIterations: MaxMacrostepIterations
+      })
+    }
+
+    const source = getRootPath(machine, current)
+    const transition = normalizeTransition(machine.handlers[source]?.on?.[event._tag])
+    if (transition !== undefined) {
+      const snapshot = snapshotFromConfiguration(machine, current)
+      const collected = collectTransition(machine, transition.transition, {
+        state: getActiveValue(current, source),
+        parent: undefined,
+        parents: {},
+        event,
+        snapshot,
+        target: getTargetBuilder(machine, source)
+      })
+      validateDeclaredTransitionTarget(
+        source,
+        { type: "event", event: event._tag },
+        transition.targets,
+        collected.state
+      )
+
+      let next = current
+      let targetPath: string | undefined
+      if (collected.state !== undefined) {
+        if (!isTarget(collected.state) && !isSnapshot(collected.state)) {
+          throw new Error("Machine expected transition target to be a snapshot or target builder result")
+        }
+        targetPath = getTargetNodePath(collected.state)
+        if (!descriptor.paths.has(targetPath)) {
+          throw new Error(`Machine expected flat transition target "${targetPath}" to be a root state`)
+        }
+        next = normalizeTargetConfigurationSync(machine, current, collected.state as any)
+      }
+      const changed = transition.reenter || source !== targetPath && targetPath !== undefined
+      const exitPaths = changed ? [source] : []
+      const entryPaths = changed ? [getRootPath(machine, next)] : []
+      const step = {
+        next,
+        event,
+        transitions: [{
+          source,
+          trigger: { type: "event" as const, event: event._tag },
+          reenter: transition.reenter,
+          target: targetPath,
+          resolvedTarget: targetPath
+        }],
+        commands: collected.commands,
+        raisedEvents: collected.raisedEvents,
+        emittedEvents: collected.emittedEvents,
+        exitPaths,
+        entryPaths,
+        changed
+      }
+      current = next
+      commands.push(...collected.commands)
+      pending.push(...collected.raisedEvents)
+      emittedEvents.push(...collected.emittedEvents)
+      microsteps.push(step)
+
+      if (isActiveFinalConfiguration(machine, current)) {
+        const completed = completeConfigurationSync(machine, current, event)
+        const root = getRootPath(machine, completed.configuration)
+        if (!completed.configuration.outputs.has(root)) {
+          throw new Error("Machine reached a terminal configuration without a completed root output")
+        }
+        return {
+          next: completed.configuration,
+          commands,
+          emittedEvents,
+          microsteps,
+          done: true,
+          output: completed.configuration.outputs.get(root)
+        }
+      }
+    }
+
+    if (pendingIndex >= pending.length) {
+      return {
+        next: current,
+        commands,
+        emittedEvents,
+        microsteps,
+        done: false,
+        output: undefined
+      }
+    }
+    event = pending[pendingIndex++]
+  }
+}
+
+export interface CompiledExecutionPlan {
+  readonly plan: (
+    configuration: ActiveConfiguration,
+    event: unknown
+  ) => MacrostepPlan<ActiveConfiguration, any, any, any, any>
+}
+
+const executionPlanCache = new WeakMap<Machine.Any, CompiledExecutionPlan>()
+
+export const compileExecutionPlan = (machine: Machine.Any): CompiledExecutionPlan => {
+  const cached = executionPlanCache.get(machine)
+  if (cached !== undefined) {
+    return cached
+  }
+  const flat = compileFlatExecutionDescriptor(machine)
+  const compiled: CompiledExecutionPlan = flat === undefined
+    ? { plan: (configuration, event) => planConfiguration(machine as any, configuration, event as any) }
+    : { plan: (configuration, event) => planFlatConfiguration(machine, flat, configuration, event) }
+  executionPlanCache.set(machine, compiled)
+  return compiled
 }
 
 const snapshotMacrostep = <

--- a/src/internal/machineProcess.ts
+++ b/src/internal/machineProcess.ts
@@ -160,6 +160,311 @@ const makeInvokeSnapshotHandler = (
     )
 }
 
+const makeChildlessCompiledDrain = (
+  machine: Machine.Any
+): (
+  context: internalRuntime.CompiledProcessContext<any, any>
+) => Effect.Effect<Option.Option<any>, any, any> => {
+  const executionPlan = internalPlanner.compileExecutionPlan(machine)
+  return (context) => {
+    let current = context.state()
+    if (internalPlanner.isFinalState(machine, current)) {
+      return internalPlanner.getFinalOutputEffect(
+        machine,
+        current,
+        internalPlanner.InitialEvent
+      ).pipe(Effect.map(Option.some))
+    }
+
+    let configuration = context.executionState as Model.ActiveConfiguration | undefined
+    let liveRuntime: Runtime<unknown, unknown> | undefined
+    let loop: Effect.Effect<Option.Option<any>, any, any>
+    loop = Effect.suspend(() => {
+      const pending = context.poll()
+      if (Option.isNone(pending)) {
+        context.executionState = undefined
+        return Effect.succeed(Option.none())
+      }
+
+      let planned
+      try {
+        planned = executionPlan.plan(
+          configuration ?? Model.normalizeConfigurationSync(machine, current),
+          pending.value
+        )
+      } catch (error) {
+        return error instanceof InfiniteTransitionError || error instanceof MachineSchemaDecodeError
+          ? Effect.fail(error)
+          : Effect.die(error)
+      }
+      configuration = planned.next
+      context.executionState = configuration
+      if (planned.microsteps.length === 0) {
+        return loop
+      }
+
+      const next = Model.snapshotFromConfiguration(machine, planned.next)
+      const beforeCommit = planned.commands.length === 0
+        ? undefined
+        : internalPlanner.runCommands(planned.commands, context.scope)
+      const afterCommit = planned.emittedEvents.length === 0
+        ? undefined
+        : internalPlanner.runEmittedEvents(
+          planned.emittedEvents,
+          liveRuntime ??= internalPlanner.makeLiveRuntime(machine, context.scope)
+        )
+      const commit = (): Effect.Effect<void> | undefined => {
+        const notification = context.commit(next)
+        current = next
+        return notification
+      }
+      const continueAfterCommit = (): Effect.Effect<Option.Option<any>, any, any> => {
+        const continued = planned.done ? Effect.succeed(Option.some(planned.output)) : loop
+        return afterCommit === undefined ? continued : afterCommit.pipe(Effect.andThen(continued))
+      }
+
+      if (beforeCommit === undefined) {
+        const notification = commit()
+        const continued = continueAfterCommit()
+        return notification === undefined ? continued : notification.pipe(Effect.andThen(continued))
+      }
+      return beforeCommit.pipe(
+        Effect.andThen(Effect.suspend(() => commit() ?? Effect.void)),
+        Effect.andThen(continueAfterCommit())
+      )
+    })
+    return internalRuntime.provideMachineRuntime(loop, context.scope)
+  }
+}
+
+interface InvokeExecutionState {
+  readonly sessions: Map<string, InvokeSession>
+  configuration: Model.ActiveConfiguration | undefined
+  initialized: boolean
+}
+
+const makeInvokingCompiledDrain = (
+  machine: Machine.Any
+): (
+  context: internalRuntime.CompiledProcessContext<any, any>
+) => Effect.Effect<Option.Option<any>, any, any> => {
+  const executionPlan = internalPlanner.compileExecutionPlan(machine)
+  return (context) => {
+    let current = context.state()
+    if (internalPlanner.isFinalState(machine, current)) {
+      return internalPlanner.getFinalOutputEffect(
+        machine,
+        current,
+        internalPlanner.InitialEvent
+      ).pipe(Effect.map(Option.some))
+    }
+
+    const scope = context.scope
+    const execution = (context.executionState ??= {
+      sessions: new Map(),
+      configuration: undefined,
+      initialized: false
+    }) as InvokeExecutionState
+    const invokeSessions = execution.sessions
+    let liveRuntime: Runtime<any, any> | undefined
+
+    const makeInvokeSessionKey = (path: string, id: string): string => `${path.length}:${path}${id}`
+    const makeInvokeChildId = (path: string, id: string): string => `Machine.invoke:${makeInvokeSessionKey(path, id)}`
+    const stopInvokeSession = (session: InvokeSession): Effect.Effect<void> => scope.stopChild(session.childId)
+    const removeInvoke = (
+      key: string,
+      token: symbol | undefined
+    ): Effect.Effect<void> =>
+      Effect.sync(() => {
+        const current = invokeSessions.get(key)
+        if (current === undefined || (token !== undefined && current.token !== token)) {
+          return undefined
+        }
+        invokeSessions.delete(key)
+        return current
+      }).pipe(
+        Effect.flatMap((session) => session === undefined ? Effect.void : stopInvokeSession(session))
+      )
+    const stopInvoke = (key: string): Effect.Effect<void> => removeInvoke(key, undefined)
+    const stopAllInvokes = (): Effect.Effect<void> =>
+      Effect.suspend(() => {
+        const effects = Array.from(invokeSessions.values(), stopInvokeSession)
+        invokeSessions.clear()
+        return runParallelDiscard(effects)
+      })
+    const startInvoke = Effect.fnUntraced(function*(path: string, config: AnyInvokeConfig) {
+      const token = Symbol()
+      const invokeId = String(config.id)
+      const key = makeInvokeSessionKey(path, invokeId)
+      const childId = config.address === undefined ? makeInvokeChildId(path, invokeId) : String(config.address)
+      const reserved = yield* Effect.sync(() => {
+        if (invokeSessions.has(key)) {
+          return false
+        }
+        invokeSessions.set(key, { token, childId, path })
+        return true
+      })
+      if (!reserved) {
+        return yield* Effect.fail(new ChildAlreadyExistsError({ id: invokeId }))
+      }
+      const logic = config.src() as internalRuntime.ProcessLogic<any, any, any, any, any, any>
+      const sendParent = makeInvokeSendParent(invokeSessions, scope.self, key, token)
+      yield* scope.spawn(
+        logic,
+        {
+          id: childId,
+          ...(config.descriptor === undefined ? undefined : { descriptor: config.descriptor }),
+          [internalRuntime.sendParentOverride]: sendParent,
+          onOutcome: makeInvokeOutcomeHandler(
+            invokeSessions,
+            scope.self,
+            scope.failCause,
+            config,
+            key,
+            token
+          ),
+          ...(config.snapshot === undefined ? undefined : {
+            [internalRuntime.activeSnapshotObserver]: makeInvokeSnapshotHandler(
+              invokeSessions,
+              scope.self,
+              config,
+              key,
+              token
+            )
+          })
+        }
+      ).pipe(
+        Effect.onExit((exit) => Exit.isFailure(exit) ? removeInvoke(key, token) : Effect.void)
+      )
+    })
+    const startInvokes = (
+      configuration: Model.ActiveConfiguration,
+      paths: ReadonlyArray<string>,
+      event: Machine.LifecycleEvent<any>
+    ): Effect.Effect<void, any, any> | undefined => {
+      const effects = internalPlanner.sortEntryPaths(machine, paths)
+        .filter((path) => configuration.active.has(path))
+        .flatMap((path) =>
+          getInvokes(Model.getStateConfigByPath(machine, path), {
+            state: Model.getActiveValue(configuration, path),
+            parent: Model.getParentValue(machine, configuration, path),
+            parents: Model.getParentValues(machine, configuration, path),
+            event
+          }).map((config) => startInvoke(path, config))
+        )
+      return effects.length === 0 ? undefined : runSequentialDiscard(effects)
+    }
+    const stopInvokes = (paths: ReadonlyArray<string>): Effect.Effect<void> | undefined => {
+      const keys = new Set(internalPlanner.sortExitPaths(machine, paths))
+      const effects = Array.from(invokeSessions.entries())
+        .filter(([, session]) => keys.has(session.path))
+        .map(([key]) => stopInvoke(key))
+      return effects.length === 0 ? undefined : runParallelDiscard(effects)
+    }
+
+    let loop: Effect.Effect<Option.Option<any>, any, any>
+    loop = Effect.suspend(() => {
+      const pending = context.poll()
+      if (Option.isNone(pending)) {
+        execution.configuration = undefined
+        return Effect.succeed(Option.none())
+      }
+
+      let planned
+      try {
+        planned = executionPlan.plan(
+          execution.configuration ?? Model.normalizeConfigurationSync(machine, current),
+          pending.value
+        )
+      } catch (error) {
+        return error instanceof InfiniteTransitionError || error instanceof MachineSchemaDecodeError
+          ? Effect.fail(error)
+          : Effect.die(error)
+      }
+      execution.configuration = planned.next
+      if (planned.microsteps.length === 0) {
+        return loop
+      }
+
+      const changed = planned.microsteps.some((step) => step.changed)
+      const exitPaths = changed ? planned.microsteps.flatMap((step) => step.exitPaths) : []
+      const entryEvents = new Map<string, Machine.LifecycleEvent<any>>()
+      if (changed) {
+        for (const step of planned.microsteps) {
+          if (step.changed) {
+            for (const path of step.entryPaths) {
+              entryEvents.set(path, step.event)
+            }
+          }
+        }
+      }
+
+      const next = Model.snapshotFromConfiguration(machine, planned.next)
+      const beforeCommit: Array<Effect.Effect<void, any, any>> = []
+      if (planned.commands.length > 0) {
+        beforeCommit.push(internalPlanner.runCommands(planned.commands, scope))
+      }
+      if (changed) {
+        const stopping = stopInvokes(exitPaths)
+        if (stopping !== undefined) beforeCommit.push(stopping)
+      }
+      const afterCommit: Array<Effect.Effect<void, any, any>> = []
+      if (planned.emittedEvents.length > 0) {
+        afterCommit.push(
+          internalPlanner.runEmittedEvents(
+            planned.emittedEvents,
+            liveRuntime ??= internalPlanner.makeLiveRuntime(machine, scope)
+          )
+        )
+      }
+      if (planned.done) {
+        afterCommit.push(stopAllInvokes())
+      } else if (changed) {
+        for (const [path, entryEvent] of entryEvents) {
+          const starting = startInvokes(planned.next, [path], entryEvent)
+          if (starting !== undefined) afterCommit.push(starting)
+        }
+      }
+
+      const commit = (): Effect.Effect<void> | undefined => {
+        const notification = context.commit(next)
+        current = next
+        return notification
+      }
+      const continueAfterCommit = (): Effect.Effect<Option.Option<any>, any, any> => {
+        const continued = planned.done ? Effect.succeed(Option.some(planned.output)) : loop
+        return afterCommit.length === 0
+          ? continued
+          : runSequentialDiscard(afterCommit).pipe(Effect.andThen(continued))
+      }
+      if (beforeCommit.length === 0) {
+        const notification = commit()
+        const continued = continueAfterCommit()
+        return notification === undefined ? continued : notification.pipe(Effect.andThen(continued))
+      }
+      return runSequentialDiscard(beforeCommit).pipe(
+        Effect.andThen(Effect.suspend(() => commit() ?? Effect.void)),
+        Effect.andThen(continueAfterCommit())
+      )
+    })
+
+    const initialize = (): Effect.Effect<Option.Option<any>, any, any> => {
+      if (execution.initialized) {
+        return loop
+      }
+      execution.configuration = Model.normalizeConfigurationSync(machine, current)
+      const starting = startInvokes(
+        execution.configuration,
+        Model.getInitialEntryPaths(machine, execution.configuration),
+        internalPlanner.InitialEvent
+      )
+      execution.initialized = true
+      return starting === undefined ? loop : starting.pipe(Effect.andThen(loop))
+    }
+    return internalRuntime.provideMachineRuntime(Effect.suspend(initialize), scope)
+  }
+}
+
 const makeProcessLogic: <
   const States extends Machine.StateSchemas,
   const Events extends ReadonlyArray<Machine.TaggedSchema>,
@@ -209,263 +514,34 @@ const makeProcessLogic: <
   entry: ProcessEntry<States, Input>
 ) => {
   const hasInvokes = hasInvokeCapability(machine)
-  // A process logic value may be reused for multiple starts. Key retained
-  // invoke state by the stable process address so each running instance owns
-  // its own table even when an invoke wrapper decorates the context object.
-  const invokeSessionsByContext = new WeakMap<object, {
-    readonly sessions: Map<string, InvokeSession>
-    initialized: boolean
-  }>()
   return ({
     [internalRuntime.childlessProcess]: hasInvokes ? undefined : true,
     [internalRuntime.compiledProcess]: true,
+    [internalRuntime.compiledProcessDrain]: hasInvokes
+      ? makeInvokingCompiledDrain(machine)
+      : makeChildlessCompiledDrain(machine),
     initial: (scope) =>
       internalRuntime.provideMachineRuntime(
-        Effect.gen(function*() {
-          if (entry._tag === "Resume") {
-            return yield* Model.normalizeSnapshotEffect(machine, entry.snapshot)
-          }
-          const planned = yield* internalPlanner.planInitial(machine, ...entry.args)
-          yield* internalPlanner.runCommands(
-            planned.commands,
-            scope
-          )
-          if (planned.emittedEvents.length > 0) {
-            yield* internalPlanner.runEmittedEvents(
-              planned.emittedEvents,
-              internalPlanner.makeLiveRuntime<Machine.EventOf<Events>, Machine.EmitOf<Emits>>(machine, scope)
-            )
-          }
-          return planned.state
-        }),
+        entry._tag === "Resume"
+          ? Model.normalizeSnapshotEffect(machine, entry.snapshot)
+          : internalPlanner.planInitial(machine, ...entry.args).pipe(Effect.flatMap((planned) => {
+            const commands = planned.commands.length === 0
+              ? undefined
+              : internalPlanner.runCommands(planned.commands, scope)
+            const emitted = planned.emittedEvents.length === 0
+              ? undefined
+              : internalPlanner.runEmittedEvents(
+                planned.emittedEvents,
+                internalPlanner.makeLiveRuntime<Machine.EventOf<Events>, Machine.EmitOf<Emits>>(machine, scope)
+              )
+            const result = Effect.succeed(planned.state)
+            return commands === undefined
+              ? emitted === undefined ? result : emitted.pipe(Effect.andThen(result))
+              : emitted === undefined
+              ? commands.pipe(Effect.andThen(result))
+              : commands.pipe(Effect.andThen(emitted), Effect.andThen(result))
+          })),
         scope
-      ),
-    drain: (context: internalRuntime.ProcessContext<Machine.Snapshot<States>, Machine.EventOf<Events>>) =>
-      internalRuntime.provideMachineRuntime(
-        Effect.gen(function*() {
-          const poll = context.poll ?? Queue.poll(context.mailbox!)
-          const { state, setState } = context
-          let current = yield* state
-          if (internalPlanner.isFinalState(machine, current)) {
-            return Option.some(
-              yield* internalPlanner.getFinalOutputEffect<States, Events, Output>(
-                machine,
-                current,
-                internalPlanner.InitialEvent
-              )
-            )
-          }
-
-          let configuration: Model.ActiveConfiguration | undefined
-          let liveRuntime: Runtime<Machine.EventOf<Events>, Machine.EmitOf<Emits>> | undefined
-
-          let stopAllInvokes: Effect.Effect<void> | undefined
-          let startInvokes:
-            | ((
-              configuration: Model.ActiveConfiguration,
-              paths: ReadonlyArray<string>,
-              event: Machine.LifecycleEvent<Events>
-            ) => Effect.Effect<void, E | MachineSchemaDecodeError, R>)
-            | undefined
-          let stopInvokes: ((paths: ReadonlyArray<string>) => Effect.Effect<void>) | undefined
-
-          if (hasInvokes) {
-            let session = invokeSessionsByContext.get(context.self)
-            if (session === undefined) {
-              session = { sessions: new Map(), initialized: false }
-              invokeSessionsByContext.set(context.self, session)
-            }
-            const invokeSessions = session.sessions
-            const makeInvokeSessionKey = (path: string, id: string): string => `${path.length}:${path}${id}`
-            const makeInvokeChildId = (path: string, id: string): string =>
-              `Machine.invoke:${makeInvokeSessionKey(path, id)}`
-            const stopInvokeSession = (session: InvokeSession): Effect.Effect<void> =>
-              context.stopChild(session.childId)
-            const removeInvoke = (
-              key: string,
-              token: symbol | undefined
-            ): Effect.Effect<void> =>
-              Effect.sync(() => {
-                const current = invokeSessions.get(key)
-                if (current === undefined || (token !== undefined && current.token !== token)) {
-                  return undefined
-                }
-                invokeSessions.delete(key)
-                return current
-              }).pipe(
-                Effect.flatMap((session) =>
-                  session === undefined
-                    ? Effect.void
-                    : stopInvokeSession(session)
-                )
-              )
-            const stopInvoke = (key: string): Effect.Effect<void> => removeInvoke(key, undefined)
-            stopAllInvokes = Effect.suspend(() => {
-              const effects = Array.from(invokeSessions.values(), stopInvokeSession)
-              invokeSessions.clear()
-              return runParallelDiscard(effects)
-            })
-            const startInvoke = Effect.fnUntraced(function*<StateId extends Machine.StateIdentifier<States>>(
-              path: StateId,
-              config: AnyInvokeConfig
-            ) {
-              const token = Symbol()
-              const invokeId = String(config.id)
-              const key = makeInvokeSessionKey(path, invokeId)
-              const childId = config.address === undefined ? makeInvokeChildId(path, invokeId) : String(config.address)
-              const reserved = yield* Effect.sync(() => {
-                if (invokeSessions.has(key)) {
-                  return false
-                }
-                invokeSessions.set(key, { token, childId, path })
-                return true
-              })
-              if (!reserved) {
-                return yield* Effect.fail(new ChildAlreadyExistsError({ id: invokeId }))
-              }
-              const logic = config.src()
-              const processLogic = logic as internalRuntime.ProcessLogic<any, any, any, any, any, any>
-              const sendParent = makeInvokeSendParent(invokeSessions, context.self, key, token)
-              yield* context.spawn(
-                processLogic,
-                {
-                  id: childId,
-                  ...(config.descriptor === undefined ? undefined : { descriptor: config.descriptor }),
-                  [internalRuntime.sendParentOverride]: sendParent,
-                  onOutcome: makeInvokeOutcomeHandler(
-                    invokeSessions,
-                    context.self,
-                    context.failCause,
-                    config,
-                    key,
-                    token
-                  ),
-                  ...(config.snapshot === undefined ? undefined : {
-                    [internalRuntime.activeSnapshotObserver]: makeInvokeSnapshotHandler(
-                      invokeSessions,
-                      context.self,
-                      config,
-                      key,
-                      token
-                    )
-                  })
-                }
-              ).pipe(
-                Effect.onExit((exit) =>
-                  Exit.isFailure(exit)
-                    ? removeInvoke(key, token)
-                    : Effect.void
-                )
-              )
-            })
-            startInvokes = (
-              configuration: Model.ActiveConfiguration,
-              paths: ReadonlyArray<string>,
-              event: Machine.LifecycleEvent<Events>
-            ) =>
-              runSequentialDiscard(
-                internalPlanner.sortEntryPaths(machine, paths)
-                  .filter((path) => configuration.active.has(path))
-                  .flatMap((path) =>
-                    getInvokes(Model.getStateConfigByPath(machine, path), {
-                      state: Model.getActiveValue(configuration, path),
-                      parent: Model.getParentValue(machine, configuration, path),
-                      parents: Model.getParentValues(machine, configuration, path),
-                      event
-                    }).map((config) =>
-                      startInvoke(
-                        path as Machine.StateIdentifier<States>,
-                        config
-                      ) as Effect.Effect<void, E | MachineSchemaDecodeError, R>
-                    )
-                  )
-              )
-            stopInvokes = (paths) =>
-              Effect.suspend(() =>
-                runParallelDiscard(
-                  internalPlanner.sortExitPaths(machine, paths).flatMap((path) =>
-                    Array.from(invokeSessions.entries())
-                      .filter(([, session]) => session.path === path)
-                      .map(([key]) => stopInvoke(key))
-                  )
-                )
-              )
-
-            configuration = Model.normalizeConfigurationSync(machine, current)
-            if (!session.initialized) {
-              yield* startInvokes(
-                configuration,
-                Model.getInitialEntryPaths(machine, configuration),
-                internalPlanner.InitialEvent
-              )
-              session.initialized = true
-            }
-          }
-
-          while (true) {
-            const pending = yield* poll
-            if (Option.isNone(pending)) {
-              return Option.none<Output>()
-            }
-            const event = pending.value
-            let planned
-            try {
-              planned = internalPlanner.planConfiguration(
-                machine,
-                configuration ?? Model.normalizeConfigurationSync(machine, current),
-                event
-              )
-            } catch (error) {
-              if (error instanceof InfiniteTransitionError || error instanceof MachineSchemaDecodeError) {
-                return yield* error
-              }
-              throw error
-            }
-            configuration = planned.next
-
-            if (planned.microsteps.length > 0) {
-              let changed = false
-              let exitPaths: ReadonlyArray<string> = []
-              let entryEvents: Map<string, Machine.LifecycleEvent<Events>> | undefined
-              if (hasInvokes) {
-                changed = planned.microsteps.some((step) => step.changed)
-                exitPaths = planned.microsteps.flatMap((step) => step.exitPaths)
-                entryEvents = new Map()
-                for (const step of planned.microsteps) {
-                  if (step.changed) {
-                    for (const path of step.entryPaths) {
-                      entryEvents.set(path, step.event as Machine.LifecycleEvent<Events>)
-                    }
-                  }
-                }
-              }
-              const next = Model.snapshotFromConfiguration<States>(machine, planned.next)
-              yield* internalPlanner.runCommands(planned.commands, context)
-              if (changed) {
-                yield* stopInvokes!(exitPaths)
-              }
-              yield* setState(next)
-              current = next
-              if (planned.emittedEvents.length > 0) {
-                yield* internalPlanner.runEmittedEvents(
-                  planned.emittedEvents as ReadonlyArray<Machine.EmitOf<Emits>>,
-                  liveRuntime ??= internalPlanner.makeLiveRuntime(machine, context)
-                )
-              }
-              if (planned.done) {
-                if (stopAllInvokes !== undefined) {
-                  yield* stopAllInvokes
-                }
-                return Option.some(planned.output as Output)
-              } else if (changed) {
-                for (const [path, entryEvent] of entryEvents!) {
-                  yield* startInvokes!(planned.next, [path], entryEvent)
-                }
-              }
-            }
-          }
-        }),
-        context
       ),
     run: (context) =>
       internalRuntime.provideMachineRuntime(

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -51,6 +51,9 @@ export const childlessProcess: unique symbol = Symbol.for("effect/Machine/childl
 export const compiledProcess: unique symbol = Symbol.for("effect/Machine/compiledProcess")
 
 /** @internal */
+export const compiledProcessDrain: unique symbol = Symbol.for("effect/Machine/compiledProcessDrain")
+
+/** @internal */
 export const sendParentOverride: unique symbol = Symbol.for("effect/Machine/sendParentOverride")
 
 type ChildObservation = Option.Option<MachineRef<any, any, any, any>>
@@ -204,6 +207,24 @@ export interface ProcessContext<State, Event> extends ProcessScope<Event> {
   ) => Effect.Effect<void, E, R>
 }
 
+/**
+ * Owner-local execution context for compiled statecharts.
+ *
+ * Unlike `ProcessContext`, synchronous mailbox and state operations do not
+ * introduce an Effect boundary. The compiled drain still returns an Effect so
+ * actor commands, invokes, observation callbacks, interruption, and the Effect
+ * scheduler remain explicit at their actual boundaries.
+ *
+ * @internal
+ */
+export interface CompiledProcessContext<State, Event> {
+  readonly scope: ProcessScope<Event>
+  readonly poll: () => Option.Option<Event>
+  readonly state: () => State
+  readonly commit: (state: State) => Effect.Effect<void> | undefined
+  executionState: unknown
+}
+
 interface CompactProcessMailbox<Event> {
   items: Array<Event> | undefined
   index: number
@@ -250,6 +271,10 @@ export interface ProcessLogic<
   /** @internal */
   readonly drain?: (
     context: ProcessContext<State, Event>
+  ) => Effect.Effect<Option.Option<Output>, Error, Requirements>
+  /** @internal */
+  readonly [compiledProcessDrain]?: (
+    context: CompiledProcessContext<State, Event>
   ) => Effect.Effect<Option.Option<Output>, Error, Requirements>
 }
 
@@ -1216,7 +1241,8 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
   private readonly address: ProcessAddress<unknown>
   private childRuntime: ChildRuntime = childlessRuntime
   private processScope!: ProcessScope<unknown>
-  private processContext!: ProcessContext<unknown, unknown>
+  private processContext: ProcessContext<unknown, unknown> | undefined
+  private compiledContext: CompiledProcessContext<unknown, unknown> | undefined
   private current!: VersionedSnapshot<unknown, unknown, unknown>
   private completion: Effect.Effect<unknown, unknown> | undefined
   private waiter: Deferred.Deferred<unknown, unknown> | undefined
@@ -1277,13 +1303,23 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
         changes: undefined,
         snapshot: { status: "active", state: initial }
       }
-      self.processContext = {
-        ...self.processScope,
-        receive: Effect.never,
-        poll: Effect.sync(() => pollCompactMailbox(self.mailbox)),
-        state: Effect.sync(() => self.current.snapshot.state),
-        setState: (state: unknown) => self.setActiveState(state),
-        updateState: (f) => self.updateState(f)
+      if (self.logic[compiledProcessDrain] === undefined) {
+        self.processContext = {
+          ...self.processScope,
+          receive: Effect.never,
+          poll: Effect.sync(() => pollCompactMailbox(self.mailbox)),
+          state: Effect.sync(() => self.current.snapshot.state),
+          setState: (state: unknown) => self.setActiveState(state),
+          updateState: (f) => self.updateState(f)
+        }
+      } else {
+        self.compiledContext = {
+          scope: self.processScope,
+          poll: () => pollCompactMailbox(self.mailbox),
+          state: () => self.current.snapshot.state,
+          commit: (state: unknown) => self.commitActiveState(state),
+          executionState: undefined
+        }
       }
 
       if (self.options.onReady !== undefined) {
@@ -1470,7 +1506,14 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
             return yield* self.finishRequestedTermination()
           }
 
-          const exit = yield* restore(Effect.suspend(() => self.logic.drain!(self.processContext))).pipe(Effect.exit)
+          const exit = yield* restore(
+            Effect.suspend(() => {
+              const compiledDrain = self.logic[compiledProcessDrain]
+              return compiledDrain === undefined
+                ? self.logic.drain!(self.processContext!)
+                : compiledDrain(self.compiledContext!)
+            })
+          ).pipe(Effect.exit)
           if (Exit.isFailure(exit)) {
             if (self.requestedTermination === undefined) {
               yield* self.requestTermination({ _tag: "Failure", cause: exit.cause })
@@ -1533,6 +1576,9 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
             this.draining = false
             this.worker = undefined
             this.interruptRequested = false
+            if (this.compiledContext !== undefined) {
+              this.compiledContext.executionState = undefined
+            }
             this.completion = completion
             if (this.waiter !== undefined) {
               Deferred.doneUnsafe(this.waiter, completion)
@@ -1579,20 +1625,27 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
   }
 
   private setActiveState(state: unknown): Effect.Effect<void> {
-    return Effect.suspend(() => {
-      const latest = this.current
-      if (latest.terminalizing || latest.snapshot.status !== "active") {
-        return Effect.void
-      }
-      const versioned = {
-        revision: latest.revision + 1,
-        snapshot: { status: "active" as const, state },
-        terminalizing: false,
-        changes: latest.changes
-      }
-      this.current = versioned
-      return this.publishSnapshot(versioned).pipe(Effect.asVoid)
-    })
+    return Effect.suspend(() => this.commitActiveState(state) ?? Effect.void)
+  }
+
+  private commitActiveState(state: unknown): Effect.Effect<void> | undefined {
+    const latest = this.current
+    if (latest.terminalizing || latest.snapshot.status !== "active") {
+      return undefined
+    }
+    const versioned = {
+      revision: latest.revision + 1,
+      snapshot: { status: "active" as const, state },
+      terminalizing: false,
+      changes: latest.changes
+    }
+    this.current = versioned
+    if (versioned.changes !== undefined) {
+      PubSub.publishUnsafe(versioned.changes, [versioned] as const)
+    }
+    return this.options.onSnapshot === undefined
+      ? undefined
+      : notifyActiveSnapshot(this.options.onSnapshot, versioned.snapshot)
   }
 
   private updateState<E, R>(
@@ -1687,7 +1740,7 @@ const startLogicInternal: typeof startGenericInternal = ((
   logic: ProcessLogic<any, any, any, any, any, any>,
   options: StartInternalOptions
 ) =>
-  logic[compiledProcess] === true && logic.drain !== undefined
+  logic[compiledProcess] === true && (logic.drain !== undefined || logic[compiledProcessDrain] !== undefined)
     ? startCompactCompiledInternal(logic, options)
     : startGenericInternal(logic, options)) as typeof startGenericInternal
 

--- a/test/MachineRuntimeDifferential.test.ts
+++ b/test/MachineRuntimeDifferential.test.ts
@@ -3,6 +3,7 @@ import { Cause, Data, Effect, Fiber, Ref, Schema, Stream } from "effect"
 import { FastCheck } from "effect/testing"
 import { Machine } from "../src/index.js"
 import { MachineTest } from "../src/testing.js"
+import type { DifferentialStep } from "./support/machineRuntimeDifferential.js"
 import { traceBoundary, traceSteps, verifyManagedExecution } from "./support/machineRuntimeDifferential.js"
 
 const event = (_tag: string): { readonly _tag: string } => ({ _tag })
@@ -32,6 +33,62 @@ const generated = MachineTest.finiteModels({
 })
 
 describe("pure planning and managed runtime differential", () => {
+  it.effect("matches the compiled flat-state executor across raised and terminal transitions", () =>
+    Effect.gen(function*() {
+      class Count extends Schema.TaggedClass<Count>("FlatDifferentialCount")("Count", {
+        value: Schema.Number
+      }) {}
+      class Done extends Schema.TaggedClass<Done>("FlatDifferentialDone")("Done", {
+        value: Schema.Number
+      }) {}
+      class Cascade extends Schema.TaggedClass<Cascade>("FlatDifferentialCascade")("Cascade", {}) {}
+      class Increment extends Schema.TaggedClass<Increment>("FlatDifferentialIncrement")("Increment", {}) {}
+      class Ignore extends Schema.TaggedClass<Ignore>("FlatDifferentialIgnore")("Ignore", {}) {}
+      class Finish extends Schema.TaggedClass<Finish>("FlatDifferentialFinish")("Finish", {}) {}
+
+      const states = Machine.defineStates({
+        Count,
+        Done: { schema: Done, type: "final", output: Schema.Number }
+      })
+      const machine = Machine.make({
+        states: states.states,
+        events: [Cascade, Ignore, Finish],
+        internalEvents: [Increment],
+        initial: () => states.initial.Count(new Count({ value: 0 }))
+      }).handle({
+        Count: {
+          on: {
+            Cascade: (_, enqueue) => {
+              enqueue.raise(new Increment({}))
+            },
+            Increment: ({ state, target }) => target.full.Count(new Count({ value: state.value + 1 })),
+            Finish: ({ state, target }) => target.full.Done(new Done({ value: state.value }))
+          }
+        },
+        Done: { output: ({ state }) => state.value }
+      })
+
+      const initial = yield* Machine.planInitial(machine) as Effect.Effect<any, unknown, never>
+      const requested = [new Ignore({}), new Cascade({}), new Cascade({}), new Finish({})]
+      const steps: Array<DifferentialStep> = []
+      let state = initial.state
+      for (const nextEvent of requested) {
+        const plan = yield* Machine.plan(machine, state, nextEvent) as Effect.Effect<any, unknown, never>
+        steps.push({ event: nextEvent, plan })
+        state = plan.next
+      }
+
+      assert.deepStrictEqual(steps.map(({ plan }) => plan.microsteps.length), [0, 2, 2, 1])
+      assert.strictEqual(steps.at(-1)?.plan.output, 2)
+      yield* verifyManagedExecution({
+        machine,
+        open: Machine.start(machine) as Effect.Effect<Machine.MachineRef<any, any, any, any>, unknown, never>,
+        initial: { state: initial.state, done: initial.done, output: initial.output },
+        steps,
+        label: "compiled flat state"
+      })
+    }) as Effect.Effect<void, unknown, any>)
+
   it.effect("matches deterministic generated start and resumed executions", () =>
     Effect.gen(function*() {
       const samples = FastCheck.sample(generated.arbitrary, { numRuns: 36, seed: 93_701 })


### PR DESCRIPTION
## Summary

- compile and cache reusable machine execution metadata, including target builders
- run eligible flat statecharts through a specialized synchronous planner inside the compact Effect process kernel
- keep Effect boundaries for commands, emissions, invokes, observation callbacks, interruption, terminalization, and scheduler-controlled cooperative yield
- retain the general planner and process contract for hierarchical machines and arbitrary `Machine.logic`
- add a focused pure-planner versus managed-runtime differential covering unhandled, raised, value, and terminal transitions

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (no examples changed)
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed (no public API or inference change; `pnpm perf:types` passes)
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed

Local five-process interleaved runtime comparison on Apple M1 / Node 24.16.0:

- runtime burst: +147.1% (0.7% PR MAD)
- observed burst: +125.3% (1.3% PR MAD)
- child lookup/send: +131.6% (1.0% PR MAD)
- machine lifecycle: +12.8%
- parent/child lifecycle: +13.2%
- idle machine heap slope: -12.2%
- parent/child heap slope: -8.1%

The runtime workflow remains the authoritative remote comparison and will update the PR automatically.
