### PR TITLE
Compile hierarchical machine execution

### DIFF
--- a/.changeset/swift-hierarchies-compile.md
+++ b/.changeset/swift-hierarchies-compile.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Compile event dispatch, ancestry lookup, value-only leaf updates, and final-state checks for compound and parallel machines that do not use automatic or lifecycle transitions. Unsupported statechart capabilities continue through the general planner with unchanged semantics.

--- a/perf/runtime/counter.mjs
+++ b/perf/runtime/counter.mjs
@@ -85,8 +85,136 @@ const counterSnapshotParentMachine = Machine.make({
   }
 })
 
+const HierarchicalState = Schema.TaggedUnion({
+  Active: {},
+  Count: { value: Schema.Number },
+  Complete: { value: Schema.Number }
+})
+
+const HierarchicalEvent = Schema.TaggedUnion({
+  Increment: {},
+  IncrementLeft: {},
+  IncrementRight: {},
+  Finish: {}
+})
+
+const HierarchicalStates = Machine.defineStates({
+  Active: {
+    schema: HierarchicalState.cases.Active,
+    initial: "Count",
+    states: {
+      Count: HierarchicalState.cases.Count
+    }
+  },
+  Complete: {
+    schema: HierarchicalState.cases.Complete,
+    type: "final",
+    output: Schema.Number
+  }
+})
+
+const hierarchicalCounterMachine = Machine.make({
+  id: "RuntimeBenchmarkHierarchicalCounter",
+  states: HierarchicalStates.states,
+  events: [HierarchicalEvent.cases.Increment, HierarchicalEvent.cases.Finish],
+  initial: () =>
+    HierarchicalStates.initial.Active(
+      HierarchicalState.cases.Active.make({}),
+      (active) => active.Count(HierarchicalState.cases.Count.make({ value: 0 }))
+    )
+}).handle({
+  Active: {
+    states: {
+      Count: {
+        on: {
+          Increment: ({ state, target }) =>
+            target.local.Count(HierarchicalState.cases.Count.make({ value: state.value + 1 })),
+          Finish: ({ state, target }) =>
+            target.full.Complete(HierarchicalState.cases.Complete.make({ value: state.value }))
+        }
+      }
+    }
+  },
+  Complete: {
+    output: ({ state }) => state.value
+  }
+})
+
+const ParallelState = Schema.TaggedUnion({
+  Active: {},
+  Left: { value: Schema.Number },
+  Right: { value: Schema.Number },
+  Complete: { value: Schema.Number }
+})
+
+const ParallelStates = Machine.defineStates({
+  Active: {
+    schema: ParallelState.cases.Active,
+    type: "parallel",
+    states: {
+      Left: ParallelState.cases.Left,
+      Right: ParallelState.cases.Right
+    }
+  },
+  Complete: {
+    schema: ParallelState.cases.Complete,
+    type: "final",
+    output: Schema.Number
+  }
+})
+
+const parallelCounterMachine = Machine.make({
+  id: "RuntimeBenchmarkParallelCounter",
+  states: ParallelStates.states,
+  events: [
+    HierarchicalEvent.cases.IncrementLeft,
+    HierarchicalEvent.cases.IncrementRight,
+    HierarchicalEvent.cases.Finish
+  ],
+  initial: () =>
+    ParallelStates.initial.Active(
+      ParallelState.cases.Active.make({}),
+      (active) =>
+        active
+          .Left(ParallelState.cases.Left.make({ value: 0 }))
+          .Right(ParallelState.cases.Right.make({ value: 0 }))
+    )
+}).handle({
+  Active: {
+    on: {
+      Finish: ({ snapshot, target }) =>
+        target.full.Complete(
+          ParallelState.cases.Complete.make({
+            value: snapshot.states.Left.value.value + snapshot.states.Right.value.value
+          })
+        )
+    },
+    states: {
+      Left: {
+        on: {
+          IncrementLeft: ({ state, target }) =>
+            target.branch.Active.Left(ParallelState.cases.Left.make({ value: state.value + 1 }))
+        }
+      },
+      Right: {
+        on: {
+          IncrementRight: ({ state, target }) =>
+            target.branch.Active.Right(ParallelState.cases.Right.make({ value: state.value + 1 }))
+        }
+      }
+    }
+  },
+  Complete: {
+    output: ({ state }) => state.value
+  }
+})
+
 export const incrementEvent = CounterEvent.cases.Increment.make({})
 const finishEvent = CounterEvent.cases.Finish.make({})
+const hierarchicalIncrementEvent = HierarchicalEvent.cases.Increment.make({})
+const parallelIncrementLeftEvent = HierarchicalEvent.cases.IncrementLeft.make({})
+const parallelIncrementRightEvent = HierarchicalEvent.cases.IncrementRight.make({})
+const hierarchicalFinishEvent = HierarchicalEvent.cases.Finish.make({})
 
 export const initialCounterSnapshot = Effect.runSync(
   Machine.planInitial(counterMachine).pipe(Effect.map((planned) => planned.state))
@@ -187,6 +315,31 @@ export const runCounterBurst = (ref, size) =>
         yield* ref.send(incrementEvent)
       }
       yield* ref.send(finishEvent)
+      return yield* ref.join
+    })
+  )
+
+const startHierarchicalCounter = () => Effect.runPromise(Machine.start(hierarchicalCounterMachine))
+const startParallelCounter = () => Effect.runPromise(Machine.start(parallelCounterMachine))
+
+const runHierarchicalCounterBurst = (ref, size) =>
+  Effect.runPromise(
+    Effect.gen(function*() {
+      for (let index = 0; index < size; index += 1) {
+        yield* ref.send(hierarchicalIncrementEvent)
+      }
+      yield* ref.send(hierarchicalFinishEvent)
+      return yield* ref.join
+    })
+  )
+
+const runParallelCounterBurst = (ref, size) =>
+  Effect.runPromise(
+    Effect.gen(function*() {
+      for (let index = 0; index < size; index += 1) {
+        yield* ref.send(index % 2 === 0 ? parallelIncrementLeftEvent : parallelIncrementRightEvent)
+      }
+      yield* ref.send(hierarchicalFinishEvent)
       return yield* ref.join
     })
   )
@@ -346,6 +499,28 @@ export const effectMachineAdapter = {
   stopChildCounters,
   stopObservedCounter,
   stopCounters,
+  additionalMachineBenchmarks: [
+    {
+      id: "hierarchical-runtime-burst",
+      label: "Drain burst through a compound state",
+      unit: "events/s",
+      operations: ({ burstBatchSize }) => burstBatchSize,
+      expected: (operations) => operations,
+      start: startHierarchicalCounter,
+      run: runHierarchicalCounterBurst,
+      stop: stopCounter
+    },
+    {
+      id: "parallel-runtime-burst",
+      label: "Drain burst through two parallel regions",
+      unit: "events/s",
+      operations: ({ burstBatchSize }) => burstBatchSize,
+      expected: (operations) => operations,
+      start: startParallelCounter,
+      run: runParallelCounterBurst,
+      stop: stopCounter
+    }
+  ],
   runtimeBenchmarks: [
     {
       id: "compiled-process-start-stop",

--- a/perf/runtime/xstate.mjs
+++ b/perf/runtime/xstate.mjs
@@ -1,4 +1,6 @@
 const incrementEvent = Object.freeze({ type: "Increment" })
+const incrementLeftEvent = Object.freeze({ type: "IncrementLeft" })
+const incrementRightEvent = Object.freeze({ type: "IncrementRight" })
 const finishEvent = Object.freeze({ type: "Finish" })
 
 export const makeXStateAdapter = (options) => {
@@ -37,6 +39,55 @@ export const makeXStateAdapter = (options) => {
           src: machine
         }
       }
+    }
+  })
+  const hierarchicalMachine = xstate.createMachine({
+    id: `RuntimeBenchmarkHierarchicalCounter-${implementation}`,
+    context: { value: 0 },
+    initial: "active",
+    states: {
+      active: {
+        initial: "counting",
+        states: {
+          counting: {
+            on: {
+              Increment: increment,
+              Finish: { target: "#complete" }
+            }
+          }
+        }
+      },
+      complete: { id: "complete", type: "final" }
+    }
+  })
+  const parallelIncrement = (key) =>
+    typeof xstate.assign === "function"
+      ? {
+        actions: xstate.assign({
+          [key]: ({ context }) => context[key] + 1
+        })
+      }
+      : ({ context }) => ({
+        context: { ...context, [key]: context[key] + 1 }
+      })
+  const parallelMachine = xstate.createMachine({
+    id: `RuntimeBenchmarkParallelCounter-${implementation}`,
+    context: { left: 0, right: 0 },
+    initial: "active",
+    states: {
+      active: {
+        type: "parallel",
+        on: { Finish: { target: "complete" } },
+        states: {
+          left: {
+            on: { IncrementLeft: parallelIncrement("left") }
+          },
+          right: {
+            on: { IncrementRight: parallelIncrement("right") }
+          }
+        }
+      },
+      complete: { type: "final" }
     }
   })
   const initialSnapshot = xstate.initialTransition(machine)[0]
@@ -93,6 +144,18 @@ export const makeXStateAdapter = (options) => {
       throw new Error(`${label} terminal fence produced status ${snapshot.status}`)
     }
     return snapshot.context.value
+  }
+
+  const runMachineBurst = (actor, size, readValue, eventAt = () => incrementEvent) => {
+    for (let index = 0; index < size; index += 1) {
+      actor.send(eventAt(index))
+    }
+    actor.send(finishEvent)
+    const snapshot = actor.getSnapshot()
+    if (snapshot.status !== "done") {
+      throw new Error(`${label} hierarchical terminal fence produced status ${snapshot.status}`)
+    }
+    return readValue(snapshot.context)
   }
 
   const runObservedCounterBurst = async ({ actor, completion, getObserved }, size) => {
@@ -207,6 +270,34 @@ export const makeXStateAdapter = (options) => {
     stopChildCounters,
     stopCounters,
     stopObservedCounter,
+    additionalMachineBenchmarks: [
+      {
+        id: "hierarchical-runtime-burst",
+        label: "Drain burst through a compound state",
+        unit: "events/s",
+        operations: ({ burstBatchSize }) => burstBatchSize,
+        expected: (operations) => operations,
+        start: () => xstate.createActor(hierarchicalMachine).start(),
+        run: (actor, size) => runMachineBurst(actor, size, (context) => context.value),
+        stop: stopCounter
+      },
+      {
+        id: "parallel-runtime-burst",
+        label: "Drain burst through two parallel regions",
+        unit: "events/s",
+        operations: ({ burstBatchSize }) => burstBatchSize,
+        expected: (operations) => operations,
+        start: () => xstate.createActor(parallelMachine).start(),
+        run: (actor, size) =>
+          runMachineBurst(
+            actor,
+            size,
+            (context) => context.left + context.right,
+            (index) => index % 2 === 0 ? incrementLeftEvent : incrementRightEvent
+          ),
+        stop: stopCounter
+      }
+    ],
     memoryProfiles: {
       idle: {
         label: "Idle machine",

--- a/scripts/runtime-performance.mjs
+++ b/scripts/runtime-performance.mjs
@@ -89,6 +89,7 @@ const benchmarkDefinitions = new Map()
 const activeBurstRefs = new Map()
 const activeChildRefs = new Map()
 const activeObservedRefs = new Map()
+const activeAdditionalRefs = new Map()
 
 for (const implementation of implementations) {
   const metadata = {
@@ -263,6 +264,43 @@ for (const implementation of implementations) {
       }
       : () => implementation.runChildLifecycle()
   )
+
+  for (const additional of implementation.additionalMachineBenchmarks ?? []) {
+    const task = `${implementation.implementation}:${additional.id}`
+    const operations = additional.operations(configuration)
+    benchmarkDefinitions.set(task, {
+      ...metadata,
+      id: additional.id,
+      label: additional.label,
+      unit: additional.unit,
+      operationsPerIteration: operations,
+      fenceEventsPerIteration: 1
+    })
+    const validate = (completed) => {
+      const expected = additional.expected(operations)
+      if (completed !== expected) {
+        throw new Error(
+          `${implementation.label} ${additional.label} produced ${completed}, expected ${expected}`
+        )
+      }
+    }
+    bench.add(
+      task,
+      implementation.async
+        ? async () => validate(await additional.run(activeAdditionalRefs.get(task), operations))
+        : () => validate(additional.run(activeAdditionalRefs.get(task), operations)),
+      {
+        beforeEach: async () => {
+          activeAdditionalRefs.set(task, await additional.start())
+        },
+        afterEach: async () => {
+          const ref = activeAdditionalRefs.get(task)
+          await additional.stop(ref)
+          activeAdditionalRefs.delete(task)
+        }
+      }
+    )
+  }
 }
 
 for (const implementation of runtimeReferenceImplementations) {
@@ -314,6 +352,14 @@ try {
     if (observedRef !== undefined) {
       await implementation.stopObservedCounter(observedRef)
       activeObservedRefs.delete(implementation.implementation)
+    }
+    for (const additional of implementation.additionalMachineBenchmarks ?? []) {
+      const task = `${implementation.implementation}:${additional.id}`
+      const ref = activeAdditionalRefs.get(task)
+      if (ref !== undefined) {
+        await additional.stop(ref)
+        activeAdditionalRefs.delete(task)
+      }
     }
   }
 }

--- a/src/internal/machinePlanner.ts
+++ b/src/internal/machinePlanner.ts
@@ -610,6 +610,29 @@ const makeTransitionContext = <
   target: getTargetBuilder(machine, path)
 })
 
+const makeCompiledTransitionContext = (
+  machine: Machine.Any,
+  configuration: ActiveConfiguration,
+  path: string,
+  event: any
+): any => {
+  let snapshot: Machine.Snapshot<any> | undefined
+  return {
+    state: getActiveValue(configuration, path),
+    get parent() {
+      return getParentValue(machine, configuration, path)
+    },
+    get parents() {
+      return getParentValues(machine, configuration, path)
+    },
+    event,
+    get snapshot() {
+      return snapshot ??= snapshotFromConfiguration(machine, configuration)
+    },
+    target: getTargetBuilder(machine, path)
+  }
+}
+
 const makeDoneContext = <
   const States extends Machine.StateSchemas,
   const Events extends ReadonlyArray<Machine.TaggedSchema>,
@@ -2098,6 +2121,361 @@ const planFlatConfiguration = (
   }
 }
 
+interface HierarchicalExecutionDescriptor {
+  readonly leafPaths: ReadonlyArray<string>
+  readonly finalPaths: ReadonlyArray<string>
+  readonly candidatesByLeaf: ReadonlyMap<string, ReadonlyArray<string>>
+  readonly transitionsByPath: ReadonlyMap<
+    PropertyKey,
+    ReadonlyMap<PropertyKey, MicrostepTransition<any, any, any, any>>
+  >
+}
+
+const compileHierarchicalExecutionDescriptor = (
+  machine: Machine.Any
+): HierarchicalExecutionDescriptor | undefined => {
+  const candidatesByLeaf = new Map<string, ReadonlyArray<string>>()
+  const leafPaths: Array<string> = []
+  const finalPaths: Array<string> = []
+  const transitionsByPath = new Map<
+    PropertyKey,
+    ReadonlyMap<PropertyKey, MicrostepTransition<any, any, any, any>>
+  >()
+
+  for (const node of machine.stateNodes.byPath.values() as Iterable<Machine.StateNode>) {
+    if (node.type === "choice" || node.type === "history") {
+      return undefined
+    }
+    if (node.type === "atomic" || node.type === "final") {
+      leafPaths.push(node.path)
+      candidatesByLeaf.set(node.path, [...getPathToRoot(machine, node.path)].reverse())
+    }
+    if (node.type === "final") {
+      finalPaths.push(node.path)
+    }
+
+    const config = machine.handlers[node.path] as Machine.AnyStateConfig | undefined
+    if (
+      config?.entry !== undefined || config?.exit !== undefined || config?.always !== undefined ||
+      config?.onDone !== undefined || config?.invoke !== undefined || (config as any)?.choice !== undefined ||
+      (config as any)?.history !== undefined
+    ) {
+      return undefined
+    }
+    if (config?.on === undefined) {
+      continue
+    }
+    const byEvent = new Map<PropertyKey, MicrostepTransition<any, any, any, any>>()
+    for (const tag of Reflect.ownKeys(config.on)) {
+      const transition = normalizeTransition(config.on[tag])
+      if (transition !== undefined) {
+        byEvent.set(tag, transition)
+      }
+    }
+    if (byEvent.size > 0) {
+      transitionsByPath.set(node.path, byEvent)
+    }
+  }
+
+  leafPaths.sort((left, right) => compareDocumentOrder(machine, left, right))
+  finalPaths.sort((left, right) => compareDocumentOrder(machine, left, right))
+  return {
+    leafPaths,
+    finalPaths,
+    candidatesByLeaf,
+    transitionsByPath
+  }
+}
+
+const selectCompiledEventTransitions = (
+  machine: Machine.Any,
+  descriptor: HierarchicalExecutionDescriptor,
+  configuration: ActiveConfiguration,
+  event: any
+): ReadonlyArray<SelectedTransition<any, any, any, any>> => {
+  const selected: Array<SelectedTransition<any, any, any, any>> = []
+  const selectedSources = new Set<string>()
+
+  for (const leaf of descriptor.leafPaths) {
+    if (!configuration.active.has(leaf)) {
+      continue
+    }
+    const candidates = descriptor.candidatesByLeaf.get(leaf)
+    if (candidates === undefined) {
+      throw new Error(`Machine expected compiled candidates for active leaf "${leaf}"`)
+    }
+    for (const path of candidates) {
+      const transition = descriptor.transitionsByPath.get(path)?.get(event._tag)
+      if (transition === undefined) {
+        continue
+      }
+      if (!selectedSources.has(path)) {
+        selectedSources.add(path)
+        selected.push({
+          sourcePath: path,
+          leafPath: leaf,
+          trigger: { type: "event", event: event._tag },
+          transition,
+          context: makeCompiledTransitionContext(machine, configuration, path, event)
+        })
+      }
+      break
+    }
+  }
+  return selected
+}
+
+type CompiledEvaluatedTransition = EvaluatedTransition<any, any, any, any, any> & {
+  readonly next: ActiveConfiguration
+}
+
+const normalizeCompiledTargetConfigurationSync = (
+  machine: Machine.Any,
+  current: ActiveConfiguration,
+  target: Machine.Target<any, any> | Machine.Snapshot<any>,
+  activeLeaf: string
+): ActiveConfiguration => {
+  if (
+    isTarget(target) && String(target.path) === activeLeaf && current.active.has(activeLeaf) &&
+    target[TargetSnapshotTypeId] === undefined && target.values === undefined && current.outputs.size === 0
+  ) {
+    const values = new Map(current.values)
+    values.set(activeLeaf, decodeStateValueSync(machine, getNode(machine, activeLeaf), target.value))
+    return {
+      active: current.active,
+      values,
+      outputs: current.outputs,
+      history: current.history
+    }
+  }
+  return normalizeTargetConfigurationSync(machine, current, target)
+}
+
+const collectCompiledEvaluatedTransition = (
+  machine: Machine.Any,
+  state: ActiveConfiguration,
+  selection: SelectedTransition<any, any, any, any>
+): CompiledEvaluatedTransition => {
+  const transitionResult = collectTransition(
+    machine,
+    selection.transition.transition,
+    selection.context
+  )
+  const target = transitionResult.state === undefined ? undefined : transitionResult.state
+  validateDeclaredTransitionTarget(
+    selection.sourcePath,
+    selection.trigger,
+    selection.transition.targets,
+    target
+  )
+  if (target !== undefined && !isTarget(target) && !isSnapshot(target)) {
+    throw new Error("Machine expected compiled transition target to be a snapshot or target builder result")
+  }
+
+  const next = target === undefined
+    ? state
+    : normalizeCompiledTargetConfigurationSync(machine, state, target as any, selection.leafPath)
+  const changed = selection.transition.reenter || !hasSameActivePaths(state, next)
+  if (!changed) {
+    return {
+      selection,
+      unresolvedTarget: target as any,
+      target: target as any,
+      next,
+      commands: transitionResult.commands,
+      raisedEvents: transitionResult.raisedEvents,
+      emittedEvents: transitionResult.emittedEvents,
+      changed: false,
+      exitPaths: [],
+      entryPaths: [],
+      choiceTransitions: []
+    }
+  }
+
+  const targetPath = target === undefined ? undefined : getTargetNodePath(target as any)
+  const naturalBoundary = targetPath === undefined
+    ? getNode(machine, selection.sourcePath).parent
+    : getLeastCommonAncestor(machine, selection.leafPath, targetPath)
+  const reentryBoundary = getNode(machine, selection.sourcePath).parent
+  const boundary = selection.transition.reenter
+    ? broadenTransitionBoundary(naturalBoundary, reentryBoundary)
+    : naturalBoundary
+  return {
+    selection,
+    unresolvedTarget: target as any,
+    target: target as any,
+    next,
+    commands: transitionResult.commands,
+    raisedEvents: transitionResult.raisedEvents,
+    emittedEvents: transitionResult.emittedEvents,
+    changed: true,
+    exitPaths: getExitPaths(machine, state, boundary),
+    entryPaths: getEntryPaths(machine, next, boundary),
+    choiceTransitions: []
+  }
+}
+
+const compiledMicrostep = (
+  machine: Machine.Any,
+  state: ActiveConfiguration,
+  event: any,
+  selections: ReadonlyArray<SelectedTransition<any, any, any, any>>
+): MicrostepPlan<ActiveConfiguration, any, any, any> => {
+  if (selections.length === 1) {
+    const transition = collectCompiledEvaluatedTransition(machine, state, selections[0]!)
+    return {
+      next: transition.next,
+      event,
+      transitions: [],
+      commands: transition.commands,
+      raisedEvents: transition.raisedEvents,
+      emittedEvents: transition.emittedEvents,
+      exitPaths: transition.exitPaths,
+      entryPaths: transition.entryPaths,
+      changed: transition.changed
+    }
+  }
+  const activeSelections = removePreemptedAncestorSelections(selections)
+  const evaluated = activeSelections.map((selection) => collectCompiledEvaluatedTransition(machine, state, selection))
+  const transitions = sortEvaluatedTransitions(
+    machine,
+    removeConflictingTransitions(machine, evaluated)
+  ) as ReadonlyArray<CompiledEvaluatedTransition>
+
+  let next = state
+  if (transitions.length === 1) {
+    next = transitions[0]!.next
+  } else {
+    const applicationOrder = [
+      ...transitions.filter((transition) => !transition.changed),
+      ...transitions.filter((transition) => transition.changed)
+    ]
+    for (const transition of applicationOrder) {
+      if (transition.target !== undefined) {
+        next = normalizeTargetConfigurationSync(machine, next, transition.target)
+      }
+    }
+  }
+
+  const commands = transitions.flatMap((transition) => transition.commands)
+  const raisedEvents = transitions.flatMap((transition) => transition.raisedEvents)
+  const emittedEvents = transitions.flatMap((transition) => transition.emittedEvents)
+  const changed = transitions.some((transition) => transition.changed)
+  return {
+    next,
+    event,
+    transitions: [],
+    commands,
+    raisedEvents,
+    emittedEvents,
+    exitPaths: changed ? sortExitPaths(machine, transitions.flatMap((transition) => transition.exitPaths)) : [],
+    entryPaths: changed ? sortEntryPaths(machine, transitions.flatMap((transition) => transition.entryPaths)) : [],
+    changed
+  }
+}
+
+const planHierarchicalConfiguration = (
+  machine: Machine.Any,
+  descriptor: HierarchicalExecutionDescriptor,
+  configuration: ActiveConfiguration,
+  input: unknown
+): MacrostepPlan<ActiveConfiguration, any, any, any, any> => {
+  const decoded = decodeEventSync(machine, input) as { readonly _tag: PropertyKey }
+  if (
+    descriptor.finalPaths.some((path) => configuration.active.has(path)) &&
+    isActiveFinalConfiguration(machine, configuration)
+  ) {
+    const completed = completeConfigurationSync(machine, configuration, decoded)
+    const root = getRootPath(machine, completed.configuration)
+    if (!completed.configuration.outputs.has(root)) {
+      throw new Error("Machine reached a terminal configuration without a completed root output")
+    }
+    return {
+      next: completed.configuration,
+      commands: [],
+      emittedEvents: [],
+      microsteps: [],
+      done: true,
+      output: completed.configuration.outputs.get(root)
+    }
+  }
+
+  const selections = selectCompiledEventTransitions(machine, descriptor, configuration, decoded)
+  if (selections.length === 0) {
+    return {
+      next: configuration,
+      commands: [],
+      emittedEvents: [],
+      microsteps: [],
+      done: false,
+      output: undefined
+    }
+  }
+
+  const first = compiledMicrostep(machine, configuration, decoded, selections)
+  let current = first.next
+  let currentEvent: any = decoded
+  const commands = [...first.commands]
+  const raisedEvents = [...first.raisedEvents]
+  const emittedEvents = [...first.emittedEvents]
+  const microsteps = [first]
+  let raisedIndex = 0
+  let iterations = 0
+
+  while (true) {
+    iterations += 1
+    if (iterations > MaxMacrostepIterations) {
+      throw new InfiniteTransitionError({
+        machineId: machine.id,
+        state: String(getLeafPath(machine, current)),
+        maxIterations: MaxMacrostepIterations
+      })
+    }
+
+    if (descriptor.finalPaths.some((path) => current.active.has(path))) {
+      current = completeConfigurationSync(machine, current, currentEvent).configuration
+      if (isActiveFinalConfiguration(machine, current)) {
+        const root = getRootPath(machine, current)
+        if (!current.outputs.has(root)) {
+          throw new Error("Machine reached a terminal configuration without a completed root output")
+        }
+        return {
+          next: current,
+          commands,
+          emittedEvents,
+          microsteps,
+          done: true,
+          output: current.outputs.get(root)
+        }
+      }
+    }
+
+    const raised = raisedEvents[raisedIndex]
+    if (raised === undefined) {
+      return {
+        next: current,
+        commands,
+        emittedEvents,
+        microsteps,
+        done: false,
+        output: undefined
+      }
+    }
+    raisedIndex += 1
+    currentEvent = raised
+    const raisedSelections = selectCompiledEventTransitions(machine, descriptor, current, raised)
+    if (raisedSelections.length === 0) {
+      continue
+    }
+    const step = compiledMicrostep(machine, current, raised, raisedSelections)
+    current = step.next
+    commands.push(...step.commands)
+    raisedEvents.push(...step.raisedEvents)
+    emittedEvents.push(...step.emittedEvents)
+    microsteps.push(step)
+  }
+}
+
 export interface CompiledExecutionPlan {
   readonly plan: (
     configuration: ActiveConfiguration,
@@ -2113,9 +2491,12 @@ export const compileExecutionPlan = (machine: Machine.Any): CompiledExecutionPla
     return cached
   }
   const flat = compileFlatExecutionDescriptor(machine)
-  const compiled: CompiledExecutionPlan = flat === undefined
-    ? { plan: (configuration, event) => planConfiguration(machine as any, configuration, event as any) }
-    : { plan: (configuration, event) => planFlatConfiguration(machine, flat, configuration, event) }
+  const hierarchical = flat === undefined ? compileHierarchicalExecutionDescriptor(machine) : undefined
+  const compiled: CompiledExecutionPlan = flat !== undefined
+    ? { plan: (configuration, event) => planFlatConfiguration(machine, flat, configuration, event) }
+    : hierarchical !== undefined
+    ? { plan: (configuration, event) => planHierarchicalConfiguration(machine, hierarchical, configuration, event) }
+    : { plan: (configuration, event) => planConfiguration(machine as any, configuration, event as any) }
   executionPlanCache.set(machine, compiled)
   return compiled
 }

--- a/test/MachineRuntimeDifferential.test.ts
+++ b/test/MachineRuntimeDifferential.test.ts
@@ -89,6 +89,126 @@ describe("pure planning and managed runtime differential", () => {
       })
     }) as Effect.Effect<void, unknown, any>)
 
+  it.effect("matches the compiled hierarchical executor across parallel and raised transitions", () =>
+    Effect.gen(function*() {
+      class Running extends Schema.TaggedClass<Running>("HierarchicalDifferentialRunning")("Running", {}) {}
+      class Left extends Schema.TaggedClass<Left>("HierarchicalDifferentialLeft")("Left", {
+        value: Schema.Number
+      }) {}
+      class Right extends Schema.TaggedClass<Right>("HierarchicalDifferentialRight")("Right", {
+        value: Schema.Number
+      }) {}
+      class Done extends Schema.TaggedClass<Done>("HierarchicalDifferentialDone")("Done", {
+        value: Schema.Number
+      }) {}
+      class Advance extends Schema.TaggedClass<Advance>("HierarchicalDifferentialAdvance")("Advance", {}) {}
+      class Inspect extends Schema.TaggedClass<Inspect>("HierarchicalDifferentialInspect")("Inspect", {}) {}
+      class Finish extends Schema.TaggedClass<Finish>("HierarchicalDifferentialFinish")("Finish", {}) {}
+      class Bump extends Schema.TaggedClass<Bump>("HierarchicalDifferentialBump")("Bump", {}) {}
+
+      const states = Machine.defineStates({
+        Running: {
+          schema: Running,
+          type: "parallel",
+          states: { Left, Right }
+        },
+        Done: { schema: Done, type: "final", output: Schema.Number }
+      })
+      const observations: Array<{
+        readonly state: number
+        readonly parent: string
+        readonly parents: string
+        readonly left: number
+        readonly right: number
+      }> = []
+      const machine = Machine.make({
+        states: states.states,
+        events: [Advance, Inspect, Finish],
+        internalEvents: [Bump],
+        initial: () =>
+          states.initial.Running(
+            new Running({}),
+            (running) => running.Left(new Left({ value: 0 })).Right(new Right({ value: 0 }))
+          )
+      }).handle({
+        Running: {
+          on: {
+            Finish: ({ snapshot, target }) => {
+              if (snapshot.path !== "Running") throw new Error("expected Running snapshot")
+              return target.full.Done(
+                new Done({
+                  value: snapshot.states.Left.value.value + snapshot.states.Right.value.value
+                })
+              )
+            }
+          },
+          states: {
+            Left: {
+              on: {
+                Advance: ({ state, target }, enqueue) => {
+                  enqueue.raise(new Bump({}))
+                  return target.branch.Running.Left(new Left({ value: state.value + 1 }))
+                }
+              }
+            },
+            Right: {
+              on: {
+                Advance: ({ state, target }) => target.branch.Running.Right(new Right({ value: state.value + 10 })),
+                Bump: ({ state, target }) => target.branch.Running.Right(new Right({ value: state.value + 100 })),
+                Inspect: ({ state, parent, parents, snapshot }) => {
+                  if (snapshot.path !== "Running") throw new Error("expected Running snapshot")
+                  observations.push({
+                    state: state.value,
+                    parent: parent._tag,
+                    parents: parents.Running._tag,
+                    left: snapshot.states.Left.value.value,
+                    right: snapshot.states.Right.value.value
+                  })
+                }
+              }
+            }
+          }
+        },
+        Done: { output: ({ state }) => state.value }
+      })
+
+      const initial = yield* Machine.planInitial(machine)
+      const requested = [new Advance({}), new Inspect({}), new Finish({})]
+      const steps: Array<DifferentialStep> = []
+      let state = initial.state
+      for (const nextEvent of requested) {
+        const plan = yield* Machine.plan(machine, state, nextEvent)
+        steps.push({ event: nextEvent, plan })
+        state = plan.next
+      }
+
+      assert.deepStrictEqual(steps.map(({ plan }) => plan.microsteps.length), [2, 1, 1])
+      assert.strictEqual(steps.at(-1)?.plan.output, 111)
+      assert.deepStrictEqual(observations, [{
+        state: 110,
+        parent: "Running",
+        parents: "Running",
+        left: 1,
+        right: 110
+      }])
+      observations.length = 0
+
+      yield* verifyManagedExecution({
+        machine,
+        open: Machine.start(machine),
+        initial: { state: initial.state, done: initial.done, output: initial.output },
+        steps,
+        label: "compiled hierarchical state"
+      })
+      assert.deepStrictEqual(observations, [{
+        state: 110,
+        parent: "Running",
+        parents: "Running",
+        left: 1,
+        right: 110
+      }])
+    }) as Effect.Effect<void, unknown, any>)
+
   it.effect("matches deterministic generated start and resumed executions", () =>
     Effect.gen(function*() {
       const samples = FastCheck.sample(generated.arbitrary, { numRuns: 36, seed: 93_701 })


### PR DESCRIPTION
## Summary

- compile event dispatch and hierarchy metadata for eligible compound and parallel machines
- specialize value-only leaf updates, final-state checks, and single-transition microsteps while preserving the general planner fallback
- add repeatable compound and parallel runtime benchmarks for Effect Machine, XState 5, and XState 6
- add differential coverage for parallel transitions, raised events, lazy context reads, completion, and managed runtime publication

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed

Local runtime comparison (Apple M1, Node v24.16.0; 5 base and 3 final-candidate processes) measured +88.9% compound-state throughput and +112.6% parallel-state throughput, with existing throughput and memory metrics unchanged within process variability.
