### PR TITLE
Optimize atomic snapshot transitions

### DIFF
--- a/.changeset/fast-flat-atomic-snapshots.md
+++ b/.changeset/fast-flat-atomic-snapshots.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Avoid rebuilding a complete configuration for same-state atomic snapshot transitions in the compiled flat executor.

--- a/src/internal/machinePlanner.ts
+++ b/src/internal/machinePlanner.ts
@@ -2537,10 +2537,12 @@ const planIndexedFlatConfiguration = (
 
       let next = current
       if (target !== undefined) {
-        const targetIndex = isTarget(target) ? descriptor.indexByPath.get(String(target.path)) : undefined
+        const targetIndex = descriptor.indexByPath.get(String(target.path))
+        const isSimpleTarget = isTarget(target)
+          ? target[TargetSnapshotTypeId] === undefined && target.values === undefined
+          : !("state" in target) && !("states" in target) && !("completed" in target) && !("history" in target)
         if (
-          targetIndex === sourceIndex && isTarget(target) && target[TargetSnapshotTypeId] === undefined &&
-          target.values === undefined && current.completedOrder.length === 0
+          targetIndex === sourceIndex && isSimpleTarget && current.completedOrder.length === 0
         ) {
           current.values[sourceIndex] = decodeStateValueSync(
             machine,

--- a/test/Machine.test.ts
+++ b/test/Machine.test.ts
@@ -1136,6 +1136,34 @@ describe("Machine", () => {
         assertMachineSchemaDecodeError(error, "state", { state: "NonEmptyLoading" })
       }))
 
+    it.effect("decodes same-state atomic snapshot targets in the compiled runtime", () =>
+      Effect.gen(function*() {
+        const states = Machine.defineStates({ NonEmptyIdle })
+        const machine = Machine.make({
+          states: states.states,
+          events: [NonEmptySubmit],
+          initial: () => states.initial.NonEmptyIdle(new NonEmptyIdle({ userId: "user-1" }))
+        }).handle({
+          NonEmptyIdle: {
+            on: {
+              NonEmptySubmit: ({ target }) =>
+                target.full.NonEmptyIdle(unsafeTagged({ _tag: "NonEmptyIdle", userId: "" }))
+            }
+          }
+        })
+        const actor = yield* Machine.start(machine)
+
+        const snapshot = yield* sendAndWaitForSnapshot(
+          actor,
+          new NonEmptySubmit({ value: "request-1" }),
+          (snapshot) => snapshot.status === "error"
+        )
+        const error = yield* Effect.flip(actor.join)
+
+        assertMachineSchemaDecodeError(error, "state", { state: "NonEmptyIdle" })
+        assert.strictEqual(snapshot.status, "error")
+      }))
+
     it.effect("decodes final state output before caching it", () =>
       Effect.gen(function*() {
         const states = Machine.defineStates({


### PR DESCRIPTION
## Summary

- fast-path same-state atomic snapshot transitions in the compiled flat executor
- preserve schema decoding and lifecycle failures for invalid transition values
- avoid rebuilding a generic active configuration for the common `target.full.State(...)` update path

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (no examples changed)
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed (no public type change; `pnpm perf:types` passes)
- [ ] Reviewed the automated runtime-performance report, when runtime behavior changed

Local paired profiling showed approximately +31% flat burst throughput, +18% observed burst throughput, and +25% child delivery throughput. The automated report remains the merge gate.
