### PR TITLE
Optimize hierarchical transition contexts

### DIFF
--- a/.changeset/eager-transition-contexts.md
+++ b/.changeset/eager-transition-contexts.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Reduce hierarchical transition overhead by materializing the compiled transition context as a plain object.

--- a/src/internal/machinePlanner.ts
+++ b/src/internal/machinePlanner.ts
@@ -2186,24 +2186,17 @@ const makeIndexedTransitionContext = (
   event: any
 ): any => {
   const source = descriptor.nodes[sourceIndex]!
-  let snapshot: Machine.Snapshot<any> | undefined
+  const parentIndex = descriptor.parentIndices[sourceIndex]!
+  const parents: Record<string, unknown> = {}
+  for (const ancestorIndex of descriptor.ancestorIndices[sourceIndex]!) {
+    parents[descriptor.nodes[ancestorIndex]!.path] = configuration.values[ancestorIndex]
+  }
   return {
     state: configuration.values[sourceIndex],
-    get parent() {
-      const parentIndex = descriptor.parentIndices[sourceIndex]!
-      return parentIndex < 0 ? undefined : configuration.values[parentIndex]
-    },
-    get parents() {
-      const parents: Record<string, unknown> = {}
-      for (const ancestorIndex of descriptor.ancestorIndices[sourceIndex]!) {
-        parents[descriptor.nodes[ancestorIndex]!.path] = configuration.values[ancestorIndex]
-      }
-      return parents
-    },
+    parent: parentIndex < 0 ? undefined : configuration.values[parentIndex],
+    parents,
     event,
-    get snapshot() {
-      return snapshot ??= snapshotFromIndexed(descriptor, configuration)
-    },
+    snapshot: snapshotFromIndexed(descriptor, configuration),
     target: getTargetBuilder(machine, source.path)
   }
 }

--- a/test/MachineRuntimeDifferential.test.ts
+++ b/test/MachineRuntimeDifferential.test.ts
@@ -169,8 +169,19 @@ describe("pure planning and managed runtime differential", () => {
               on: {
                 Advance: ({ state, target }) => target.branch.Running.Right(new Right({ value: state.value + 10 })),
                 Bump: ({ state, target }) => target.branch.Running.Right(new Right({ value: state.value + 100 })),
-                Inspect: ({ state, parent, parents, snapshot }) => {
+                Inspect: (context) => {
+                  const { state, parent, parents, snapshot } = context
                   if (snapshot.path !== "Running") throw new Error("expected Running snapshot")
+                  const expectedKeys = ["state", "parent", "parents", "event", "snapshot", "target"]
+                  const spread = { ...context }
+                  assert.deepStrictEqual(Object.keys(context), expectedKeys)
+                  assert.deepStrictEqual(Object.keys(spread), expectedKeys)
+                  assert.strictEqual(spread.state, state)
+                  assert.strictEqual(spread.parent, parent)
+                  assert.strictEqual(spread.parents, parents)
+                  assert.strictEqual(spread.event, context.event)
+                  assert.strictEqual(spread.snapshot, snapshot)
+                  assert.strictEqual(spread.target, context.target)
                   observations.push({
                     state: state.value,
                     parent: parent._tag,


### PR DESCRIPTION
## Summary

- materialize compiled hierarchical transition contexts as plain objects instead of allocating lazy accessor closures
- preserve the existing enumerable field order, spread behavior, values, type inference, and transition semantics
- add regression assertions for the public context shape

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (no examples changed)
- [x] `pnpm perf:types`
- [ ] Reviewed the automated type-performance report, when the public TypeScript API or inference changed
- [ ] Reviewed the automated runtime-performance report, when runtime behavior changed

Local paired benchmark: compound hierarchy +30.7%, two parallel regions +19.3%; flat and child paths were neutral within normal noise.