### PR TITLE
Validate constructed machine values once

### DIFF
--- a/.changeset/quick-events-once.md
+++ b/.changeset/quick-events-once.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Add `Machine.event` for constructing protocol-owned events that validate once and avoid redundant decoding on repeated delivery.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,27 @@ const machine = Machine.make({
 })
 ```
 
+Construct reusable events with `Machine.event` when the schema is owned by the
+machine protocol:
+
+```ts
+const save = Machine.event(machine, Command.cases.Save)
+yield * ref.send(save)
+```
+
+The schema constructor runs once and the decoded value is trusted by that
+machine and definitions derived from it with `handle`. This avoids decoding a
+known event again on every delivery. A configured `Schema.TaggedUnion` can use
+either the union schema itself or one of its `cases`. Treat the returned event
+as immutable; sending it to an unrelated machine goes through that machine's
+normal decoder.
+
+Ordinary values remain valid and are decoded at every boundary:
+
+```ts
+yield * ref.send({ _tag: "Save" })
+```
+
 Handlers and machine logic see the complete union. Local public APIs such as
 `MachineRef.send`, `machineAtom.send`, and `Machine.plan` expose only `events`
 in TypeScript. The local planner and runtime still share the complete event

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -471,9 +471,24 @@ const machine = Machine.make({
   states: States.states,
   events: [Event.cases.Save],
   internalEvents: [InternalEvent.cases.Saved, InternalEvent.cases.SaveFailed],
-  initial: () => States.initial.Idle(State.cases.Idle.make({}))
+  initial: () => States.initial.Idle.from()
 })
 ```
+
+When the same already-constructed event may be delivered repeatedly, construct
+it once through its owning machine protocol:
+
+```ts
+const save = Machine.event(machine, Event.cases.Save)
+yield* ref.send(save)
+```
+
+`Machine.event` runs the configured schema constructor once. That machine and
+definitions derived from it with `handle` then recognize the decoded event as
+trusted and do not decode it again. Tagged-union case schemas are recognized
+when their union is configured. Treat the returned event as immutable. Raw
+objects and values constructed for another machine continue through normal
+runtime validation on every delivery.
 
 Use the exported utility types when another API must preserve the boundary:
 

--- a/perf/runtime/counter.mjs
+++ b/perf/runtime/counter.mjs
@@ -43,13 +43,13 @@ export const counterMachine = Machine.make({
   id: "RuntimeBenchmarkCounter",
   states: CounterStates.states,
   events: [CounterEvent.cases.Increment, CounterEvent.cases.Finish],
-  initial: () => CounterStates.initial.Count(CounterState.cases.Count.make({ value: 0 }))
+  initial: () => CounterStates.initial.Count.from({ value: 0 })
 }).handle({
   Count: {
     on: {
       Increment: ({ state, target }) =>
-        target.full.Count(CounterState.cases.Count.make({ value: state.value + 1 })),
-      Finish: ({ state, target }) => target.full.Done(CounterState.cases.Done.make({ value: state.value }))
+        target.full.Count.from({ value: state.value + 1 }),
+      Finish: ({ state, target }) => target.full.Done.from({ value: state.value })
     }
   },
   Done: {
@@ -64,7 +64,7 @@ const counterParentMachine = Machine.make({
   id: "RuntimeBenchmarkCounterParent",
   states: ParentStates.states,
   events: [],
-  initial: () => ParentStates.initial.Active(ParentState.cases.Active.make({}))
+  initial: () => ParentStates.initial.Active.from()
 }).handle({
   Active: {
     invoke: Machine.invokeMachine({ child: CounterChild })
@@ -75,7 +75,7 @@ const counterSnapshotParentMachine = Machine.make({
   id: "RuntimeBenchmarkSnapshotCounterParent",
   states: ParentStates.states,
   events: [],
-  initial: () => ParentStates.initial.Active(ParentState.cases.Active.make({}))
+  initial: () => ParentStates.initial.Active.from()
 }).handle({
   Active: {
     invoke: Machine.invokeMachine({
@@ -118,9 +118,8 @@ const hierarchicalCounterMachine = Machine.make({
   states: HierarchicalStates.states,
   events: [HierarchicalEvent.cases.Increment, HierarchicalEvent.cases.Finish],
   initial: () =>
-    HierarchicalStates.initial.Active(
-      HierarchicalState.cases.Active.make({}),
-      (active) => active.Count(HierarchicalState.cases.Count.make({ value: 0 }))
+    HierarchicalStates.initial.Active.from(
+      (active) => active.Count.from({ value: 0 })
     )
 }).handle({
   Active: {
@@ -128,9 +127,9 @@ const hierarchicalCounterMachine = Machine.make({
       Count: {
         on: {
           Increment: ({ state, target }) =>
-            target.local.Count(HierarchicalState.cases.Count.make({ value: state.value + 1 })),
+            target.local.Count.from({ value: state.value + 1 }),
           Finish: ({ state, target }) =>
-            target.full.Complete(HierarchicalState.cases.Complete.make({ value: state.value }))
+            target.full.Complete.from({ value: state.value })
         }
       }
     }
@@ -172,34 +171,31 @@ const parallelCounterMachine = Machine.make({
     HierarchicalEvent.cases.Finish
   ],
   initial: () =>
-    ParallelStates.initial.Active(
-      ParallelState.cases.Active.make({}),
+    ParallelStates.initial.Active.from(
       (active) =>
         active
-          .Left(ParallelState.cases.Left.make({ value: 0 }))
-          .Right(ParallelState.cases.Right.make({ value: 0 }))
+          .Left.from({ value: 0 })
+          .Right.from({ value: 0 })
     )
 }).handle({
   Active: {
     on: {
       Finish: ({ snapshot, target }) =>
-        target.full.Complete(
-          ParallelState.cases.Complete.make({
-            value: snapshot.states.Left.value.value + snapshot.states.Right.value.value
-          })
-        )
+        target.full.Complete.from({
+          value: snapshot.states.Left.value.value + snapshot.states.Right.value.value
+        })
     },
     states: {
       Left: {
         on: {
           IncrementLeft: ({ state, target }) =>
-            target.branch.Active.Left(ParallelState.cases.Left.make({ value: state.value + 1 }))
+            target.branch.Active.Left.from({ value: state.value + 1 })
         }
       },
       Right: {
         on: {
           IncrementRight: ({ state, target }) =>
-            target.branch.Active.Right(ParallelState.cases.Right.make({ value: state.value + 1 }))
+            target.branch.Active.Right.from({ value: state.value + 1 })
         }
       }
     }
@@ -209,12 +205,13 @@ const parallelCounterMachine = Machine.make({
   }
 })
 
-export const incrementEvent = CounterEvent.cases.Increment.make({})
-const finishEvent = CounterEvent.cases.Finish.make({})
-const hierarchicalIncrementEvent = HierarchicalEvent.cases.Increment.make({})
-const parallelIncrementLeftEvent = HierarchicalEvent.cases.IncrementLeft.make({})
-const parallelIncrementRightEvent = HierarchicalEvent.cases.IncrementRight.make({})
-const hierarchicalFinishEvent = HierarchicalEvent.cases.Finish.make({})
+export const incrementEvent = Machine.event(counterMachine, CounterEvent.cases.Increment)
+const finishEvent = Machine.event(counterMachine, CounterEvent.cases.Finish)
+const hierarchicalIncrementEvent = Machine.event(hierarchicalCounterMachine, HierarchicalEvent.cases.Increment)
+const hierarchicalFinishEvent = Machine.event(hierarchicalCounterMachine, HierarchicalEvent.cases.Finish)
+const parallelIncrementLeftEvent = Machine.event(parallelCounterMachine, HierarchicalEvent.cases.IncrementLeft)
+const parallelIncrementRightEvent = Machine.event(parallelCounterMachine, HierarchicalEvent.cases.IncrementRight)
+const parallelFinishEvent = Machine.event(parallelCounterMachine, HierarchicalEvent.cases.Finish)
 
 export const initialCounterSnapshot = Effect.runSync(
   Machine.planInitial(counterMachine).pipe(Effect.map((planned) => planned.state))
@@ -339,7 +336,7 @@ const runParallelCounterBurst = (ref, size) =>
       for (let index = 0; index < size; index += 1) {
         yield* ref.send(index % 2 === 0 ? parallelIncrementLeftEvent : parallelIncrementRightEvent)
       }
-      yield* ref.send(hierarchicalFinishEvent)
+      yield* ref.send(parallelFinishEvent)
       return yield* ref.join
     })
   )

--- a/perf/runtime/counter.mjs
+++ b/perf/runtime/counter.mjs
@@ -205,13 +205,18 @@ const parallelCounterMachine = Machine.make({
   }
 })
 
-export const incrementEvent = Machine.event(counterMachine, CounterEvent.cases.Increment)
-const finishEvent = Machine.event(counterMachine, CounterEvent.cases.Finish)
-const hierarchicalIncrementEvent = Machine.event(hierarchicalCounterMachine, HierarchicalEvent.cases.Increment)
-const hierarchicalFinishEvent = Machine.event(hierarchicalCounterMachine, HierarchicalEvent.cases.Finish)
-const parallelIncrementLeftEvent = Machine.event(parallelCounterMachine, HierarchicalEvent.cases.IncrementLeft)
-const parallelIncrementRightEvent = Machine.event(parallelCounterMachine, HierarchicalEvent.cases.IncrementRight)
-const parallelFinishEvent = Machine.event(parallelCounterMachine, HierarchicalEvent.cases.Finish)
+// The pull-request harness evaluates this fixture against both the base and
+// candidate builds. Older base builds do not expose Machine.event yet.
+const makeEvent = (machine, schema) =>
+  typeof Machine.event === "function" ? Machine.event(machine, schema) : schema.make({})
+
+export const incrementEvent = makeEvent(counterMachine, CounterEvent.cases.Increment)
+const finishEvent = makeEvent(counterMachine, CounterEvent.cases.Finish)
+const hierarchicalIncrementEvent = makeEvent(hierarchicalCounterMachine, HierarchicalEvent.cases.Increment)
+const hierarchicalFinishEvent = makeEvent(hierarchicalCounterMachine, HierarchicalEvent.cases.Finish)
+const parallelIncrementLeftEvent = makeEvent(parallelCounterMachine, HierarchicalEvent.cases.IncrementLeft)
+const parallelIncrementRightEvent = makeEvent(parallelCounterMachine, HierarchicalEvent.cases.IncrementRight)
+const parallelFinishEvent = makeEvent(parallelCounterMachine, HierarchicalEvent.cases.Finish)
 
 export const initialCounterSnapshot = Effect.runSync(
   Machine.planInitial(counterMachine).pipe(Effect.map((planned) => planned.state))

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -5384,7 +5384,7 @@ const withFrom = <Method extends (value: unknown, ...args: ReadonlyArray<any>) =
       const omitted = args.length === 0 || (kind === "nested" && args.length === 1 && typeof args[0] === "function")
       const input = omitted ? {} : args[0]
       const rest = omitted ? args : args.slice(1)
-      return Model.markStateConstruction(method(Model.makeStateInput(input), ...rest))
+      return method(Model.makeStateInput(input), ...rest)
     },
     enumerable: false
   })
@@ -5426,10 +5426,6 @@ const makeParallelSnapshotBuilder = (
     value: regions,
     enumerable: false
   })
-  Object.defineProperty(builder, SnapshotBuilderConstructionTypeId, {
-    value: Model.isStateConstruction(builder),
-    enumerable: false
-  })
   for (const key of Object.keys(states)) {
     const pseudoType = (states[key] as { readonly type?: unknown }).type
     if (pseudoType === "history" || pseudoType === "choice") {
@@ -5446,8 +5442,7 @@ const makeParallelSnapshotBuilder = (
         nextRegions[regionKey] = regions[regionKey]
       }
       nextRegions[key] = makeSnapshotForNode(states[key], key, value, selector, options)
-      const next = makeParallelSnapshotBuilder(states, options, nextRegions)
-      return Model.isStateConstruction(builder) ? Model.markStateConstruction(next) : next
+      return makeParallelSnapshotBuilder(states, options, nextRegions)
     }, node.states === undefined ? "leaf" : "nested")
   }
   return builder
@@ -5499,14 +5494,14 @@ const makeSnapshotForNode = (
     const builder = makeParallelSnapshotBuilder(node.states, { ...options, prefix: path }, {})
     const selected = selector(builder)
     snapshot.states = getParallelSnapshotBuilderRegions(path, node.states, selected)
-    return Model.isStateConstruction(selected) ? Model.markStateConstruction(snapshot) : snapshot
+    return snapshot
   }
   const childStates = options.mode === "initial" && node.initial !== undefined
     ? { [node.initial]: node.states[node.initial] }
     : node.states
   const selected = selector(makeSnapshotBuilder(childStates, { ...options, prefix: path }))
   snapshot.state = selected
-  return Model.isStateConstruction(selected) ? Model.markStateConstruction(snapshot) : snapshot
+  return snapshot
 }
 
 const getTargetBuilderNode = (
@@ -6024,6 +6019,44 @@ export const make: Make = (<
   Model.setProtocol(self)
   return self
 }) as Make
+
+type EventConstructorArgs<EventSchema extends Machine.TaggedSchema> = {} extends EventSchema["~type.make.in"] ?
+  [input?: EventSchema["~type.make.in"]]
+  : [input: EventSchema["~type.make.in"]]
+
+/**
+ * Constructs an event from a schema owned by a machine's protocol.
+ *
+ * **Details**
+ *
+ * The schema constructor runs exactly once. The resulting decoded event is
+ * trusted by this machine and definitions derived from it with `handle`, so
+ * repeated delivery does not decode the same already-constructed value again.
+ * Events supplied through ordinary `send` and `plan` calls remain untrusted
+ * and continue through full runtime schema validation.
+ * Treat the returned event as immutable after construction.
+ *
+ * The schema must be one of the machine's configured public or internal event
+ * schemas, or a case schema belonging to a configured `Schema.TaggedUnion`.
+ *
+ * **Example**
+ *
+ * ```ts
+ * const increment = Machine.event(counter, Increment, { by: 1 })
+ * yield* ref.send(increment)
+ * ```
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const event = <
+  const M extends Machine.Any,
+  const EventSchema extends Machine.TaggedSchema
+>(
+  machine: M,
+  schema: EventSchema & ([EventSchema["Type"]] extends [Machine.Event<M>] ? unknown : never),
+  ...args: EventConstructorArgs<EventSchema>
+): EventSchema["Type"] => Model.makeEvent(machine, schema, args.length === 0 ? {} : args[0])
 
 /**
  * Encodes a decoded machine snapshot into a normalized data representation.

--- a/src/internal/machineModel.ts
+++ b/src/internal/machineModel.ts
@@ -628,18 +628,6 @@ export const makeStateInput = (input: unknown): StateInput => ({
 
 const isStateInput = (u: unknown): u is StateInput => hasProperty(u, StateInputTypeId)
 
-export const markStateConstruction = <A>(value: A): A => {
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.defineProperty(value, StateConstructionTypeId, {
-      value: StateConstructionTypeId,
-      enumerable: false
-    })
-  }
-  return value
-}
-
-export const isStateConstruction = (u: unknown): boolean => hasProperty(u, StateConstructionTypeId)
-
 export const isSnapshot = (u: unknown): u is Machine.AtomicSnapshot<string, unknown> =>
   hasProperty(u, "path") && hasProperty(u, "value")
 
@@ -698,6 +686,8 @@ interface CompletionResult extends FinalCompletion {
 interface MachineProtocolSchemas {
   readonly event: Schema.Top
   readonly emit: Schema.Top
+  readonly eventConstructors: ReadonlySet<object>
+  readonly trustedEvents: WeakSet<object>
 }
 
 type BoundaryDecoder = (value: unknown) => Effect.Effect<unknown, Schema.SchemaError, unknown>
@@ -746,10 +736,35 @@ const setProtocolSchemas = (machine: Machine.Any, protocol: MachineProtocolSchem
   })
 }
 
+const collectEventConstructors = (
+  schemas: ReadonlyArray<Machine.TaggedSchema>
+): ReadonlySet<object> => {
+  const constructors = new Set<object>()
+  const add = (schema: Machine.TaggedSchema): void => {
+    const key = schema as object
+    if (constructors.has(key)) return
+    constructors.add(key)
+    if (!hasProperty(schema, "cases") || typeof schema.cases !== "object" || schema.cases === null) return
+    for (const candidate of Object.values(schema.cases)) {
+      if (
+        ((typeof candidate === "object" && candidate !== null) || typeof candidate === "function") &&
+        hasProperty(candidate, "make")
+      ) {
+        add(candidate as Machine.TaggedSchema)
+      }
+    }
+  }
+  for (const schema of schemas) add(schema)
+  return constructors
+}
+
 export const setProtocol = (machine: Machine.Any): void => {
+  const events = [...machine.events, ...machine.internalEvents]
   setProtocolSchemas(machine, {
-    event: Schema.Union([...machine.events, ...machine.internalEvents]),
-    emit: Schema.Union(machine.emits)
+    event: Schema.Union(events),
+    emit: Schema.Union(machine.emits),
+    eventConstructors: collectEventConstructors(events),
+    trustedEvents: new WeakSet()
   })
 }
 
@@ -796,6 +811,56 @@ export const decodeBoundarySync = <A>(
   return decoded.success as A
 }
 
+const makeBoundarySync = <A>(
+  machine: Machine.Any,
+  schema: Schema.Top,
+  input: unknown,
+  options: DecodeBoundaryOptions
+): A => {
+  try {
+    return schema.make(input as never) as A
+  } catch (cause) {
+    const issue = cause instanceof Error ? cause.cause : undefined
+    throw new MachineSchemaDecodeError({
+      machineId: machine.id,
+      boundary: options.boundary,
+      cause: Schema.isSchemaError(cause)
+        ? cause
+        : hasProperty(issue, "~effect/SchemaIssue/Issue")
+        ? new Schema.SchemaError(issue as any)
+        : Cause.die(cause),
+      ...(options.state === undefined ? {} : { state: options.state }),
+      ...(options.event === undefined ? {} : { event: options.event })
+    })
+  }
+}
+
+/** Constructs an event through one of the machine protocol's own schemas and
+ * records the decoded value as trusted by that protocol. Machine clones share
+ * the protocol record, while unrelated machines retain independent trust. */
+export const makeEvent = <Schema extends Machine.TaggedSchema>(
+  machine: Machine.Any,
+  schema: Schema,
+  input: unknown
+): Schema["Type"] => {
+  const protocol = getProtocolSchemas(machine)
+  if (!protocol.eventConstructors.has(schema as object)) {
+    throw new Error("Machine.event expected a schema from the machine event protocol")
+  }
+  const inputName = getEventName(input)
+  const event = makeBoundarySync<Schema["Type"]>(
+    machine,
+    schema,
+    input,
+    inputName === undefined ? { boundary: "event" } : { boundary: "event", event: inputName }
+  )
+  protocol.trustedEvents.add(event as object)
+  return event
+}
+
+const isTrustedEvent = (protocol: MachineProtocolSchemas, event: unknown): boolean =>
+  typeof event === "object" && event !== null && protocol.trustedEvents.has(event)
+
 export const decodeInput = <Input extends Schema.Top>(
   machine: Machine.Any,
   schema: Input,
@@ -807,10 +872,14 @@ export const decodeEvent = <const Events extends ReadonlyArray<Machine.TaggedSch
   machine: Machine.Any,
   event: unknown
 ): Effect.Effect<Machine.EventOf<Events>, MachineSchemaDecodeError> => {
+  const protocol = getProtocolSchemas(machine)
+  if (isTrustedEvent(protocol, event)) {
+    return Effect.succeed(event as Machine.EventOf<Events>)
+  }
   const eventName = getEventName(event)
   return decodeBoundary<Machine.EventOf<Events>>(
     machine,
-    getProtocolSchemas(machine).event,
+    protocol.event,
     event,
     eventName === undefined ? { boundary: "event" } : { boundary: "event", event: eventName }
   )
@@ -820,10 +889,14 @@ export const decodeEventSync = <const Events extends ReadonlyArray<Machine.Tagge
   machine: Machine.Any,
   event: unknown
 ): Machine.EventOf<Events> => {
+  const protocol = getProtocolSchemas(machine)
+  if (isTrustedEvent(protocol, event)) {
+    return event as Machine.EventOf<Events>
+  }
   const eventName = getEventName(event)
   return decodeBoundarySync<Machine.EventOf<Events>>(
     machine,
-    getProtocolSchemas(machine).event,
+    protocol.event,
     event,
     eventName === undefined ? { boundary: "event" } : { boundary: "event", event: eventName }
   )
@@ -887,21 +960,10 @@ export const decodeStateValueSync = (
   if (!isStateInput(value)) {
     return decodeBoundarySync(machine, getStateNodeSchema(node), value, { boundary: "state", state: node.path })
   }
-  try {
-    return getStateNodeSchema(node).make(value.input as never)
-  } catch (cause) {
-    const issue = cause instanceof Error ? cause.cause : undefined
-    throw new MachineSchemaDecodeError({
-      machineId: machine.id,
-      boundary: "state",
-      state: node.path,
-      cause: Schema.isSchemaError(cause)
-        ? cause
-        : hasProperty(issue, "~effect/SchemaIssue/Issue")
-        ? new Schema.SchemaError(issue as any)
-        : Cause.die(cause)
-    })
-  }
+  return makeBoundarySync(machine, getStateNodeSchema(node), value.input, {
+    boundary: "state",
+    state: node.path
+  })
 }
 
 export const decodeOutputValue = (

--- a/test/Machine.test.ts
+++ b/test/Machine.test.ts
@@ -548,6 +548,106 @@ describe("Machine", () => {
       })
     }))
 
+  describe("event constructor", () => {
+    it.effect("validates once and shares trust only with derived machine definitions", () =>
+      Effect.gen(function*() {
+        let validations = 0
+        const Tick = Schema.TaggedStruct("ConstructedTick", { value: Schema.Number }).pipe(
+          Schema.refine((event): event is typeof event => {
+            validations += 1
+            return true
+          })
+        )
+        const AlternateTick = Schema.TaggedStruct("ConstructedTick", { value: Schema.Number })
+        const Counter = Schema.TaggedStruct("ConstructedCounter", { value: Schema.Number })
+        const states = Machine.defineStates({ Counter })
+        const definition = Machine.make({
+          states: states.states,
+          events: [Tick],
+          initial: () => states.initial.Counter.from({ value: 0 })
+        })
+
+        const tick = Machine.event(definition, Tick, { value: 1 })
+        assert.deepStrictEqual(tick, { _tag: "ConstructedTick", value: 1 })
+        assert.strictEqual(validations, 1)
+
+        const machine = definition.handle({
+          Counter: {
+            on: {
+              ConstructedTick: () => undefined
+            }
+          }
+        })
+        const initial = yield* Machine.planInitial(machine)
+        for (let index = 0; index < 5; index++) {
+          yield* Machine.plan(machine, initial.state, tick)
+        }
+        assert.strictEqual(validations, 1)
+
+        const raw = Tick.make({ value: 2 })
+        assert.strictEqual(validations, 2)
+        yield* Machine.plan(machine, initial.state, raw)
+        assert.strictEqual(validations, 3)
+
+        const unrelated = Machine.make({
+          states: states.states,
+          events: [Tick],
+          initial: () => states.initial.Counter.from({ value: 0 })
+        }).handle({
+          Counter: {
+            on: {
+              ConstructedTick: () => undefined
+            }
+          }
+        })
+        yield* Machine.plan(unrelated, (yield* Machine.planInitial(unrelated)).state, tick)
+        assert.strictEqual(validations, 4)
+
+        assert.throws(
+          () => Machine.event(machine, AlternateTick, { value: 1 }),
+          "Machine.event expected a schema from the machine event protocol"
+        )
+
+        let invalid: unknown
+        try {
+          Machine.event(definition, Tick, { value: "invalid" } as never)
+        } catch (cause) {
+          invalid = cause
+        }
+        assertMachineSchemaDecodeError(invalid, "event")
+      }))
+
+    it("constructs configured TaggedUnion cases", () => {
+      const Event = Schema.TaggedUnion({
+        Ping: { message: Schema.String },
+        Stop: {}
+      })
+      class Defaulted extends Schema.TaggedClass<Defaulted>("ConstructedDefaulted")("Defaulted", {
+        id: Schema.String,
+        label: Schema.String.pipe(
+          Schema.optionalKey,
+          Schema.withConstructorDefault(Effect.succeed("default-label"))
+        )
+      }) {}
+      const State = Schema.TaggedStruct("EventConstructorIdle", {})
+      const states = Machine.defineStates({ Idle: State })
+      const machine = Machine.make({
+        states: states.states,
+        events: [Event, Defaulted],
+        initial: () => states.initial.Idle.from()
+      })
+
+      assert.deepStrictEqual(
+        Machine.event(machine, Event.cases.Ping, { message: "hello" }),
+        { _tag: "Ping", message: "hello" }
+      )
+      assert.deepStrictEqual(Machine.event(machine, Event.cases.Stop), { _tag: "Stop" })
+      const defaulted = Machine.event(machine, Defaulted, { id: "event-1" })
+      assert.instanceOf(defaulted, Defaulted)
+      assert.deepStrictEqual(defaulted, new Defaulted({ id: "event-1", label: "default-label" }))
+    })
+  })
+
   describe("state builder from", () => {
     it.effect("constructs TaggedClass initial state and applies constructor defaults", () =>
       Effect.gen(function*() {

--- a/typetest/Machine.tst.ts
+++ b/typetest/Machine.tst.ts
@@ -195,6 +195,40 @@ describe("Machine", () => {
     >()
   })
 
+  it("constructs exact public and internal event values from machine-owned schemas", () => {
+    const Event = Schema.TaggedUnion({
+      Tick: { amount: Schema.Number },
+      Stop: {}
+    })
+    class Internal extends Schema.TaggedClass<Internal>("ConstructedInternal")("ConstructedInternal", {
+      id: Schema.String
+    }) {}
+    class Unknown extends Schema.TaggedClass<Unknown>("ConstructedUnknown")("ConstructedUnknown", {}) {}
+    class InvalidTick extends Schema.TaggedClass<InvalidTick>("InvalidTick")("Tick", {
+      amount: Schema.String
+    }) {}
+    const State = Schema.TaggedStruct("ConstructedEventState", {})
+    const States = Machine.defineStates({ State })
+    const machine = Machine.make({
+      states: States.states,
+      events: [Event],
+      internalEvents: [Internal],
+      initial: () => States.initial.State.from()
+    })
+
+    expect(Machine.event(machine, Event.cases.Tick, { amount: 1 })).type.toBe<{
+      readonly _tag: "Tick"
+      readonly amount: number
+    }>()
+    expect(Machine.event(machine, Event.cases.Stop)).type.toBe<{ readonly _tag: "Stop" }>()
+    expect(Machine.event(machine, Internal, { id: "internal-1" })).type.toBe<Internal>()
+    expect(Machine.event).type.not.toBeCallableWith(machine, Event.cases.Tick)
+    expect(Machine.event).type.not.toBeCallableWith(machine, Event.cases.Tick, { amount: "1" })
+    expect(Machine.event).type.not.toBeCallableWith(machine, Internal, {})
+    expect(Machine.event).type.not.toBeCallableWith(machine, Unknown, {})
+    expect(Machine.event).type.not.toBeCallableWith(machine, InvalidTick, { amount: "1" })
+  })
+
   it("machine contexts expose type-safe parent state values", () => {
     const nested = null as unknown as SignedOutContext
     expect(nested.parent).type.toBe<Auth>()


### PR DESCRIPTION
## Summary

- add `Machine.event` to construct protocol-owned events once and skip redundant schema decoding when the same immutable value is delivered repeatedly
- use the existing `.from` state constructors throughout the runtime benchmark so schema construction happens at the machine boundary exactly once
- remove redundant runtime state-construction markers while preserving the opaque TypeScript construction model
- document trust scope, raw-value fallback behavior, and the immutability requirement

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [ ] Relevant example checks, when examples changed
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed

Local focused benchmarks show repeatable improvements across flat, child, hierarchical, and parallel event bursts. The automated runtime report remains the merge gate.
