### PR TITLE
Defer stopped completion errors

### DIFF
--- a/.changeset/fast-stopped-completion.md
+++ b/.changeset/fast-stopped-completion.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Defer construction of a compiled machine's `StoppedError` until its stopped `join` result is observed.

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -1220,6 +1220,14 @@ type CompiledTermination =
   | { readonly _tag: "Done"; readonly output: unknown }
   | { readonly _tag: "Failure"; readonly cause: Cause.Cause<unknown> }
 
+// Stopping is commonly used only for resource cleanup. Keep that path free of
+// Error stack capture and materialize the typed join failure only if observed.
+const CompiledStoppedCompletion: unique symbol = Symbol("effect/Machine/CompiledStoppedCompletion")
+
+type CompiledCompletion =
+  | Effect.Effect<unknown, unknown>
+  | typeof CompiledStoppedCompletion
+
 /**
  * Compact runtime for compiled statecharts.
  *
@@ -1244,7 +1252,7 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
   private processContext: ProcessContext<unknown, unknown> | undefined
   private compiledContext: CompiledProcessContext<unknown, unknown> | undefined
   private current!: VersionedSnapshot<unknown, unknown, unknown>
-  private completion: Effect.Effect<unknown, unknown> | undefined
+  private completion: CompiledCompletion | undefined
   private waiter: Deferred.Deferred<unknown, unknown> | undefined
   private requestedTermination: CompiledTermination | undefined
   private reservedTerminationSnapshot: RuntimeSnapshot<unknown, unknown, unknown> | undefined
@@ -1350,7 +1358,7 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
   get join(): Effect.Effect<unknown, unknown> {
     return Effect.suspend(() => {
       if (this.completion !== undefined) {
-        return this.completion
+        return this.resolveCompletion(this.completion)
       }
       this.waiter ??= Deferred.makeUnsafe<unknown, unknown>()
       return Deferred.await(this.waiter)
@@ -1452,7 +1460,7 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
   private stopEffect(): Effect.Effect<void> {
     return Effect.suspend(() => {
       if (this.completion !== undefined) {
-        return this.awaitCompletion()
+        return Effect.void
       }
       const requested = { _tag: "Stopped" } as const
       return this.requestTermination(requested).pipe(
@@ -1493,7 +1501,18 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
   }
 
   private awaitCompletion(): Effect.Effect<void> {
-    return this.join.pipe(Effect.exit, Effect.asVoid)
+    return this.completion === undefined
+      ? this.join.pipe(Effect.exit, Effect.asVoid)
+      : Effect.void
+  }
+
+  private resolveCompletion(completion: CompiledCompletion): Effect.Effect<unknown, unknown> {
+    if (completion !== CompiledStoppedCompletion) {
+      return completion
+    }
+    const stopped = Effect.fail(new StoppedError())
+    this.completion = stopped
+    return stopped
   }
 
   private drainRuntime(): Effect.Effect<void, never, any> {
@@ -1555,8 +1574,8 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
         : requested._tag === "Done"
         ? Exit.succeed(requested.output)
         : Exit.failCause(requested.cause)
-      const completion = requested._tag === "Stopped"
-        ? Effect.fail(new StoppedError())
+      const completion: CompiledCompletion = requested._tag === "Stopped"
+        ? CompiledStoppedCompletion
         : requested._tag === "Done"
         ? Effect.succeed(requested.output)
         : Effect.failCause(requested.cause)
@@ -1581,7 +1600,7 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
             }
             this.completion = completion
             if (this.waiter !== undefined) {
-              Deferred.doneUnsafe(this.waiter, completion)
+              Deferred.doneUnsafe(this.waiter, this.resolveCompletion(completion))
               this.waiter = undefined
             }
           }))

--- a/test/MachineProcessLifecycle.test.ts
+++ b/test/MachineProcessLifecycle.test.ts
@@ -262,6 +262,34 @@ describe("machine process lifecycle", () => {
       assert.instanceOf(yield* Effect.flip(ref.join), Machine.StoppedError)
     }))
 
+  it.effect("materializes and reuses the stopped completion when a compiled process is joined", () =>
+    Effect.gen(function*() {
+      const start = () =>
+        MachineRuntime.startProcess<number, void>({
+          [MachineRuntime.childlessProcess]: true,
+          [MachineRuntime.compiledProcess]: true,
+          initial: () => Effect.succeed(1),
+          run: () => Effect.never,
+          drain: () => Effect.succeed(Option.none())
+        })
+
+      const stoppedBeforeJoin = yield* start()
+      yield* stoppedBeforeJoin.stop
+      yield* stoppedBeforeJoin.stop
+      const first = yield* Effect.flip(stoppedBeforeJoin.join)
+      const second = yield* Effect.flip(stoppedBeforeJoin.join)
+      assert.instanceOf(first, Machine.StoppedError)
+      assert.strictEqual(second, first)
+
+      const joinedBeforeStop = yield* start()
+      const pending = yield* Effect.flip(joinedBeforeStop.join).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+      yield* joinedBeforeStop.stop
+      const pendingError = yield* Fiber.join(pending)
+      assert.instanceOf(pendingError, Machine.StoppedError)
+      assert.strictEqual(yield* Effect.flip(joinedBeforeStop.join), pendingError)
+    }))
+
   it.effect("terminalizes once when concurrent callers stop the same process", () =>
     Effect.gen(function*() {
       const cleanupCount = yield* Ref.make(0)


### PR DESCRIPTION
## Summary

- represent an unobserved stopped completion with an internal sentinel instead of eagerly constructing a `StoppedError`
- materialize and cache the typed failure only when `join` is actually evaluated
- preserve pending joins, repeated stops, concurrent terminalization, and error identity after materialization

The root cause was `StoppedError` stack capture on every ordinary cleanup, even though most callers stop a machine without subsequently joining it. Local isolated lifecycle screening showed a large repeatable improvement; the automated runtime report remains the merge gate.

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [ ] Relevant example checks, when examples changed
- [ ] Reviewed the automated type-performance report, when the public TypeScript API or inference changed
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed
