### PR TITLE
Batch observed snapshot publications

### DIFF
--- a/.changeset/brisk-observers-batch.md
+++ b/.changeset/brisk-observers-batch.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Batch lossless ordered snapshot publications across each synchronous compiled machine drain segment and share the compact process context through prototype methods.

--- a/src/internal/machineProcess.ts
+++ b/src/internal/machineProcess.ts
@@ -222,15 +222,21 @@ const makeChildlessCompiledDrain = (
         const continued = planned.done ? Effect.succeed(Option.some(planned.output)) : loop
         return afterCommit === undefined ? continued : afterCommit.pipe(Effect.andThen(continued))
       }
-
-      if (beforeCommit === undefined) {
+      const commitAndContinue = (): Effect.Effect<Option.Option<any>, any, any> => {
         const notification = commit()
+        if (notification !== undefined || afterCommit !== undefined) {
+          context.flush()
+        }
         const continued = continueAfterCommit()
         return notification === undefined ? continued : notification.pipe(Effect.andThen(continued))
       }
+
+      if (beforeCommit === undefined) {
+        return commitAndContinue()
+      }
+      context.flush()
       return beforeCommit.pipe(
-        Effect.andThen(Effect.suspend(() => commit() ?? Effect.void)),
-        Effect.andThen(continueAfterCommit())
+        Effect.andThen(Effect.suspend(commitAndContinue))
       )
     })
     return internalRuntime.provideMachineRuntime(loop, context.scope)
@@ -439,14 +445,20 @@ const makeInvokingCompiledDrain = (
           ? continued
           : runSequentialDiscard(afterCommit).pipe(Effect.andThen(continued))
       }
-      if (beforeCommit.length === 0) {
+      const commitAndContinue = (): Effect.Effect<Option.Option<any>, any, any> => {
         const notification = commit()
+        if (notification !== undefined || afterCommit.length > 0) {
+          context.flush()
+        }
         const continued = continueAfterCommit()
         return notification === undefined ? continued : notification.pipe(Effect.andThen(continued))
       }
+      if (beforeCommit.length === 0) {
+        return commitAndContinue()
+      }
+      context.flush()
       return runSequentialDiscard(beforeCommit).pipe(
-        Effect.andThen(Effect.suspend(() => commit() ?? Effect.void)),
-        Effect.andThen(continueAfterCommit())
+        Effect.andThen(Effect.suspend(commitAndContinue))
       )
     })
 

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -128,7 +128,14 @@ interface VersionedSnapshot<State, Error, Output> {
   readonly snapshot: RuntimeSnapshot<State, Error, Output>
   readonly terminalizing: boolean
   readonly changes: PubSub.PubSub<Take.Take<VersionedSnapshot<State, Error, Output>>> | undefined
+  /** Compiled drains retain one non-empty publication chunk until their next Effect boundary. */
+  pendingChanges?: VersionedSnapshotBatch<State, Error, Output> | undefined
 }
+
+type VersionedSnapshotBatch<State, Error, Output> = [
+  VersionedSnapshot<State, Error, Output>,
+  ...Array<VersionedSnapshot<State, Error, Output>>
+]
 
 export type RuntimeOutcome<State, Error = never, Output = never> =
   | {
@@ -222,6 +229,8 @@ export interface CompiledProcessContext<State, Event> {
   readonly poll: () => Option.Option<Event>
   readonly state: () => State
   readonly commit: (state: State) => Effect.Effect<void> | undefined
+  /** Publishes every committed snapshot accumulated by the current synchronous segment. */
+  readonly flush: () => void
   executionState: unknown
 }
 
@@ -1321,13 +1330,7 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
           updateState: (f) => self.updateState(f)
         }
       } else {
-        self.compiledContext = {
-          scope: self.processScope,
-          poll: () => pollCompactMailbox(self.mailbox),
-          state: () => self.current.snapshot.state,
-          commit: (state: unknown) => self.commitActiveState(state),
-          executionState: undefined
-        }
+        self.compiledContext = new CompiledProcessContextImpl(self.processScope, self)
       }
 
       if (self.options.onReady !== undefined) {
@@ -1533,6 +1536,7 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
                 : compiledDrain(self.compiledContext!)
             })
           ).pipe(Effect.exit)
+          self.flushPendingChanges()
           if (Exit.isFailure(exit)) {
             if (self.requestedTermination === undefined) {
               yield* self.requestTermination({ _tag: "Failure", cause: exit.cause })
@@ -1629,6 +1633,7 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
 
   private setAndPublishSnapshot(snapshot: RuntimeSnapshot<unknown, unknown, unknown>): Effect.Effect<void> {
     return Effect.suspend(() => {
+      this.flushPendingChanges()
       const versioned = {
         revision: this.current.revision + 1,
         snapshot,
@@ -1647,24 +1652,64 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
     return Effect.suspend(() => this.commitActiveState(state) ?? Effect.void)
   }
 
-  private commitActiveState(state: unknown): Effect.Effect<void> | undefined {
+  pollCompiledEvent(): Option.Option<unknown> {
+    return pollCompactMailbox(this.mailbox)
+  }
+
+  compiledState(): unknown {
+    return this.current.snapshot.state
+  }
+
+  commitCompiledState(state: unknown): Effect.Effect<void> | undefined {
+    return this.commitActiveState(state, true)
+  }
+
+  private commitActiveState(state: unknown, batchChanges = false): Effect.Effect<void> | undefined {
     const latest = this.current
     if (latest.terminalizing || latest.snapshot.status !== "active") {
       return undefined
     }
+    const pendingChanges = latest.pendingChanges
+    if (pendingChanges !== undefined) {
+      latest.pendingChanges = undefined
+    }
+    const activeSnapshot = { status: "active" as const, state }
     const versioned = {
       revision: latest.revision + 1,
-      snapshot: { status: "active" as const, state },
+      snapshot: activeSnapshot,
       terminalizing: false,
       changes: latest.changes
-    }
+    } as VersionedSnapshot<unknown, unknown, unknown>
     this.current = versioned
     if (versioned.changes !== undefined) {
-      PubSub.publishUnsafe(versioned.changes, [versioned] as const)
+      if (pendingChanges === undefined) {
+        if (batchChanges) {
+          versioned.pendingChanges = [versioned]
+        } else {
+          PubSub.publishUnsafe(versioned.changes, [versioned] as const)
+        }
+      } else {
+        pendingChanges.push(versioned)
+        if (batchChanges) {
+          versioned.pendingChanges = pendingChanges
+        } else {
+          PubSub.publishUnsafe(versioned.changes, pendingChanges)
+        }
+      }
     }
     return this.options.onSnapshot === undefined
       ? undefined
-      : notifyActiveSnapshot(this.options.onSnapshot, versioned.snapshot)
+      : notifyActiveSnapshot(this.options.onSnapshot, activeSnapshot)
+  }
+
+  flushPendingChanges(): void {
+    const current = this.current
+    const pendingChanges = current?.pendingChanges
+    if (pendingChanges === undefined || current.changes === undefined) {
+      return
+    }
+    current.pendingChanges = undefined
+    PubSub.publishUnsafe(current.changes, pendingChanges)
   }
 
   private updateState<E, R>(
@@ -1742,6 +1787,31 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
         )
       })
     )
+  }
+}
+
+class CompiledProcessContextImpl implements CompiledProcessContext<unknown, unknown> {
+  executionState: unknown
+
+  constructor(
+    readonly scope: ProcessScope<unknown>,
+    private readonly process: CompiledProcess
+  ) {}
+
+  poll(): Option.Option<unknown> {
+    return this.process.pollCompiledEvent()
+  }
+
+  state(): unknown {
+    return this.process.compiledState()
+  }
+
+  commit(state: unknown): Effect.Effect<void> | undefined {
+    return this.process.commitCompiledState(state)
+  }
+
+  flush(): void {
+    this.process.flushPendingChanges()
   }
 }
 

--- a/test/MachineProcessLifecycle.test.ts
+++ b/test/MachineProcessLifecycle.test.ts
@@ -39,6 +39,43 @@ describe("machine process lifecycle", () => {
       assert.instanceOf(yield* Effect.flip(ref.send({ _tag: "Done" })), Machine.StoppedError)
     }))
 
+  it.effect("publishes a compiled transition burst as one lossless ordered chunk", () =>
+    Effect.gen(function*() {
+      const ref = yield* MachineRuntime.startProcess<number, { readonly count: number }, never, never, number>({
+        [MachineRuntime.childlessProcess]: true,
+        [MachineRuntime.compiledProcess]: true,
+        initial: () => Effect.succeed(0),
+        run: () => Effect.never,
+        [MachineRuntime.compiledProcessDrain]: (context) =>
+          Effect.sync(() => {
+            const pending = context.poll()
+            if (Option.isNone(pending)) {
+              return Option.none()
+            }
+            for (let state = 1; state <= pending.value.count; state += 1) {
+              context.commit(state)
+            }
+            return Option.some(pending.value.count)
+          })
+      })
+      const publications = yield* ref.changes.pipe(
+        Stream.chunks,
+        Stream.runCollect,
+        Effect.forkChild({ startImmediately: true })
+      )
+
+      yield* ref.send({ count: 100 })
+      assert.strictEqual(yield* ref.join, 100)
+
+      const chunks = Array.from(yield* Fiber.join(publications), (chunk) => Array.from(chunk))
+      assert.deepStrictEqual(chunks.map((chunk) => chunk.length), [1, 100, 1])
+      assert.deepStrictEqual(
+        chunks.flatMap((chunk) => chunk).map((snapshot) => snapshot.state),
+        Array.from({ length: 101 }, (_, state) => state).concat(100)
+      )
+      assert.deepStrictEqual(chunks.at(-1)?.[0], { status: "done", state: 100, output: 100 })
+    }))
+
   it.effect("wakes an on-demand compiled process across consecutive idle periods", () =>
     Effect.gen(function*() {
       type Event = {


### PR DESCRIPTION
## Summary

- batch lossless ordered snapshot publications across each synchronous compiled machine drain segment
- flush pending snapshots before commands, emissions, invokes, callbacks, termination, and idle completion
- replace per-machine compiled-context closures with shared prototype methods
- cover chunk boundaries, terminal delivery, order, and all intermediate states

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (no examples changed)
- [x] `pnpm perf:types`
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed

<!--
The type- and runtime-performance workflows post and update their base-versus-PR comparisons automatically.
Do not copy a manually measured table into this description.
-->
