### PR TITLE
Compact compiled machine lifecycles

### DIFF
--- a/.changeset/fast-lifecycle-kernel.md
+++ b/.changeset/fast-lifecycle-kernel.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Reuse settled startup outcomes, fast-path idle childless startup and stop, and move invoked session coordination onto a compact parent-owned kernel.

--- a/src/internal/machineProcess.ts
+++ b/src/internal/machineProcess.ts
@@ -161,14 +161,15 @@ const makeInvokeSnapshotHandler = (
 }
 
 const makeChildlessCompiledDrain = (
-  machine: Machine.Any
+  machine: Machine.Any,
+  checkInitialFinal: boolean
 ): (
   context: internalRuntime.CompiledProcessContext<any, any>
 ) => Effect.Effect<Option.Option<any>, any, any> => {
   const executionPlan = internalPlanner.compileExecutionPlan(machine)
   return (context) => {
     let current = context.state()
-    if (internalPlanner.isFinalState(machine, current)) {
+    if (checkInitialFinal && internalPlanner.isFinalState(machine, current)) {
       return internalPlanner.getFinalOutputEffect(
         machine,
         current,
@@ -250,14 +251,15 @@ interface InvokeExecutionState {
 }
 
 const makeInvokingCompiledDrain = (
-  machine: Machine.Any
+  machine: Machine.Any,
+  checkInitialFinal: boolean
 ): (
   context: internalRuntime.CompiledProcessContext<any, any>
 ) => Effect.Effect<Option.Option<any>, any, any> => {
   const executionPlan = internalPlanner.compileExecutionPlan(machine)
   return (context) => {
     let current = context.state()
-    if (internalPlanner.isFinalState(machine, current)) {
+    if (checkInitialFinal && internalPlanner.isFinalState(machine, current)) {
       return internalPlanner.getFinalOutputEffect(
         machine,
         current,
@@ -529,35 +531,47 @@ const makeProcessLogic: <
   entry: ProcessEntry<States, Input>
 ) => {
   const hasInvokes = hasInvokeCapability(machine)
+  const initialArgs = entry._tag === "Initial" ? entry.args : []
+  const makeInitial = (
+    scope: internalRuntime.ProcessScope<Machine.EventOf<Events>>
+  ) =>
+    internalRuntime.provideMachineRuntime(
+      internalPlanner.planInitial(machine, ...initialArgs).pipe(
+        Effect.flatMap((planned) => {
+          const commands = planned.commands.length === 0
+            ? undefined
+            : internalPlanner.runCommands(planned.commands, scope)
+          const emitted = planned.emittedEvents.length === 0
+            ? undefined
+            : internalPlanner.runEmittedEvents(
+              planned.emittedEvents,
+              internalPlanner.makeLiveRuntime<Machine.EventOf<Events>, Machine.EmitOf<Emits>>(machine, scope)
+            )
+          const result = Effect.succeed({
+            state: planned.state,
+            done: planned.done,
+            output: planned.output
+          })
+          return commands === undefined
+            ? emitted === undefined ? result : emitted.pipe(Effect.andThen(result))
+            : emitted === undefined
+            ? commands.pipe(Effect.andThen(result))
+            : commands.pipe(Effect.andThen(emitted), Effect.andThen(result))
+        })
+      ),
+      scope
+    )
   return ({
     [internalRuntime.childlessProcess]: hasInvokes ? undefined : true,
     [internalRuntime.compiledProcess]: true,
+    [internalRuntime.compiledProcessInitial]: entry._tag === "Initial" ? makeInitial : undefined,
     [internalRuntime.compiledProcessDrain]: hasInvokes
-      ? makeInvokingCompiledDrain(machine)
-      : makeChildlessCompiledDrain(machine),
+      ? makeInvokingCompiledDrain(machine, entry._tag === "Resume")
+      : makeChildlessCompiledDrain(machine, entry._tag === "Resume"),
     initial: (scope) =>
-      internalRuntime.provideMachineRuntime(
-        entry._tag === "Resume"
-          ? Model.normalizeSnapshotEffect(machine, entry.snapshot)
-          : internalPlanner.planInitial(machine, ...entry.args).pipe(Effect.flatMap((planned) => {
-            const commands = planned.commands.length === 0
-              ? undefined
-              : internalPlanner.runCommands(planned.commands, scope)
-            const emitted = planned.emittedEvents.length === 0
-              ? undefined
-              : internalPlanner.runEmittedEvents(
-                planned.emittedEvents,
-                internalPlanner.makeLiveRuntime<Machine.EventOf<Events>, Machine.EmitOf<Emits>>(machine, scope)
-              )
-            const result = Effect.succeed(planned.state)
-            return commands === undefined
-              ? emitted === undefined ? result : emitted.pipe(Effect.andThen(result))
-              : emitted === undefined
-              ? commands.pipe(Effect.andThen(result))
-              : commands.pipe(Effect.andThen(emitted), Effect.andThen(result))
-          })),
-        scope
-      ),
+      entry._tag === "Resume"
+        ? internalRuntime.provideMachineRuntime(Model.normalizeSnapshotEffect(machine, entry.snapshot), scope)
+        : makeInitial(scope).pipe(Effect.map((initialized) => initialized.state)),
     run: (context) =>
       internalRuntime.provideMachineRuntime(
         Effect.gen(function*() {

--- a/src/internal/machineProcess.ts
+++ b/src/internal/machineProcess.ts
@@ -244,10 +244,135 @@ const makeChildlessCompiledDrain = (
   }
 }
 
-interface InvokeExecutionState {
+class InvokeExecutionKernel {
   readonly sessions: Map<string, InvokeSession>
-  configuration: unknown
-  initialized: boolean
+  initialized = false
+
+  constructor() {
+    this.sessions = new Map()
+  }
+
+  private makeSessionKey(path: string, id: string): string {
+    return `${path.length}:${path}${id}`
+  }
+
+  private makeChildId(path: string, id: string): string {
+    return `Machine.invoke:${this.makeSessionKey(path, id)}`
+  }
+
+  private stopSession(
+    scope: internalRuntime.ProcessScope<any>,
+    session: InvokeSession
+  ): Effect.Effect<void> {
+    return scope.stopChild(session.childId)
+  }
+
+  private remove(
+    scope: internalRuntime.ProcessScope<any>,
+    key: string,
+    token: symbol | undefined
+  ): Effect.Effect<void> {
+    return Effect.suspend(() => {
+      const current = this.sessions.get(key)
+      if (current === undefined || (token !== undefined && current.token !== token)) {
+        return Effect.void
+      }
+      this.sessions.delete(key)
+      return this.stopSession(scope, current)
+    })
+  }
+
+  stop(scope: internalRuntime.ProcessScope<any>, key: string): Effect.Effect<void> {
+    return this.remove(scope, key, undefined)
+  }
+
+  stopAll(scope: internalRuntime.ProcessScope<any>): Effect.Effect<void> {
+    return Effect.suspend(() => {
+      const effects = Array.from(this.sessions.values(), (session) => this.stopSession(scope, session))
+      this.sessions.clear()
+      return runParallelDiscard(effects)
+    })
+  }
+
+  start(
+    context: internalRuntime.CompiledProcessContext<any, any>,
+    path: string,
+    config: AnyInvokeConfig
+  ): Effect.Effect<void, any, any> {
+    return Effect.suspend(() => {
+      const token = Symbol()
+      const invokeId = String(config.id)
+      const key = this.makeSessionKey(path, invokeId)
+      const childId = config.address === undefined ? this.makeChildId(path, invokeId) : String(config.address)
+      if (this.sessions.has(key)) {
+        return Effect.fail(new ChildAlreadyExistsError({ id: invokeId }))
+      }
+      this.sessions.set(key, { token, childId, path })
+      const logic = config.src() as internalRuntime.ProcessLogic<any, any, any, any, any, any>
+      const scope = context.scope
+      const sendParent = makeInvokeSendParent(this.sessions, scope.self, key, token)
+      return scope.spawn(
+        logic,
+        {
+          id: childId,
+          ...(config.descriptor === undefined ? undefined : { descriptor: config.descriptor }),
+          [internalRuntime.sendParentOverride]: sendParent,
+          onOutcome: makeInvokeOutcomeHandler(
+            this.sessions,
+            scope.self,
+            scope.failCause,
+            config,
+            key,
+            token
+          ),
+          ...(config.snapshot === undefined ? undefined : {
+            [internalRuntime.activeSnapshotObserver]: makeInvokeSnapshotHandler(
+              this.sessions,
+              scope.self,
+              config,
+              key,
+              token
+            )
+          })
+        }
+      ).pipe(
+        Effect.onExit((exit) => Exit.isFailure(exit) ? this.remove(scope, key, token) : Effect.void),
+        Effect.asVoid
+      )
+    })
+  }
+
+  startAll(
+    machine: Machine.Any,
+    context: internalRuntime.CompiledProcessContext<any, any>,
+    configuration: Model.ActiveConfiguration,
+    paths: ReadonlyArray<string>,
+    event: Machine.LifecycleEvent<any>
+  ): Effect.Effect<void, any, any> | undefined {
+    const effects = internalPlanner.sortEntryPaths(machine, paths)
+      .filter((path) => configuration.active.has(path))
+      .flatMap((path) =>
+        getInvokes(Model.getStateConfigByPath(machine, path), {
+          state: Model.getActiveValue(configuration, path),
+          parent: Model.getParentValue(machine, configuration, path),
+          parents: Model.getParentValues(machine, configuration, path),
+          event
+        }).map((config) => this.start(context, path, config))
+      )
+    return effects.length === 0 ? undefined : runSequentialDiscard(effects)
+  }
+
+  stopPaths(
+    machine: Machine.Any,
+    scope: internalRuntime.ProcessScope<any>,
+    paths: ReadonlyArray<string>
+  ): Effect.Effect<void> | undefined {
+    const keys = new Set(internalPlanner.sortExitPaths(machine, paths))
+    const effects = Array.from(this.sessions.entries())
+      .filter(([, session]) => keys.has(session.path))
+      .map(([key]) => this.stop(scope, key))
+    return effects.length === 0 ? undefined : runParallelDiscard(effects)
+  }
 }
 
 const makeInvokingCompiledDrain = (
@@ -268,120 +393,26 @@ const makeInvokingCompiledDrain = (
     }
 
     const scope = context.scope
-    const execution = (context.executionState ??= {
-      sessions: new Map(),
-      configuration: undefined,
-      initialized: false
-    }) as InvokeExecutionState
-    const invokeSessions = execution.sessions
+    const stored = context.executionState
+    const execution = stored instanceof InvokeExecutionKernel
+      ? stored
+      : new InvokeExecutionKernel()
+    context.executionState = execution
     let liveRuntime: Runtime<any, any> | undefined
-
-    const makeInvokeSessionKey = (path: string, id: string): string => `${path.length}:${path}${id}`
-    const makeInvokeChildId = (path: string, id: string): string => `Machine.invoke:${makeInvokeSessionKey(path, id)}`
-    const stopInvokeSession = (session: InvokeSession): Effect.Effect<void> => scope.stopChild(session.childId)
-    const removeInvoke = (
-      key: string,
-      token: symbol | undefined
-    ): Effect.Effect<void> =>
-      Effect.sync(() => {
-        const current = invokeSessions.get(key)
-        if (current === undefined || (token !== undefined && current.token !== token)) {
-          return undefined
-        }
-        invokeSessions.delete(key)
-        return current
-      }).pipe(
-        Effect.flatMap((session) => session === undefined ? Effect.void : stopInvokeSession(session))
-      )
-    const stopInvoke = (key: string): Effect.Effect<void> => removeInvoke(key, undefined)
-    const stopAllInvokes = (): Effect.Effect<void> =>
-      Effect.suspend(() => {
-        const effects = Array.from(invokeSessions.values(), stopInvokeSession)
-        invokeSessions.clear()
-        return runParallelDiscard(effects)
-      })
-    const startInvoke = Effect.fnUntraced(function*(path: string, config: AnyInvokeConfig) {
-      const token = Symbol()
-      const invokeId = String(config.id)
-      const key = makeInvokeSessionKey(path, invokeId)
-      const childId = config.address === undefined ? makeInvokeChildId(path, invokeId) : String(config.address)
-      const reserved = yield* Effect.sync(() => {
-        if (invokeSessions.has(key)) {
-          return false
-        }
-        invokeSessions.set(key, { token, childId, path })
-        return true
-      })
-      if (!reserved) {
-        return yield* Effect.fail(new ChildAlreadyExistsError({ id: invokeId }))
-      }
-      const logic = config.src() as internalRuntime.ProcessLogic<any, any, any, any, any, any>
-      const sendParent = makeInvokeSendParent(invokeSessions, scope.self, key, token)
-      yield* scope.spawn(
-        logic,
-        {
-          id: childId,
-          ...(config.descriptor === undefined ? undefined : { descriptor: config.descriptor }),
-          [internalRuntime.sendParentOverride]: sendParent,
-          onOutcome: makeInvokeOutcomeHandler(
-            invokeSessions,
-            scope.self,
-            scope.failCause,
-            config,
-            key,
-            token
-          ),
-          ...(config.snapshot === undefined ? undefined : {
-            [internalRuntime.activeSnapshotObserver]: makeInvokeSnapshotHandler(
-              invokeSessions,
-              scope.self,
-              config,
-              key,
-              token
-            )
-          })
-        }
-      ).pipe(
-        Effect.onExit((exit) => Exit.isFailure(exit) ? removeInvoke(key, token) : Effect.void)
-      )
-    })
-    const startInvokes = (
-      configuration: Model.ActiveConfiguration,
-      paths: ReadonlyArray<string>,
-      event: Machine.LifecycleEvent<any>
-    ): Effect.Effect<void, any, any> | undefined => {
-      const effects = internalPlanner.sortEntryPaths(machine, paths)
-        .filter((path) => configuration.active.has(path))
-        .flatMap((path) =>
-          getInvokes(Model.getStateConfigByPath(machine, path), {
-            state: Model.getActiveValue(configuration, path),
-            parent: Model.getParentValue(machine, configuration, path),
-            parents: Model.getParentValues(machine, configuration, path),
-            event
-          }).map((config) => startInvoke(path, config))
-        )
-      return effects.length === 0 ? undefined : runSequentialDiscard(effects)
-    }
-    const stopInvokes = (paths: ReadonlyArray<string>): Effect.Effect<void> | undefined => {
-      const keys = new Set(internalPlanner.sortExitPaths(machine, paths))
-      const effects = Array.from(invokeSessions.entries())
-        .filter(([, session]) => keys.has(session.path))
-        .map(([key]) => stopInvoke(key))
-      return effects.length === 0 ? undefined : runParallelDiscard(effects)
-    }
+    let configuration: unknown
 
     let loop: Effect.Effect<Option.Option<any>, any, any>
     loop = Effect.suspend(() => {
       const pending = context.poll()
       if (Option.isNone(pending)) {
-        execution.configuration = undefined
+        configuration = undefined
         return Effect.succeed(Option.none())
       }
 
       let planned
       try {
         planned = executionPlan.plan(
-          execution.configuration ??
+          configuration ??
             executionPlan.fromConfiguration(Model.normalizeConfigurationSync(machine, current)),
           pending.value
         )
@@ -390,7 +421,7 @@ const makeInvokingCompiledDrain = (
           ? Effect.fail(error)
           : Effect.die(error)
       }
-      execution.configuration = planned.next
+      configuration = planned.next
       if (planned.microsteps.length === 0) {
         return loop
       }
@@ -415,7 +446,7 @@ const makeInvokingCompiledDrain = (
         beforeCommit.push(internalPlanner.runCommands(planned.commands, scope))
       }
       if (changed) {
-        const stopping = stopInvokes(exitPaths)
+        const stopping = execution.stopPaths(machine, scope, exitPaths)
         if (stopping !== undefined) beforeCommit.push(stopping)
       }
       const afterCommit: Array<Effect.Effect<void, any, any>> = []
@@ -428,10 +459,10 @@ const makeInvokingCompiledDrain = (
         )
       }
       if (planned.done) {
-        afterCommit.push(stopAllInvokes())
+        afterCommit.push(execution.stopAll(scope))
       } else if (changed) {
         for (const [path, entryEvent] of entryEvents) {
-          const starting = startInvokes(activeConfiguration, [path], entryEvent)
+          const starting = execution.startAll(machine, context, activeConfiguration, [path], entryEvent)
           if (starting !== undefined) afterCommit.push(starting)
         }
       }
@@ -469,8 +500,10 @@ const makeInvokingCompiledDrain = (
         return loop
       }
       const initialConfiguration = Model.normalizeConfigurationSync(machine, current)
-      execution.configuration = executionPlan.fromConfiguration(initialConfiguration)
-      const starting = startInvokes(
+      configuration = executionPlan.fromConfiguration(initialConfiguration)
+      const starting = execution.startAll(
+        machine,
+        context,
         initialConfiguration,
         Model.getInitialEntryPaths(machine, initialConfiguration),
         internalPlanner.InitialEvent

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -1366,6 +1366,18 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
         yield* self.requestTermination({ _tag: "Done", output: initialized.output })
       }
 
+      // A compiled machine startup plan has already settled entry actions,
+      // raised events, and eventless transitions. If it is known active and
+      // neither startup hooks nor emitted work queued an event, there is no
+      // first drain to perform. Future sends observe `draining === false` and
+      // schedule the ordinary compiled worker.
+      if (
+        initialized.done === false && self.logic[childlessProcess] === true &&
+        self.requestedTermination === undefined && self.mailbox.items === undefined
+      ) {
+        return self
+      }
+
       self.draining = true
       yield* self.drainRuntime()
       return self
@@ -1491,6 +1503,9 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
       if (this.completion !== undefined) {
         return Effect.void
       }
+      if (this.finishIdleChildlessStop()) {
+        return Effect.void
+      }
       const requested = { _tag: "Stopped" } as const
       return this.requestTermination(requested).pipe(
         Effect.flatMap((accepted) =>
@@ -1500,6 +1515,37 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
         )
       )
     })
+  }
+
+  private finishIdleChildlessStop(): boolean {
+    if (
+      this.logic[childlessProcess] !== true || this.draining || this.worker !== undefined ||
+      this.requestedTermination !== undefined || this.options.onOutcome !== undefined ||
+      this.options.onStop !== undefined || this.current.changes !== undefined ||
+      this.current.terminalizing || this.current.snapshot.status !== "active"
+    ) {
+      return false
+    }
+    const snapshot = { status: "stopped" as const, state: this.current.snapshot.state }
+    this.requestedTermination = { _tag: "Stopped" }
+    this.reservedTerminationSnapshot = snapshot
+    closeCompactMailbox(this.mailbox)
+    this.current = {
+      revision: this.current.revision + 1,
+      terminalizing: true,
+      changes: undefined,
+      snapshot
+    }
+    this.interruptRequested = false
+    if (this.compiledContext !== undefined) {
+      this.compiledContext.executionState = undefined
+    }
+    this.completion = CompiledStoppedCompletion
+    if (this.waiter !== undefined) {
+      Deferred.doneUnsafe(this.waiter, this.resolveCompletion(CompiledStoppedCompletion))
+      this.waiter = undefined
+    }
+    return true
   }
 
   private settleRequestedTermination(): Effect.Effect<void> {

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -54,6 +54,9 @@ export const compiledProcess: unique symbol = Symbol.for("effect/Machine/compile
 export const compiledProcessDrain: unique symbol = Symbol.for("effect/Machine/compiledProcessDrain")
 
 /** @internal */
+export const compiledProcessInitial: unique symbol = Symbol.for("effect/Machine/compiledProcessInitial")
+
+/** @internal */
 export const sendParentOverride: unique symbol = Symbol.for("effect/Machine/sendParentOverride")
 
 type ChildObservation = Option.Option<MachineRef<any, any, any, any>>
@@ -276,6 +279,15 @@ export interface ProcessLogic<
   readonly [childlessProcess]?: true
   readonly [compiledProcess]?: true
   initial(scope: ProcessScope<Event>): Effect.Effect<State, InitialError, Requirements>
+  /** @internal */
+  readonly [compiledProcessInitial]?: (
+    scope: ProcessScope<Event>
+  ) => Effect.Effect<
+    | { readonly state: State; readonly done: false; readonly output: undefined }
+    | { readonly state: State; readonly done: true; readonly output: Output },
+    InitialError,
+    Requirements
+  >
   run(context: ProcessContext<State, Event>): Effect.Effect<Output, Error, Requirements>
   /** @internal */
   readonly drain?: (
@@ -1308,12 +1320,23 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
 
       const cleanupStartupFailure = <A, E>(exit: Exit.Exit<A, E>): Effect.Effect<void> =>
         Exit.isFailure(exit) ? self.childRuntime.close(exit) : Effect.void
-      const initial = yield* self.logic.initial(self.processScope).pipe(
+      const compiledInitial = self.logic[compiledProcessInitial]
+      const initializeEffect: Effect.Effect<{
+        readonly state: unknown
+        readonly done: boolean | undefined
+        readonly output: unknown
+      }, unknown, any> = compiledInitial === undefined
+        ? self.logic.initial(self.processScope).pipe(
+          Effect.map((state) => ({ state, done: undefined, output: undefined } as const))
+        )
+        : compiledInitial(self.processScope)
+      const initialized = yield* initializeEffect.pipe(
         Effect.onExit(cleanupStartupFailure),
         Effect.ensuring(Effect.sync(() => {
           self.initializing = false
         }))
       )
+      const initial = initialized.state
       self.current = {
         revision: 0,
         terminalizing: false,
@@ -1338,6 +1361,9 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
       }
       if (self.options.onSnapshot !== undefined) {
         yield* notifyActiveSnapshot(self.options.onSnapshot, { status: "active", state: initial })
+      }
+      if (initialized.done === true && self.requestedTermination === undefined) {
+        yield* self.requestTermination({ _tag: "Done", output: initialized.output })
       }
 
       self.draining = true

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -1321,11 +1321,15 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
       const cleanupStartupFailure = <A, E>(exit: Exit.Exit<A, E>): Effect.Effect<void> =>
         Exit.isFailure(exit) ? self.childRuntime.close(exit) : Effect.void
       const compiledInitial = self.logic[compiledProcessInitial]
-      const initializeEffect: Effect.Effect<{
-        readonly state: unknown
-        readonly done: boolean | undefined
-        readonly output: unknown
-      }, unknown, any> = compiledInitial === undefined
+      const initializeEffect: Effect.Effect<
+        {
+          readonly state: unknown
+          readonly done: boolean | undefined
+          readonly output: unknown
+        },
+        unknown,
+        any
+      > = compiledInitial === undefined
         ? self.logic.initial(self.processScope).pipe(
           Effect.map((state) => ({ state, done: undefined, output: undefined } as const))
         )

--- a/test/MachineProcessLifecycle.test.ts
+++ b/test/MachineProcessLifecycle.test.ts
@@ -11,9 +11,8 @@ describe("machine process lifecycle", () => {
       const ref = yield* MachineRuntime.startProcess<number, void>({
         [MachineRuntime.childlessProcess]: true,
         [MachineRuntime.compiledProcess]: true,
-        [MachineRuntime.compiledProcessInitial]: () =>
-          Effect.succeed({ state: 1, done: false, output: undefined }),
-        initial: () => Effect.dieMessage("compiled startup unexpectedly used the general initial effect"),
+        [MachineRuntime.compiledProcessInitial]: () => Effect.succeed({ state: 1, done: false, output: undefined }),
+        initial: () => Effect.die(new Error("compiled startup unexpectedly used the general initial effect")),
         run: () => Effect.never,
         drain: (context) =>
           Ref.update(drainCount, (count) => count + 1).pipe(
@@ -35,9 +34,8 @@ describe("machine process lifecycle", () => {
       const ref = yield* MachineRuntime.startProcess<number, never, never, never, string>({
         [MachineRuntime.childlessProcess]: true,
         [MachineRuntime.compiledProcess]: true,
-        [MachineRuntime.compiledProcessInitial]: () =>
-          Effect.succeed({ state: 1, done: true, output: "complete" }),
-        initial: () => Effect.dieMessage("compiled startup unexpectedly used the general initial effect"),
+        [MachineRuntime.compiledProcessInitial]: () => Effect.succeed({ state: 1, done: true, output: "complete" }),
+        initial: () => Effect.die(new Error("compiled startup unexpectedly used the general initial effect")),
         run: () => Effect.never,
         drain: () => Ref.update(drainCount, (count) => count + 1).pipe(Effect.as(Option.none()))
       })

--- a/test/MachineProcessLifecycle.test.ts
+++ b/test/MachineProcessLifecycle.test.ts
@@ -4,6 +4,49 @@ import { Machine } from "../src/index.js"
 import * as MachineRuntime from "../src/internal/machineRuntime.js"
 
 describe("machine process lifecycle", () => {
+  it.effect("reuses a settled active startup without running an empty compiled drain", () =>
+    Effect.gen(function*() {
+      const drained = yield* Deferred.make<void>()
+      const drainCount = yield* Ref.make(0)
+      const ref = yield* MachineRuntime.startProcess<number, void>({
+        [MachineRuntime.childlessProcess]: true,
+        [MachineRuntime.compiledProcess]: true,
+        [MachineRuntime.compiledProcessInitial]: () =>
+          Effect.succeed({ state: 1, done: false, output: undefined }),
+        initial: () => Effect.dieMessage("compiled startup unexpectedly used the general initial effect"),
+        run: () => Effect.never,
+        drain: (context) =>
+          Ref.update(drainCount, (count) => count + 1).pipe(
+            Effect.andThen(Deferred.succeed(drained, undefined)),
+            Effect.as(Option.none())
+          )
+      })
+
+      assert.strictEqual(yield* Ref.get(drainCount), 0)
+      yield* ref.send(undefined)
+      yield* Deferred.await(drained)
+      assert.strictEqual(yield* Ref.get(drainCount), 1)
+      yield* ref.stop
+    }))
+
+  it.effect("terminalizes a settled compiled startup without re-planning its output", () =>
+    Effect.gen(function*() {
+      const drainCount = yield* Ref.make(0)
+      const ref = yield* MachineRuntime.startProcess<number, never, never, never, string>({
+        [MachineRuntime.childlessProcess]: true,
+        [MachineRuntime.compiledProcess]: true,
+        [MachineRuntime.compiledProcessInitial]: () =>
+          Effect.succeed({ state: 1, done: true, output: "complete" }),
+        initial: () => Effect.dieMessage("compiled startup unexpectedly used the general initial effect"),
+        run: () => Effect.never,
+        drain: () => Ref.update(drainCount, (count) => count + 1).pipe(Effect.as(Option.none()))
+      })
+
+      assert.strictEqual(yield* ref.join, "complete")
+      assert.strictEqual(yield* Ref.get(drainCount), 0)
+      assert.deepStrictEqual(yield* ref.snapshot, { status: "done", state: 1, output: "complete" })
+    }))
+
   it.effect("preserves FIFO order while draining a compact compiled mailbox", () =>
     Effect.gen(function*() {
       type Event =


### PR DESCRIPTION
## Summary

- Reuse the settled startup outcome in compiled machines instead of reconstructing final state and output in the first drain.
- Skip empty startup drains and synchronously terminalize idle, unobserved, childless compiled machines.
- Move invoked-session lifecycle helpers onto a compact parent-owned kernel, avoiding per-drain closure allocation while preserving child ownership and observation semantics.
- Add focused lifecycle coverage for active and terminal compiled startup outcomes.

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (no examples changed)
- [x] Reviewed the automated type-performance report; `pnpm perf:types` passes unchanged budgets
- [x] Reviewed local runtime and memory reports; the automated PR comparison remains the merge gate