### PR TITLE
Compile startup and unify invoked child ownership

### DIFF
--- a/.changeset/compiled-machine-startup.md
+++ b/.changeset/compiled-machine-startup.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Compile eligible machine initial-state normalization and reuse the validated startup configuration when initializing invoked children.

--- a/.changeset/compiled-machine-startup.md
+++ b/.changeset/compiled-machine-startup.md
@@ -2,4 +2,4 @@
 "@typeonce/effect-machine": patch
 ---
 
-Compile eligible machine initial-state normalization and reuse the validated startup configuration when initializing invoked children.
+Compile eligible machine initial-state normalization, reuse the validated startup configuration, and unify invoked-child ownership with the runtime child registry.

--- a/src/internal/machinePlanner.ts
+++ b/src/internal/machinePlanner.ts
@@ -1991,7 +1991,7 @@ const compileIndexedExecutionDescriptor = (
     const config = machine.handlers[node.path] as Machine.AnyStateConfig | undefined
     if (
       config?.entry !== undefined || config?.exit !== undefined || config?.always !== undefined ||
-      config?.onDone !== undefined || config?.invoke !== undefined || (config as any)?.choice !== undefined ||
+      config?.onDone !== undefined || (config as any)?.choice !== undefined ||
       (config as any)?.history !== undefined
     ) {
       return undefined
@@ -2710,6 +2710,16 @@ export interface CompiledExecutionPlan {
     state: unknown,
     event: unknown
   ) => MacrostepPlan<any, any, any, any, any>
+  readonly initial?: (
+    args: ReadonlyArray<unknown>
+  ) => {
+    readonly state: Machine.Snapshot<any>
+    readonly configuration: unknown
+    readonly activeConfiguration: ActiveConfiguration
+    readonly initialEntryPaths: ReadonlyArray<string>
+    readonly done: boolean
+    readonly output: unknown
+  }
 }
 
 const executionPlanCache = new WeakMap<Machine.Any, CompiledExecutionPlan>()
@@ -2733,7 +2743,43 @@ export const compileExecutionPlan = (machine: Machine.Any): CompiledExecutionPla
       fromConfiguration: (configuration) => indexedConfigurationFromActive(indexed, configuration),
       toConfiguration: (state) => activeConfigurationFromIndexed(indexed, state as IndexedConfiguration),
       snapshot: (state) => snapshotFromIndexed(indexed, state as IndexedConfiguration),
-      plan: (state, event) => planIndexedConfiguration(machine, indexed, state as IndexedConfiguration, event)
+      plan: (state, event) => planIndexedConfiguration(machine, indexed, state as IndexedConfiguration, event),
+      initial: (args) => {
+        const inputArgs = machine.input === undefined
+          ? args
+          : args.length === 0
+          ? (decodeInputSync(machine, machine.input, undefined), args)
+          : [decodeInputSync(machine, machine.input, args[0])]
+        const initial = machine.initial(...inputArgs as any)
+        const active = normalizeConfigurationSync(machine, initial as Machine.Snapshot<any>)
+        validateInitialConfiguration(machine, active)
+        const completed = completeConfigurationSync(machine, active, InitialEvent).configuration
+        const configuration = indexedConfigurationFromActive(indexed, completed)
+        const state = snapshotFromIndexed(indexed, configuration)
+        const done = isActiveFinalConfiguration(machine, completed)
+        if (!done) {
+          return {
+            state,
+            configuration,
+            activeConfiguration: completed,
+            initialEntryPaths: getInitialEntryPaths(machine, completed),
+            done: false,
+            output: undefined
+          }
+        }
+        const root = getRootPath(machine, completed)
+        if (!completed.outputs.has(root)) {
+          throw new Error("Machine reached a terminal configuration without a completed root output")
+        }
+        return {
+          state,
+          configuration,
+          activeConfiguration: completed,
+          initialEntryPaths: getInitialEntryPaths(machine, completed),
+          done: true,
+          output: completed.outputs.get(root)
+        }
+      }
     }
     : activePlan((configuration, event) => planConfiguration(machine as any, configuration, event as any))
   executionPlanCache.set(machine, compiled)

--- a/src/internal/machineProcess.ts
+++ b/src/internal/machineProcess.ts
@@ -4,14 +4,20 @@
  * @since 4.0.0
  */
 
+import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Option from "effect/Option"
 import * as Queue from "effect/Queue"
 import type * as Schema from "effect/Schema"
 import type { ActionError, ExecutionServices, Machine, Runtime } from "../Machine.js"
-import { ChildAlreadyExistsError, InfiniteTransitionError, MachineSchemaDecodeError } from "./machineErrors.js"
-import type { StartupError, StoppedError } from "./machineErrors.js"
+import {
+  ChildAlreadyExistsError,
+  InfiniteTransitionError,
+  MachineSchemaDecodeError,
+  StartupError
+} from "./machineErrors.js"
+import type { StoppedError } from "./machineErrors.js"
 import * as Model from "./machineModel.js"
 import * as internalPlanner from "./machinePlanner.js"
 import * as internalRuntime from "./machineRuntime.js"
@@ -247,9 +253,21 @@ const makeChildlessCompiledDrain = (
 class InvokeExecutionKernel {
   readonly sessions: Map<string, InvokeSession>
   initialized = false
+  initial:
+    | {
+      readonly configuration: unknown
+      readonly activeConfiguration: Model.ActiveConfiguration
+      readonly entryPaths: ReadonlyArray<string>
+    }
+    | undefined
 
-  constructor() {
+  constructor(initial?: {
+    readonly configuration: unknown
+    readonly activeConfiguration: Model.ActiveConfiguration
+    readonly entryPaths: ReadonlyArray<string>
+  }) {
     this.sessions = new Map()
+    this.initial = initial
   }
 
   private makeSessionKey(path: string, id: string): string {
@@ -499,15 +517,17 @@ const makeInvokingCompiledDrain = (
       if (execution.initialized) {
         return loop
       }
-      const initialConfiguration = Model.normalizeConfigurationSync(machine, current)
-      configuration = executionPlan.fromConfiguration(initialConfiguration)
+      const seeded = execution.initial
+      const initialConfiguration = seeded?.activeConfiguration ?? Model.normalizeConfigurationSync(machine, current)
+      configuration = seeded?.configuration ?? executionPlan.fromConfiguration(initialConfiguration)
       const starting = execution.startAll(
         machine,
         context,
         initialConfiguration,
-        Model.getInitialEntryPaths(machine, initialConfiguration),
+        seeded?.entryPaths ?? Model.getInitialEntryPaths(machine, initialConfiguration),
         internalPlanner.InitialEvent
       )
+      execution.initial = undefined
       execution.initialized = true
       return starting === undefined ? loop : starting.pipe(Effect.andThen(loop))
     }
@@ -564,36 +584,63 @@ const makeProcessLogic: <
   entry: ProcessEntry<States, Input>
 ) => {
   const hasInvokes = hasInvokeCapability(machine)
+  const executionPlan = internalPlanner.compileExecutionPlan(machine)
   const initialArgs = entry._tag === "Initial" ? entry.args : []
+  const compiledInitial = entry._tag === "Initial" ? executionPlan.initial : undefined
   const makeInitial = (
     scope: internalRuntime.ProcessScope<Machine.EventOf<Events>>
   ) =>
-    internalRuntime.provideMachineRuntime(
-      internalPlanner.planInitial(machine, ...initialArgs).pipe(
-        Effect.flatMap((planned) => {
-          const commands = planned.commands.length === 0
-            ? undefined
-            : internalPlanner.runCommands(planned.commands, scope)
-          const emitted = planned.emittedEvents.length === 0
-            ? undefined
-            : internalPlanner.runEmittedEvents(
-              planned.emittedEvents,
-              internalPlanner.makeLiveRuntime<Machine.EventOf<Events>, Machine.EmitOf<Emits>>(machine, scope)
-            )
-          const result = Effect.succeed({
-            state: planned.state,
-            done: planned.done,
-            output: planned.output
+    compiledInitial === undefined
+      ? internalRuntime.provideMachineRuntime(
+        internalPlanner.planInitial(machine, ...initialArgs).pipe(
+          Effect.flatMap((planned) => {
+            const commands = planned.commands.length === 0
+              ? undefined
+              : internalPlanner.runCommands(planned.commands, scope)
+            const emitted = planned.emittedEvents.length === 0
+              ? undefined
+              : internalPlanner.runEmittedEvents(
+                planned.emittedEvents,
+                internalPlanner.makeLiveRuntime<Machine.EventOf<Events>, Machine.EmitOf<Emits>>(machine, scope)
+              )
+            const result = Effect.succeed({
+              state: planned.state,
+              done: planned.done,
+              output: planned.output
+            })
+            return commands === undefined
+              ? emitted === undefined ? result : emitted.pipe(Effect.andThen(result))
+              : emitted === undefined
+              ? commands.pipe(Effect.andThen(result))
+              : commands.pipe(Effect.andThen(emitted), Effect.andThen(result))
           })
-          return commands === undefined
-            ? emitted === undefined ? result : emitted.pipe(Effect.andThen(result))
-            : emitted === undefined
-            ? commands.pipe(Effect.andThen(result))
-            : commands.pipe(Effect.andThen(emitted), Effect.andThen(result))
-        })
-      ),
-      scope
-    )
+        ),
+        scope
+      )
+      : Effect.try({
+        try: () => {
+          const planned = compiledInitial(initialArgs)
+          const result = {
+            state: planned.state as Machine.Snapshot<States>,
+            done: planned.done,
+            output: planned.output as Output | undefined
+          }
+          return hasInvokes
+            ? {
+              ...result,
+              executionState: new InvokeExecutionKernel({
+                configuration: planned.configuration,
+                activeConfiguration: planned.activeConfiguration,
+                entryPaths: planned.initialEntryPaths
+              })
+            }
+            : result
+        },
+        catch: (error) =>
+          error instanceof InfiniteTransitionError || error instanceof MachineSchemaDecodeError
+            ? error
+            : new StartupError({ cause: Cause.die(error) })
+      })
   return ({
     [internalRuntime.childlessProcess]: hasInvokes ? undefined : true,
     [internalRuntime.compiledProcess]: true,

--- a/src/internal/machineProcess.ts
+++ b/src/internal/machineProcess.ts
@@ -251,7 +251,6 @@ const makeChildlessCompiledDrain = (
 }
 
 class InvokeExecutionKernel {
-  readonly sessions: Map<string, InvokeSession>
   initialized = false
   initial:
     | {
@@ -266,7 +265,6 @@ class InvokeExecutionKernel {
     readonly activeConfiguration: Model.ActiveConfiguration
     readonly entryPaths: ReadonlyArray<string>
   }) {
-    this.sessions = new Map()
     this.initial = initial
   }
 
@@ -278,84 +276,46 @@ class InvokeExecutionKernel {
     return `Machine.invoke:${this.makeSessionKey(path, id)}`
   }
 
-  private stopSession(
-    scope: internalRuntime.ProcessScope<any>,
-    session: InvokeSession
-  ): Effect.Effect<void> {
-    return scope.stopChild(session.childId)
-  }
-
-  private remove(
-    scope: internalRuntime.ProcessScope<any>,
-    key: string,
-    token: symbol | undefined
-  ): Effect.Effect<void> {
-    return Effect.suspend(() => {
-      const current = this.sessions.get(key)
-      if (current === undefined || (token !== undefined && current.token !== token)) {
-        return Effect.void
-      }
-      this.sessions.delete(key)
-      return this.stopSession(scope, current)
-    })
-  }
-
-  stop(scope: internalRuntime.ProcessScope<any>, key: string): Effect.Effect<void> {
-    return this.remove(scope, key, undefined)
-  }
-
-  stopAll(scope: internalRuntime.ProcessScope<any>): Effect.Effect<void> {
-    return Effect.suspend(() => {
-      const effects = Array.from(this.sessions.values(), (session) => this.stopSession(scope, session))
-      this.sessions.clear()
-      return runParallelDiscard(effects)
-    })
-  }
-
   start(
     context: internalRuntime.CompiledProcessContext<any, any>,
     path: string,
     config: AnyInvokeConfig
   ): Effect.Effect<void, any, any> {
     return Effect.suspend(() => {
-      const token = Symbol()
       const invokeId = String(config.id)
       const key = this.makeSessionKey(path, invokeId)
       const childId = config.address === undefined ? this.makeChildId(path, invokeId) : String(config.address)
-      if (this.sessions.has(key)) {
-        return Effect.fail(new ChildAlreadyExistsError({ id: invokeId }))
-      }
-      this.sessions.set(key, { token, childId, path })
       const logic = config.src() as internalRuntime.ProcessLogic<any, any, any, any, any, any>
       const scope = context.scope
-      const sendParent = makeInvokeSendParent(this.sessions, scope.self, key, token)
-      return scope.spawn(
+      return context.ownedChildren.spawn(
         logic,
         {
+          key,
+          path,
           id: childId,
+          duplicateId: invokeId,
           ...(config.descriptor === undefined ? undefined : { descriptor: config.descriptor }),
-          [internalRuntime.sendParentOverride]: sendParent,
-          onOutcome: makeInvokeOutcomeHandler(
-            this.sessions,
-            scope.self,
-            scope.failCause,
-            config,
-            key,
-            token
-          ),
+          sendParent: (isCurrent, event) => isCurrent() ? scope.self.send(event) : Effect.void,
+          onOutcome: (isCurrent, outcome) => {
+            if (outcome._tag === "Stopped" || !isCurrent()) return Effect.void
+            if (outcome._tag !== "Done") return scope.failCause(outcome.cause)
+            const mappedEvent = config.onDone === undefined
+              ? outcome.output
+              : config.onDone({ id: config.id, output: outcome.output })
+            return mappedEvent === undefined
+              ? Effect.void
+              : scope.self.send(mappedEvent).pipe(Effect.catchTag("StoppedError", () => Effect.void))
+          },
           ...(config.snapshot === undefined ? undefined : {
-            [internalRuntime.activeSnapshotObserver]: makeInvokeSnapshotHandler(
-              this.sessions,
-              scope.self,
-              config,
-              key,
-              token
-            )
+            onSnapshot: (isCurrent: () => boolean, snapshot: any) => {
+              if (!isCurrent()) return Effect.void
+              const mappedEvent = config.snapshot!({ id: config.id, snapshot })
+              return mappedEvent === undefined
+                ? Effect.void
+                : scope.self.send(mappedEvent).pipe(Effect.catchTag("StoppedError", () => Effect.void))
+            }
           })
         }
-      ).pipe(
-        Effect.onExit((exit) => Exit.isFailure(exit) ? this.remove(scope, key, token) : Effect.void),
-        Effect.asVoid
       )
     })
   }
@@ -378,18 +338,6 @@ class InvokeExecutionKernel {
         }).map((config) => this.start(context, path, config))
       )
     return effects.length === 0 ? undefined : runSequentialDiscard(effects)
-  }
-
-  stopPaths(
-    machine: Machine.Any,
-    scope: internalRuntime.ProcessScope<any>,
-    paths: ReadonlyArray<string>
-  ): Effect.Effect<void> | undefined {
-    const keys = new Set(internalPlanner.sortExitPaths(machine, paths))
-    const effects = Array.from(this.sessions.entries())
-      .filter(([, session]) => keys.has(session.path))
-      .map(([key]) => this.stop(scope, key))
-    return effects.length === 0 ? undefined : runParallelDiscard(effects)
   }
 }
 
@@ -464,7 +412,7 @@ const makeInvokingCompiledDrain = (
         beforeCommit.push(internalPlanner.runCommands(planned.commands, scope))
       }
       if (changed) {
-        const stopping = execution.stopPaths(machine, scope, exitPaths)
+        const stopping = context.ownedChildren.stopPaths(exitPaths)
         if (stopping !== undefined) beforeCommit.push(stopping)
       }
       const afterCommit: Array<Effect.Effect<void, any, any>> = []
@@ -477,7 +425,7 @@ const makeInvokingCompiledDrain = (
         )
       }
       if (planned.done) {
-        afterCommit.push(execution.stopAll(scope))
+        afterCommit.push(context.ownedChildren.stopAll())
       } else if (changed) {
         for (const [path, entryEvent] of entryEvents) {
           const starting = execution.startAll(machine, context, activeConfiguration, [path], entryEvent)

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -30,12 +30,18 @@ type ChildEntry =
   | {
     readonly _tag: "Starting"
     readonly token: symbol
+    readonly ownerKey?: string
+    readonly ownerPath?: string
+    ownerActive?: boolean
   }
   | {
     readonly _tag: "Started"
     readonly token: symbol
     readonly descriptor: ChildDescriptor | undefined
     readonly ref: MachineRef<any, any, any, any>
+    readonly ownerKey?: string
+    readonly ownerPath?: string
+    ownerActive?: boolean
   }
 
 type ChildSelector = string | ChildDescriptor
@@ -104,6 +110,68 @@ interface ChildRegistry {
   readonly children: Map<ChildKey, ChildEntry>
   observers: Set<ChildObserver> | undefined
   scope: Scope.Closeable | undefined
+}
+
+const matchesChild = (
+  entry: ChildEntry,
+  child: ChildSelector
+): entry is Extract<ChildEntry, { readonly _tag: "Started" }> =>
+  entry._tag === "Started" && (typeof child === "string" || (
+    entry.descriptor !== undefined &&
+    entry.descriptor.id === child.id &&
+    entry.descriptor.machine === child.machine
+  ))
+
+const selectRegistryChild = (
+  registry: ChildRegistry,
+  id: string,
+  child: ChildSelector
+): ChildObservation => {
+  if (registry.closed) return Option.none()
+  const entry = registry.children.get(id)
+  return entry !== undefined && matchesChild(entry, child) ? Option.some(entry.ref) : Option.none()
+}
+
+const publishRegistryChange = (registry: ChildRegistry): void => {
+  if (registry.observers === undefined) return
+  for (const observer of registry.observers) {
+    offerChildObservation(observer, selectRegistryChild(registry, observer.id, observer.child))
+  }
+}
+
+const unregisterChild = (registry: ChildRegistry, key: ChildKey, token: symbol): void => {
+  const entry = registry.children.get(key)
+  if (entry === undefined || entry.token !== token) return
+  registry.children.delete(key)
+  if (typeof key === "string") publishRegistryChange(registry)
+}
+
+const registerChild = (
+  registry: ChildRegistry,
+  key: ChildKey,
+  token: symbol,
+  ref: MachineRef<any, any, any, any>,
+  descriptor: ChildDescriptor | undefined
+): boolean => {
+  const entry = registry.children.get(key)
+  if (registry.closed || entry === undefined || entry._tag !== "Starting" || entry.token !== token) {
+    return false
+  }
+  registry.children.delete(key)
+  const started: ChildEntry = entry.ownerKey === undefined
+    ? { _tag: "Started", token, descriptor, ref }
+    : {
+      _tag: "Started",
+      token,
+      descriptor,
+      ref,
+      ownerKey: entry.ownerKey,
+      ownerPath: entry.ownerPath!,
+      ownerActive: entry.ownerActive === true
+    }
+  registry.children.set(key, started)
+  if (typeof key === "string") publishRegistryChange(registry)
+  return true
 }
 
 export type RuntimeSnapshot<State, Error = never, Output = never> =
@@ -229,6 +297,7 @@ export interface ProcessContext<State, Event> extends ProcessScope<Event> {
  */
 export interface CompiledProcessContext<State, Event> {
   readonly scope: ProcessScope<Event>
+  readonly ownedChildren: OwnedChildRuntime
   readonly poll: () => Option.Option<Event>
   readonly state: () => State
   readonly commit: (state: State) => Effect.Effect<void> | undefined
@@ -441,10 +510,42 @@ interface StartInternalOptions {
     ref: MachineRef<any, any, any, any>,
     requestStop: Effect.Effect<void>
   ) => Effect.Effect<void>
+  readonly onReadySync?: (ref: MachineRef<any, any, any, any>) => boolean
   readonly onStop?: Effect.Effect<void>
+  readonly onStopSync?: () => void
+  readonly skipStoppedOutcome?: boolean
   readonly parent?: ProcessAddress<unknown>
   readonly runtime: ProcessRuntime
   readonly sendParent?: (event: unknown) => Effect.Effect<void, StoppedError>
+}
+
+interface OwnedChildSpawnOptions {
+  readonly key: string
+  readonly path: string
+  readonly id: string
+  readonly duplicateId: string
+  readonly descriptor?: ChildDescriptor
+  readonly onOutcome: (
+    isCurrent: () => boolean,
+    outcome: RuntimeOutcome<any, any, any>
+  ) => Effect.Effect<void>
+  readonly onSnapshot?: (
+    isCurrent: () => boolean,
+    snapshot: Extract<RuntimeSnapshot<any, any, any>, { readonly status: "active" }>
+  ) => Effect.Effect<void>
+  readonly sendParent: (
+    isCurrent: () => boolean,
+    event: unknown
+  ) => Effect.Effect<void, StoppedError>
+}
+
+interface OwnedChildRuntime {
+  readonly spawn: (
+    logic: ProcessLogic<any, any, any, any, any, any>,
+    options: OwnedChildSpawnOptions
+  ) => Effect.Effect<void, any, any>
+  readonly stopAll: () => Effect.Effect<void>
+  readonly stopPaths: (paths: ReadonlyArray<string>) => Effect.Effect<void> | undefined
 }
 
 interface ChildRuntime {
@@ -458,6 +559,108 @@ interface ChildRuntime {
   ) => Stream.Stream<Option.Option<MachineRef<ChildState, ChildEvent, ChildError, ChildOutput>>>
   readonly sendTo: (child: ChildSelector, event: unknown) => Effect.Effect<void, StoppedError>
   readonly stop: (child: ChildSelector) => Effect.Effect<void>
+  readonly owned: OwnedChildRuntime
+}
+
+class OwnedChildRuntimeImpl implements OwnedChildRuntime {
+  constructor(
+    private readonly registry: ChildRegistry,
+    private readonly self: ProcessAddress<any>,
+    private readonly runtime: ProcessRuntime
+  ) {}
+
+  private has(key: string): boolean {
+    for (const entry of this.registry.children.values()) {
+      if (entry.ownerActive && entry.ownerKey === key) return true
+    }
+    return false
+  }
+
+  private stopEntry(entry: ChildEntry): Effect.Effect<void> {
+    entry.ownerActive = false
+    return entry._tag === "Started" ? entry.ref.stop : Effect.void
+  }
+
+  spawn(
+    logic: ProcessLogic<any, any, any, any, any, any>,
+    options: OwnedChildSpawnOptions
+  ): Effect.Effect<void, any, any> {
+    const token = Symbol()
+    let startedChild: MachineRef<any, any, any, any> | undefined
+    const isCurrent = (): boolean => {
+      const entry = this.registry.children.get(options.id)
+      return entry?.token === token && entry.ownerKey === options.key && entry.ownerActive === true
+    }
+    return Effect.suspend(() => {
+      if (this.registry.closed) return Effect.interrupt
+      if (this.has(options.key) || this.registry.children.has(options.id)) {
+        return Effect.fail(new ChildAlreadyExistsError({ id: options.duplicateId }))
+      }
+      this.registry.scope ??= Scope.makeUnsafe("parallel")
+      this.registry.children.set(options.id, {
+        _tag: "Starting",
+        token,
+        ownerKey: options.key,
+        ownerPath: options.path,
+        ownerActive: true
+      })
+      return startLogicInternal(logic, {
+        detached: true,
+        id: options.id,
+        sendParent: (event) => options.sendParent(isCurrent, event),
+        onOutcome: (outcome) => options.onOutcome(isCurrent, outcome),
+        ...(options.onSnapshot === undefined
+          ? undefined
+          : { onSnapshot: (snapshot) => options.onSnapshot!(isCurrent, snapshot) }),
+        onReadySync: (child) => {
+          startedChild = child
+          return registerChild(this.registry, options.id, token, child, options.descriptor)
+        },
+        onStopSync: () => unregisterChild(this.registry, options.id, token),
+        skipStoppedOutcome: true,
+        parent: this.self,
+        runtime: this.runtime
+      }).pipe(
+        Effect.onExit((exit) => {
+          if (Exit.isSuccess(exit)) return Effect.void
+          unregisterChild(this.registry, options.id, token)
+          return startedChild === undefined ? Effect.void : startedChild.stop
+        }),
+        Scope.provide(this.registry.scope),
+        Effect.asVoid
+      )
+    })
+  }
+
+  stopAll(): Effect.Effect<void> {
+    return Effect.suspend(() => {
+      const effects: Array<Effect.Effect<void>> = []
+      for (const entry of this.registry.children.values()) {
+        if (entry.ownerActive) effects.push(this.stopEntry(entry))
+      }
+      return effects.length === 0
+        ? Effect.void
+        : effects.length === 1
+        ? effects[0]!
+        : Effect.all(effects, { concurrency: "unbounded", discard: true })
+    })
+  }
+
+  stopPaths(paths: ReadonlyArray<string>): Effect.Effect<void> | undefined {
+    if (paths.length === 0) return undefined
+    const pathSet = new Set(paths)
+    const effects: Array<Effect.Effect<void>> = []
+    for (const entry of this.registry.children.values()) {
+      if (entry.ownerActive && entry.ownerPath !== undefined && pathSet.has(entry.ownerPath)) {
+        effects.push(this.stopEntry(entry))
+      }
+    }
+    return effects.length === 0
+      ? undefined
+      : effects.length === 1
+      ? effects[0]!
+      : Effect.all(effects, { concurrency: "unbounded", discard: true })
+  }
 }
 
 const noChildChanges = Stream.succeed(Option.none()).pipe(Stream.concat(Stream.never))
@@ -469,7 +672,12 @@ const childlessRuntime: ChildRuntime = {
   get: () => Effect.succeed(Option.none()),
   changes: () => noChildChanges,
   sendTo: () => Effect.void,
-  stop: () => Effect.void
+  stop: () => Effect.void,
+  owned: {
+    spawn: () => Effect.die(new Error("Childless machine logic cannot spawn an owned process")),
+    stopAll: () => Effect.void,
+    stopPaths: () => undefined
+  }
 }
 
 const makeChildRuntime = (
@@ -486,38 +694,6 @@ const makeChildRuntime = (
       children: new Map(),
       observers: undefined,
       scope: undefined
-    }
-
-    const matches = (
-      entry: ChildEntry,
-      child: ChildSelector
-    ): entry is Extract<ChildEntry, { readonly _tag: "Started" }> =>
-      entry._tag === "Started" && (typeof child === "string" || (
-        entry.descriptor !== undefined &&
-        entry.descriptor.id === child.id &&
-        entry.descriptor.machine === child.machine
-      ))
-
-    const selectChild = (
-      id: string,
-      child: ChildSelector
-    ): ChildObservation => {
-      if (registry.closed) {
-        return Option.none()
-      }
-      const entry = registry.children.get(id)
-      return entry !== undefined && matches(entry, child)
-        ? Option.some(entry.ref)
-        : Option.none()
-    }
-
-    const publishRegistryChange = (): void => {
-      if (registry.observers === undefined) {
-        return
-      }
-      for (const observer of registry.observers) {
-        offerChildObservation(observer, selectChild(observer.id, observer.child))
-      }
     }
 
     const close = <A, E>(exit: Exit.Exit<A, E>): Effect.Effect<void> =>
@@ -562,43 +738,14 @@ const makeChildRuntime = (
     const unregister = (
       key: ChildKey,
       token: symbol
-    ): Effect.Effect<void> =>
-      Effect.sync(() => {
-        const entry = registry.children.get(key)
-        if (entry === undefined || entry.token !== token) {
-          return
-        }
-        const observable = typeof key === "string"
-        registry.children.delete(key)
-        if (observable) {
-          publishRegistryChange()
-        }
-      })
+    ): Effect.Effect<void> => Effect.sync(() => unregisterChild(registry, key, token))
 
     const register = (
       key: ChildKey,
       token: symbol,
       ref: MachineRef<any, any, any, any>,
       descriptor: ChildDescriptor | undefined
-    ): Effect.Effect<boolean> =>
-      Effect.sync(() => {
-        const entry = registry.children.get(key)
-        if (
-          registry.closed ||
-          entry === undefined ||
-          entry._tag !== "Starting" ||
-          entry.token !== token
-        ) {
-          return false
-        }
-        const observable = typeof key === "string"
-        registry.children.delete(key)
-        registry.children.set(key, { _tag: "Started", token, descriptor, ref })
-        if (observable) {
-          publishRegistryChange()
-        }
-        return true
-      })
+    ): Effect.Effect<boolean> => Effect.sync(() => registerChild(registry, key, token, ref, descriptor))
 
     const get: ChildRuntime["get"] = (child) => {
       const id = typeof child === "string" ? child : child.id
@@ -607,7 +754,7 @@ const makeChildRuntime = (
           return Option.none()
         }
         const entry = registry.children.get(id)
-        return entry !== undefined && matches(entry, child)
+        return entry !== undefined && matchesChild(entry, child)
           ? Option.some(entry.ref)
           : Option.none()
       })
@@ -636,7 +783,7 @@ const makeChildRuntime = (
                       registry.observers ??= new Set()
                       registry.observers.add(observer)
                     }
-                    offerChildObservation(observer, selectChild(id, child))
+                    offerChildObservation(observer, selectRegistryChild(registry, id, child))
                   })
                 ),
                 Effect.as(takeChildObservations(observer))
@@ -654,7 +801,7 @@ const makeChildRuntime = (
           return Effect.void
         }
         const entry = registry.children.get(id)
-        return entry !== undefined && matches(entry, child)
+        return entry !== undefined && matchesChild(entry, child)
           ? entry.ref.send(event)
           : Effect.void
       })
@@ -667,7 +814,7 @@ const makeChildRuntime = (
           return Effect.void
         }
         const entry = registry.children.get(id)
-        return entry !== undefined && matches(entry, child)
+        return entry !== undefined && matchesChild(entry, child)
           ? entry.ref.stop
           : Effect.void
       })
@@ -769,7 +916,15 @@ const makeChildRuntime = (
       >
     }
 
-    return { close, spawn, get, changes, sendTo, stop }
+    return {
+      close,
+      spawn,
+      get,
+      changes,
+      sendTo,
+      stop,
+      owned: new OwnedChildRuntimeImpl(registry, self, runtime)
+    }
   })
 
 // `Machine.logic` permits an arbitrary Effect program, including programs that
@@ -798,8 +953,10 @@ const startGenericInternal: <
     id: requestedId,
     onOutcome,
     onReady,
+    onReadySync,
     onSnapshot,
     onStop,
+    onStopSync,
     parent,
     runtime,
     sendParent: overrideSendParent
@@ -858,7 +1015,7 @@ const startGenericInternal: <
     Exit.isFailure(exit)
       ? closeChildren(exit)
       : Effect.void
-  const cleanup = onStop ?? Effect.void
+  const cleanup = onStopSync === undefined ? onStop ?? Effect.void : Effect.sync(onStopSync)
   const sendParent = overrideSendParent ?? (parent === undefined ? noParentSend : parent.send)
 
   const scope: ProcessScope<Event> = {
@@ -1025,12 +1182,13 @@ const startGenericInternal: <
     exit: Exit.Exit<unknown, unknown>,
     completeDone: Effect.Effect<void>
   ): Effect.Effect<void> => {
-    const notifyOutcome = onOutcome === undefined
-      ? Effect.void
-      : Effect.suspend(() => onOutcome(classifyOutcome(snapshot)!)).pipe(
-        Effect.exit,
-        Effect.asVoid
-      )
+    const notifyOutcome =
+      onOutcome === undefined || (snapshot.status === "stopped" && options.skipStoppedOutcome === true)
+        ? Effect.void
+        : Effect.suspend(() => onOutcome(classifyOutcome(snapshot)!)).pipe(
+          Effect.exit,
+          Effect.asVoid
+        )
     return Effect.uninterruptible(
       Queue.shutdown(queue).pipe(
         Effect.andThen(closeChildren(exit)),
@@ -1161,7 +1319,9 @@ const startGenericInternal: <
     childChanges
   }
 
-  if (onReady !== undefined) {
+  if (onReadySync !== undefined && !onReadySync(ref)) {
+    yield* requestStop
+  } else if (onReady !== undefined) {
     yield* onReady(ref, requestStop)
   }
   if (onSnapshot !== undefined) {
@@ -1363,13 +1523,15 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
           updateState: (f) => self.updateState(f)
         }
       } else {
-        self.compiledContext = new CompiledProcessContextImpl(self.processScope, self)
+        self.compiledContext = new CompiledProcessContextImpl(self.processScope, self.childRuntime.owned, self)
         if ("executionState" in initialized) {
           self.compiledContext.executionState = initialized.executionState
         }
       }
 
-      if (self.options.onReady !== undefined) {
+      if (self.options.onReadySync !== undefined && !self.options.onReadySync(self)) {
+        yield* self.requestTermination({ _tag: "Stopped" })
+      } else if (self.options.onReady !== undefined) {
         yield* self.options.onReady(self, self.requestTermination({ _tag: "Stopped" }).pipe(Effect.asVoid))
       }
       if (self.options.onSnapshot !== undefined) {
@@ -1534,7 +1696,8 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
     if (
       this.logic[childlessProcess] !== true || this.draining || this.worker !== undefined ||
       this.requestedTermination !== undefined || this.options.onOutcome !== undefined ||
-      this.options.onStop !== undefined || this.current.changes !== undefined ||
+      this.options.onStop !== undefined || this.options.onStopSync !== undefined ||
+      this.current.changes !== undefined ||
       this.current.terminalizing || this.current.snapshot.status !== "active"
     ) {
       return false
@@ -1668,7 +1831,8 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
         : requested._tag === "Done"
         ? Effect.succeed(requested.output)
         : Effect.failCause(requested.cause)
-      const notifyOutcome = this.options.onOutcome === undefined
+      const notifyOutcome = this.options.onOutcome === undefined ||
+          (requested._tag === "Stopped" && this.options.skipStoppedOutcome === true)
         ? Effect.void
         : Effect.suspend(() => this.options.onOutcome!(classifyOutcome(snapshot)!)).pipe(
           Effect.exit,
@@ -1681,6 +1845,7 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
           Effect.andThen(notifyOutcome),
           Effect.andThen(this.options.onStop ?? Effect.void),
           Effect.andThen(Effect.sync(() => {
+            this.options.onStopSync?.()
             this.draining = false
             this.worker = undefined
             this.interruptRequested = false
@@ -1880,6 +2045,7 @@ class CompiledProcessContextImpl implements CompiledProcessContext<unknown, unkn
 
   constructor(
     readonly scope: ProcessScope<unknown>,
+    readonly ownedChildren: OwnedChildRuntime,
     private readonly process: CompiledProcess
   ) {}
 

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -284,7 +284,13 @@ export interface ProcessLogic<
     scope: ProcessScope<Event>
   ) => Effect.Effect<
     | { readonly state: State; readonly done: false; readonly output: undefined }
-    | { readonly state: State; readonly done: true; readonly output: Output },
+    | { readonly state: State; readonly done: true; readonly output: Output }
+    | {
+      readonly state: State
+      readonly done: boolean
+      readonly output: Output | undefined
+      readonly executionState: unknown
+    },
     InitialError,
     Requirements
   >
@@ -1358,6 +1364,9 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
         }
       } else {
         self.compiledContext = new CompiledProcessContextImpl(self.processScope, self)
+        if ("executionState" in initialized) {
+          self.compiledContext.executionState = initialized.executionState
+        }
       }
 
       if (self.options.onReady !== undefined) {


### PR DESCRIPTION
## Summary

- compile eligible initial-state normalization and carry the validated configuration into invoked startup
- let invoke-capable machines use the indexed execution topology
- unify invoked-session identity with the child registry and specialize owned-child registration/cleanup
- retain the public API, Effect model, type inference, stale-callback protection, child observation, and duplicate-id behavior

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (not applicable; no examples changed)
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed (local instantiations unchanged; awaiting PR report)
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed (local full report plus alternating checkpoint comparisons; awaiting PR report)

<!--
The type- and runtime-performance workflows post and update their base-versus-PR comparisons automatically.
Do not copy a manually measured table into this description.
-->
