### PR TITLE
Specialize compiled invoked child startup

### DIFF
--- a/.changeset/fast-static-children.md
+++ b/.changeset/fast-static-children.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Start eligible compiled invoked machines directly from their synchronous initial kernel while preserving per-instance input evaluation, inherited services, scoped ownership, observation, and terminal behavior. Reuse the immutable process descriptor captured by `Machine.invokeMachine` across parent instances.

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -6643,14 +6643,16 @@ export const invokeMachine: {
   readonly onDone?: (context: Machine.InvokeDoneContext<any>) => unknown
 }) => {
   const machine = config.child.machine
+  // An invoke descriptor fixes both its machine and input. Compile its process
+  // logic once; all mutable execution state belongs to the process instance.
+  const logic = machine.input === undefined
+    ? (internalProcess.toProcessLogic as any)(machine)
+    : (internalProcess.toProcessLogic as any)(machine, config.input)
   return {
     id: config.child.id,
     address: config.child.id,
     descriptor: config.child,
-    src: () =>
-      machine.input === undefined
-        ? (internalProcess.toProcessLogic as any)(machine)
-        : (internalProcess.toProcessLogic as any)(machine, config.input),
+    src: () => logic,
     snapshot: config.snapshot,
     onDone: config.onDone,
     [Activities.ActivityMetadataTypeId]: {

--- a/src/internal/machineProcess.ts
+++ b/src/internal/machineProcess.ts
@@ -535,6 +535,30 @@ const makeProcessLogic: <
   const executionPlan = internalPlanner.compileExecutionPlan(machine)
   const initialArgs = entry._tag === "Initial" ? entry.args : []
   const compiledInitial = entry._tag === "Initial" ? executionPlan.initial : undefined
+  const makeCompiledInitial = compiledInitial === undefined ? undefined : () => {
+    try {
+      const planned = compiledInitial(initialArgs)
+      const result = {
+        state: planned.state as Machine.Snapshot<States>,
+        done: planned.done,
+        output: planned.output as Output | undefined
+      }
+      return hasInvokes
+        ? {
+          ...result,
+          executionState: new InvokeExecutionKernel({
+            configuration: planned.configuration,
+            activeConfiguration: planned.activeConfiguration,
+            entryPaths: planned.initialEntryPaths
+          })
+        }
+        : result
+    } catch (error) {
+      throw error instanceof InfiniteTransitionError || error instanceof MachineSchemaDecodeError
+        ? error
+        : new StartupError({ cause: Cause.die(error) })
+    }
+  }
   const makeInitial = (
     scope: internalRuntime.ProcessScope<Machine.EventOf<Events>>
   ) =>
@@ -565,34 +589,12 @@ const makeProcessLogic: <
         ),
         scope
       )
-      : Effect.try({
-        try: () => {
-          const planned = compiledInitial(initialArgs)
-          const result = {
-            state: planned.state as Machine.Snapshot<States>,
-            done: planned.done,
-            output: planned.output as Output | undefined
-          }
-          return hasInvokes
-            ? {
-              ...result,
-              executionState: new InvokeExecutionKernel({
-                configuration: planned.configuration,
-                activeConfiguration: planned.activeConfiguration,
-                entryPaths: planned.initialEntryPaths
-              })
-            }
-            : result
-        },
-        catch: (error) =>
-          error instanceof InfiniteTransitionError || error instanceof MachineSchemaDecodeError
-            ? error
-            : new StartupError({ cause: Cause.die(error) })
-      })
+      : Effect.try({ try: makeCompiledInitial!, catch: (error) => error as any })
   return ({
     [internalRuntime.childlessProcess]: hasInvokes ? undefined : true,
     [internalRuntime.compiledProcess]: true,
     [internalRuntime.compiledProcessInitial]: entry._tag === "Initial" ? makeInitial : undefined,
+    [internalRuntime.compiledProcessInitialSync]: makeCompiledInitial,
     [internalRuntime.compiledProcessDrain]: hasInvokes
       ? makeInvokingCompiledDrain(machine, entry._tag === "Resume")
       : makeChildlessCompiledDrain(machine, entry._tag === "Resume"),

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -505,15 +505,12 @@ export const watch = <State, Event, Error = never, Output = never>(
 
 interface ProcessRuntime {
   readonly nextSessionId: Effect.Effect<string>
-  readonly nextSessionIdUnsafe: () => string
 }
 
 const makeProcessRuntime: Effect.Effect<ProcessRuntime> = Effect.sync(() => {
   let sessionIdCounter = 0
-  const nextSessionIdUnsafe = (): string => `machine:${sessionIdCounter++}`
   return {
-    nextSessionId: Effect.sync(nextSessionIdUnsafe),
-    nextSessionIdUnsafe
+    nextSessionId: Effect.sync(() => `machine:${sessionIdCounter++}`)
   }
 })
 
@@ -646,12 +643,16 @@ class OwnedChildRuntimeImpl implements OwnedChildRuntime {
         logic[childlessProcess] === true && logic[compiledProcessDrain] !== undefined &&
         logic[compiledProcessInitialSync] !== undefined
       const start = synchronous
-        ? new CompiledProcess(
-          logic,
-          startOptions,
-          this.scopedServices ??= Context.add(this.services!, Scope.Scope, scope),
-          this.runtime.nextSessionIdUnsafe()
-        ).initializeOwnedSync()
+        ? Effect.flatMap(
+          this.runtime.nextSessionId,
+          (sessionId) =>
+            new CompiledProcess(
+              logic,
+              startOptions,
+              this.scopedServices ??= Context.add(this.services!, Scope.Scope, scope),
+              sessionId
+            ).initializeOwnedSync()
+        )
         : startLogicInternal(logic, startOptions)
       const guarded = start.pipe(
         Effect.onExit((exit) => {
@@ -1506,7 +1507,7 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
     }
   }
 
-  private initializeScope(): void {
+  initializeOwnedSync(): Effect.Effect<MachineRef<any, any, any, any>, unknown> {
     const parent = this.options.parent
     const sendParent = this.options.sendParent ?? (parent === undefined ? noParentSend : parent.send)
     this.processScope = {
@@ -1518,34 +1519,6 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
       stopChild: this.childRuntime.stop,
       failCause: (cause: Cause.Cause<unknown>) => this.failCause(cause)
     }
-  }
-
-  private activate(initialized: CompiledInitialized): void {
-    this.current = {
-      revision: 0,
-      terminalizing: false,
-      changes: undefined,
-      snapshot: { status: "active", state: initialized.state }
-    }
-    if (this.logic[compiledProcessDrain] === undefined) {
-      this.processContext = {
-        ...this.processScope,
-        receive: Effect.never,
-        poll: Effect.sync(() => pollCompactMailbox(this.mailbox)),
-        state: Effect.sync(() => this.current.snapshot.state),
-        setState: (state: unknown) => this.setActiveState(state),
-        updateState: (f) => this.updateState(f)
-      }
-    } else {
-      this.compiledContext = new CompiledProcessContextImpl(this.processScope, this.childRuntime.owned, this)
-      if ("executionState" in initialized) {
-        this.compiledContext.executionState = initialized.executionState
-      }
-    }
-  }
-
-  initializeOwnedSync(): Effect.Effect<MachineRef<any, any, any, any>, unknown> {
-    this.initializeScope()
     const compiledInitial = this.logic[compiledProcessInitialSync]!
     let initialized: CompiledInitialized
     try {
@@ -1555,7 +1528,16 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
       return Effect.fail(error)
     }
     this.initializing = false
-    this.activate(initialized)
+    this.current = {
+      revision: 0,
+      terminalizing: false,
+      changes: undefined,
+      snapshot: { status: "active", state: initialized.state }
+    }
+    this.compiledContext = new CompiledProcessContextImpl(this.processScope, this.childRuntime.owned, this)
+    if ("executionState" in initialized) {
+      this.compiledContext.executionState = initialized.executionState
+    }
     if (this.options.onReadySync !== undefined && !this.options.onReadySync(this)) {
       this.requestTerminationSync({ _tag: "Stopped" })
     }
@@ -1578,7 +1560,17 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
       if (self.logic[childlessProcess] !== true) {
         self.childRuntime = yield* makeChildRuntime(self.address, self.options.runtime, self.services)
       }
-      self.initializeScope()
+      const parent = self.options.parent
+      const sendParent = self.options.sendParent ?? (parent === undefined ? noParentSend : parent.send)
+      self.processScope = {
+        self: self.address,
+        parent,
+        spawn: self.childRuntime.spawn,
+        sendParent,
+        sendTo: self.childRuntime.sendTo,
+        stopChild: self.childRuntime.stop,
+        failCause: (cause: Cause.Cause<unknown>) => self.failCause(cause)
+      }
 
       const cleanupStartupFailure = <A, E>(exit: Exit.Exit<A, E>): Effect.Effect<void> =>
         Exit.isFailure(exit) ? self.childRuntime.close(exit) : Effect.void
@@ -1603,7 +1595,27 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
         }))
       )
       const initial = initialized.state
-      self.activate(initialized)
+      self.current = {
+        revision: 0,
+        terminalizing: false,
+        changes: undefined,
+        snapshot: { status: "active", state: initial }
+      }
+      if (self.logic[compiledProcessDrain] === undefined) {
+        self.processContext = {
+          ...self.processScope,
+          receive: Effect.never,
+          poll: Effect.sync(() => pollCompactMailbox(self.mailbox)),
+          state: Effect.sync(() => self.current.snapshot.state),
+          setState: (state: unknown) => self.setActiveState(state),
+          updateState: (f) => self.updateState(f)
+        }
+      } else {
+        self.compiledContext = new CompiledProcessContextImpl(self.processScope, self.childRuntime.owned, self)
+        if ("executionState" in initialized) {
+          self.compiledContext.executionState = initialized.executionState
+        }
+      }
 
       if (self.options.onReadySync !== undefined && !self.options.onReadySync(self)) {
         yield* self.requestTermination({ _tag: "Stopped" })

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -63,6 +63,9 @@ export const compiledProcessDrain: unique symbol = Symbol.for("effect/Machine/co
 export const compiledProcessInitial: unique symbol = Symbol.for("effect/Machine/compiledProcessInitial")
 
 /** @internal */
+export const compiledProcessInitialSync: unique symbol = Symbol.for("effect/Machine/compiledProcessInitialSync")
+
+/** @internal */
 export const sendParentOverride: unique symbol = Symbol.for("effect/Machine/sendParentOverride")
 
 type ChildObservation = Option.Option<MachineRef<any, any, any, any>>
@@ -363,6 +366,18 @@ export interface ProcessLogic<
     InitialError,
     Requirements
   >
+  /** @internal */
+  readonly [compiledProcessInitialSync]?: (
+    scope: ProcessScope<Event>
+  ) =>
+    | { readonly state: State; readonly done: false; readonly output: undefined }
+    | { readonly state: State; readonly done: true; readonly output: Output }
+    | {
+      readonly state: State
+      readonly done: boolean
+      readonly output: Output | undefined
+      readonly executionState: unknown
+    }
   run(context: ProcessContext<State, Event>): Effect.Effect<Output, Error, Requirements>
   /** @internal */
   readonly drain?: (
@@ -490,12 +505,15 @@ export const watch = <State, Event, Error = never, Output = never>(
 
 interface ProcessRuntime {
   readonly nextSessionId: Effect.Effect<string>
+  readonly nextSessionIdUnsafe: () => string
 }
 
 const makeProcessRuntime: Effect.Effect<ProcessRuntime> = Effect.sync(() => {
   let sessionIdCounter = 0
+  const nextSessionIdUnsafe = (): string => `machine:${sessionIdCounter++}`
   return {
-    nextSessionId: Effect.sync(() => `machine:${sessionIdCounter++}`)
+    nextSessionId: Effect.sync(nextSessionIdUnsafe),
+    nextSessionIdUnsafe
   }
 })
 
@@ -563,10 +581,13 @@ interface ChildRuntime {
 }
 
 class OwnedChildRuntimeImpl implements OwnedChildRuntime {
+  private scopedServices: Context.Context<any> | undefined
+
   constructor(
     private readonly registry: ChildRegistry,
     private readonly self: ProcessAddress<any>,
-    private readonly runtime: ProcessRuntime
+    private readonly runtime: ProcessRuntime,
+    private readonly services?: Context.Context<any>
   ) {}
 
   private has(key: string): boolean {
@@ -596,7 +617,7 @@ class OwnedChildRuntimeImpl implements OwnedChildRuntime {
       if (this.has(options.key) || this.registry.children.has(options.id)) {
         return Effect.fail(new ChildAlreadyExistsError({ id: options.duplicateId }))
       }
-      this.registry.scope ??= Scope.makeUnsafe("parallel")
+      const scope = this.registry.scope ??= Scope.makeUnsafe("parallel")
       this.registry.children.set(options.id, {
         _tag: "Starting",
         token,
@@ -604,7 +625,7 @@ class OwnedChildRuntimeImpl implements OwnedChildRuntime {
         ownerPath: options.path,
         ownerActive: true
       })
-      return startLogicInternal(logic, {
+      const startOptions: StartInternalOptions = {
         detached: true,
         id: options.id,
         sendParent: (event) => options.sendParent(isCurrent, event),
@@ -620,15 +641,26 @@ class OwnedChildRuntimeImpl implements OwnedChildRuntime {
         skipStoppedOutcome: true,
         parent: this.self,
         runtime: this.runtime
-      }).pipe(
+      }
+      const synchronous = this.services !== undefined && options.onSnapshot === undefined &&
+        logic[childlessProcess] === true && logic[compiledProcessDrain] !== undefined &&
+        logic[compiledProcessInitialSync] !== undefined
+      const start = synchronous
+        ? new CompiledProcess(
+          logic,
+          startOptions,
+          this.scopedServices ??= Context.add(this.services!, Scope.Scope, scope),
+          this.runtime.nextSessionIdUnsafe()
+        ).initializeOwnedSync()
+        : startLogicInternal(logic, startOptions)
+      const guarded = start.pipe(
         Effect.onExit((exit) => {
           if (Exit.isSuccess(exit)) return Effect.void
           unregisterChild(this.registry, options.id, token)
           return startedChild === undefined ? Effect.void : startedChild.stop
-        }),
-        Scope.provide(this.registry.scope),
-        Effect.asVoid
+        })
       )
+      return (synchronous ? guarded : Scope.provide(guarded, scope)).pipe(Effect.asVoid)
     })
   }
 
@@ -682,7 +714,8 @@ const childlessRuntime: ChildRuntime = {
 
 const makeChildRuntime = (
   self: ProcessAddress<any>,
-  runtime: ProcessRuntime
+  runtime: ProcessRuntime,
+  services?: Context.Context<any>
 ): Effect.Effect<ChildRuntime> =>
   Effect.sync(() => {
     // Child-registry decisions are synchronous and every access below runs in
@@ -923,7 +956,7 @@ const makeChildRuntime = (
       changes,
       sendTo,
       stop,
-      owned: new OwnedChildRuntimeImpl(registry, self, runtime)
+      owned: new OwnedChildRuntimeImpl(registry, self, runtime, services)
     }
   })
 
@@ -1407,6 +1440,13 @@ type CompiledTermination =
   | { readonly _tag: "Done"; readonly output: unknown }
   | { readonly _tag: "Failure"; readonly cause: Cause.Cause<unknown> }
 
+type CompiledInitialized = {
+  readonly state: unknown
+  readonly done: boolean | undefined
+  readonly output: unknown
+  readonly executionState?: unknown
+}
+
 // Stopping is commonly used only for resource cleanup. Keep that path free of
 // Error stack capture and materialize the typed join failure only if observed.
 const CompiledStoppedCompletion: unique symbol = Symbol("effect/Machine/CompiledStoppedCompletion")
@@ -1466,23 +1506,79 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
     }
   }
 
+  private initializeScope(): void {
+    const parent = this.options.parent
+    const sendParent = this.options.sendParent ?? (parent === undefined ? noParentSend : parent.send)
+    this.processScope = {
+      self: this.address,
+      parent,
+      spawn: this.childRuntime.spawn,
+      sendParent,
+      sendTo: this.childRuntime.sendTo,
+      stopChild: this.childRuntime.stop,
+      failCause: (cause: Cause.Cause<unknown>) => this.failCause(cause)
+    }
+  }
+
+  private activate(initialized: CompiledInitialized): void {
+    this.current = {
+      revision: 0,
+      terminalizing: false,
+      changes: undefined,
+      snapshot: { status: "active", state: initialized.state }
+    }
+    if (this.logic[compiledProcessDrain] === undefined) {
+      this.processContext = {
+        ...this.processScope,
+        receive: Effect.never,
+        poll: Effect.sync(() => pollCompactMailbox(this.mailbox)),
+        state: Effect.sync(() => this.current.snapshot.state),
+        setState: (state: unknown) => this.setActiveState(state),
+        updateState: (f) => this.updateState(f)
+      }
+    } else {
+      this.compiledContext = new CompiledProcessContextImpl(this.processScope, this.childRuntime.owned, this)
+      if ("executionState" in initialized) {
+        this.compiledContext.executionState = initialized.executionState
+      }
+    }
+  }
+
+  initializeOwnedSync(): Effect.Effect<MachineRef<any, any, any, any>, unknown> {
+    this.initializeScope()
+    const compiledInitial = this.logic[compiledProcessInitialSync]!
+    let initialized: CompiledInitialized
+    try {
+      initialized = compiledInitial(this.processScope)
+    } catch (error) {
+      this.initializing = false
+      return Effect.fail(error)
+    }
+    this.initializing = false
+    this.activate(initialized)
+    if (this.options.onReadySync !== undefined && !this.options.onReadySync(this)) {
+      this.requestTerminationSync({ _tag: "Stopped" })
+    }
+    if (initialized.done === true && this.requestedTermination === undefined) {
+      this.requestTerminationSync({ _tag: "Done", output: initialized.output })
+    }
+    if (
+      initialized.done === false && this.requestedTermination === undefined &&
+      this.mailbox.items === undefined
+    ) {
+      return Effect.succeed(this)
+    }
+    this.draining = true
+    return Effect.provideContext(this.drainRuntime(), this.services).pipe(Effect.as(this))
+  }
+
   initialize(): Effect.Effect<MachineRef<any, any, any, any>, unknown, any> {
     const self = this
     return Effect.gen(function*() {
       if (self.logic[childlessProcess] !== true) {
-        self.childRuntime = yield* makeChildRuntime(self.address, self.options.runtime)
+        self.childRuntime = yield* makeChildRuntime(self.address, self.options.runtime, self.services)
       }
-      const parent = self.options.parent
-      const sendParent = self.options.sendParent ?? (parent === undefined ? noParentSend : parent.send)
-      self.processScope = {
-        self: self.address,
-        parent,
-        spawn: self.childRuntime.spawn,
-        sendParent,
-        sendTo: self.childRuntime.sendTo,
-        stopChild: self.childRuntime.stop,
-        failCause: (cause: Cause.Cause<unknown>) => self.failCause(cause)
-      }
+      self.initializeScope()
 
       const cleanupStartupFailure = <A, E>(exit: Exit.Exit<A, E>): Effect.Effect<void> =>
         Exit.isFailure(exit) ? self.childRuntime.close(exit) : Effect.void
@@ -1507,27 +1603,7 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
         }))
       )
       const initial = initialized.state
-      self.current = {
-        revision: 0,
-        terminalizing: false,
-        changes: undefined,
-        snapshot: { status: "active", state: initial }
-      }
-      if (self.logic[compiledProcessDrain] === undefined) {
-        self.processContext = {
-          ...self.processScope,
-          receive: Effect.never,
-          poll: Effect.sync(() => pollCompactMailbox(self.mailbox)),
-          state: Effect.sync(() => self.current.snapshot.state),
-          setState: (state: unknown) => self.setActiveState(state),
-          updateState: (f) => self.updateState(f)
-        }
-      } else {
-        self.compiledContext = new CompiledProcessContextImpl(self.processScope, self.childRuntime.owned, self)
-        if ("executionState" in initialized) {
-          self.compiledContext.executionState = initialized.executionState
-        }
-      }
+      self.activate(initialized)
 
       if (self.options.onReadySync !== undefined && !self.options.onReadySync(self)) {
         yield* self.requestTermination({ _tag: "Stopped" })
@@ -1594,14 +1670,16 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
   }
 
   private requestTermination(requested: CompiledTermination): Effect.Effect<boolean> {
-    return Effect.sync(() => {
-      if (this.requestedTermination !== undefined) {
-        return false
-      }
-      this.requestedTermination = requested
-      this.reservedTerminationSnapshot = this.reserveTermination(requested)
-      return true
-    })
+    return Effect.sync(() => this.requestTerminationSync(requested))
+  }
+
+  private requestTerminationSync(requested: CompiledTermination): boolean {
+    if (this.requestedTermination !== undefined) {
+      return false
+    }
+    this.requestedTermination = requested
+    this.reservedTerminationSnapshot = this.reserveTermination(requested)
+    return true
   }
 
   private reserveTermination(

--- a/test/Machine.test.ts
+++ b/test/Machine.test.ts
@@ -4132,6 +4132,90 @@ describe("Machine", () => {
       yield* second.stop
     }))
 
+  it.effect("evaluates precompiled input-bearing invoked children for every start", () =>
+    Effect.gen(function*() {
+      let starts = 0
+      const childStates = Machine.defineStates({ Idle })
+      const childMachine = Machine.make({
+        states: childStates.states,
+        events: [],
+        input: Input,
+        initial: (input) => {
+          starts += 1
+          return childStates.initial.Idle(new Idle({ userId: input.userId }))
+        }
+      }).handle({ Idle: {} })
+      const Child = Machine.child("input-child", childMachine)
+      const parentStates = Machine.defineStates({ Loading })
+      const parentMachine = Machine.make({
+        states: parentStates.states,
+        events: [],
+        initial: () => parentStates.initial.Loading(new Loading({ requestId: "parent" }))
+      }).handle({
+        Loading: {
+          invoke: Machine.invokeMachine({ child: Child, input: { userId: "configured" } })
+        }
+      })
+
+      const [first, second] = yield* Effect.all(
+        [Machine.start(parentMachine), Machine.start(parentMachine)],
+        { concurrency: "unbounded" }
+      )
+      const [firstChild, secondChild] = yield* Effect.all([first.child(Child), second.child(Child)])
+
+      assert.strictEqual(starts, 2)
+      assert(Option.isSome(firstChild))
+      assert(Option.isSome(secondChild))
+      assert.notStrictEqual(firstChild.value, secondChild.value)
+      assert.deepStrictEqual(yield* firstChild.value.state, {
+        path: "Idle",
+        value: new Idle({ userId: "configured" })
+      })
+      yield* Effect.all([first.stop, second.stop], { concurrency: "unbounded" })
+    }))
+
+  it.effect("delivers completion from an initially final compiled child", () =>
+    Effect.gen(function*() {
+      class ChildFinished extends Schema.TaggedClass<ChildFinished>("ChildFinished")("ChildFinished", {
+        output: Schema.String
+      }) {}
+      const childStates = Machine.defineStates({
+        Success: { schema: Success, type: "final", output: Schema.String }
+      })
+      const childMachine = Machine.make({
+        states: childStates.states,
+        events: [],
+        initial: () => childStates.initial.Success(new Success({ requestId: "child-output" }))
+      }).handle({
+        Success: { output: ({ state }) => state.requestId }
+      })
+      const Child = Machine.child("final-child", childMachine)
+      const parentStates = Machine.defineStates({
+        Loading,
+        Success: { schema: Success, type: "final", output: Schema.String }
+      })
+      const parentMachine = Machine.make({
+        states: parentStates.states,
+        events: [ChildFinished],
+        initial: () => parentStates.initial.Loading(new Loading({ requestId: "parent" }))
+      }).handle({
+        Loading: {
+          invoke: Machine.invokeMachine({
+            child: Child,
+            onDone: ({ output }) => new ChildFinished({ output })
+          }),
+          on: {
+            ChildFinished: ({ event, target }) => target.full.Success(new Success({ requestId: event.output }))
+          }
+        },
+        Success: { output: ({ state }) => state.requestId }
+      })
+
+      const parent = yield* Machine.start(parentMachine)
+
+      assert.strictEqual(yield* parent.join, "child-output")
+    }))
+
   it.effect("keeps input-bearing process descriptors instance-specific", () =>
     Effect.gen(function*() {
       const states = Machine.defineStates({ Idle })


### PR DESCRIPTION
## Summary

- start eligible compiled invoked machines directly from their synchronous initial kernel while preserving the existing Effect-based transition, service, scope, observation, and completion semantics
- compile each `Machine.invokeMachine` process descriptor once while keeping initialization and runtime state isolated per parent instance
- cover input-bearing descriptor reuse and initially-final child completion

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (no examples changed)
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed (local budgets pass; no public API change)
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed

The final five-process CI comparison improves parent-plus-child lifecycle from 39,373 to 45,304 families/s (+15.1%) with standalone lifecycle +0.3%. Parent-plus-child heap changes by +0.5% (about 25 bytes); local focused runs measured +13.9% aggregate / +14.7% paired-median lifecycle with all nine pairs positive.
