### PR TITLE
Optimize idle invoked child teardown

### DIFF
--- a/.changeset/synchronous-owned-child-teardown.md
+++ b/.changeset/synchronous-owned-child-teardown.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Use the compact synchronous teardown path for idle compiled invoked children while preserving ownership cleanup and stopped completion behavior.

--- a/src/internal/machineRuntime.ts
+++ b/src/internal/machineRuntime.ts
@@ -1785,8 +1785,9 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
   private finishIdleChildlessStop(): boolean {
     if (
       this.logic[childlessProcess] !== true || this.draining || this.worker !== undefined ||
-      this.requestedTermination !== undefined || this.options.onOutcome !== undefined ||
-      this.options.onStop !== undefined || this.options.onStopSync !== undefined ||
+      this.requestedTermination !== undefined ||
+      (this.options.onOutcome !== undefined && this.options.skipStoppedOutcome !== true) ||
+      this.options.onStop !== undefined ||
       this.current.changes !== undefined ||
       this.current.terminalizing || this.current.snapshot.status !== "active"
     ) {
@@ -1806,6 +1807,7 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
     if (this.compiledContext !== undefined) {
       this.compiledContext.executionState = undefined
     }
+    this.options.onStopSync?.()
     this.completion = CompiledStoppedCompletion
     if (this.waiter !== undefined) {
       Deferred.doneUnsafe(this.waiter, this.resolveCompletion(CompiledStoppedCompletion))

--- a/test/Machine.test.ts
+++ b/test/Machine.test.ts
@@ -4132,6 +4132,38 @@ describe("Machine", () => {
       yield* second.stop
     }))
 
+  it.effect("stops an idle compiled invoked child with its parent", () =>
+    Effect.gen(function*() {
+      const childStates = Machine.defineStates({ Idle })
+      const childMachine = Machine.make({
+        states: childStates.states,
+        events: [],
+        initial: () => childStates.initial.Idle(new Idle({ userId: "child" }))
+      }).handle({ Idle: {} })
+      const Child = Machine.child("owned-child", childMachine)
+      const parentStates = Machine.defineStates({ Loading })
+      const parentMachine = Machine.make({
+        states: parentStates.states,
+        events: [],
+        initial: () => parentStates.initial.Loading(new Loading({ requestId: "parent" }))
+      }).handle({
+        Loading: { invoke: Machine.invokeMachine({ child: Child }) }
+      })
+
+      const parent = yield* Machine.start(parentMachine)
+      const child = yield* parent.child(Child)
+      assert(Option.isSome(child))
+
+      yield* parent.stop
+
+      assert.deepStrictEqual(yield* child.value.snapshot, {
+        status: "stopped",
+        state: { path: "Idle", value: new Idle({ userId: "child" }) }
+      })
+      assert.instanceOf(yield* Effect.flip(child.value.join), Machine.StoppedError)
+      assert(Option.isNone(yield* parent.child(Child)))
+    }))
+
   it.effect("evaluates precompiled input-bearing invoked children for every start", () =>
     Effect.gen(function*() {
       let starts = 0


### PR DESCRIPTION
## Summary

- let idle compiled invoked children use the compact synchronous stop path when stopped outcomes are intentionally skipped
- preserve owner unregistration, terminal snapshots, and typed stopped completion
- cover parent-owned child teardown with a focused regression test

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed

Local focused validation used 11 alternating same-Node processes: the child lifecycle paired median improved by 8.0%, with all 11 pairs positive. Parent-with-child retained heap remained effectively flat (5009.91 to 5009.95 bytes per family).

The five-process CI report confirmed +5.3% parent-with-child lifecycle throughput, effectively flat standalone/other runtime paths, unchanged type instantiations, and unchanged retained heap.