### PR TITLE
Update Effect and XState benchmark runtimes

### DIFF
--- a/.changeset/fresh-runtimes-align.md
+++ b/.changeset/fresh-runtimes-align.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Update the supported Effect 4 beta to 4.0.0-beta.107, preserve schema-arbitrary diagnostics across Effect's new generator factory API, and refresh the XState v6 runtime benchmark baseline to 6.0.0-alpha.31.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Schema-first state machines and statecharts for Effect.
 ## Installation
 
 ```sh
-pnpm add @typeonce/effect-machine effect@4.0.0-beta.105
+pnpm add @typeonce/effect-machine effect@4.0.0-beta.107
 ```
 
 `effect` is an exact peer dependency, not a bundled runtime dependency.
-Consumers must install `effect@4.0.0-beta.105`. Upgrading this package may
+Consumers must install `effect@4.0.0-beta.107`. Upgrading this package may
 require upgrading Effect in lockstep; do not override the peer to another beta.
 
 ## Entrypoints

--- a/examples/platformer/package.json
+++ b/examples/platformer/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@typeonce/effect-machine": "file:../..",
-    "effect": "4.0.0-beta.105"
+    "effect": "4.0.0-beta.107"
   },
   "devDependencies": {
     "typescript": "6.0.3",

--- a/examples/platformer/pnpm-lock.yaml
+++ b/examples/platformer/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  effect: 4.0.0-beta.105
+  effect: 4.0.0-beta.107
 
 importers:
 
@@ -13,10 +13,10 @@ importers:
     dependencies:
       '@typeonce/effect-machine':
         specifier: file:../..
-        version: file:../..(effect@4.0.0-beta.105)
+        version: file:../..(effect@4.0.0-beta.107)
       effect:
-        specifier: 4.0.0-beta.105
-        version: 4.0.0-beta.105
+        specifier: 4.0.0-beta.107
+        version: 4.0.0-beta.107
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -190,7 +190,7 @@ packages:
     resolution: {directory: ../.., type: directory}
     engines: {node: '>=20'}
     peerDependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-beta.107
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -245,8 +245,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  effect@4.0.0-beta.105:
-    resolution: {integrity: sha512-7U5OzWVNlpnZFvXiZfOeu8V+dCQUa3Om569HnYG2Dx8C8V6uoKS920kFJkIDEYVhlSGhzkRqaGKmYY9bPkBMMQ==}
+  effect@4.0.0-beta.107:
+    resolution: {integrity: sha512-OoBAv8eF+yanc+C6xhgEUnWeXUSHA6ynnscYqpkAY9GSnzZWystsIjBowVqCkLpHGlnRtdIqYT3wHwpOY6JDnQ==}
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
@@ -637,9 +637,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@typeonce/effect-machine@file:../..(effect@4.0.0-beta.105)':
+  '@typeonce/effect-machine@file:../..(effect@4.0.0-beta.107)':
     dependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-beta.107
 
   '@types/chai@5.2.3':
     dependencies:
@@ -699,7 +699,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  effect@4.0.0-beta.105:
+  effect@4.0.0-beta.107:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.9.0

--- a/examples/platformer/pnpm-workspace.yaml
+++ b/examples/platformer/pnpm-workspace.yaml
@@ -2,9 +2,9 @@ packages:
   - "."
 
 overrides:
-  effect: 4.0.0-beta.105
+  effect: 4.0.0-beta.107
 
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
-  - effect@4.0.0-beta.105
+  - effect
   - vite@8.1.5

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -13,16 +13,16 @@
     "check": "pnpm test && pnpm build"
   },
   "dependencies": {
-    "@effect/atom-react": "4.0.0-beta.105",
+    "@effect/atom-react": "4.0.0-beta.107",
     "@tanstack/react-router": "1.170.18",
     "@typeonce/effect-machine": "file:../..",
-    "effect": "4.0.0-beta.105",
+    "effect": "4.0.0-beta.107",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "scheduler": "0.27.0"
   },
   "devDependencies": {
-    "@effect/vitest": "4.0.0-beta.105",
+    "@effect/vitest": "4.0.0-beta.107",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.2",
     "@vitejs/plugin-react": "6.0.4",

--- a/examples/playground/pnpm-lock.yaml
+++ b/examples/playground/pnpm-lock.yaml
@@ -5,26 +5,26 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  effect: 4.0.0-beta.105
-  '@effect/atom-react': 4.0.0-beta.105
-  '@effect/vitest': 4.0.0-beta.105
+  effect: 4.0.0-beta.107
+  '@effect/atom-react': 4.0.0-beta.107
+  '@effect/vitest': 4.0.0-beta.107
 
 importers:
 
   .:
     dependencies:
       '@effect/atom-react':
-        specifier: 4.0.0-beta.105
-        version: 4.0.0-beta.105(effect@4.0.0-beta.105)(react@19.2.7)(scheduler@0.27.0)
+        specifier: 4.0.0-beta.107
+        version: 4.0.0-beta.107(effect@4.0.0-beta.107)(react@19.2.7)(scheduler@0.27.0)
       '@tanstack/react-router':
         specifier: 1.170.18
         version: 1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@typeonce/effect-machine':
         specifier: file:../..
-        version: file:../..(effect@4.0.0-beta.105)
+        version: file:../..(effect@4.0.0-beta.107)
       effect:
-        specifier: 4.0.0-beta.105
-        version: 4.0.0-beta.105
+        specifier: 4.0.0-beta.107
+        version: 4.0.0-beta.107
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -36,8 +36,8 @@ importers:
         version: 0.27.0
     devDependencies:
       '@effect/vitest':
-        specifier: 4.0.0-beta.105
-        version: 4.0.0-beta.105(effect@4.0.0-beta.105)(vitest@4.1.10(vite@8.1.5(yaml@2.9.0)))
+        specifier: 4.0.0-beta.107
+        version: 4.0.0-beta.107(effect@4.0.0-beta.107)(vitest@4.1.10(vite@8.1.5(yaml@2.9.0)))
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
@@ -59,17 +59,17 @@ importers:
 
 packages:
 
-  '@effect/atom-react@4.0.0-beta.105':
-    resolution: {integrity: sha512-ldHOwlnrHMYCDb6ln6+uR+LwYV8Q2aQksaXQ92wAxP+YMvIpXP8PVfBdBoAooagmj9hGBgbyRnyE+wnjQRPkTQ==}
+  '@effect/atom-react@4.0.0-beta.107':
+    resolution: {integrity: sha512-dSx8Mmgge8oy3On8k95V3dyaRo9od8Eg0our56PIrTlRZBBRLXM2vc/X7GsxAYtHs2PMracVFUJqizXCcPsCyQ==}
     peerDependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-beta.107
       react: '>=19.2.7 <20.0.0'
       scheduler: '>=0.27.0 <0.28.0'
 
-  '@effect/vitest@4.0.0-beta.105':
-    resolution: {integrity: sha512-2t1J/H/+9hAKDC1S3iFyUVZJhdMpKvuggnOGNXPTmxZcVdxG/VkhjQjo7wzOHWs6SZcX8Cr/EsB+uiVAn9G0Ng==}
+  '@effect/vitest@4.0.0-beta.107':
+    resolution: {integrity: sha512-n4/qsx4DnT4dEI/wNgMivxyUeJoeiU1TCSz0WnoHWk/dny40Oxjip2P9IXGQDgPb9fsYVnerF0QRA6nPUuExQA==}
     peerDependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-beta.107
       vitest: '>=4.1.0 <5.0.0'
 
   '@emnapi/core@1.11.1':
@@ -256,7 +256,7 @@ packages:
     resolution: {directory: ../.., type: directory}
     engines: {node: '>=20'}
     peerDependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-beta.107
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -338,8 +338,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  effect@4.0.0-beta.105:
-    resolution: {integrity: sha512-7U5OzWVNlpnZFvXiZfOeu8V+dCQUa3Om569HnYG2Dx8C8V6uoKS920kFJkIDEYVhlSGhzkRqaGKmYY9bPkBMMQ==}
+  effect@4.0.0-beta.107:
+    resolution: {integrity: sha512-OoBAv8eF+yanc+C6xhgEUnWeXUSHA6ynnscYqpkAY9GSnzZWystsIjBowVqCkLpHGlnRtdIqYT3wHwpOY6JDnQ==}
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
@@ -658,15 +658,15 @@ packages:
 
 snapshots:
 
-  '@effect/atom-react@4.0.0-beta.105(effect@4.0.0-beta.105)(react@19.2.7)(scheduler@0.27.0)':
+  '@effect/atom-react@4.0.0-beta.107(effect@4.0.0-beta.107)(react@19.2.7)(scheduler@0.27.0)':
     dependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-beta.107
       react: 19.2.7
       scheduler: 0.27.0
 
-  '@effect/vitest@4.0.0-beta.105(effect@4.0.0-beta.105)(vitest@4.1.10(vite@8.1.5(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-beta.107(effect@4.0.0-beta.107)(vitest@4.1.10(vite@8.1.5(yaml@2.9.0)))':
     dependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-beta.107
       vitest: 4.1.10(vite@8.1.5(yaml@2.9.0))
 
   '@emnapi/core@1.11.1':
@@ -799,9 +799,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@typeonce/effect-machine@file:../..(effect@4.0.0-beta.105)':
+  '@typeonce/effect-machine@file:../..(effect@4.0.0-beta.107)':
     dependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-beta.107
 
   '@types/chai@5.2.3':
     dependencies:
@@ -878,7 +878,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  effect@4.0.0-beta.105:
+  effect@4.0.0-beta.107:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.9.0

--- a/examples/playground/pnpm-workspace.yaml
+++ b/examples/playground/pnpm-workspace.yaml
@@ -2,12 +2,12 @@ packages:
   - "."
 
 overrides:
-  effect: 4.0.0-beta.105
-  "@effect/atom-react": 4.0.0-beta.105
-  "@effect/vitest": 4.0.0-beta.105
+  effect: 4.0.0-beta.107
+  "@effect/atom-react": 4.0.0-beta.107
+  "@effect/vitest": 4.0.0-beta.107
 
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
-  - effect@4.0.0-beta.105
-  - "@effect/atom-react@4.0.0-beta.105"
-  - "@effect/vitest@4.0.0-beta.105"
+  - effect
+  - "@effect/atom-react"
+  - "@effect/vitest"

--- a/examples/pokemon/package.json
+++ b/examples/pokemon/package.json
@@ -12,10 +12,10 @@
     "check": "pnpm build"
   },
   "dependencies": {
-    "@effect/atom-react": "4.0.0-beta.105",
+    "@effect/atom-react": "4.0.0-beta.107",
     "@tanstack/react-router": "1.170.18",
     "@typeonce/effect-machine": "file:../..",
-    "effect": "4.0.0-beta.105",
+    "effect": "4.0.0-beta.107",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "scheduler": "0.27.0"

--- a/examples/pokemon/pnpm-lock.yaml
+++ b/examples/pokemon/pnpm-lock.yaml
@@ -5,25 +5,25 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  effect: 4.0.0-beta.105
-  '@effect/atom-react': 4.0.0-beta.105
+  effect: 4.0.0-beta.107
+  '@effect/atom-react': 4.0.0-beta.107
 
 importers:
 
   .:
     dependencies:
       '@effect/atom-react':
-        specifier: 4.0.0-beta.105
-        version: 4.0.0-beta.105(effect@4.0.0-beta.105)(react@19.2.7)(scheduler@0.27.0)
+        specifier: 4.0.0-beta.107
+        version: 4.0.0-beta.107(effect@4.0.0-beta.107)(react@19.2.7)(scheduler@0.27.0)
       '@tanstack/react-router':
         specifier: 1.170.18
         version: 1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@typeonce/effect-machine':
         specifier: file:../..
-        version: file:../..(effect@4.0.0-beta.105)
+        version: file:../..(effect@4.0.0-beta.107)
       effect:
-        specifier: 4.0.0-beta.105
-        version: 4.0.0-beta.105
+        specifier: 4.0.0-beta.107
+        version: 4.0.0-beta.107
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -52,10 +52,10 @@ importers:
 
 packages:
 
-  '@effect/atom-react@4.0.0-beta.105':
-    resolution: {integrity: sha512-ldHOwlnrHMYCDb6ln6+uR+LwYV8Q2aQksaXQ92wAxP+YMvIpXP8PVfBdBoAooagmj9hGBgbyRnyE+wnjQRPkTQ==}
+  '@effect/atom-react@4.0.0-beta.107':
+    resolution: {integrity: sha512-dSx8Mmgge8oy3On8k95V3dyaRo9od8Eg0our56PIrTlRZBBRLXM2vc/X7GsxAYtHs2PMracVFUJqizXCcPsCyQ==}
     peerDependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-beta.107
       react: '>=19.2.7 <20.0.0'
       scheduler: '>=0.27.0 <0.28.0'
 
@@ -395,7 +395,7 @@ packages:
     resolution: {directory: ../.., type: directory}
     engines: {node: '>=20'}
     peerDependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-beta.107
 
   '@types/react-dom@19.2.2':
     resolution: {integrity: sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==}
@@ -428,8 +428,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  effect@4.0.0-beta.105:
-    resolution: {integrity: sha512-7U5OzWVNlpnZFvXiZfOeu8V+dCQUa3Om569HnYG2Dx8C8V6uoKS920kFJkIDEYVhlSGhzkRqaGKmYY9bPkBMMQ==}
+  effect@4.0.0-beta.107:
+    resolution: {integrity: sha512-OoBAv8eF+yanc+C6xhgEUnWeXUSHA6ynnscYqpkAY9GSnzZWystsIjBowVqCkLpHGlnRtdIqYT3wHwpOY6JDnQ==}
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -667,9 +667,9 @@ packages:
 
 snapshots:
 
-  '@effect/atom-react@4.0.0-beta.105(effect@4.0.0-beta.105)(react@19.2.7)(scheduler@0.27.0)':
+  '@effect/atom-react@4.0.0-beta.107(effect@4.0.0-beta.107)(react@19.2.7)(scheduler@0.27.0)':
     dependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-beta.107
       react: 19.2.7
       scheduler: 0.27.0
 
@@ -879,9 +879,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@typeonce/effect-machine@file:../..(effect@4.0.0-beta.105)':
+  '@typeonce/effect-machine@file:../..(effect@4.0.0-beta.107)':
     dependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-beta.107
 
   '@types/react-dom@19.2.2(@types/react@19.2.17)':
     dependencies:
@@ -902,7 +902,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  effect@4.0.0-beta.105:
+  effect@4.0.0-beta.107:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.9.0

--- a/examples/pokemon/pnpm-workspace.yaml
+++ b/examples/pokemon/pnpm-workspace.yaml
@@ -2,12 +2,12 @@ packages:
   - "."
 
 overrides:
-  effect: 4.0.0-beta.105
-  "@effect/atom-react": 4.0.0-beta.105
+  effect: 4.0.0-beta.107
+  "@effect/atom-react": 4.0.0-beta.107
 
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
-  - effect@4.0.0-beta.105
-  - "@effect/atom-react@4.0.0-beta.105"
+  - effect
+  - "@effect/atom-react"
   - vite@8.1.5
   - "@vitejs/plugin-react@6.0.4"

--- a/package.json
+++ b/package.json
@@ -61,20 +61,20 @@
     "release": "pnpm build && changeset publish"
   },
   "peerDependencies": {
-    "effect": "4.0.0-beta.105"
+    "effect": "4.0.0-beta.107"
   },
   "devDependencies": {
     "@changesets/cli": "2.31.0",
-    "@effect/vitest": "4.0.0-beta.105",
+    "@effect/vitest": "4.0.0-beta.107",
     "@types/node": "25.7.0",
     "dprint": "0.55.2",
-    "effect": "4.0.0-beta.105",
+    "effect": "4.0.0-beta.107",
     "tinybench": "2.9.0",
     "tstyche": "7.2.1",
     "typescript": "6.0.3",
     "vitest": "4.1.10",
     "xstate-v5": "npm:xstate@5.32.5",
-    "xstate-v6": "npm:xstate@6.0.0-alpha.27"
+    "xstate-v6": "npm:xstate@6.0.0-alpha.31"
   },
   "packageManager": "pnpm@10.17.1",
   "engines": {

--- a/perf/runtime/README.md
+++ b/perf/runtime/README.md
@@ -32,7 +32,7 @@ The comparison dependencies use package aliases, so XState 5 and 6 can be
 loaded by the same process:
 
 - `xstate-v5`: `xstate@5.32.5`, the stable v5 baseline;
-- `xstate-v6`: `xstate@6.0.0-alpha.27`, the latest published v6 alpha available
+- `xstate-v6`: `xstate@6.0.0-alpha.31`, the latest published v6 alpha available
   when the harness was added.
 
 All implementations use the same flat counter topology, immutable events, and

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  effect: 4.0.0-beta.105
-  '@effect/vitest': 4.0.0-beta.105
+  effect: 4.0.0-beta.107
+  '@effect/vitest': 4.0.0-beta.107
 
 importers:
 
@@ -16,8 +16,8 @@ importers:
         specifier: 2.31.0
         version: 2.31.0(@types/node@25.7.0)
       '@effect/vitest':
-        specifier: 4.0.0-beta.105
-        version: 4.0.0-beta.105(effect@4.0.0-beta.105)(vitest@4.1.10(@types/node@25.7.0)(vite@8.1.5(@types/node@25.7.0)(yaml@2.9.0)))
+        specifier: 4.0.0-beta.107
+        version: 4.0.0-beta.107(effect@4.0.0-beta.107)(vitest@4.1.10(@types/node@25.7.0)(vite@8.1.5(@types/node@25.7.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 25.7.0
         version: 25.7.0
@@ -25,8 +25,8 @@ importers:
         specifier: 0.55.2
         version: 0.55.2
       effect:
-        specifier: 4.0.0-beta.105
-        version: 4.0.0-beta.105
+        specifier: 4.0.0-beta.107
+        version: 4.0.0-beta.107
       tinybench:
         specifier: 2.9.0
         version: 2.9.0
@@ -43,8 +43,8 @@ importers:
         specifier: npm:xstate@5.32.5
         version: xstate@5.32.5
       xstate-v6:
-        specifier: npm:xstate@6.0.0-alpha.27
-        version: xstate@6.0.0-alpha.27
+        specifier: npm:xstate@6.0.0-alpha.31
+        version: xstate@6.0.0-alpha.31
 
 packages:
 
@@ -191,10 +191,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@effect/vitest@4.0.0-beta.105':
-    resolution: {integrity: sha512-2t1J/H/+9hAKDC1S3iFyUVZJhdMpKvuggnOGNXPTmxZcVdxG/VkhjQjo7wzOHWs6SZcX8Cr/EsB+uiVAn9G0Ng==}
+  '@effect/vitest@4.0.0-beta.107':
+    resolution: {integrity: sha512-n4/qsx4DnT4dEI/wNgMivxyUeJoeiU1TCSz0WnoHWk/dny40Oxjip2P9IXGQDgPb9fsYVnerF0QRA6nPUuExQA==}
     peerDependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-beta.107
       vitest: '>=4.1.0 <5.0.0'
 
   '@emnapi/core@1.11.1':
@@ -483,8 +483,8 @@ packages:
     resolution: {integrity: sha512-1d4D4SB9KiD2qFnBWbl3aoYjLvPVpZoth28yxTT00xJv2yXugdz0Xoyv7sGG0w0hzE6hQZMgd6B333GnySDpGQ==}
     hasBin: true
 
-  effect@4.0.0-beta.105:
-    resolution: {integrity: sha512-7U5OzWVNlpnZFvXiZfOeu8V+dCQUa3Om569HnYG2Dx8C8V6uoKS920kFJkIDEYVhlSGhzkRqaGKmYY9bPkBMMQ==}
+  effect@4.0.0-beta.107:
+    resolution: {integrity: sha512-OoBAv8eF+yanc+C6xhgEUnWeXUSHA6ynnscYqpkAY9GSnzZWystsIjBowVqCkLpHGlnRtdIqYT3wHwpOY6JDnQ==}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -1019,8 +1019,8 @@ packages:
   xstate@5.32.5:
     resolution: {integrity: sha512-ULazi1oe6wGrXl0Frb6otSlkm5HLifbbVTkMk5kkSKqz4TkxJaVpnl6jOJwKeid3ORPxYyZQgNLUSYX9q65SIA==}
 
-  xstate@6.0.0-alpha.27:
-    resolution: {integrity: sha512-gpJrSoIBWE2jguo8kNGQulNdWNPtzi4nhDvzOKh9VP3M+UHc7ISFqvLRpO2xmGjW5pvpv1sE0beK8rJ2cGFJMQ==}
+  xstate@6.0.0-alpha.31:
+    resolution: {integrity: sha512-nWdxu+Rg95zBMg8jwtKtSY3WMpe9ZgOe0ZwxOMKIdpuRUnlvAK+u9bIP2T3j+xWW3Oec/paNBVYT5J55Ya0DxA==}
     hasBin: true
 
   yaml@2.9.0:
@@ -1220,9 +1220,9 @@ snapshots:
   '@dprint/win32-x64@0.55.2':
     optional: true
 
-  '@effect/vitest@4.0.0-beta.105(effect@4.0.0-beta.105)(vitest@4.1.10(@types/node@25.7.0)(vite@8.1.5(@types/node@25.7.0)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-beta.107(effect@4.0.0-beta.107)(vitest@4.1.10(@types/node@25.7.0)(vite@8.1.5(@types/node@25.7.0)(yaml@2.9.0)))':
     dependencies:
-      effect: 4.0.0-beta.105
+      effect: 4.0.0-beta.107
       vitest: 4.1.10(@types/node@25.7.0)(vite@8.1.5(@types/node@25.7.0)(yaml@2.9.0))
 
   '@emnapi/core@1.11.1':
@@ -1479,7 +1479,7 @@ snapshots:
       '@dprint/win32-arm64': 0.55.2
       '@dprint/win32-x64': 0.55.2
 
-  effect@4.0.0-beta.105:
+  effect@4.0.0-beta.107:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.9.0
@@ -1900,7 +1900,7 @@ snapshots:
 
   xstate@5.32.5: {}
 
-  xstate@6.0.0-alpha.27: {}
+  xstate@6.0.0-alpha.31: {}
 
   yaml@2.9.0:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,10 +2,11 @@ packages:
   - "."
 
 overrides:
-  effect: 4.0.0-beta.105
-  "@effect/vitest": 4.0.0-beta.105
+  effect: 4.0.0-beta.107
+  "@effect/vitest": 4.0.0-beta.107
 
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
-  - effect@4.0.0-beta.105
-  - "@effect/vitest@4.0.0-beta.105"
+  - effect
+  - "@effect/vitest"
+  - xstate-v6

--- a/scripts/fixtures/consumer/effect-beta-compat.d.ts
+++ b/scripts/fixtures/consumer/effect-beta-compat.d.ts
@@ -1,6 +1,6 @@
 import "effect/SchemaAST"
 
-// effect@4.0.0-beta.105 references this internal type from Schema.d.ts but
+// effect@4.0.0-beta.107 references this internal type from Schema.d.ts but
 // omits it from the published SchemaAST.d.ts declaration.
 declare module "effect/SchemaAST" {
   export interface Sentinel {

--- a/src/MachineTest.ts
+++ b/src/MachineTest.ts
@@ -11,6 +11,7 @@ import * as Schema from "effect/Schema"
 import * as SchemaAST from "effect/SchemaAST"
 import { FastCheck } from "effect/testing"
 import type { EnsureExecutable } from "./internal/machineReadiness.js"
+import { type SchemaArbitraryReport, toArbitraryWithReport } from "./internal/machineTestArbitrary.js"
 import type { FiniteModel } from "./internal/machineTestFiniteModel.js"
 import * as ReferenceModel from "./internal/machineTestReferenceModel.js"
 import * as Machine from "./Machine.js"
@@ -39,6 +40,12 @@ export {
   sendCommand,
   stopCommand
 } from "./internal/machineTestRuntime.js"
+
+export type {
+  SchemaArbitraryOpaqueFilterWarning,
+  SchemaArbitraryReport,
+  SchemaArbitraryWarning
+} from "./internal/machineTestArbitrary.js"
 
 export {
   compileModel,
@@ -161,7 +168,7 @@ export type ScenarioOptions<M extends AnyMachine> =
 export interface SchemaArbitraryDiagnostic {
   readonly boundary: "input" | "event"
   readonly index: number | undefined
-  readonly report: Schema.Annotations.ToArbitrary.Report
+  readonly report: SchemaArbitraryReport
 }
 
 /**
@@ -224,7 +231,7 @@ export const scenarios = <M extends AnyMachine>(
   const diagnostics: Array<SchemaArbitraryDiagnostic> = []
   const eventArbitraries = options.eventsArbitrary === undefined
     ? machine.events.map((schema, index) => {
-      const derived = Schema.toArbitrary(schema, { report: true })
+      const derived = toArbitraryWithReport(schema)
       diagnostics.push({
         boundary: "event",
         index,
@@ -264,7 +271,7 @@ export const scenarios = <M extends AnyMachine>(
   if (options.inputArbitrary !== undefined) {
     inputArbitrary = options.inputArbitrary
   } else {
-    const derived = Schema.toArbitrary(machine.input, { report: true })
+    const derived = toArbitraryWithReport(machine.input)
     diagnostics.unshift({
       boundary: "input",
       index: undefined,

--- a/src/internal/machineTestArbitrary.ts
+++ b/src/internal/machineTestArbitrary.ts
@@ -1,0 +1,102 @@
+import * as Schema from "effect/Schema"
+import * as SchemaAST from "effect/SchemaAST"
+import { FastCheck } from "effect/testing"
+
+/**
+ * Warning emitted when schema arbitrary generation must enforce an opaque
+ * filter through rejection sampling.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface SchemaArbitraryOpaqueFilterWarning {
+  readonly _tag: "OpaqueFilter"
+  readonly path: ReadonlyArray<PropertyKey>
+  readonly description?: string
+}
+
+/**
+ * Non-fatal diagnostic emitted while deriving a schema arbitrary.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type SchemaArbitraryWarning = SchemaArbitraryOpaqueFilterWarning
+
+/**
+ * Diagnostics collected while deriving a schema arbitrary.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface SchemaArbitraryReport {
+  readonly warnings: ReadonlyArray<SchemaArbitraryWarning>
+}
+
+const reportChecks = (
+  warnings: Array<SchemaArbitraryWarning>,
+  checks: SchemaAST.Checks | undefined,
+  path: ReadonlyArray<PropertyKey>
+): void => {
+  const visit = (check: SchemaAST.Check<unknown>, covered: boolean): void => {
+    const arbitrary = check.annotations?.arbitrary
+    const nextCovered = covered || arbitrary?.constraint !== undefined || arbitrary?.candidate !== undefined
+    if (check._tag !== "Filter") {
+      for (const child of check.checks) visit(child, nextCovered)
+    } else if (!nextCovered) {
+      const description = check.annotations?.representation?.id ?? check.annotations?.identifier ??
+        check.annotations?.expected
+      warnings.push({
+        _tag: "OpaqueFilter",
+        path,
+        ...(description === undefined ? {} : { description })
+      })
+    }
+  }
+  checks?.forEach((check) => visit(check, false))
+}
+
+const reportFor = (ast: SchemaAST.AST): SchemaArbitraryReport => {
+  const warnings: Array<SchemaArbitraryWarning> = []
+  const stack = new WeakSet<SchemaAST.AST>()
+  const visit = (ast: SchemaAST.AST, path: ReadonlyArray<PropertyKey>): void => {
+    if (stack.has(ast)) return
+    stack.add(ast)
+    reportChecks(warnings, ast.checks, path)
+    switch (ast._tag) {
+      case "Declaration":
+        ast.typeParameters.forEach((typeParameter) => visit(typeParameter, path))
+        break
+      case "Arrays": {
+        const elements = [...ast.elements, ...ast.rest]
+        elements.forEach((type, index) => visit(type, [...path, index]))
+        break
+      }
+      case "Objects":
+        ast.propertySignatures.forEach((property) => visit(property.type, [...path, property.name]))
+        ast.indexSignatures.forEach((index) => {
+          visit(index.parameter, path)
+          visit(index.type, path)
+        })
+        break
+      case "Union":
+        ast.types.forEach((type) => visit(type, path))
+        break
+      case "TemplateLiteral":
+        ast.parts.forEach((part, index) => visit(SchemaAST.toEncoded(part), [...path, index]))
+        break
+      case "Suspend":
+        visit(ast.thunk(), path)
+        break
+    }
+    stack.delete(ast)
+  }
+  visit(ast, [])
+  return { warnings }
+}
+
+/** @internal */
+export const toArbitraryWithReport = <S extends Schema.Constraint>(schema: S) => ({
+  value: Schema.toArbitrary(schema)(FastCheck),
+  report: reportFor(schema.ast)
+})

--- a/src/internal/machineTestRuntime.ts
+++ b/src/internal/machineTestRuntime.ts
@@ -15,6 +15,7 @@ import * as Schema from "effect/Schema"
 import * as Stream from "effect/Stream"
 import { FastCheck, TestClock } from "effect/testing"
 import * as Machine from "../Machine.js"
+import { type SchemaArbitraryReport, toArbitraryWithReport } from "./machineTestArbitrary.js"
 
 type AnyMachine = Machine.Machine.Any
 
@@ -707,7 +708,7 @@ export interface RuntimeCommandsOptions<M extends AnyMachine> {
  */
 export interface RuntimeCommandsDiagnostics {
   readonly events: "none" | "schema" | "override"
-  readonly schemaReports: ReadonlyArray<Schema.Annotations.ToArbitrary.Report>
+  readonly schemaReports: ReadonlyArray<SchemaArbitraryReport>
   readonly includesAdvance: boolean
   readonly includesStop: boolean
   readonly includesCheckpoint: boolean
@@ -753,10 +754,10 @@ export const runtimeCommands = <M extends AnyMachine>(
     throw new Error("MachineTest.runtimeCommands expected minCommands to be less than or equal to maxCommands")
   }
 
-  const reports: Array<Schema.Annotations.ToArbitrary.Report> = []
+  const reports: Array<SchemaArbitraryReport> = []
   const eventArbitraries = options.eventArbitrary === undefined
     ? machine.events.map((schema) => {
-      const derived = Schema.toArbitrary(schema, { report: true })
+      const derived = toArbitraryWithReport(schema)
       reports.push(derived.report)
       return derived.value as FastCheck.Arbitrary<Machine.Machine.InputEvent<M>>
     })

--- a/test/MachineTest.test.ts
+++ b/test/MachineTest.test.ts
@@ -96,6 +96,30 @@ describe("MachineTest", () => {
     assert.strictEqual(generated.diagnostics.events, "override")
   })
 
+  it("preserves opaque-filter diagnostics from schema-derived arbitraries", () => {
+    const PositiveInput = Schema.Struct({
+      value: Schema.Number.check(
+        Schema.makeFilter((value) => value > 0 || "value must be positive", { identifier: "Positive" })
+      )
+    })
+    const machine = Machine.make({
+      states: States.states,
+      events: [],
+      input: PositiveInput,
+      initial: () => States.initial.Idle(new Idle({ userId: "user-1" }))
+    })
+
+    const generated = MachineTest.scenarios(machine)
+
+    assert.deepStrictEqual(generated.diagnostics.schemas, [{
+      boundary: "input",
+      index: undefined,
+      report: {
+        warnings: [{ _tag: "OpaqueFilter", path: ["value"], description: "Positive" }]
+      }
+    }])
+  })
+
   it("rejects a non-empty minimum for machines without public events", () => {
     const machine = Machine.make({
       states: States.states,


### PR DESCRIPTION
## Summary

- update Effect, `@effect/vitest`, and example Effect packages from 4.0.0-beta.105 to 4.0.0-beta.107
- update the XState v6 benchmark alias from 6.0.0-alpha.27 to 6.0.0-alpha.31; XState v5 remains current at 5.32.5
- adapt schema-derived test arbitraries to Effect's new FastCheck factory API while preserving opaque-filter diagnostics
- refresh all workspace manifests, lockfiles, installation docs, benchmark docs, and the consumer compatibility fixture

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed

Local validation also included `pnpm perf:types`, frozen-lockfile installation, and a full `pnpm perf:runtime` run. The automated reports remain the merge gate for the repeatable base-versus-PR comparison.
