### PR TITLE
Consolidate invocation ownership

### DIFF
--- a/.changeset/calm-invokes-converge.md
+++ b/.changeset/calm-invokes-converge.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Consolidate generic and compiled state-scoped invocation lifecycle handling behind one owner-local child registry, preserving duplicate detection, stale callback isolation, and path-scoped teardown without changing the public API.

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -228,6 +228,7 @@ export const checkArchitecture = ({
       "src/internal/machine/planner.ts",
       "src/internal/machine/command.ts",
       "src/internal/machine/executionPlan.ts",
+      "src/internal/machine/invocation.ts",
       "src/internal/machine/commandRuntime.ts",
       "src/internal/machine/process.ts",
       "src/internal/machine/runtime.ts"
@@ -238,6 +239,7 @@ export const checkArchitecture = ({
       "src/internal/machine/planner.ts",
       "src/internal/machine/command.ts",
       "src/internal/machine/executionPlan.ts",
+      "src/internal/machine/invocation.ts",
       "src/internal/machine/commandRuntime.ts",
       "src/internal/machine/process.ts",
       "src/internal/machine/runtime.ts"
@@ -247,6 +249,7 @@ export const checkArchitecture = ({
       "src/internal/machine/planner.ts",
       "src/internal/machine/command.ts",
       "src/internal/machine/executionPlan.ts",
+      "src/internal/machine/invocation.ts",
       "src/internal/machine/commandRuntime.ts",
       "src/internal/machine/process.ts",
       "src/internal/machine/runtime.ts"
@@ -255,12 +258,14 @@ export const checkArchitecture = ({
       "src/internal/machine/planner.ts",
       "src/internal/machine/command.ts",
       "src/internal/machine/executionPlan.ts",
+      "src/internal/machine/invocation.ts",
       "src/internal/machine/commandRuntime.ts",
       "src/internal/machine/process.ts",
       "src/internal/machine/runtime.ts"
     ])],
     ["src/internal/machine/command.ts", new Set([
       "src/internal/machine/executionPlan.ts",
+      "src/internal/machine/invocation.ts",
       "src/internal/machine/commandRuntime.ts",
       "src/internal/machine/process.ts",
       "src/internal/machine/runtime.ts"
@@ -268,12 +273,14 @@ export const checkArchitecture = ({
     ["src/internal/machine/planner.ts", new Set([
       "src/internal/machine/serialization.ts",
       "src/internal/machine/executionPlan.ts",
+      "src/internal/machine/invocation.ts",
       "src/internal/machine/commandRuntime.ts",
       "src/internal/machine/process.ts",
       "src/internal/machine/runtime.ts"
     ])],
     ["src/internal/machine/executionPlan.ts", new Set([
       "src/internal/machine/serialization.ts",
+      "src/internal/machine/invocation.ts",
       "src/internal/machine/commandRuntime.ts",
       "src/internal/machine/process.ts",
       "src/internal/machine/runtime.ts"
@@ -324,6 +331,7 @@ export const checkArchitecture = ({
       [
         "src/internal/machine/commandRuntime.ts",
         "src/internal/machine/executionPlan.ts",
+        "src/internal/machine/invocation.ts",
         "src/internal/machine/process.ts",
         "src/internal/machine/runtime.ts"
       ].includes(edge.target)
@@ -350,6 +358,7 @@ export const checkArchitecture = ({
       [
         "src/internal/machine/configuration.ts",
         "src/internal/machine/executionPlan.ts",
+        "src/internal/machine/invocation.ts",
         "src/internal/machine/planner.ts",
         "src/internal/machine/process.ts"
       ].includes(edge.target)

--- a/scripts/check-architecture.test.mjs
+++ b/scripts/check-architecture.test.mjs
@@ -85,10 +85,11 @@ test("rejects value back-edges and execution-layer inversions", () => {
 
 test("rejects outward machine semantic dependencies", () => {
   const root = makeProject({
-    "src/internal/machine/topology.ts": 'import { decode } from "./protocol.js"\nexport const topology = decode',
-    "src/internal/machine/protocol.ts": "export const decode = 1"
+    "src/internal/machine/topology.ts": 'import { decode } from "./protocol.js"\nimport { invoke } from "./invocation.js"\nexport const topology = decode + invoke',
+    "src/internal/machine/protocol.ts": "export const decode = 1",
+    "src/internal/machine/invocation.ts": "export const invoke = 1"
   })
-  assert.deepEqual(rules(root), ["ARCH005"])
+  assert.deepEqual(rules(root), ["ARCH005", "ARCH005"])
 })
 
 test("detects runtime cycles while permitting type-only cycles", () => {

--- a/src/internal/machine/invocation.ts
+++ b/src/internal/machine/invocation.ts
@@ -1,0 +1,119 @@
+/**
+ * Internal state-scoped invocation orchestration.
+ *
+ * @since 4.0.0
+ */
+
+import * as Effect from "effect/Effect"
+import type { Machine } from "../../Machine.js"
+import * as Configuration from "./configuration.js"
+import * as Planner from "./planner.js"
+import type * as Runtime from "./runtime.js"
+
+/** @internal */
+export type AnyConfig = Machine.InvokeConfig<
+  any,
+  any,
+  any,
+  any,
+  any,
+  any,
+  any,
+  any,
+  any,
+  any,
+  any,
+  any,
+  any
+>
+
+/** @internal */
+export const makeKey = (path: string, id: string): string => `${path.length}:${path}${id}`
+
+/** @internal */
+export const makeChildId = (path: string, id: string): string => `Machine.invoke:${makeKey(path, id)}`
+
+const resolve = (
+  config: Machine.AnyStateConfig | undefined,
+  context: Machine.InvokeContext<any, any, any, any>
+): ReadonlyArray<AnyConfig> => {
+  const definition = config?.invoke
+  const invokes = typeof definition === "function" ? definition(context) : definition
+  if (invokes === undefined) return []
+  return Array.isArray(invokes) ? invokes as ReadonlyArray<AnyConfig> : [invokes as AnyConfig]
+}
+
+const runSequentialDiscard = <E, R>(
+  effects: ReadonlyArray<Effect.Effect<void, E, R>>
+): Effect.Effect<void, E, R> =>
+  effects.length === 0
+    ? Effect.void
+    : effects.length === 1
+    ? effects[0]!
+    : Effect.all(effects, { discard: true })
+
+const start = (
+  scope: Runtime.ProcessScope<any>,
+  ownedChildren: Runtime.OwnedChildRuntime,
+  path: string,
+  config: AnyConfig
+): Effect.Effect<void, any, any> =>
+  Effect.suspend(() => {
+    const invokeId = String(config.id)
+    const key = makeKey(path, invokeId)
+    const childId = config.address === undefined ? makeChildId(path, invokeId) : String(config.address)
+    return ownedChildren.spawn(config.src as () => Runtime.ProcessLogic<any, any, any, any, any, any>, {
+      key,
+      path,
+      id: childId,
+      duplicateId: invokeId,
+      ...(config.descriptor === undefined ? undefined : { descriptor: config.descriptor }),
+      sendParent: (isCurrent, event) => isCurrent() ? scope.self.send(event) : Effect.void,
+      onOutcome: (isCurrent, outcome) => {
+        if (outcome._tag === "Stopped" || !isCurrent()) return Effect.void
+        if (outcome._tag !== "Done") return scope.failCause(outcome.cause)
+        const mappedEvent = config.onDone === undefined
+          ? outcome.output
+          : config.onDone({ id: config.id, output: outcome.output })
+        return mappedEvent === undefined
+          ? Effect.void
+          : scope.self.send(mappedEvent).pipe(Effect.catchTag("StoppedError", () => Effect.void))
+      },
+      ...(config.snapshot === undefined ? undefined : {
+        onSnapshot: (isCurrent: () => boolean, snapshot: any) => {
+          if (!isCurrent()) return Effect.void
+          const mappedEvent = config.snapshot!({ id: config.id, snapshot })
+          return mappedEvent === undefined
+            ? Effect.void
+            : scope.self.send(mappedEvent).pipe(Effect.catchTag("StoppedError", () => Effect.void))
+        }
+      })
+    })
+  })
+
+/**
+ * Starts every invocation owned by active entry paths in deterministic entry
+ * order. `undefined` keeps the compiled drain free of empty Effect nodes.
+ *
+ * @internal
+ */
+export const startAll = (
+  machine: Machine.Any,
+  scope: Runtime.ProcessScope<any>,
+  ownedChildren: Runtime.OwnedChildRuntime,
+  configuration: Configuration.ActiveConfiguration,
+  paths: ReadonlyArray<string>,
+  event: Machine.LifecycleEvent<any>
+): Effect.Effect<void, any, any> | undefined => {
+  const effects = Planner.sortEntryPaths(machine, paths)
+    .filter((path) => configuration.active.has(path))
+    .flatMap((path) =>
+      resolve(Configuration.getStateConfigByPath(machine, path), {
+        state: Configuration.getActiveValue(configuration, path),
+        parent: Configuration.getParentValue(machine, configuration, path),
+        parents: Configuration.getParentValues(machine, configuration, path),
+        event
+      }).map((config) => start(scope, ownedChildren, path, config))
+    )
+  return effects.length === 0 ? undefined : runSequentialDiscard(effects)
+}

--- a/src/internal/machine/process.ts
+++ b/src/internal/machine/process.ts
@@ -6,16 +6,16 @@
 
 import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
-import * as Exit from "effect/Exit"
 import * as Option from "effect/Option"
 import * as Queue from "effect/Queue"
 import type * as Schema from "effect/Schema"
 import type { ActionError, ExecutionServices, Machine, Runtime } from "../../Machine.js"
 import * as CommandRuntime from "./commandRuntime.js"
 import * as Configuration from "./configuration.js"
-import { ChildAlreadyExistsError, InfiniteTransitionError, MachineSchemaDecodeError, StartupError } from "./errors.js"
+import { InfiniteTransitionError, MachineSchemaDecodeError, StartupError } from "./errors.js"
 import type { StoppedError } from "./errors.js"
 import * as ExecutionPlan from "./executionPlan.js"
+import * as Invocation from "./invocation.js"
 import * as internalPlanner from "./planner.js"
 import * as internalRuntime from "./runtime.js"
 import * as Serialization from "./serialization.js"
@@ -30,14 +30,6 @@ type ExcludeCompatibleRuntime<Requirements, Events, Emits> = Requirements extend
   : Requirements
   : Requirements
 
-type AnyInvokeConfig = Machine.InvokeConfig<any, any, any, any, any, any, any, any, any, any, any, any, any>
-
-interface InvokeSession {
-  readonly token: symbol
-  readonly childId: string
-  readonly path: string
-}
-
 type ProcessEntry<States extends Machine.StateSchemas, Input extends Schema.Top> =
   | {
     readonly _tag: "Initial"
@@ -48,18 +40,6 @@ type ProcessEntry<States extends Machine.StateSchemas, Input extends Schema.Top>
     readonly snapshot: Machine.Snapshot<States>
   }
 
-const getInvokes = (
-  config: Machine.AnyStateConfig | undefined,
-  context: Machine.InvokeContext<any, any, any, any>
-): ReadonlyArray<AnyInvokeConfig> => {
-  const definition = config?.invoke
-  const invokes = typeof definition === "function" ? definition(context) : definition
-  if (invokes === undefined) {
-    return []
-  }
-  return Array.isArray(invokes) ? invokes as ReadonlyArray<AnyInvokeConfig> : [invokes as AnyInvokeConfig]
-}
-
 const runSequentialDiscard = <E, R>(
   effects: ReadonlyArray<Effect.Effect<void, E, R>>
 ): Effect.Effect<void, E, R> =>
@@ -68,15 +48,6 @@ const runSequentialDiscard = <E, R>(
     : effects.length === 1
     ? effects[0]!
     : Effect.all(effects, { discard: true })
-
-const runParallelDiscard = <E, R>(
-  effects: ReadonlyArray<Effect.Effect<void, E, R>>
-): Effect.Effect<void, E, R> =>
-  effects.length === 0
-    ? Effect.void
-    : effects.length === 1
-    ? effects[0]!
-    : Effect.all(effects, { discard: true, concurrency: "unbounded" })
 
 const invokeCapabilityCache = new WeakMap<Machine.Any, boolean>()
 
@@ -90,78 +61,6 @@ const hasInvokeCapability = (machine: Machine.Any): boolean => {
   ).some((config) => config.invoke !== undefined)
   invokeCapabilityCache.set(machine, hasInvokes)
   return hasInvokes
-}
-
-const isCurrentInvoke = (
-  sessions: Map<string, InvokeSession>,
-  key: string,
-  token: symbol
-): Effect.Effect<boolean> => Effect.sync(() => sessions.get(key)?.token === token)
-
-const makeInvokeSendParent = (
-  sessions: Map<string, InvokeSession>,
-  self: internalRuntime.ProcessScope<any>["self"],
-  key: string,
-  token: symbol
-): (event: unknown) => Effect.Effect<void, StoppedError> => {
-  return (event) =>
-    isCurrentInvoke(sessions, key, token).pipe(
-      Effect.flatMap((isCurrent) => isCurrent ? self.send(event) : Effect.void)
-    )
-}
-
-const makeInvokeOutcomeHandler = (
-  sessions: Map<string, InvokeSession>,
-  self: internalRuntime.ProcessScope<any>["self"],
-  failCause: internalRuntime.ProcessScope<any>["failCause"],
-  config: AnyInvokeConfig,
-  key: string,
-  token: symbol
-): (outcome: internalRuntime.RuntimeOutcome<any, any, any>) => Effect.Effect<void> => {
-  return (outcome) => {
-    if (outcome._tag === "Stopped") {
-      return Effect.void
-    }
-    return isCurrentInvoke(sessions, key, token).pipe(
-      Effect.flatMap((isCurrent) => {
-        if (!isCurrent) {
-          return Effect.void
-        }
-        if (outcome._tag === "Done") {
-          const mappedEvent = config.onDone === undefined
-            ? outcome.output
-            : config.onDone({ id: config.id, output: outcome.output })
-          return mappedEvent === undefined
-            ? Effect.void
-            : self.send(mappedEvent).pipe(Effect.catchTag("StoppedError", () => Effect.void))
-        }
-        return failCause(outcome.cause)
-      })
-    )
-  }
-}
-
-const makeInvokeSnapshotHandler = (
-  sessions: Map<string, InvokeSession>,
-  self: internalRuntime.ProcessScope<any>["self"],
-  config: AnyInvokeConfig,
-  key: string,
-  token: symbol
-): (
-  snapshot: Extract<internalRuntime.RuntimeSnapshot<any, any, any>, { readonly status: "active" }>
-) => Effect.Effect<void> => {
-  return (snapshot) =>
-    isCurrentInvoke(sessions, key, token).pipe(
-      Effect.flatMap((isCurrent) => {
-        if (!isCurrent || config.snapshot === undefined) {
-          return Effect.void
-        }
-        const mappedEvent = config.snapshot({ id: config.id, snapshot })
-        return mappedEvent === undefined
-          ? Effect.void
-          : self.send(mappedEvent).pipe(Effect.catchTag("StoppedError", () => Effect.void))
-      })
-    )
 }
 
 const makeChildlessCompiledDrain = (
@@ -247,7 +146,7 @@ const makeChildlessCompiledDrain = (
   }
 }
 
-class InvokeExecutionKernel {
+class InvokeExecutionState {
   initialized = false
   initial:
     | {
@@ -263,78 +162,6 @@ class InvokeExecutionKernel {
     readonly entryPaths: ReadonlyArray<string>
   }) {
     this.initial = initial
-  }
-
-  private makeSessionKey(path: string, id: string): string {
-    return `${path.length}:${path}${id}`
-  }
-
-  private makeChildId(path: string, id: string): string {
-    return `Machine.invoke:${this.makeSessionKey(path, id)}`
-  }
-
-  start(
-    context: internalRuntime.CompiledProcessContext<any, any>,
-    path: string,
-    config: AnyInvokeConfig
-  ): Effect.Effect<void, any, any> {
-    return Effect.suspend(() => {
-      const invokeId = String(config.id)
-      const key = this.makeSessionKey(path, invokeId)
-      const childId = config.address === undefined ? this.makeChildId(path, invokeId) : String(config.address)
-      const logic = config.src() as internalRuntime.ProcessLogic<any, any, any, any, any, any>
-      const scope = context.scope
-      return context.ownedChildren.spawn(
-        logic,
-        {
-          key,
-          path,
-          id: childId,
-          duplicateId: invokeId,
-          ...(config.descriptor === undefined ? undefined : { descriptor: config.descriptor }),
-          sendParent: (isCurrent, event) => isCurrent() ? scope.self.send(event) : Effect.void,
-          onOutcome: (isCurrent, outcome) => {
-            if (outcome._tag === "Stopped" || !isCurrent()) return Effect.void
-            if (outcome._tag !== "Done") return scope.failCause(outcome.cause)
-            const mappedEvent = config.onDone === undefined
-              ? outcome.output
-              : config.onDone({ id: config.id, output: outcome.output })
-            return mappedEvent === undefined
-              ? Effect.void
-              : scope.self.send(mappedEvent).pipe(Effect.catchTag("StoppedError", () => Effect.void))
-          },
-          ...(config.snapshot === undefined ? undefined : {
-            onSnapshot: (isCurrent: () => boolean, snapshot: any) => {
-              if (!isCurrent()) return Effect.void
-              const mappedEvent = config.snapshot!({ id: config.id, snapshot })
-              return mappedEvent === undefined
-                ? Effect.void
-                : scope.self.send(mappedEvent).pipe(Effect.catchTag("StoppedError", () => Effect.void))
-            }
-          })
-        }
-      )
-    })
-  }
-
-  startAll(
-    machine: Machine.Any,
-    context: internalRuntime.CompiledProcessContext<any, any>,
-    configuration: Configuration.ActiveConfiguration,
-    paths: ReadonlyArray<string>,
-    event: Machine.LifecycleEvent<any>
-  ): Effect.Effect<void, any, any> | undefined {
-    const effects = internalPlanner.sortEntryPaths(machine, paths)
-      .filter((path) => configuration.active.has(path))
-      .flatMap((path) =>
-        getInvokes(Configuration.getStateConfigByPath(machine, path), {
-          state: Configuration.getActiveValue(configuration, path),
-          parent: Configuration.getParentValue(machine, configuration, path),
-          parents: Configuration.getParentValues(machine, configuration, path),
-          event
-        }).map((config) => this.start(context, path, config))
-      )
-    return effects.length === 0 ? undefined : runSequentialDiscard(effects)
   }
 }
 
@@ -357,9 +184,9 @@ const makeInvokingCompiledDrain = (
 
     const scope = context.scope
     const stored = context.executionState
-    const execution = stored instanceof InvokeExecutionKernel
+    const execution = stored instanceof InvokeExecutionState
       ? stored
-      : new InvokeExecutionKernel()
+      : new InvokeExecutionState()
     context.executionState = execution
     let liveRuntime: Runtime<any, any> | undefined
     let configuration: unknown
@@ -425,7 +252,14 @@ const makeInvokingCompiledDrain = (
         afterCommit.push(context.ownedChildren.stopAll())
       } else if (changed) {
         for (const [path, entryEvent] of entryEvents) {
-          const starting = execution.startAll(machine, context, activeConfiguration, [path], entryEvent)
+          const starting = Invocation.startAll(
+            machine,
+            scope,
+            context.ownedChildren,
+            activeConfiguration,
+            [path],
+            entryEvent
+          )
           if (starting !== undefined) afterCommit.push(starting)
         }
       }
@@ -465,9 +299,10 @@ const makeInvokingCompiledDrain = (
       const initialConfiguration = seeded?.activeConfiguration ??
         Configuration.normalizeConfigurationSync(machine, current)
       configuration = seeded?.configuration ?? executionPlan.fromConfiguration(initialConfiguration)
-      const starting = execution.startAll(
+      const starting = Invocation.startAll(
         machine,
-        context,
+        scope,
+        context.ownedChildren,
         initialConfiguration,
         seeded?.entryPaths ?? Configuration.getInitialEntryPaths(machine, initialConfiguration),
         internalPlanner.InitialEvent
@@ -543,7 +378,7 @@ const makeProcessLogic: <
       return hasInvokes
         ? {
           ...result,
-          executionState: new InvokeExecutionKernel({
+          executionState: new InvokeExecutionState({
             configuration: planned.configuration,
             activeConfiguration: planned.activeConfiguration,
             entryPaths: planned.initialEntryPaths
@@ -683,128 +518,28 @@ const makeProcessLogic: <
             return terminal.output
           }
 
-          // Every session mutation is deferred inside `Effect.sync`, making a
-          // compact mutable table atomic with respect to Effect fiber steps.
-          // Tokens still distinguish stale child callbacks after reentry.
-          const invokeSessions = new Map<string, InvokeSession>()
-          const makeInvokeSessionKey = (path: string, id: string): string => `${path.length}:${path}${id}`
-          const makeInvokeChildId = (path: string, id: string): string =>
-            `Machine.invoke:${makeInvokeSessionKey(path, id)}`
-          const stopInvokeSession = (session: InvokeSession): Effect.Effect<void> => context.stopChild(session.childId)
-          const removeInvoke = (
-            key: string,
-            token: symbol | undefined
-          ): Effect.Effect<void> =>
-            Effect.sync(() => {
-              const current = invokeSessions.get(key)
-              if (current === undefined || (token !== undefined && current.token !== token)) {
-                return undefined
-              }
-              invokeSessions.delete(key)
-              return current
-            }).pipe(
-              Effect.flatMap((session) =>
-                session === undefined
-                  ? Effect.void
-                  : stopInvokeSession(session)
-              )
-            )
-          const stopInvoke = (key: string): Effect.Effect<void> => removeInvoke(key, undefined)
-          const stopAllInvokes: Effect.Effect<void> = Effect.suspend(() => {
-            const effects = Array.from(invokeSessions.values(), stopInvokeSession)
-            invokeSessions.clear()
-            return runParallelDiscard(effects)
-          })
-          const startInvoke = Effect.fnUntraced(function*<StateId extends Machine.StateIdentifier<States>>(
-            path: StateId,
-            config: AnyInvokeConfig
-          ) {
-            const token = Symbol()
-            const invokeId = String(config.id)
-            const key = makeInvokeSessionKey(path, invokeId)
-            const childId = config.address === undefined ? makeInvokeChildId(path, invokeId) : String(config.address)
-            const reserved = yield* Effect.sync(() => {
-              if (invokeSessions.has(key)) {
-                return false
-              }
-              invokeSessions.set(key, { token, childId, path })
-              return true
-            })
-            if (!reserved) {
-              return yield* Effect.fail(new ChildAlreadyExistsError({ id: invokeId }))
-            }
-            const logic = config.src()
-            const processLogic = logic as internalRuntime.ProcessLogic<any, any, any, any, any, any>
-            const sendParent = makeInvokeSendParent(invokeSessions, context.self, key, token)
-            yield* context.spawn(
-              processLogic,
-              {
-                id: childId,
-                ...(config.descriptor === undefined ? undefined : { descriptor: config.descriptor }),
-                [internalRuntime.sendParentOverride]: sendParent,
-                onOutcome: makeInvokeOutcomeHandler(
-                  invokeSessions,
-                  context.self,
-                  context.failCause,
-                  config,
-                  key,
-                  token
-                ),
-                ...(config.snapshot === undefined ? undefined : {
-                  [internalRuntime.activeSnapshotObserver]: makeInvokeSnapshotHandler(
-                    invokeSessions,
-                    context.self,
-                    config,
-                    key,
-                    token
-                  )
-                })
-              }
-            ).pipe(
-              Effect.onExit((exit) =>
-                Exit.isFailure(exit)
-                  ? removeInvoke(key, token)
-                  : Effect.void
-              )
-            )
-          })
+          // The execution descriptor requests this owner-local capability only
+          // when an invoking statechart is deliberately run by the generic
+          // reference strategy.
+          const ownedChildren = context.ownedChildren
+          if (ownedChildren === undefined) {
+            return yield* Effect.die(new Error("Invoking statechart started without an owned child runtime"))
+          }
           const startInvokes: (
             configuration: Configuration.ActiveConfiguration,
             paths: ReadonlyArray<string>,
             event: Machine.LifecycleEvent<Events>
-          ) => Effect.Effect<void, E | MachineSchemaDecodeError, R> = Effect.fnUntraced(function*(
-            configuration: Configuration.ActiveConfiguration,
-            paths: ReadonlyArray<string>,
-            event: Machine.LifecycleEvent<Events>
-          ) {
-            yield* runSequentialDiscard(
-              internalPlanner.sortEntryPaths(machine, paths)
-                .filter((path) => configuration.active.has(path))
-                .flatMap((path) =>
-                  getInvokes(Configuration.getStateConfigByPath(machine, path), {
-                    state: Configuration.getActiveValue(configuration, path),
-                    parent: Configuration.getParentValue(machine, configuration, path),
-                    parents: Configuration.getParentValues(machine, configuration, path),
-                    event
-                  }).map((config) =>
-                    startInvoke(
-                      path as Machine.StateIdentifier<States>,
-                      config
-                    ) as Effect.Effect<void, E | MachineSchemaDecodeError, R>
-                  )
-                )
-            )
-          })
+          ) => Effect.Effect<void, E | MachineSchemaDecodeError, R> = (configuration, paths, event) =>
+            (Invocation.startAll(
+              machine,
+              context,
+              ownedChildren,
+              configuration,
+              paths,
+              event
+            ) ?? Effect.void) as Effect.Effect<void, E | MachineSchemaDecodeError, R>
           const stopInvokes = (paths: ReadonlyArray<string>): Effect.Effect<void> =>
-            Effect.suspend(() =>
-              runParallelDiscard(
-                internalPlanner.sortExitPaths(machine, paths).flatMap((path) =>
-                  Array.from(invokeSessions.entries())
-                    .filter(([, session]) => session.path === path)
-                    .map(([key]) => stopInvoke(key))
-                )
-              )
-            )
+            ownedChildren.stopPaths(paths) ?? Effect.void
 
           return yield* Effect.gen(function*() {
             let configuration: Configuration.ActiveConfiguration | undefined = yield* Configuration
@@ -871,7 +606,7 @@ const makeProcessLogic: <
 
                 if (planned.done) {
                   terminal = { output: planned.output as Output }
-                  yield* stopAllInvokes
+                  yield* ownedChildren.stopAll()
                 } else if (changed) {
                   for (const [path, entryEvent] of entryEvents) {
                     yield* startInvokes(planned.next, [path], entryEvent)
@@ -895,7 +630,7 @@ const makeProcessLogic: <
             }
             return terminal.output
           }).pipe(
-            Effect.onExit(() => stopAllInvokes)
+            Effect.onExit(() => ownedChildren.stopAll())
           )
         }),
         context

--- a/src/internal/machine/runtime.ts
+++ b/src/internal/machine/runtime.ts
@@ -271,6 +271,8 @@ export interface ProcessContext<State, Event> extends ProcessScope<Event> {
   readonly updateState: <E, R>(
     f: (state: State) => Effect.Effect<State, E, R>
   ) => Effect.Effect<void, E, R>
+  /** Present only when a compiled statechart is forced through the generic runtime. @internal */
+  readonly ownedChildren?: OwnedChildRuntime
 }
 
 /**
@@ -546,7 +548,8 @@ interface StartInternalOptions {
   readonly sendParent?: (event: unknown) => Effect.Effect<void, StoppedError>
 }
 
-interface OwnedChildSpawnOptions {
+/** @internal */
+export interface OwnedChildSpawnOptions {
   readonly key: string
   readonly path: string
   readonly id: string
@@ -566,9 +569,10 @@ interface OwnedChildSpawnOptions {
   ) => Effect.Effect<void, StoppedError>
 }
 
-interface OwnedChildRuntime {
+/** @internal */
+export interface OwnedChildRuntime {
   readonly spawn: (
-    logic: ProcessLogic<any, any, any, any, any, any>,
+    makeLogic: () => ProcessLogic<any, any, any, any, any, any>,
     options: OwnedChildSpawnOptions
   ) => Effect.Effect<void, any, any>
   readonly stopAll: () => Effect.Effect<void>
@@ -612,7 +616,7 @@ class OwnedChildRuntimeImpl implements OwnedChildRuntime {
   }
 
   spawn(
-    logic: ProcessLogic<any, any, any, any, any, any>,
+    makeLogic: () => ProcessLogic<any, any, any, any, any, any>,
     options: OwnedChildSpawnOptions
   ): Effect.Effect<void, any, any> {
     const token = Symbol()
@@ -626,6 +630,7 @@ class OwnedChildRuntimeImpl implements OwnedChildRuntime {
       if (this.has(options.key) || this.registry.children.has(options.id)) {
         return Effect.fail(new ChildAlreadyExistsError({ id: options.duplicateId }))
       }
+      const logic = makeLogic()
       const scope = this.registry.scope ??= Scope.makeUnsafe("parallel")
       this.registry.children.set(options.id, {
         _tag: "Starting",
@@ -1049,6 +1054,7 @@ const startGenericInternal: <
     changes: childChanges,
     close: closeChildren,
     get: getChild,
+    owned: ownedChildren,
     sendTo,
     spawn,
     stop: stopChild
@@ -1058,6 +1064,7 @@ const startGenericInternal: <
       changes: childChanges,
       close: closeChildren,
       get: getChild,
+      owned: ownedChildren,
       sendTo,
       spawn,
       stop: stopChild
@@ -1304,6 +1311,7 @@ const startGenericInternal: <
 
   const context: ProcessContext<State, Event> = {
     ...scope,
+    ...(logic.execution?._tag === "Compiled" && !logic.execution.childless ? { ownedChildren } : undefined),
     receive: Queue.take(queue),
     mailbox: queue,
     state: SynchronizedRef.get(current).pipe(Effect.map((current) => current.snapshot.state)),

--- a/test/internal/machine/invocation.test.ts
+++ b/test/internal/machine/invocation.test.ts
@@ -1,0 +1,16 @@
+import { assert, describe, it } from "@effect/vitest"
+import { makeChildId, makeKey } from "../../../src/internal/machine/invocation.js"
+
+describe("machine invocation ownership", () => {
+  it("keeps path and invoke id boundaries collision-free", () => {
+    assert.notStrictEqual(makeKey("a", "bc"), makeKey("ab", "c"))
+    assert.notStrictEqual(makeKey("root.child", "worker"), makeKey("root", ".childworker"))
+  })
+
+  it("derives stable child addresses in the invocation namespace", () => {
+    assert.strictEqual(
+      makeChildId("root.child", "worker"),
+      "Machine.invoke:10:root.childworker"
+    )
+  })
+})

--- a/test/internal/machine/strategyDifferential.test.ts
+++ b/test/internal/machine/strategyDifferential.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Fiber, Schema, Stream } from "effect"
+import { Deferred, Effect, Fiber, Schema, Stream } from "effect"
 import { FastCheck } from "effect/testing"
 import { Machine } from "../../../src/index.js"
 import * as Configuration from "../../../src/internal/machine/configuration.js"
@@ -324,6 +324,81 @@ describe("machine planner and runtime strategies", () => {
         })
       }
       assert.deepStrictEqual(results[1], results[0])
+    }) as Effect.Effect<void, unknown, any>)
+
+  it.effect("drops stale invoke messages and snapshots after reentry in both runtime strategies", () =>
+    Effect.gen(function*() {
+      class Loading extends Schema.TaggedClass<Loading>("StrategyStaleInvokeLoading")("Loading", {
+        epoch: Schema.Number
+      }) {}
+      class Failed extends Schema.TaggedClass<Failed>("StrategyStaleInvokeFailed")("Failed", {}) {}
+      class Reenter extends Schema.TaggedClass<Reenter>("StrategyStaleInvokeReenter")("Reenter", {}) {}
+      class Stale extends Schema.TaggedClass<Stale>("StrategyStaleInvokeEvent")("Stale", {}) {}
+
+      for (const strategy of ["generic", "compiled"] as const) {
+        const firstStarted = yield* Deferred.make<void>()
+        let generation = 0
+        const states = Machine.defineStates({ Loading, Failed })
+        const machine = Machine.make({
+          states: states.states,
+          events: [Reenter, Stale],
+          initial: () => states.initial.Loading(new Loading({ epoch: 0 }))
+        }).handle({
+          Loading: {
+            invoke: Machine.invoke({
+              id: "worker",
+              src: () => {
+                generation += 1
+                const current = generation
+                return Machine.logic({
+                  initial: "active",
+                  run: ({ sendParent, setState }) =>
+                    (current === 1 ? Deferred.succeed(firstStarted, undefined) : Effect.void).pipe(
+                      Effect.andThen(Effect.never),
+                      Effect.onInterrupt(() =>
+                        setState("stale").pipe(
+                          Effect.andThen(sendParent(new Stale({})))
+                        )
+                      )
+                    )
+                })
+              },
+              snapshot: ({ snapshot }) => snapshot.state === "stale" ? new Stale({}) : undefined
+            }),
+            on: {
+              Reenter: {
+                reenter: true,
+                transition: ({ state, target }) => target.full.Loading(new Loading({ epoch: state.epoch + 1 }))
+              },
+              Stale: () => states.initial.Failed(new Failed({}))
+            }
+          },
+          Failed: {}
+        })
+
+        const ref = yield* openWithRuntimeStrategy(machine, strategy)
+        yield* Deferred.await(firstStarted)
+        const reentered = yield* ref.changes.pipe(
+          Stream.filter((snapshot) =>
+            snapshot.status === "active" &&
+            snapshot.state.path === "Loading" &&
+            snapshot.state.value.epoch === 1
+          ),
+          Stream.take(1),
+          Stream.runDrain,
+          Effect.forkChild({ startImmediately: true })
+        )
+        yield* ref.send(new Reenter({}))
+        yield* Fiber.join(reentered)
+        yield* Effect.yieldNow
+
+        const snapshot = yield* ref.snapshot
+        assert.strictEqual(snapshot.status, "active", `${strategy} accepted a stale invoke callback`)
+        assert.strictEqual(snapshot.state.path, "Loading")
+        assert.strictEqual(snapshot.state.value.epoch, 1)
+        assert.strictEqual(generation, 2)
+        yield* ref.stop
+      }
     }) as Effect.Effect<void, unknown, any>)
 
   it.effect("compares generated eligible models across canonical and indexed planners", () =>

--- a/test/machine/Machine.test.ts
+++ b/test/machine/Machine.test.ts
@@ -4311,6 +4311,11 @@ describe("Machine", () => {
     Effect.gen(function*() {
       const First = Machine.childAddress("first")
       const Second = Machine.childAddress("second")
+      let sourceEvaluations = 0
+      const source = () => {
+        sourceEvaluations += 1
+        return Machine.effect(Effect.never)
+      }
       const parentStates = Machine.defineStates({ Loading })
       const parent = Machine.make({
         states: parentStates.states,
@@ -4322,12 +4327,12 @@ describe("Machine", () => {
             Machine.invoke({
               id: "worker",
               address: First,
-              src: () => Machine.effect(Effect.never)
+              src: source
             }),
             Machine.invoke({
               id: "worker",
               address: Second,
-              src: () => Machine.effect(Effect.never)
+              src: source
             })
           ]
         }
@@ -4338,6 +4343,7 @@ describe("Machine", () => {
 
       assert.instanceOf(error, Machine.ChildAlreadyExistsError)
       assert.strictEqual(error.id, "worker")
+      assert.strictEqual(sourceEvaluations, 1)
     }))
 
   it.effect("start maps invoked child failures to machine events", () =>


### PR DESCRIPTION
## Summary

- move state-scoped invocation resolution, identity, callback mapping, and startup into a dedicated internal invocation module
- run generic and compiled statecharts through the same owner-local child registry, removing the duplicate generic session/token/deletion protocol
- reject duplicate invokes before evaluating user source factories and strengthen forced-strategy coverage for stale reentry callbacks
- extend the architecture boundary so semantic and runtime layers cannot depend outward on invocation orchestration

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (no examples changed; the aggregate examples gate passed)
- [x] Reviewed the automated type-performance report: every total and marginal instantiation count is unchanged
- [x] Reviewed the automated runtime-performance report: parent/child startup improved 10.1%, raw compiled startup improved 1.0%, and every Effect Machine heap profile is flat or lower within measurement noise

Local runtime validation also used five order-balanced base/head quick processes before the hosted gate.