### PR TITLE
Harden machine handler capture

### DIFF
--- a/.changeset/calm-machines-capture.md
+++ b/.changeset/calm-machines-capture.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Capture event dispatch definitions when handlers are registered and make compiled execution fall back safely when a state configuration contains unknown semantics.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,17 @@ The goal is eventually to merge this inside the core of the `effect` library, so
 
 Make architectural decisions for the long term. Do not accept a stopgap that only works for now and is meant to be replaced later.
 
+## Effect internal standards
+
+- Before introducing an internal abstraction or protocol, inspect the analogous implementation under `references/effect` and follow its naming, module-boundary, and ownership conventions where they apply.
+- Keep public modules declarative and route implementation through `src/internal`. Preserve directed dependencies and avoid internal barrel modules.
+- Give optimized planners and runtimes explicit contracts and ownership boundaries. Do not hide mutable state behind readonly types or retain caller-owned mutable containers in cached structures.
+- Treat the generic planner/runtime as the semantic reference. Optimized strategies must fail closed: a new capability uses the generic path until its optimized semantics are implemented deliberately.
+- Keep casts at genuine erased boundaries only. Prefer narrower internal representations, explicit invariants, and exhaustive capability checks over broad `any`-based protocols.
+- For every optimized semantic change, add forced generic-versus-optimized differential coverage and a focused regression test. Include relevant edge cases such as targetless and reentering transitions, simultaneous transitions, raised events, completion, invocation, and retained snapshots.
+- Put public behavioral tests under `test/` and implementation-strategy tests under `test/internal/`. Tests should establish observable semantics, not mirror implementation details.
+- Treat correctness, type safety, and benchmark regressions as blockers. Do not recover performance by weakening semantics or public inference.
+
 ## Verification
 
 Run:
@@ -19,6 +30,14 @@ For changes that can affect the public TypeScript API or its inference, also run
 ```sh
 pnpm perf:types
 ```
+
+For changes to planning, runtime execution, machine construction, or another hot path, also run:
+
+```sh
+pnpm perf:runtime
+```
+
+Use the pull request performance workflows to compare against the base branch; do not draw conclusions from a single noisy benchmark run. Record the relevant checks and performance result in the pull request.
 
 When an example changes, run its own check from the example directory:
 

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -200,6 +200,9 @@ export interface Machine<
    * Adds typed state handlers and returns the refined machine definition.
    * Successive calls implement the remaining unhandled states while retaining
    * accumulated errors, services, final states, and output evidence.
+   * Event dispatch maps and transition descriptors are captured by value, so
+   * later mutation of the objects supplied to this call cannot alter the
+   * resulting machine.
    *
    * @since 4.0.0
    */

--- a/src/internal/machine/executionPlan.ts
+++ b/src/internal/machine/executionPlan.ts
@@ -63,6 +63,27 @@ interface IndexedExecutionDescriptor {
   >
 }
 
+const indexedStateConfigKeys: ReadonlySet<PropertyKey> = new Set([
+  "initial",
+  "invoke",
+  "on",
+  "output"
+])
+
+// Fail closed so a newly introduced semantic field must explicitly opt into
+// indexed execution instead of being accepted before the kernel supports it.
+const supportsIndexedStateConfig = (config: Machine.AnyStateConfig | undefined): boolean => {
+  if (config === undefined) {
+    return true
+  }
+  for (const key of Reflect.ownKeys(config)) {
+    if (!indexedStateConfigKeys.has(key)) {
+      return false
+    }
+  }
+  return true
+}
+
 const compileIndexedExecutionDescriptor = (
   machine: Machine.Any
 ): IndexedExecutionDescriptor | undefined => {
@@ -87,11 +108,7 @@ const compileIndexedExecutionDescriptor = (
     }
 
     const config = machine.handlers[node.path] as Machine.AnyStateConfig | undefined
-    if (
-      config?.entry !== undefined || config?.exit !== undefined || config?.always !== undefined ||
-      config?.onDone !== undefined || (config as any)?.choice !== undefined ||
-      (config as any)?.history !== undefined
-    ) {
+    if (!supportsIndexedStateConfig(config)) {
       return undefined
     }
     if (config?.on === undefined) {

--- a/src/internal/machine/machine.ts
+++ b/src/internal/machine/machine.ts
@@ -147,6 +147,28 @@ const validateTransitionTargets = (
   }
 }
 
+const captureTransition = (transition: unknown): unknown => {
+  if (typeof transition !== "object" || transition === null) {
+    return transition
+  }
+  const captured = { ...(transition as Record<PropertyKey, unknown>) }
+  if (Array.isArray(captured.targets)) {
+    captured.targets = captured.targets.slice()
+  }
+  return captured
+}
+
+const captureEventHandlers = (on: object): Record<PropertyKey, unknown> => {
+  // The machine owns its dispatch table. Compiled plans may snapshot these
+  // definitions, so retaining caller-owned containers would let strategies
+  // observe different handlers after an unsafe external mutation.
+  const captured: Record<PropertyKey, unknown> = Object.create(null)
+  for (const event of Reflect.ownKeys(on)) {
+    captured[event] = captureTransition((on as Record<PropertyKey, unknown>)[event])
+  }
+  return captured
+}
+
 const flattenHandlers = (
   handlers: Record<PropertyKey, Machine.AnyStateConfig>,
   stateNodes: Machine.StateNodes,
@@ -166,8 +188,10 @@ const flattenHandlers = (
     const { states: childConfig, ...stateConfig } = nodeConfig as Record<string, unknown>
     const on = stateConfig.on
     if (typeof on === "object" && on !== null) {
-      for (const event of Reflect.ownKeys(on)) {
-        validateTransitionTargets(stateNodes, path, event, (on as Record<PropertyKey, unknown>)[event])
+      const capturedOn = captureEventHandlers(on)
+      stateConfig.on = capturedOn
+      for (const event of Reflect.ownKeys(capturedOn)) {
+        validateTransitionTargets(stateNodes, path, event, capturedOn[event])
       }
     }
     validateTransitionTargets(stateNodes, path, "always", stateConfig.always)

--- a/test/internal/machine/strategyDifferential.test.ts
+++ b/test/internal/machine/strategyDifferential.test.ts
@@ -194,6 +194,14 @@ describe("machine planner and runtime strategies", () => {
       })
     }))
 
+  it("falls back to the generic planner for unknown state semantics", () => {
+    const machine = makeFlatMachine()
+    const config = machine.handlers.Count as Machine.Machine.AnyStateConfig & Record<PropertyKey, unknown>
+    config.futureSemanticCapability = () => undefined
+
+    assert.strictEqual(ExecutionPlan.selectExecutionPlanForTesting(machine, "auto").strategy, "generic")
+  })
+
   it.effect("matches indexed startup for decoded input and an initially final machine", () =>
     Effect.gen(function*() {
       const Input = Schema.Struct({ value: Schema.Number })

--- a/test/machine/Machine.test.ts
+++ b/test/machine/Machine.test.ts
@@ -101,6 +101,43 @@ const assertMachineSchemaEncodeError = (
 const unsafeTagged = <A extends { readonly _tag: PropertyKey }>(value: A): A => value
 
 describe("Machine", () => {
+  it.effect("captures event dispatch definitions supplied to handle", () =>
+    Effect.gen(function*() {
+      class Stable extends Schema.TaggedClass<Stable>("Stable")("Stable", {}) {}
+      class Ping extends Schema.TaggedClass<Ping>("Ping")("Ping", {}) {}
+      const states = Machine.defineStates({ Stable })
+      const transition = {
+        reenter: false,
+        targets: [] as Array<"Stable">,
+        transition: () => undefined
+      }
+      const on: { Ping?: typeof transition } = { Ping: transition }
+      const machine = Machine.make({
+        states: states.states,
+        events: [Ping],
+        initial: () => states.initial.Stable(new Stable({}))
+      }).handle({ Stable: { on } })
+
+      delete on.Ping
+      transition.reenter = true
+      transition.targets.push("Stable")
+
+      assert.deepStrictEqual(Machine.transitionDefinitions(machine), [{
+        source: "Stable",
+        trigger: { type: "event", event: "Ping" },
+        reenter: false,
+        targets: { type: "declared", paths: [] }
+      }])
+
+      const initial = yield* Machine.planInitial(machine)
+      const planned = yield* Machine.plan(machine, initial.state, new Ping({}))
+      assert.strictEqual(planned.microsteps.length, 1)
+      const step = planned.microsteps[0]!
+      assert.isFalse(step.changed)
+      assert.deepStrictEqual(step.exitPaths, [])
+      assert.deepStrictEqual(step.entryPaths, [])
+    }))
+
   const Input = Schema.Struct({
     userId: Schema.String
   })


### PR DESCRIPTION
## Summary

- Capture event dispatch maps, transition descriptors, and declared target arrays when handlers are registered so caller-owned mutation cannot make planner strategies diverge.
- Make indexed execution eligibility fail closed: unknown state semantics now select the generic planner until explicitly supported.
- Add public and internal regression coverage, plus concise Effect-internals testing, performance, and quality guidance for future agents.

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (not applicable; no examples changed)
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed
- [x] `pnpm perf:types`
- [x] `pnpm perf:runtime`

Type instantiations are unchanged in every measured scenario. Runtime throughput and memory remain within the benchmark suite's expected run-to-run variability.
