### PR TITLE
Add causal runtime verification laws

### DIFF
--- a/.changeset/bright-runtimes-verify.md
+++ b/.changeset/bright-runtimes-verify.md
@@ -1,0 +1,7 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Add reusable runtime invariants, law-oriented causal command verification, and
+an explicit planner/runtime agreement check. Causal probe microsteps now retain
+stable public snapshots even when the optimized runtime reuses internal state.

--- a/README.md
+++ b/README.md
@@ -811,6 +811,56 @@ bursts or retains outstanding mailbox work. Its model steps continue to use
 `formatRuntimeTranscript` names are deprecated aliases for the enqueue-oriented
 runner and formatter because their delivery semantics were not visible.
 
+### Runtime invariants and planner agreement
+
+Planner invariants and runtime invariants are deliberately separate. Runtime
+laws inspect causal command evidence, explicit asynchronous observations, and
+runtime status without requiring a duplicate reference model:
+
+```ts
+const invariant = MachineTest.runtimeInvariants(machine)
+const laws = [
+  invariant.snapshot("count never becomes negative", ({ snapshot }) => snapshot.state.value.count >= 0),
+  invariant.command(
+    "every accepted add is processed",
+    ({ command, result }) =>
+      command._tag !== "Send" || command.event._tag !== "Add" ||
+      result._tag === "SendProcessed"
+  )
+]
+
+const transcript = yield * MachineTest.verifyCausalCommands(
+  probe,
+  commands,
+  { invariants: laws }
+)
+```
+
+Use the existing `runCausalCommands` when a simplified application model
+provides exact expected results. Its returned transcript implements the same
+model-independent evidence interface, so reusable runtime laws compose with
+it directly:
+
+```ts
+const transcript = yield * MachineTest.runCausalCommands(probe, commands, model)
+
+yield * MachineTest.assertRuntimeInvariants(machine, transcript, laws)
+yield * MachineTest.assertPlannerRuntimeAgreement(machine, transcript)
+```
+
+`checkRuntimeInvariants` returns an aggregate report; `assertRuntimeInvariants`
+fails with every predicate and non-vacuity violation. Snapshot laws observe the
+initial and post-command snapshots by default. Select `"awaited"`, `"all"`, or
+`"final"` explicitly when a law targets observations retained by
+`probe.await.until` or only the final runtime snapshot.
+
+`assertPlannerRuntimeAgreement` is an explicit consistency check, not an
+application oracle. For each processed send it freshly plans from the receipt's
+`before` snapshot and compares handled/change flags, the public next snapshots,
+completion, command counts, emitted events, and public microstep evidence. It
+does not prove that the planner implements the intended business rules; use a
+reference model and runtime invariants for that.
+
 ## Current limits
 
 Declarative first-class guards are not part of the current API. Ordinary

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -840,6 +840,37 @@ policies observe public snapshots but do not turn send acceptance into causal
 completion. Do not use the deprecated `runRuntimeCommands` name in new code;
 it is an alias for enqueue behavior and hides that important distinction.
 
+For semantic laws over live execution, bind runtime invariant constructors to
+the machine and use the law-oriented causal verifier:
+
+```ts
+const invariant = MachineTest.runtimeInvariants(machine)
+
+const laws = [
+  invariant.snapshot("balance never becomes negative", ({ snapshot }) =>
+    snapshot.state.value.balance >= 0
+  ),
+  invariant.command("stopped sends are rejected", ({ previous, result }) =>
+    previous?.result._tag !== "Stopped" || result._tag === "SendRejected"
+  )
+]
+
+yield* MachineTest.verifyCausalCommands(probe, commands, { invariants: laws })
+```
+
+Do not create a dummy model merely to run runtime laws. Continue to use
+`runCausalCommands` when an independent simplified model supplies exact
+expected results, then apply the same laws to its returned transcript with
+`assertRuntimeInvariants`. Conditional laws that must execute should declare
+`require.minObservations` so irrelevant generated commands cannot pass them
+vacuously.
+
+Use `assertPlannerRuntimeAgreement(machine, transcript)` only to check the
+managed runtime boundary against a fresh pure plan. It is not an independent
+business oracle and is intentionally an explicit operation rather than a
+generic conformance mode. Combine it with application runtime laws or a
+reference model when correctness of the expected behavior matters.
+
 ## Common compiler errors
 
 ### `initial` is not callable

--- a/src/internal/machine/executionPlan.ts
+++ b/src/internal/machine/executionPlan.ts
@@ -194,6 +194,20 @@ interface OwnedIndexedState {
   readonly completedOrder: ReadonlyArray<number>
 }
 
+const copyOwnedIndexedState = (state: OwnedIndexedState): OwnedIndexedState => ({
+  active: state.active.slice(),
+  activeLeaves: state.activeLeaves.slice(),
+  values: state.values.slice(),
+  completed: state.completed.slice(),
+  outputs: state.outputs.slice(),
+  completedOrder: state.completedOrder.slice()
+})
+
+const retainIndexedMicrostep = (
+  step: ExecutionMicrostep<OwnedIndexedState>,
+  retain: boolean
+): ExecutionMicrostep<OwnedIndexedState> => retain ? { ...step, next: copyOwnedIndexedState(step.next) } : step
+
 const updateOwnedIndexedValue = (
   state: OwnedIndexedState,
   index: number,
@@ -607,7 +621,8 @@ const planIndexedFlatState = (
   machine: Machine.Any,
   descriptor: IndexedExecutionDescriptor,
   configuration: OwnedIndexedState,
-  decoded: { readonly _tag: PropertyKey }
+  decoded: { readonly _tag: PropertyKey },
+  retainMicrosteps: boolean
 ): ExecutionMacrostep<OwnedIndexedState> => {
   let current = configuration
   let event: any = decoded
@@ -716,7 +731,7 @@ const planIndexedFlatState = (
         changed
       }
       current = next
-      ;(microsteps ??= []).push(step)
+      ;(microsteps ??= []).push(retainIndexedMicrostep(step, retainMicrosteps))
       if (transitionResult.commands.length > 0) {
         ;(commands ??= []).push(...transitionResult.commands)
       }
@@ -751,11 +766,12 @@ const planIndexedState = (
   machine: Machine.Any,
   descriptor: IndexedExecutionDescriptor,
   configuration: OwnedIndexedState,
-  input: unknown
+  input: unknown,
+  retainMicrosteps: boolean
 ): ExecutionMacrostep<OwnedIndexedState> => {
   const decoded = decodeEventSync(machine, input)
   if (descriptor.flat) {
-    return planIndexedFlatState(machine, descriptor, configuration, decoded)
+    return planIndexedFlatState(machine, descriptor, configuration, decoded, retainMicrosteps)
   }
   if (descriptor.finalIndices.some((index) => configuration.active[index] === 1)) {
     const active = activeConfigurationFromIndexedState(descriptor, configuration)
@@ -794,7 +810,7 @@ const planIndexedState = (
   const commands = [...first.commands]
   const raisedEvents = [...first.raisedEvents]
   const emittedEvents = [...first.emittedEvents]
-  const microsteps = [first]
+  const microsteps = [retainIndexedMicrostep(first, retainMicrosteps)]
   let raisedIndex = 0
   let iterations = 0
 
@@ -851,7 +867,7 @@ const planIndexedState = (
     commands.push(...step.commands)
     raisedEvents.push(...step.raisedEvents)
     emittedEvents.push(...step.emittedEvents)
-    microsteps.push(step)
+    microsteps.push(retainIndexedMicrostep(step, retainMicrosteps))
   }
 }
 
@@ -861,7 +877,8 @@ export interface CompiledExecutionPlan {
   readonly snapshot: (state: unknown) => Machine.Snapshot<any>
   readonly plan: (
     state: unknown,
-    event: unknown
+    event: unknown,
+    retainMicrosteps?: boolean
   ) => ExecutionMacrostep
   readonly initial?: (
     args: ReadonlyArray<unknown>
@@ -891,7 +908,8 @@ const makeIndexedExecutionPlan = (
   fromConfiguration: (configuration) => ownedIndexedStateFromActive(indexed, configuration),
   toConfiguration: (state) => activeConfigurationFromIndexedState(indexed, state as OwnedIndexedState),
   snapshot: (state) => snapshotFromIndexedState(indexed, state as OwnedIndexedState),
-  plan: (state, event) => planIndexedState(machine, indexed, state as OwnedIndexedState, event),
+  plan: (state, event, retainMicrosteps = false) =>
+    planIndexedState(machine, indexed, state as OwnedIndexedState, event, retainMicrosteps),
   initial: (args) => {
     const inputArgs = machine.input === undefined
       ? args

--- a/src/internal/machine/process.ts
+++ b/src/internal/machine/process.ts
@@ -48,6 +48,38 @@ const runSequentialDiscard = <E, R>(
     ? effects[0]!
     : Effect.all(effects, { discard: true })
 
+const acknowledgedPlan = (
+  planned: {
+    readonly next: unknown
+    readonly commands: ReadonlyArray<unknown>
+    readonly emittedEvents: ReadonlyArray<unknown>
+    readonly microsteps: ReadonlyArray<{
+      readonly next: unknown
+      readonly event: unknown
+      readonly transitions?: ReadonlyArray<unknown>
+      readonly commands: ReadonlyArray<unknown>
+      readonly raisedEvents: ReadonlyArray<unknown>
+      readonly emittedEvents: ReadonlyArray<unknown>
+      readonly exitPaths: ReadonlyArray<string>
+      readonly entryPaths: ReadonlyArray<string>
+      readonly changed: boolean
+    }>
+    readonly done: boolean
+    readonly output: unknown
+  },
+  snapshot: (state: unknown) => unknown
+): unknown => ({
+  next: snapshot(planned.next),
+  commands: planned.commands,
+  emittedEvents: planned.emittedEvents,
+  microsteps: planned.microsteps.map((microstep) => {
+    const { transitions: _, ...evidence } = microstep
+    return { ...evidence, next: snapshot(microstep.next) }
+  }),
+  done: planned.done,
+  output: planned.output
+})
+
 const invokeCapabilityCache = new WeakMap<Machine.Any, boolean>()
 
 const hasInvokeCapability = (machine: Machine.Any): boolean => {
@@ -98,7 +130,8 @@ const makeChildlessCompiledDrain = (
       try {
         planned = executionPlan.plan(
           configuration ?? executionPlan.fromConfiguration(Configuration.normalizeConfigurationSync(machine, current)),
-          event
+          event,
+          acknowledged
         )
       } catch (error) {
         return error instanceof InfiniteTransitionError || error instanceof MachineSchemaDecodeError
@@ -108,7 +141,9 @@ const makeChildlessCompiledDrain = (
       configuration = planned.next
       context.executionState = configuration
       if (planned.microsteps.length === 0) {
-        if (acknowledged) context.completeMessage({ before, plan: planned, after: current })
+        if (acknowledged) {
+          context.completeMessage({ before, plan: acknowledgedPlan(planned, executionPlan.snapshot), after: current })
+        }
         return loop
       }
 
@@ -129,7 +164,9 @@ const makeChildlessCompiledDrain = (
       }
       const continueAfterCommit = (): Effect.Effect<Option.Option<any>, any, any> => {
         const continued = Effect.suspend(() => {
-          if (acknowledged) context.completeMessage({ before, plan: planned, after: next })
+          if (acknowledged) {
+            context.completeMessage({ before, plan: acknowledgedPlan(planned, executionPlan.snapshot), after: next })
+          }
           return planned.done ? Effect.succeed(Option.some(planned.output)) : loop
         })
         return afterCommit === undefined ? continued : afterCommit.pipe(Effect.andThen(continued))
@@ -217,7 +254,8 @@ const makeInvokingCompiledDrain = (
         planned = executionPlan.plan(
           configuration ??
             executionPlan.fromConfiguration(Configuration.normalizeConfigurationSync(machine, current)),
-          event
+          event,
+          acknowledged
         )
       } catch (error) {
         return error instanceof InfiniteTransitionError || error instanceof MachineSchemaDecodeError
@@ -226,7 +264,9 @@ const makeInvokingCompiledDrain = (
       }
       configuration = planned.next
       if (planned.microsteps.length === 0) {
-        if (acknowledged) context.completeMessage({ before, plan: planned, after: current })
+        if (acknowledged) {
+          context.completeMessage({ before, plan: acknowledgedPlan(planned, executionPlan.snapshot), after: current })
+        }
         return loop
       }
 
@@ -285,7 +325,9 @@ const makeInvokingCompiledDrain = (
       }
       const continueAfterCommit = (): Effect.Effect<Option.Option<any>, any, any> => {
         const continued = Effect.suspend(() => {
-          if (acknowledged) context.completeMessage({ before, plan: planned, after: next })
+          if (acknowledged) {
+            context.completeMessage({ before, plan: acknowledgedPlan(planned, executionPlan.snapshot), after: next })
+          }
           return planned.done ? Effect.succeed(Option.some(planned.output)) : loop
         })
         return afterCommit.length === 0
@@ -522,7 +564,17 @@ const makeProcessLogic: <
                 }
               }
 
-              if (acknowledged) completeMessage({ before, plan: planned, after: current })
+              if (acknowledged) {
+                completeMessage({
+                  before,
+                  plan: acknowledgedPlan(
+                    planned,
+                    (state) =>
+                      Configuration.snapshotFromConfiguration(machine, state as Configuration.ActiveConfiguration)
+                  ),
+                  after: current
+                })
+              }
 
               if (terminal === undefined) {
                 pendingMessage = yield* pollMessage
@@ -638,7 +690,17 @@ const makeProcessLogic: <
                 }
               }
 
-              if (acknowledged) completeMessage({ before, plan: planned, after: current })
+              if (acknowledged) {
+                completeMessage({
+                  before,
+                  plan: acknowledgedPlan(
+                    planned,
+                    (state) =>
+                      Configuration.snapshotFromConfiguration(machine, state as Configuration.ActiveConfiguration)
+                  ),
+                  after: current
+                })
+              }
 
               if (terminal === undefined) {
                 pendingMessage = yield* pollMessage

--- a/src/internal/testing/machine/runtime.ts
+++ b/src/internal/testing/machine/runtime.ts
@@ -14,8 +14,9 @@ import * as Queue from "effect/Queue"
 import * as Stream from "effect/Stream"
 import { FastCheck, TestClock } from "effect/testing"
 import * as Machine from "../../../Machine.js"
-import type { Probe, ProbeStep } from "../../../testing/MachineTest.js"
+import type { CausalRuntimeEvidence, Probe, ProbeStep, RuntimeInvariant } from "../../../testing/MachineTest.js"
 import { type SchemaArbitraryReport, toArbitraryWithReport } from "./arbitrary.js"
+import { assertRuntimeInvariants, type RuntimeInvariantError } from "./runtimeInvariant.js"
 
 type AnyMachine = Machine.Machine.Any
 
@@ -308,6 +309,27 @@ export interface CausalRuntimeModelOptions<
     context: CausalRuntimeAssertionContext<M, Model, Expected, Error, Output, Observed>
   ) => Effect.Effect<void, AssertionError, AssertionServices>
 }
+
+/** Context used to select additional asynchronous observation for a law-oriented command run. */
+export interface CausalVerificationAwaitContext<M extends AnyMachine, Error, Output> {
+  readonly index: number
+  readonly command: RuntimeCommand<Machine.Machine.InputEvent<M>>
+  readonly probe: Probe<M, Error, Output>
+}
+
+/** Configuration for causal verification without a separate reference model. */
+export interface CausalVerificationOptions<M extends AnyMachine, Error, Output> {
+  readonly invariants: ReadonlyArray<RuntimeInvariant<M>>
+  readonly observationTimeout?: Duration.Input
+  readonly await?: (
+    context: CausalVerificationAwaitContext<M, Error, Output>
+  ) => RuntimeAwait<Machine.Machine.Snapshot<Machine.Machine.States<M>>, Error, Output>
+}
+
+/** A law-oriented causal transcript without dummy model or expected fields. */
+export interface CausalVerificationTranscript<M extends AnyMachine, Error, Output>
+  extends CausalRuntimeEvidence<M, Error, Output>
+{}
 
 /**
  * Actual evidence made available to a runtime command assertion.
@@ -1322,6 +1344,53 @@ export const runCausalCommands = <
       finalModel: model,
       final
     }
+  })
+
+/**
+ * Causally executes commands and checks reusable runtime invariants without
+ * requiring a dummy reference model. Use `runCausalCommands` when exact
+ * expected results come from an application model.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const verifyCausalCommands = <M extends AnyMachine, Error, Output>(
+  probe: Probe<M, Error, Output>,
+  commands: Iterable<RuntimeCommand<Machine.Machine.InputEvent<M>>>,
+  options: CausalVerificationOptions<M, Error, Output>
+): Effect.Effect<
+  CausalVerificationTranscript<M, Error, Output>,
+  | CausalRuntimeCommandFailure<
+    Error | RuntimeObservationError,
+    M,
+    undefined,
+    undefined,
+    Error,
+    Output,
+    never
+  >
+  | RuntimeInvariantError<M>
+> =>
+  Effect.gen(function*() {
+    const transcript = yield* runCausalCommands(probe, commands, {
+      initialModel: undefined,
+      ...(options.observationTimeout === undefined ? {} : { observationTimeout: options.observationTimeout }),
+      transition: (_model, command, index) =>
+        Effect.sync(() => ({
+          model: undefined,
+          expected: undefined,
+          ...(options.await === undefined ? {} : { await: options.await({ index, command, probe }) })
+        })),
+      assert: () => Effect.void
+    })
+    const evidence: CausalVerificationTranscript<M, Error, Output> = {
+      commands: transcript.commands,
+      initial: transcript.initial,
+      records: transcript.records.map(({ actual, command, index }) => ({ index, command, actual })),
+      final: transcript.final
+    }
+    yield* assertRuntimeInvariants(probe.machine, evidence, options.invariants)
+    return evidence
   })
 
 /**

--- a/src/internal/testing/machine/runtimeInvariant.ts
+++ b/src/internal/testing/machine/runtimeInvariant.ts
@@ -1,0 +1,486 @@
+/**
+ * User-defined semantic invariants over retained causal runtime evidence.
+ *
+ * @since 4.0.0
+ */
+
+import * as Data from "effect/Data"
+import * as Effect from "effect/Effect"
+import * as Result from "effect/Result"
+import * as Machine from "../../../Machine.js"
+import type {
+  CausalRuntimeEvidence,
+  InvariantOptions,
+  InvariantOutcome,
+  PlannerRuntimeAgreementViolation,
+  RuntimeCommandInvariant,
+  RuntimeCommandInvariantContext,
+  RuntimeInvariant,
+  RuntimeInvariantBuilder,
+  RuntimeInvariantCheckResult,
+  RuntimeInvariantRecord,
+  RuntimeInvariantReport,
+  RuntimeInvariantScope,
+  RuntimeInvariantTranscript,
+  RuntimeInvariantViolation,
+  RuntimeSnapshotInvariant,
+  RuntimeSnapshotInvariantContext,
+  RuntimeSnapshotInvariantOptions,
+  RuntimeSnapshotObservation,
+  RuntimeTranscriptInvariant,
+  RuntimeTranscriptInvariantContext
+} from "../../../testing/MachineTest.js"
+
+type AnyMachine = Machine.Machine.Any
+
+const validateName = (name: string): void => {
+  if (name.trim().length === 0) {
+    throw new Error("MachineTest.runtimeInvariants expected name to be a non-empty string")
+  }
+}
+
+const validateRequirement = <Context>(options: InvariantOptions<Context>): void => {
+  const minimum = options.require?.minObservations
+  if (minimum !== undefined && (!Number.isSafeInteger(minimum) || minimum < 0)) {
+    throw new Error("MachineTest.runtimeInvariants expected minObservations to be a non-negative safe integer")
+  }
+}
+
+const snapshotInvariant = <M extends AnyMachine>(
+  name: string,
+  check: (context: RuntimeSnapshotInvariantContext<M>) => InvariantOutcome,
+  options: RuntimeSnapshotInvariantOptions<M> = {}
+): RuntimeSnapshotInvariant<M> => {
+  validateName(name)
+  validateRequirement(options)
+  return Object.freeze({
+    _tag: "RuntimeSnapshotInvariant" as const,
+    name,
+    observe: options.observe ?? "settled",
+    check,
+    ...(options.when === undefined ? {} : { when: options.when }),
+    ...(options.require === undefined ? {} : { require: Object.freeze({ ...options.require }) })
+  })
+}
+
+const commandInvariant = <M extends AnyMachine>(
+  name: string,
+  check: (context: RuntimeCommandInvariantContext<M>) => InvariantOutcome,
+  options: InvariantOptions<RuntimeCommandInvariantContext<M>> = {}
+): RuntimeCommandInvariant<M> => {
+  validateName(name)
+  validateRequirement(options)
+  return Object.freeze({
+    _tag: "RuntimeCommandInvariant" as const,
+    name,
+    check,
+    ...(options.when === undefined ? {} : { when: options.when }),
+    ...(options.require === undefined ? {} : { require: Object.freeze({ ...options.require }) })
+  })
+}
+
+const transcriptInvariant = <M extends AnyMachine>(
+  name: string,
+  check: (context: RuntimeTranscriptInvariantContext<M>) => InvariantOutcome,
+  options: InvariantOptions<RuntimeTranscriptInvariantContext<M>> = {}
+): RuntimeTranscriptInvariant<M> => {
+  validateName(name)
+  validateRequirement(options)
+  return Object.freeze({
+    _tag: "RuntimeTranscriptInvariant" as const,
+    name,
+    check,
+    ...(options.when === undefined ? {} : { when: options.when }),
+    ...(options.require === undefined ? {} : { require: Object.freeze({ ...options.require }) })
+  })
+}
+
+export const runtimeInvariants = <M extends AnyMachine>(_machine: M): RuntimeInvariantBuilder<M> =>
+  Object.freeze({
+    snapshot: snapshotInvariant,
+    command: commandInvariant,
+    transcript: transcriptInvariant
+  })
+
+export class RuntimeInvariantError<M extends AnyMachine = AnyMachine> extends Data.TaggedError(
+  "MachineTestRuntimeInvariantError"
+)<{
+  readonly transcript: RuntimeInvariantTranscript<M>
+  readonly violations: ReadonlyArray<RuntimeInvariantViolation<M>>
+  readonly report: RuntimeInvariantReport
+}> {}
+
+const normalizeTranscript = <M extends AnyMachine, Error, Output>(
+  transcript: CausalRuntimeEvidence<M, Error, Output>
+): RuntimeInvariantTranscript<M> => ({
+  commands: transcript.commands,
+  initial: transcript.initial as RuntimeInvariantTranscript<M>["initial"],
+  records: transcript.records.map(({ actual, command, index }) => ({
+    index,
+    command,
+    result: actual.result,
+    snapshot: actual.snapshot as RuntimeInvariantRecord<M>["snapshot"],
+    awaited: actual.awaited as RuntimeInvariantRecord<M>["awaited"]
+  })),
+  final: transcript.final as RuntimeInvariantTranscript<M>["final"]
+})
+
+interface Observation<M extends AnyMachine, Context> {
+  readonly context: Context
+  readonly observationIndex?: number
+  readonly commandIndex: number | undefined
+  readonly awaitedIndex?: number
+  readonly phase?: RuntimeSnapshotObservation
+  readonly command?: RuntimeInvariantRecord<M>["command"]
+}
+
+const snapshotObservations = <M extends AnyMachine>(
+  machine: M,
+  transcript: RuntimeInvariantTranscript<M>,
+  invariant: RuntimeSnapshotInvariant<M>
+): ReadonlyArray<Observation<M, RuntimeSnapshotInvariantContext<M>>> => {
+  const observations: Array<Observation<M, RuntimeSnapshotInvariantContext<M>>> = []
+  let observationIndex = 0
+  const add = (
+    snapshot: RuntimeInvariantTranscript<M>["initial"],
+    phase: RuntimeSnapshotObservation,
+    record?: RuntimeInvariantRecord<M>,
+    awaitedIndex?: number
+  ): void => {
+    const context: RuntimeSnapshotInvariantContext<M> = {
+      machine,
+      transcript,
+      snapshot,
+      observationIndex,
+      phase,
+      commandIndex: record?.index,
+      awaitedIndex,
+      command: record?.command,
+      result: record?.result
+    }
+    observations.push({
+      context,
+      observationIndex,
+      commandIndex: record?.index,
+      ...(awaitedIndex === undefined ? {} : { awaitedIndex }),
+      phase,
+      ...(record === undefined ? {} : { command: record.command })
+    })
+    observationIndex += 1
+  }
+
+  if (invariant.observe === "final") {
+    add(transcript.final, "final")
+    return observations
+  }
+
+  if (invariant.observe === "settled" || invariant.observe === "all") {
+    add(transcript.initial, "initial")
+    for (const record of transcript.records) add(record.snapshot, "command", record)
+  }
+
+  if (invariant.observe === "awaited" || invariant.observe === "all") {
+    for (const record of transcript.records) {
+      record.awaited.forEach((snapshot, awaitedIndex) => add(snapshot, "awaited", record, awaitedIndex))
+    }
+  }
+
+  return observations
+}
+
+const commandObservations = <M extends AnyMachine>(
+  machine: M,
+  transcript: RuntimeInvariantTranscript<M>
+): ReadonlyArray<Observation<M, RuntimeCommandInvariantContext<M>>> =>
+  transcript.records.map((record, index) => ({
+    context: {
+      machine,
+      transcript,
+      record,
+      previous: transcript.records[index - 1],
+      index: record.index,
+      command: record.command,
+      result: record.result,
+      snapshot: record.snapshot,
+      awaited: record.awaited
+    },
+    commandIndex: record.index,
+    command: record.command
+  }))
+
+const transcriptObservations = <M extends AnyMachine>(
+  machine: M,
+  transcript: RuntimeInvariantTranscript<M>
+): ReadonlyArray<Observation<M, RuntimeTranscriptInvariantContext<M>>> => [{
+  context: { machine, transcript },
+  commandIndex: undefined
+}]
+
+const scopeOf = <M extends AnyMachine>(invariant: RuntimeInvariant<M>): RuntimeInvariantScope => {
+  switch (invariant._tag) {
+    case "RuntimeSnapshotInvariant":
+      return "snapshot"
+    case "RuntimeCommandInvariant":
+      return "command"
+    case "RuntimeTranscriptInvariant":
+      return "transcript"
+  }
+}
+
+const messageOf = (outcome: InvariantOutcome): string | undefined =>
+  outcome === true ? undefined : typeof outcome === "string" ? outcome : "Invariant predicate returned false"
+
+type EvaluatedInvariant<Context> = InvariantOptions<Context> & {
+  readonly name: string
+  readonly check: (context: Context) => InvariantOutcome
+}
+
+const evaluateInvariant = <M extends AnyMachine, Context>(
+  invariant: EvaluatedInvariant<Context>,
+  scope: RuntimeInvariantScope,
+  observations: ReadonlyArray<Observation<M, Context>>
+): {
+  readonly check: RuntimeInvariantCheckResult
+  readonly violations: ReadonlyArray<RuntimeInvariantViolation<M>>
+} => {
+  let observed = 0
+  let failures = 0
+  const violations: Array<RuntimeInvariantViolation<M>> = []
+
+  for (const observation of observations) {
+    if (invariant.when !== undefined && !invariant.when(observation.context)) continue
+    observed += 1
+    const message = messageOf(invariant.check(observation.context))
+    if (message === undefined) continue
+    failures += 1
+    violations.push({
+      invariant: invariant.name,
+      scope,
+      kind: "predicate",
+      ...(observation.observationIndex === undefined ? {} : { observationIndex: observation.observationIndex }),
+      commandIndex: observation.commandIndex,
+      ...(observation.awaitedIndex === undefined ? {} : { awaitedIndex: observation.awaitedIndex }),
+      ...(observation.phase === undefined ? {} : { phase: observation.phase }),
+      ...(observation.command === undefined ? {} : { command: observation.command }),
+      message
+    })
+  }
+
+  const minimum = invariant.require?.minObservations ?? 0
+  const insufficient = observed < minimum
+  if (insufficient) {
+    violations.push({
+      invariant: invariant.name,
+      scope,
+      kind: "observations",
+      commandIndex: undefined,
+      message: `Invariant required at least ${minimum} observation${minimum === 1 ? "" : "s"} but observed ${observed}`
+    })
+  }
+
+  return {
+    check: {
+      invariant: invariant.name,
+      scope,
+      status: failures > 0 ? "failed" : insufficient ? "insufficient" : observed === 0 ? "untested" : "passed",
+      observations: observed,
+      failures
+    },
+    violations
+  }
+}
+
+export const checkRuntimeInvariants = <M extends AnyMachine, Error, Output>(
+  machine: M,
+  evidence: CausalRuntimeEvidence<M, Error, Output>,
+  invariants: ReadonlyArray<RuntimeInvariant<M>>
+): Effect.Effect<RuntimeInvariantReport, RuntimeInvariantError<M>> =>
+  Effect.suspend(() => {
+    const transcript = normalizeTranscript(evidence)
+    const checks: Array<RuntimeInvariantCheckResult> = []
+    const violations: Array<RuntimeInvariantViolation<M>> = []
+
+    for (const invariant of invariants) {
+      const scope = scopeOf(invariant)
+      const result = invariant._tag === "RuntimeSnapshotInvariant"
+        ? evaluateInvariant(invariant, scope, snapshotObservations(machine, transcript, invariant))
+        : invariant._tag === "RuntimeCommandInvariant"
+        ? evaluateInvariant(invariant, scope, commandObservations(machine, transcript))
+        : evaluateInvariant(invariant, scope, transcriptObservations(machine, transcript))
+      checks.push(result.check)
+      violations.push(...result.violations)
+    }
+
+    const report: RuntimeInvariantReport = { checks }
+    return violations.length === 0
+      ? Effect.succeed(report)
+      : Effect.fail(new RuntimeInvariantError({ transcript, violations, report }))
+  })
+
+export const assertRuntimeInvariants = <M extends AnyMachine, Error, Output>(
+  machine: M,
+  transcript: CausalRuntimeEvidence<M, Error, Output>,
+  invariants: ReadonlyArray<RuntimeInvariant<M>>
+): Effect.Effect<void, RuntimeInvariantError<M>> =>
+  checkRuntimeInvariants(machine, transcript, invariants).pipe(Effect.asVoid)
+
+export class PlannerRuntimeAgreementError<M extends AnyMachine = AnyMachine> extends Data.TaggedError(
+  "MachineTestPlannerRuntimeAgreementError"
+)<{
+  readonly evidence: CausalRuntimeEvidence<M, unknown, unknown>
+  readonly violations: ReadonlyArray<PlannerRuntimeAgreementViolation<M>>
+}> {}
+
+const fingerprint = (value: unknown): string => {
+  const active = new WeakSet<object>()
+  const visit = (current: unknown): unknown => {
+    if (current === undefined) return ["undefined"]
+    if (current === null || typeof current === "boolean" || typeof current === "string") return current
+    if (typeof current === "number") {
+      if (Number.isNaN(current)) return ["number", "NaN"]
+      if (Object.is(current, -0)) return ["number", "-0"]
+      return current
+    }
+    if (typeof current === "bigint") return ["bigint", String(current)]
+    if (typeof current === "symbol") return ["symbol", Symbol.keyFor(current) ?? String(current)]
+    if (typeof current === "function") return ["function", current.name]
+    if (active.has(current)) return ["circular"]
+    active.add(current)
+    let result: unknown
+    if (current instanceof Date) {
+      result = ["date", Number.isNaN(current.getTime()) ? "Invalid Date" : current.toISOString()]
+    } else if (current instanceof Error) {
+      result = [
+        "error",
+        current.name,
+        current.message,
+        Object.keys(current).sort().map((key) => [key, visit((current as unknown as Record<string, unknown>)[key])])
+      ]
+    } else if (ArrayBuffer.isView(current)) {
+      result = [current.constructor.name, Array.from(current as unknown as ArrayLike<number>)]
+    } else if (Array.isArray(current)) {
+      result = current.map(visit)
+    } else if (current instanceof Map) {
+      result = [
+        "map",
+        Array.from(current, ([key, item]) => [visit(key), visit(item)]).sort((left, right) =>
+          JSON.stringify(left).localeCompare(JSON.stringify(right))
+        )
+      ]
+    } else if (current instanceof Set) {
+      result = [
+        "set",
+        Array.from(current, visit).sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)))
+      ]
+    } else {
+      result = Object.keys(current).sort().map((key) => [key, visit((current as Record<string, unknown>)[key])])
+    }
+    active.delete(current)
+    return result
+  }
+  return JSON.stringify(visit(value))
+}
+
+const projection = (plan: {
+  readonly next: unknown
+  readonly commands: ReadonlyArray<unknown>
+  readonly emittedEvents: ReadonlyArray<unknown>
+  readonly microsteps: ReadonlyArray<{
+    readonly next: unknown
+    readonly event: unknown
+    readonly commands: ReadonlyArray<unknown>
+    readonly raisedEvents: ReadonlyArray<unknown>
+    readonly emittedEvents: ReadonlyArray<unknown>
+    readonly exitPaths: ReadonlyArray<string>
+    readonly entryPaths: ReadonlyArray<string>
+    readonly changed: boolean
+  }>
+  readonly done: boolean
+  readonly output: unknown
+}) => ({
+  after: plan.next,
+  completion: { done: plan.done, output: plan.output },
+  commands: plan.commands.length,
+  emittedEvents: plan.emittedEvents,
+  microsteps: plan.microsteps.map((microstep) => ({
+    next: microstep.next,
+    event: microstep.event,
+    commands: microstep.commands.length,
+    raisedEvents: microstep.raisedEvents,
+    emittedEvents: microstep.emittedEvents,
+    exitPaths: microstep.exitPaths,
+    entryPaths: microstep.entryPaths,
+    changed: microstep.changed
+  }))
+})
+
+export const assertPlannerRuntimeAgreement = <M extends AnyMachine, Error, Output>(
+  machine: M,
+  evidence: CausalRuntimeEvidence<M, Error, Output>
+): Effect.Effect<void, PlannerRuntimeAgreementError<M>> =>
+  Effect.gen(function*() {
+    const violations: Array<PlannerRuntimeAgreementViolation<M>> = []
+    const add = (
+      record: CausalRuntimeEvidence<M, Error, Output>["records"][number],
+      field: PlannerRuntimeAgreementViolation<M>["field"],
+      message: string
+    ): void => {
+      violations.push({ commandIndex: record.index, command: record.command, field, message })
+    }
+
+    for (const record of evidence.records) {
+      if (record.command._tag !== "Send" || record.actual.result._tag !== "SendProcessed") continue
+      const step = record.actual.result.step
+      const planned = yield* Effect.result(
+        Machine.plan(machine as any, step.before as any, record.command.event as any) as Effect.Effect<any, unknown>
+      )
+      if (Result.isFailure(planned)) {
+        add(record, "planning", `Fresh planning failed: ${String(planned.failure)}`)
+        continue
+      }
+
+      const expected = projection(planned.success)
+      const actual = projection(step.plan)
+      const compare = (
+        field: "planNext" | "after" | "completion" | "commands" | "emittedEvents" | "microsteps",
+        left: unknown,
+        right: unknown
+      ): void => {
+        const actualFingerprint = fingerprint(left)
+        const expectedFingerprint = fingerprint(right)
+        if (actualFingerprint !== expectedFingerprint) {
+          add(
+            record,
+            field,
+            `Runtime ${field} disagreed with fresh planning: expected ${expectedFingerprint}, actual ${actualFingerprint}`
+          )
+        }
+      }
+      compare("planNext", actual.after, expected.after)
+      compare("after", step.after, expected.after)
+      compare("completion", actual.completion, expected.completion)
+      compare("commands", actual.commands, expected.commands)
+      compare("emittedEvents", actual.emittedEvents, expected.emittedEvents)
+      compare("microsteps", actual.microsteps, expected.microsteps)
+
+      const handled = planned.success.microsteps.length > 0
+      if (step.handled !== handled) add(record, "handled", `Expected handled=${handled} but observed ${step.handled}`)
+      const configurationChanged = planned.success.microsteps.some(({ changed }: { readonly changed: boolean }) =>
+        changed
+      )
+      if (step.configurationChanged !== configurationChanged) {
+        add(
+          record,
+          "configurationChanged",
+          `Expected configurationChanged=${configurationChanged} but observed ${step.configurationChanged}`
+        )
+      }
+    }
+
+    if (violations.length > 0) {
+      return yield* new PlannerRuntimeAgreementError({
+        evidence: evidence as CausalRuntimeEvidence<M, unknown, unknown>,
+        violations
+      })
+    }
+  })

--- a/src/internal/testing/machine/verification.ts
+++ b/src/internal/testing/machine/verification.ts
@@ -51,6 +51,9 @@ export {
   type CausalRuntimeModelOptions,
   type CausalRuntimeModelStep,
   type CausalRuntimeTranscript,
+  type CausalVerificationAwaitContext,
+  type CausalVerificationOptions,
+  type CausalVerificationTranscript,
   checkpointCommand,
   type EnqueuedRuntimeAssertionContext,
   type EnqueuedRuntimeCommandActual,
@@ -83,7 +86,8 @@ export {
   RuntimeSynchronization,
   type RuntimeTranscript,
   sendCommand,
-  stopCommand
+  stopCommand,
+  verifyCausalCommands
 } from "./runtime.js"
 
 export type { SchemaArbitraryOpaqueFilterWarning, SchemaArbitraryReport, SchemaArbitraryWarning } from "./arbitrary.js"
@@ -127,6 +131,15 @@ export {
 } from "./referenceModel.js"
 
 export { assertInvariants, checkInvariants, Invariant, InvariantError, invariants } from "./invariant.js"
+
+export {
+  assertPlannerRuntimeAgreement,
+  assertRuntimeInvariants,
+  checkRuntimeInvariants,
+  PlannerRuntimeAgreementError,
+  RuntimeInvariantError,
+  runtimeInvariants
+} from "./runtimeInvariant.js"
 
 export { assertReachable, assertUnreachable, explore, findShortest, ReachabilityError } from "./exploration.js"
 

--- a/src/testing/MachineTest.ts
+++ b/src/testing/MachineTest.ts
@@ -27,6 +27,9 @@ export {
   type CausalRuntimeModelOptions,
   type CausalRuntimeModelStep,
   type CausalRuntimeTranscript,
+  type CausalVerificationAwaitContext,
+  type CausalVerificationOptions,
+  type CausalVerificationTranscript,
   checkpointCommand,
   type EnqueuedRuntimeAssertionContext,
   type EnqueuedRuntimeCommandActual,
@@ -59,7 +62,8 @@ export {
   RuntimeSynchronization,
   type RuntimeTranscript,
   sendCommand,
-  stopCommand
+  stopCommand,
+  verifyCausalCommands
 } from "../internal/testing/machine/verification.js"
 
 export type {
@@ -457,6 +461,240 @@ export const probe: <M extends AnyMachine, Error, Output>(
     Output
   >
 ) => Effect.Effect<Probe<M, Error, Output>, internal.ProbeUnavailableError> = internal.probe
+
+/** The runtime error channel exposed by a managed reference for a machine. */
+export type RuntimeInvariantErrorChannel<M extends AnyMachine> =
+  | Machine.Machine.Error<M>
+  | Machine.ActionError<Machine.Machine.Services<M>>
+  | Machine.InfiniteTransitionError
+  | Machine.MachineSchemaDecodeError
+  | Machine.StoppedError
+
+/** A causal command record projected independently of a reference model. */
+export interface CausalRuntimeEvidenceRecord<M extends AnyMachine, Error, Output> {
+  readonly index: number
+  readonly command: internal.RuntimeCommand<Machine.Machine.InputEvent<M>>
+  readonly actual: internal.CausalRuntimeCommandActual<M, Error, Output, unknown>
+}
+
+/** The model-independent evidence shared by causal command transcripts. */
+export interface CausalRuntimeEvidence<M extends AnyMachine, Error, Output> {
+  readonly commands: ReadonlyArray<internal.RuntimeCommand<Machine.Machine.InputEvent<M>>>
+  readonly initial: Machine.RuntimeSnapshot<Machine.Machine.Snapshot<Machine.Machine.States<M>>, Error, Output>
+  readonly records: ReadonlyArray<CausalRuntimeEvidenceRecord<M, Error, Output>>
+  readonly final: Machine.RuntimeSnapshot<Machine.Machine.Snapshot<Machine.Machine.States<M>>, Error, Output>
+}
+
+/** The runtime snapshots selected by one snapshot invariant. */
+export type RuntimeSnapshotObservationMode = "settled" | "awaited" | "all" | "final"
+
+/** The semantic location of one retained runtime snapshot. */
+export type RuntimeSnapshotObservation = "initial" | "command" | "awaited" | "final"
+
+/** A model-independent command record supplied to runtime laws. */
+export interface RuntimeInvariantRecord<M extends AnyMachine> {
+  readonly index: number
+  readonly command: internal.RuntimeCommand<Machine.Machine.InputEvent<M>>
+  readonly result: internal.CausalRuntimeCommandResult<M>
+  readonly snapshot: Machine.RuntimeSnapshot<
+    Machine.Machine.Snapshot<Machine.Machine.States<M>>,
+    RuntimeInvariantErrorChannel<M>,
+    Machine.Machine.Output<M>
+  >
+  readonly awaited: ReadonlyArray<
+    Machine.RuntimeSnapshot<
+      Machine.Machine.Snapshot<Machine.Machine.States<M>>,
+      RuntimeInvariantErrorChannel<M>,
+      Machine.Machine.Output<M>
+    >
+  >
+}
+
+/** A model-independent causal transcript supplied to runtime laws. */
+export interface RuntimeInvariantTranscript<M extends AnyMachine> {
+  readonly commands: ReadonlyArray<internal.RuntimeCommand<Machine.Machine.InputEvent<M>>>
+  readonly initial: Machine.RuntimeSnapshot<
+    Machine.Machine.Snapshot<Machine.Machine.States<M>>,
+    RuntimeInvariantErrorChannel<M>,
+    Machine.Machine.Output<M>
+  >
+  readonly records: ReadonlyArray<RuntimeInvariantRecord<M>>
+  readonly final: Machine.RuntimeSnapshot<
+    Machine.Machine.Snapshot<Machine.Machine.States<M>>,
+    RuntimeInvariantErrorChannel<M>,
+    Machine.Machine.Output<M>
+  >
+}
+
+/** Evidence passed to a runtime snapshot invariant. */
+export interface RuntimeSnapshotInvariantContext<M extends AnyMachine> {
+  readonly machine: M
+  readonly transcript: RuntimeInvariantTranscript<M>
+  readonly snapshot: RuntimeInvariantTranscript<M>["initial"]
+  readonly observationIndex: number
+  readonly phase: RuntimeSnapshotObservation
+  readonly commandIndex: number | undefined
+  readonly awaitedIndex: number | undefined
+  readonly command: internal.RuntimeCommand<Machine.Machine.InputEvent<M>> | undefined
+  readonly result: internal.CausalRuntimeCommandResult<M> | undefined
+}
+
+/** Evidence passed to an invariant for one completed causal command. */
+export interface RuntimeCommandInvariantContext<M extends AnyMachine> {
+  readonly machine: M
+  readonly transcript: RuntimeInvariantTranscript<M>
+  readonly record: RuntimeInvariantRecord<M>
+  readonly previous: RuntimeInvariantRecord<M> | undefined
+  readonly index: number
+  readonly command: internal.RuntimeCommand<Machine.Machine.InputEvent<M>>
+  readonly result: internal.CausalRuntimeCommandResult<M>
+  readonly snapshot: RuntimeInvariantRecord<M>["snapshot"]
+  readonly awaited: RuntimeInvariantRecord<M>["awaited"]
+}
+
+/** Evidence passed to a whole-runtime-transcript invariant. */
+export interface RuntimeTranscriptInvariantContext<M extends AnyMachine> {
+  readonly machine: M
+  readonly transcript: RuntimeInvariantTranscript<M>
+}
+
+/** Options for a runtime snapshot invariant. */
+export interface RuntimeSnapshotInvariantOptions<M extends AnyMachine>
+  extends InvariantOptions<RuntimeSnapshotInvariantContext<M>>
+{
+  readonly observe?: RuntimeSnapshotObservationMode
+}
+
+/** A semantic property checked against selected live runtime snapshots. */
+export interface RuntimeSnapshotInvariant<M extends AnyMachine>
+  extends InvariantOptions<RuntimeSnapshotInvariantContext<M>>
+{
+  readonly _tag: "RuntimeSnapshotInvariant"
+  readonly name: string
+  readonly observe: RuntimeSnapshotObservationMode
+  readonly check: (context: RuntimeSnapshotInvariantContext<M>) => InvariantOutcome
+}
+
+/** A semantic property checked after every completed causal command. */
+export interface RuntimeCommandInvariant<M extends AnyMachine>
+  extends InvariantOptions<RuntimeCommandInvariantContext<M>>
+{
+  readonly _tag: "RuntimeCommandInvariant"
+  readonly name: string
+  readonly check: (context: RuntimeCommandInvariantContext<M>) => InvariantOutcome
+}
+
+/** A semantic property checked once against a complete causal transcript. */
+export interface RuntimeTranscriptInvariant<M extends AnyMachine>
+  extends InvariantOptions<RuntimeTranscriptInvariantContext<M>>
+{
+  readonly _tag: "RuntimeTranscriptInvariant"
+  readonly name: string
+  readonly check: (context: RuntimeTranscriptInvariantContext<M>) => InvariantOutcome
+}
+
+/** A user-defined semantic property over retained live runtime evidence. */
+export type RuntimeInvariant<M extends AnyMachine> =
+  | RuntimeSnapshotInvariant<M>
+  | RuntimeCommandInvariant<M>
+  | RuntimeTranscriptInvariant<M>
+
+/** Machine-bound runtime invariant constructors with exact event inference. */
+export interface RuntimeInvariantBuilder<M extends AnyMachine> {
+  readonly snapshot: (
+    name: string,
+    check: (context: RuntimeSnapshotInvariantContext<M>) => InvariantOutcome,
+    options?: RuntimeSnapshotInvariantOptions<M>
+  ) => RuntimeSnapshotInvariant<M>
+  readonly command: (
+    name: string,
+    check: (context: RuntimeCommandInvariantContext<M>) => InvariantOutcome,
+    options?: InvariantOptions<RuntimeCommandInvariantContext<M>>
+  ) => RuntimeCommandInvariant<M>
+  readonly transcript: (
+    name: string,
+    check: (context: RuntimeTranscriptInvariantContext<M>) => InvariantOutcome,
+    options?: InvariantOptions<RuntimeTranscriptInvariantContext<M>>
+  ) => RuntimeTranscriptInvariant<M>
+}
+
+/** Creates reusable semantic laws for causal runtime evidence. */
+export const runtimeInvariants: <M extends AnyMachine>(machine: M) => RuntimeInvariantBuilder<M> =
+  internal.runtimeInvariants
+
+/** Scope of a runtime invariant. */
+export type RuntimeInvariantScope = "snapshot" | "command" | "transcript"
+
+/** Aggregate result for one runtime invariant. */
+export interface RuntimeInvariantCheckResult {
+  readonly invariant: string
+  readonly scope: RuntimeInvariantScope
+  readonly status: InvariantStatus
+  readonly observations: number
+  readonly failures: number
+}
+
+/** Aggregate result for all checked runtime invariants. */
+export interface RuntimeInvariantReport {
+  readonly checks: ReadonlyArray<RuntimeInvariantCheckResult>
+}
+
+/** One runtime invariant violation and its exact retained location. */
+export interface RuntimeInvariantViolation<M extends AnyMachine = AnyMachine> {
+  readonly invariant: string
+  readonly scope: RuntimeInvariantScope
+  readonly kind: "predicate" | "observations"
+  readonly observationIndex?: number
+  readonly commandIndex: number | undefined
+  readonly awaitedIndex?: number
+  readonly phase?: RuntimeSnapshotObservation
+  readonly command?: internal.RuntimeCommand<Machine.Machine.InputEvent<M>>
+  readonly message: string
+}
+
+/** All violations found in one causal runtime transcript. */
+export { RuntimeInvariantError } from "../internal/testing/machine/verification.js"
+
+/** Checks runtime invariants and returns their complete non-vacuity report. */
+export const checkRuntimeInvariants: <M extends AnyMachine, Error, Output>(
+  machine: M,
+  transcript: CausalRuntimeEvidence<M, Error, Output>,
+  invariants: ReadonlyArray<RuntimeInvariant<M>>
+) => Effect.Effect<RuntimeInvariantReport, internal.RuntimeInvariantError<M>> = internal.checkRuntimeInvariants
+
+/** Asserts runtime invariants against an existing causal transcript. */
+export const assertRuntimeInvariants: <M extends AnyMachine, Error, Output>(
+  machine: M,
+  transcript: CausalRuntimeEvidence<M, Error, Output>,
+  invariants: ReadonlyArray<RuntimeInvariant<M>>
+) => Effect.Effect<void, internal.RuntimeInvariantError<M>> = internal.assertRuntimeInvariants
+
+/** One disagreement between pure planning and a causally processed send. */
+export interface PlannerRuntimeAgreementViolation<M extends AnyMachine = AnyMachine> {
+  readonly commandIndex: number
+  readonly command: internal.RuntimeCommand<Machine.Machine.InputEvent<M>>
+  readonly field:
+    | "planning"
+    | "handled"
+    | "configurationChanged"
+    | "planNext"
+    | "after"
+    | "completion"
+    | "commands"
+    | "emittedEvents"
+    | "microsteps"
+  readonly message: string
+}
+
+/** Raised when live causal evidence disagrees with a fresh pure plan. */
+export { PlannerRuntimeAgreementError } from "../internal/testing/machine/verification.js"
+
+/** Checks that every processed public send agrees with a fresh pure plan. */
+export const assertPlannerRuntimeAgreement: <M extends AnyMachine, Error, Output>(
+  machine: ReadyMachine<M>,
+  transcript: CausalRuntimeEvidence<M, Error, Output>
+) => Effect.Effect<void, internal.PlannerRuntimeAgreementError<M>, RunServices<M>> =
+  internal.assertPlannerRuntimeAgreement
 
 /**
  * The result of evaluating one semantic invariant.

--- a/test/internal/machine/strategyDifferential.test.ts
+++ b/test/internal/machine/strategyDifferential.test.ts
@@ -283,6 +283,7 @@ describe("machine planner and runtime strategies", () => {
             done: step.plan.done,
             microsteps: step.plan.microsteps.map((microstep) => ({
               event: microstep.event._tag,
+              next: microstep.next.value.value,
               changed: microstep.changed,
               exitPaths: microstep.exitPaths,
               entryPaths: microstep.entryPaths

--- a/test/testing/Probe.test.ts
+++ b/test/testing/Probe.test.ts
@@ -95,8 +95,12 @@ describe("MachineTest probe", () => {
 
       const burst = yield* probe.sendAndAwait(new Burst({}))
       assert.deepStrictEqual(burst.plan.microsteps.map(({ event }) => event._tag), ["Burst", "RaisedIncrement"])
+      assert.deepStrictEqual(burst.plan.microsteps.map(({ next }) => next.value.count), [3, 13])
       assert.strictEqual(burst.before.value.count, 2)
       assert.strictEqual(burst.after.value.count, 13)
+
+      yield* probe.sendAndAwait(new Increment({ amount: 5 }))
+      assert.deepStrictEqual(burst.plan.microsteps.map(({ next }) => next.value.count), [3, 13])
 
       yield* ref.stop
     }))

--- a/test/testing/Runtime.test.ts
+++ b/test/testing/Runtime.test.ts
@@ -565,6 +565,18 @@ describe("MachineTest runtime commands", () => {
 })
 
 describe("MachineTest causal runtime commands", () => {
+  it("validates runtime invariant names and non-vacuity requirements", () => {
+    const invariant = MachineTest.runtimeInvariants(causalMachine)
+    assert.throws(
+      () => invariant.snapshot(" ", () => true),
+      /name to be a non-empty string/
+    )
+    assert.throws(
+      () => invariant.command("invalid minimum", () => true, { require: { minObservations: -1 } }),
+      /minObservations to be a non-negative safe integer/
+    )
+  })
+
   it.effect("attributes ignored, targetless, raised, and changing macrosteps to their exact sends", () =>
     Effect.gen(function*() {
       const ref = yield* Machine.start(causalMachine)
@@ -727,6 +739,30 @@ describe("MachineTest causal runtime commands", () => {
 
       assert.strictEqual(transcript.final.state.path, "TimedOut")
       yield* ref.stop
+
+      const verifiedRef = yield* Machine.start(timerMachine)
+      const verifiedProbe = yield* MachineTest.probe(timerMachine, verifiedRef)
+      const invariant = MachineTest.runtimeInvariants(timerMachine)
+      const verified = yield* MachineTest.verifyCausalCommands(
+        verifiedProbe,
+        [MachineTest.advanceCommand(1_000)],
+        {
+          await: () => verifiedProbe.await.until((snapshot) => snapshot.state.path === "TimedOut"),
+          invariants: [
+            invariant.snapshot(
+              "awaited timer observations remain active",
+              ({ snapshot }) => snapshot.status === "active",
+              { observe: "awaited", require: { minObservations: 1 } }
+            ),
+            invariant.transcript(
+              "the awaited timer reaches TimedOut",
+              ({ transcript }) => transcript.final.state.path === "TimedOut"
+            )
+          ]
+        }
+      )
+      assert.isAtLeast(verified.records[0]?.actual.awaited.length ?? 0, 1)
+      yield* verifiedRef.stop
     }))
 
   it.effect("attributes processing failures to the exact causal command and prefix", () =>
@@ -790,6 +826,204 @@ describe("MachineTest causal runtime commands", () => {
 
       assert.strictEqual(failure.phase, "execution")
       assert.instanceOf(Cause.squash(failure.cause), Machine.StoppedError)
+      yield* ref.stop
+    }))
+
+  it.effect("checks reusable snapshot, command, and transcript laws over causal evidence", () =>
+    Effect.gen(function*() {
+      const ref = yield* Machine.start(causalMachine)
+      const probe = yield* MachineTest.probe(causalMachine, ref)
+      const transcript = yield* MachineTest.runCausalCommands(probe, [
+        MachineTest.sendCommand(new Add({ amount: 2 })),
+        MachineTest.sendCommand(new Noop({}))
+      ], {
+        initialModel: undefined,
+        transition: (model) => Effect.succeed({ model, expected: undefined }),
+        assert: () => Effect.void
+      })
+      const invariant = MachineTest.runtimeInvariants(causalMachine)
+      const report = yield* MachineTest.checkRuntimeInvariants(causalMachine, transcript, [
+        invariant.snapshot(
+          "count is non-negative",
+          ({ snapshot }) => snapshot.state.value.count >= 0
+        ),
+        invariant.command(
+          "add is processed",
+          ({ command, result }) =>
+            command._tag !== "Send" || command.event._tag !== "Add" ||
+            result._tag === "SendProcessed",
+          {
+            when: ({ command }) => command._tag === "Send" && command.event._tag === "Add",
+            require: { minObservations: 1 }
+          }
+        ),
+        invariant.transcript(
+          "a targetless command was retained",
+          ({ transcript }) =>
+            transcript.records.some(({ result }) =>
+              result._tag === "SendProcessed" && result.step.handled && !result.step.configurationChanged
+            )
+        ),
+        invariant.snapshot(
+          "an optional await law remains explicitly untested",
+          () => true,
+          { observe: "awaited" }
+        ),
+        invariant.snapshot(
+          "the final retained snapshot is available",
+          ({ snapshot }) => snapshot.state.value.count === 2,
+          { observe: "final" }
+        )
+      ])
+
+      assert.deepStrictEqual(
+        report.checks.map(({ observations, scope, status }) => ({
+          observations,
+          scope,
+          status
+        })),
+        [
+          { observations: 3, scope: "snapshot", status: "passed" },
+          { observations: 1, scope: "command", status: "passed" },
+          { observations: 1, scope: "transcript", status: "passed" },
+          { observations: 0, scope: "snapshot", status: "untested" },
+          { observations: 1, scope: "snapshot", status: "passed" }
+        ]
+      )
+      yield* ref.stop
+    }))
+
+  it.effect("retains every runtime law violation and detects vacuous conditional laws", () =>
+    Effect.gen(function*() {
+      const ref = yield* Machine.start(causalMachine)
+      const probe = yield* MachineTest.probe(causalMachine, ref)
+      const transcript = yield* MachineTest.verifyCausalCommands(probe, [
+        MachineTest.sendCommand(new Add({ amount: -2 }))
+      ], {
+        invariants: []
+      })
+      const invariant = MachineTest.runtimeInvariants(causalMachine)
+      const failure = yield* MachineTest.assertRuntimeInvariants(causalMachine, transcript, [
+        invariant.snapshot(
+          "count stays non-negative",
+          ({ snapshot }) => snapshot.state.value.count >= 0 || `negative count: ${snapshot.state.value.count}`
+        ),
+        invariant.command(
+          "burst is exercised",
+          () => true,
+          {
+            when: ({ command }) => command._tag === "Send" && command.event._tag === "Burst",
+            require: { minObservations: 1 }
+          }
+        )
+      ]).pipe(Effect.flip)
+
+      assert.deepStrictEqual(failure.report.checks.map(({ status }) => status), ["failed", "insufficient"])
+      assert.strictEqual(failure.violations.length, 2)
+      assert.deepStrictEqual(failure.violations[0], {
+        invariant: "count stays non-negative",
+        scope: "snapshot",
+        kind: "predicate",
+        observationIndex: 1,
+        commandIndex: 0,
+        phase: "command",
+        command: MachineTest.sendCommand(new Add({ amount: -2 })),
+        message: "negative count: -2"
+      })
+      assert.strictEqual(failure.violations[1]?.kind, "observations")
+      assert.strictEqual(failure.transcript.records.length, 1)
+      yield* ref.stop
+    }))
+
+  it.effect("verifies causal laws without requiring dummy model callbacks", () =>
+    Effect.gen(function*() {
+      const ref = yield* Machine.start(causalMachine)
+      const probe = yield* MachineTest.probe(causalMachine, ref)
+      const invariant = MachineTest.runtimeInvariants(causalMachine)
+      const transcript = yield* MachineTest.verifyCausalCommands(probe, [
+        MachineTest.sendCommand(new Ignored({})),
+        MachineTest.sendCommand(new Add({ amount: 3 })),
+        MachineTest.sendCommand(new Burst({}))
+      ], {
+        invariants: [
+          invariant.snapshot("count stays non-negative", ({ snapshot }) => snapshot.state.value.count >= 0),
+          invariant.command("every send is acknowledged", ({ command, result }) =>
+            command._tag !== "Send" || result._tag === "SendProcessed")
+        ]
+      })
+
+      assert.strictEqual(transcript.records.length, 3)
+      assert.strictEqual(transcript.final.state.value.count, 14)
+      assert.strictEqual("finalModel" in transcript, false)
+      yield* MachineTest.assertPlannerRuntimeAgreement(causalMachine, transcript)
+      yield* ref.stop
+    }))
+
+  it.effect.prop(
+    "checks generated causal commands with reusable runtime laws and planner agreement",
+    {
+      commands: MachineTest.runtimeCommands(causalMachine, {
+        maxCommands: 20,
+        eventArbitrary: FastCheck.oneof(
+          FastCheck.integer({ min: -10, max: 10 }).map((amount) => new Add({ amount })),
+          FastCheck.constant(new Ignored({})),
+          FastCheck.constant(new Noop({}))
+        ),
+        includeAdvance: false,
+        includeStop: false,
+        includeCheckpoint: false
+      }).arbitrary
+    },
+    ({ commands }) =>
+      Effect.gen(function*() {
+        const ref = yield* Machine.start(causalMachine)
+        const probe = yield* MachineTest.probe(causalMachine, ref)
+        const invariant = MachineTest.runtimeInvariants(causalMachine)
+        const transcript = yield* MachineTest.verifyCausalCommands(probe, commands, {
+          invariants: [
+            invariant.command("add applies exactly once", ({ command, result }) => {
+              if (
+                command._tag !== "Send" || command.event._tag !== "Add" ||
+                result._tag !== "SendProcessed"
+              ) return true
+              return result.step.after.value.count === result.step.before.value.count + command.event.amount
+            })
+          ]
+        })
+        yield* MachineTest.assertPlannerRuntimeAgreement(causalMachine, transcript)
+        yield* ref.stop
+      }),
+    { fastCheck: { numRuns: 100, seed: 81_440 } }
+  )
+
+  it.effect("reports the exact field when causal evidence disagrees with fresh planning", () =>
+    Effect.gen(function*() {
+      const ref = yield* Machine.start(causalMachine)
+      const probe = yield* MachineTest.probe(causalMachine, ref)
+      const transcript = yield* MachineTest.verifyCausalCommands(probe, [
+        MachineTest.sendCommand(new Ignored({}))
+      ], { invariants: [] })
+      const record = transcript.records[0]!
+      assert.strictEqual(record.actual.result._tag, "SendProcessed")
+      if (record.actual.result._tag !== "SendProcessed") return
+      const corrupted = {
+        ...transcript,
+        records: [{
+          ...record,
+          actual: {
+            ...record.actual,
+            result: {
+              ...record.actual.result,
+              step: { ...record.actual.result.step, handled: true }
+            }
+          }
+        }]
+      }
+      const failure = yield* MachineTest.assertPlannerRuntimeAgreement(causalMachine, corrupted).pipe(Effect.flip)
+
+      assert.deepStrictEqual(failure.violations.map(({ commandIndex, field }) => ({ commandIndex, field })), [
+        { commandIndex: 0, field: "handled" }
+      ])
       yield* ref.stop
     }))
 })

--- a/typetest/testing/Probe.tst.ts
+++ b/typetest/testing/Probe.tst.ts
@@ -82,4 +82,55 @@ describe("MachineTest probe", () => {
     >
     expect<CausalFailure>().type.not.toBe<never>()
   })
+
+  it("infers reusable runtime laws and law-oriented causal verification", () => {
+    const invariant = MachineTest.runtimeInvariants(machine)
+    const laws = [
+      invariant.snapshot("state is typed", ({ snapshot, command }) => {
+        expect(snapshot.state.value).type.toBe<State>()
+        expect(command).type.toBe<MachineTest.RuntimeCommand<PublicEvent> | undefined>()
+        return snapshot.state.value.count >= 0
+      }),
+      invariant.command("public commands are typed", ({ command, result }) => {
+        expect(command).type.toBe<MachineTest.RuntimeCommand<PublicEvent>>()
+        expect(result).type.toBe<MachineTest.CausalRuntimeCommandResult<typeof machine>>()
+        return true
+      }),
+      invariant.transcript("transcript is typed", ({ transcript }) => {
+        expect(transcript.records[0]!.command).type.toBe<MachineTest.RuntimeCommand<PublicEvent>>()
+        return true
+      })
+    ]
+    const verified = Effect.flatMap(
+      Machine.start(machine),
+      (ref) =>
+        Effect.flatMap(MachineTest.probe(machine, ref), (probe) =>
+          MachineTest.verifyCausalCommands(probe, [
+            MachineTest.sendCommand(new PublicEvent({}))
+          ], { invariants: laws }))
+    )
+
+    expect<Effect.Success<typeof verified>>().type.toBe<
+      MachineTest.CausalVerificationTranscript<
+        typeof machine,
+        MachineTest.RuntimeInvariantErrorChannel<typeof machine>,
+        never
+      >
+    >()
+    expect<Effect.Success<typeof verified>["records"][number]["actual"]["result"]>().type.toBe<
+      MachineTest.CausalRuntimeCommandResult<typeof machine>
+    >()
+    type InvariantFailure = Extract<Effect.Error<typeof verified>, MachineTest.RuntimeInvariantError<typeof machine>>
+    expect<InvariantFailure>().type.not.toBe<never>()
+
+    const agreement = Effect.flatMap(
+      verified,
+      (transcript) => MachineTest.assertPlannerRuntimeAgreement(machine, transcript)
+    )
+    type AgreementFailure = Extract<
+      Effect.Error<typeof agreement>,
+      MachineTest.PlannerRuntimeAgreementError<typeof machine>
+    >
+    expect<AgreementFailure>().type.not.toBe<never>()
+  })
 })


### PR DESCRIPTION
## Summary

- add reusable snapshot, command, and transcript runtime invariants with filtering, observation requirements, aggregate reports, and exact violation locations
- add `verifyCausalCommands` for law-oriented causal tests without a dummy reference model, plus explicit planner/runtime agreement assertions
- retain stable public microstep snapshots for acknowledged probe sends while keeping cloning out of ordinary production sends
- document the new testing workflow and add runtime, property-based, regression, and type-inference coverage

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (no examples changed)
- [x] Reviewed the automated type-performance report, when the public TypeScript API or inference changed
- [x] Reviewed the automated runtime-performance report, when runtime behavior changed

Local validation also included `pnpm perf:types` and two successful `pnpm perf:runtime` runs. The automated base-versus-PR performance reports will be reviewed before merge.