### PR TITLE
Upgrade XState v6 alpha

### DIFF
--- a/.changeset/bright-taxis-juggle.md
+++ b/.changeset/bright-taxis-juggle.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Upgrade the XState v6 performance comparison to `6.0.0-alpha.36`.

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "typescript": "6.0.3",
     "vitest": "4.1.10",
     "xstate-v5": "npm:xstate@5.32.5",
-    "xstate-v6": "npm:xstate@6.0.0-alpha.31"
+    "xstate-v6": "npm:xstate@6.0.0-alpha.36"
   },
   "packageManager": "pnpm@10.17.1",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: npm:xstate@5.32.5
         version: xstate@5.32.5
       xstate-v6:
-        specifier: npm:xstate@6.0.0-alpha.31
-        version: xstate@6.0.0-alpha.31
+        specifier: npm:xstate@6.0.0-alpha.36
+        version: xstate@6.0.0-alpha.36
 
 packages:
 
@@ -1131,8 +1131,8 @@ packages:
   xstate@5.32.5:
     resolution: {integrity: sha512-ULazi1oe6wGrXl0Frb6otSlkm5HLifbbVTkMk5kkSKqz4TkxJaVpnl6jOJwKeid3ORPxYyZQgNLUSYX9q65SIA==}
 
-  xstate@6.0.0-alpha.31:
-    resolution: {integrity: sha512-nWdxu+Rg95zBMg8jwtKtSY3WMpe9ZgOe0ZwxOMKIdpuRUnlvAK+u9bIP2T3j+xWW3Oec/paNBVYT5J55Ya0DxA==}
+  xstate@6.0.0-alpha.36:
+    resolution: {integrity: sha512-8zXcB9BU/o0j3NTrOLovqMr9h0Ni0Y06Dz1BW6g7ZHTg/C64RcTqZkkLdR1KywhMdTN44DzTbNwqgdY3rQz6DA==}
     hasBin: true
 
   yaml@2.9.0:
@@ -2119,6 +2119,6 @@ snapshots:
 
   xstate@5.32.5: {}
 
-  xstate@6.0.0-alpha.31: {}
+  xstate@6.0.0-alpha.36: {}
 
   yaml@2.9.0: {}


### PR DESCRIPTION
## Summary

- upgrade the XState v6 benchmark dependency from `6.0.0-alpha.31` to `6.0.0-alpha.36`
- refresh the pnpm lockfile
- add the required patch changeset

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] `pnpm perf:types`
- [x] `pnpm perf:runtime`
- [ ] Relevant example checks, when examples changed (not applicable)
- [ ] Reviewed the automated type-performance report, when the public TypeScript API or inference changed (not applicable)
- [x] Reviewed the automated runtime-performance report

The local runtime benchmark completed successfully with XState `6.0.0-alpha.36`.

The automated base-versus-PR runtime workflow was run twice (five independent processes per revision in each run). Type instantiations were exactly unchanged, heap slopes were effectively flat, and the first run's isolated `-3.5%` / `-3.9%` throughput readings did not reproduce (`-0.1%` / `-1.3%` on confirmation). The remaining differences were within the reported shared-runner variability.
