### PR TITLE
Ship TypeScript sources in releases

### DIFF
--- a/.changeset/strong-cats-share.md
+++ b/.changeset/strong-cats-share.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Include the original TypeScript sources in the published package.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "sideEffects": false,
   "files": [
+    "src/**/*.ts",
     "dist",
     "docs",
     "README.md",

--- a/scripts/pack-check.mjs
+++ b/scripts/pack-check.mjs
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdtemp, readdir, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { spawnSync } from "node:child_process"
@@ -18,7 +18,11 @@ try {
   const listing = spawnSync("tar", ["-tzf", archive], { encoding: "utf8" })
   if (listing.status !== 0) throw new Error(listing.stderr)
   const files = listing.stdout.trim().split("\n")
+  const sourceFiles = (await readdir(join(root, "src"), { recursive: true }))
+    .filter((file) => file.endsWith(".ts"))
+    .map((file) => `package/src/${file.replaceAll("\\", "/")}`)
   const required = [
+    ...sourceFiles,
     "package/dist/index.js",
     "package/dist/index.d.ts",
     "package/dist/unstable/reactivity/index.js",
@@ -47,7 +51,7 @@ try {
   if (legacyBuildFiles.length > 0) {
     throw new Error(`tarball contains legacy entrypoint artifacts:\n${legacyBuildFiles.join("\n")}`)
   }
-  const forbidden = files.filter((file) => /^package\/(?:src|test|typetest|scripts|\.github|\.changeset)\//.test(file))
+  const forbidden = files.filter((file) => /^package\/(?:test|typetest|scripts|\.github|\.changeset)\//.test(file))
   if (forbidden.length > 0) throw new Error(`tarball contains repository files:\n${forbidden.join("\n")}`)
   console.log(`pack verification passed (${files.length} files)`)
 } finally {


### PR DESCRIPTION
## Summary

- include every original `src/**/*.ts` file in the published package, matching Effect's release layout
- keep runtime and type exports pointed at the compiled `dist` output
- make the pack check verify every source file is present in the release archive
- add a patch changeset

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (not applicable)
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required

The release tarball contains all 37 TypeScript source files and passes `pnpm pack:check` with 194 packaged files.
