### PR TITLE
Allow active states to omit schemas

### DIFF
--- a/.changeset/quiet-states.md
+++ b/.changeset/quiet-states.md
@@ -1,0 +1,16 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Allow active states to omit `schema` when they own no data. Schema-less atomic, compound, parallel, and final states keep full control-flow semantics while exposing value-free `.from(...)` builders, `undefined` handler state, and snapshot-only query APIs.
+
+```ts
+const States = Machine.defineStates({
+  Form: {
+    initial: "Editing",
+    states: { Editing: {}, Saving }
+  }
+})
+
+States.initial.Form.from((form) => form.Editing.from())
+```

--- a/README.md
+++ b/README.md
@@ -94,6 +94,27 @@ defaults, refinements, and tagged-class identity are therefore preserved, and
 decode failures remain typed machine failures. Pass a value directly only when
 it is already decoded, such as a value returned by `Machine.retag`.
 
+Omit `schema` when a state represents control flow but owns no data:
+
+```ts
+const States = Machine.defineStates({
+  Form: {
+    initial: "Editing",
+    states: {
+      Editing: {},
+      Saving
+    }
+  }
+})
+
+States.initial.Form.from((form) => form.Editing.from())
+```
+
+Schema-less states remain active, targetable, matchable, and visible through
+`getSnapshot`, but have no value to read. Their builders expose only `.from`,
+their handler `state` is `undefined`, and `get` / `getWithParents` accept only
+schema-backed paths. Add a schema later if the state starts owning data.
+
 Put data on the narrowest state where it is valid. If sibling phases share
 data, put it on their compound parent.
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -21,7 +21,7 @@ Use this order so inference has all schemas available when handlers are
 declared:
 
 1. Domain schemas used by state and event fields.
-2. Tagged state schemas.
+2. Tagged schemas for states that own data.
 3. Tagged public-event, internal-event, and emitted-event schemas.
 4. `Machine.defineStates`.
 5. `Machine.make`, including input, events, internal events, emits, and the
@@ -108,24 +108,63 @@ its extra control is required:
 
 ## Atomic, compound, parallel, and history states
 
+An active state does not need a schema unless it owns data. Omit `schema` for
+control-only atomic, compound, parallel, and final states:
+
+```ts
+const States = Machine.defineStates({
+  Idle: {},
+  Form: {
+    initial: "Editing",
+    states: {
+      Editing: {},
+      Saving: State.cases.Saving
+    }
+  }
+})
+
+States.initial.Idle.from()
+States.initial.Form.from((form) => form.Editing.from())
+```
+
+Schema-less states have the same control semantics as schema-backed states:
+they are active, targetable, matchable, receive lifecycle handlers, and appear
+in snapshots. They do not have a state value:
+
+```ts
+Idle: {
+  on: {
+    Start: ({ state, target }) => {
+      // state: undefined
+      return target.full.Form.from((form) => form.Editing.from())
+    }
+  }
+}
+
+States.matches(snapshot, "Form")              // allowed
+States.getSnapshot(snapshot, "Form")          // allowed
+States.get(snapshot, "Form")                  // type error: no value schema
+```
+
+For a schema-less path, builders expose only `.from(...)`; the direct callable
+form is reserved for already-decoded schema values. Structural ancestors are
+also omitted from `parents`; an immediate structural parent is typed as
+`undefined`. Add `schema` when a state begins to own data or needs runtime
+validation and persistence for that data.
+
 Use an atomic state when no child phase can be active beneath it.
 
 Use a compound state when exactly one child phase is active. It must declare an
 `initial` child:
 
 ```ts
-const FormState = Schema.TaggedUnion({
-  Form: { draft: Schema.String },
-  Editing: {},
-  Saving: {}
-})
+const FormState = Schema.TaggedUnion({ Saving: { draft: Schema.String } })
 
 const FormStates = Machine.defineStates({
   Form: {
-    schema: FormState.cases.Form,
     initial: "Editing",
     states: {
-      Editing: FormState.cases.Editing,
+      Editing: {},
       Saving: FormState.cases.Saving
     }
   }
@@ -135,35 +174,22 @@ const FormStates = Machine.defineStates({
 Use a parallel state when every direct region is active:
 
 ```ts
-const ParallelState = Schema.TaggedUnion({
-  Screen: {},
-  Network: {},
-  Online: {},
-  Offline: {},
-  Panel: {},
-  Closed: {},
-  Open: {}
-})
-
 const ParallelStates = Machine.defineStates({
   Screen: {
-    schema: ParallelState.cases.Screen,
     type: "parallel",
     states: {
       network: {
-        schema: ParallelState.cases.Network,
         initial: "Online",
         states: {
-          Online: ParallelState.cases.Online,
-          Offline: ParallelState.cases.Offline
+          Online: {},
+          Offline: {}
         }
       },
       panel: {
-        schema: ParallelState.cases.Panel,
         initial: "Closed",
         states: {
-          Closed: ParallelState.cases.Closed,
-          Open: ParallelState.cases.Open
+          Closed: {},
+          Open: {}
         }
       }
     }
@@ -366,9 +392,11 @@ const ready = Option.getOrThrow(States.getSnapshot(snapshot, "Route.Ready"))
 States.matches(ready, "Route.Ready.Saving")
 ```
 
-All paths are checked against the definition. `context.parent` is the immediate
-typed parent (`undefined` at a root). Use `parents` when another ancestor is
-needed:
+All paths are checked against the definition. `get` and `getWithParents` accept
+only schema-backed paths; use `matches` or `getSnapshot` for any active path.
+`context.parent` is the immediate typed parent value (`undefined` at a root or
+when that parent is schema-less). `parents` contains only valued ancestors. Use
+its full paths when another ancestor value is needed:
 
 ```ts
 parents["Route.Ready"]

--- a/examples/platformer/src/machine.ts
+++ b/examples/platformer/src/machine.ts
@@ -7,32 +7,14 @@ export type Axis = typeof Axis.Type
 const JumpKind = Schema.Literals(["Ground", "Double", "Wall"])
 
 const State = Schema.TaggedUnion({
-  Character: {},
-  Locomotion: {},
-  Playing: {},
   Paused: { pausedAt: Schema.Number },
-  Grounded: {},
-  Standing: {},
   Running: { startedAt: Schema.Number },
   Ducking: { startedAt: Schema.Number },
   Landing: { impact: Schema.Number, resumeAxis: Axis, landedAt: Schema.Number },
   Airborne: { originY: Schema.Number },
-  Motion: {},
   Jumping: { startedAt: Schema.Number, push: Axis, kind: JumpKind },
   Falling: { apexY: Schema.Number },
-  Diving: { startedAt: Schema.Number },
-  AirJump: {},
-  AirJumpGroundLock: {},
-  AirJumpWallLock: {},
-  AirJumpReady: {},
-  AirJumpSpent: {},
-  WallContact: {},
-  NoWall: {},
-  LeftWall: {},
-  RightWall: {},
-  Facing: {},
-  Left: {},
-  Right: {}
+  Diving: { startedAt: Schema.Number }
 })
 
 // Inputs and physics facts are one runtime-decoded, statically typed protocol.
@@ -61,22 +43,18 @@ const awayFrom = (wall: Axis): Axis => (wall === -1 ? 1 : wall === 1 ? -1 : 0)
 
 export const CharacterStates = Machine.defineStates({
   Character: {
-    schema: State.cases.Character,
     type: "parallel",
     states: {
       locomotion: {
-        schema: State.cases.Locomotion,
         initial: "Playing",
         states: {
           Playing: {
-            schema: State.cases.Playing,
             initial: "Grounded",
             states: {
               Grounded: {
-                schema: State.cases.Grounded,
                 initial: "Standing",
                 states: {
-                  Standing: State.cases.Standing,
+                  Standing: {},
                   Running: State.cases.Running,
                   Ducking: State.cases.Ducking,
                   Landing: State.cases.Landing
@@ -87,7 +65,6 @@ export const CharacterStates = Machine.defineStates({
                 type: "parallel",
                 states: {
                   motion: {
-                    schema: State.cases.Motion,
                     initial: "Jumping",
                     states: {
                       Jumping: State.cases.Jumping,
@@ -96,13 +73,12 @@ export const CharacterStates = Machine.defineStates({
                     }
                   },
                   airJump: {
-                    schema: State.cases.AirJump,
                     initial: "AirJumpGroundLock",
                     states: {
-                      AirJumpGroundLock: State.cases.AirJumpGroundLock,
-                      AirJumpWallLock: State.cases.AirJumpWallLock,
-                      AirJumpReady: State.cases.AirJumpReady,
-                      AirJumpSpent: State.cases.AirJumpSpent
+                      AirJumpGroundLock: {},
+                      AirJumpWallLock: {},
+                      AirJumpReady: {},
+                      AirJumpSpent: {}
                     }
                   }
                 }
@@ -117,20 +93,18 @@ export const CharacterStates = Machine.defineStates({
         }
       },
       facing: {
-        schema: State.cases.Facing,
         initial: "Right",
         states: {
-          Left: State.cases.Left,
-          Right: State.cases.Right
+          Left: {},
+          Right: {}
         }
       },
       contact: {
-        schema: State.cases.WallContact,
         initial: "NoWall",
         states: {
-          NoWall: State.cases.NoWall,
-          LeftWall: State.cases.LeftWall,
-          RightWall: State.cases.RightWall
+          NoWall: {},
+          LeftWall: {},
+          RightWall: {}
         }
       }
     }
@@ -457,9 +431,12 @@ export const locomotionState = (snapshot: CharacterSnapshot) => {
   }
 
   const playing = locomotion.state
-  return playing.path === "Character.locomotion.Playing.Grounded"
-    ? playing.state.value
-    : playing.states.motion.state.value
+  if (playing.path === "Character.locomotion.Playing.Airborne") {
+    return playing.states.motion.state.value
+  }
+  return playing.state.path === "Character.locomotion.Playing.Grounded.Standing"
+    ? { _tag: "Standing" as const }
+    : playing.state.value
 }
 
 export type LocomotionMode = ReturnType<typeof locomotionState>["_tag"]
@@ -468,22 +445,32 @@ export const locomotionMode = (snapshot: CharacterSnapshot): LocomotionMode => l
 
 export const locomotionBranch = (snapshot: CharacterSnapshot) => {
   const locomotion = snapshot.states.locomotion.state
-  return locomotion.path === "Character.locomotion.Paused" ? locomotion.value._tag : locomotion.state.value._tag
+  if (locomotion.path === "Character.locomotion.Paused") return "Paused" as const
+  return locomotion.state.path === "Character.locomotion.Playing.Grounded" ? "Grounded" as const : "Airborne" as const
 }
 
 export const airJumpMode = (snapshot: CharacterSnapshot) => {
   const locomotion = snapshot.states.locomotion.state
-  return locomotion.path === "Character.locomotion.Playing" &&
-      locomotion.state.path === "Character.locomotion.Playing.Airborne"
-    ? locomotion.state.states.airJump.state.value._tag
-    : undefined
+  if (
+    locomotion.path !== "Character.locomotion.Playing" ||
+    locomotion.state.path !== "Character.locomotion.Playing.Airborne"
+  ) return undefined
+
+  const path = locomotion.state.states.airJump.state.path
+  if (path === "Character.locomotion.Playing.Airborne.airJump.AirJumpGroundLock") return "AirJumpGroundLock" as const
+  if (path === "Character.locomotion.Playing.Airborne.airJump.AirJumpWallLock") return "AirJumpWallLock" as const
+  if (path === "Character.locomotion.Playing.Airborne.airJump.AirJumpReady") return "AirJumpReady" as const
+  return "AirJumpSpent" as const
 }
 
 export const wallContact = (snapshot: CharacterSnapshot) => {
-  return snapshot.states.contact.state.value._tag
+  const path = snapshot.states.contact.state.path
+  if (path === "Character.contact.NoWall") return "NoWall" as const
+  return path === "Character.contact.LeftWall" ? "LeftWall" as const : "RightWall" as const
 }
 
-export const facingDirection = (snapshot: CharacterSnapshot) => snapshot.states.facing.state.value._tag
+export const facingDirection = (snapshot: CharacterSnapshot) =>
+  snapshot.states.facing.state.path === "Character.facing.Left" ? "Left" as const : "Right" as const
 
 export const activeStateData = (snapshot: CharacterSnapshot) => {
   const locomotion = snapshot.states.locomotion.state
@@ -493,15 +480,16 @@ export const activeStateData = (snapshot: CharacterSnapshot) => {
   }
 
   const playing = locomotion.state
-  const { _tag: _branch, ...branchData } = playing.value
   if (playing.path === "Character.locomotion.Playing.Grounded") {
+    if (playing.state.path === "Character.locomotion.Playing.Grounded.Standing") return {}
     const { _tag: _leaf, ...leafData } = playing.state.value
-    return { ...branchData, ...leafData }
+    return leafData
   }
+  const { _tag: _branch, ...branchData } = playing.value
   const { _tag: _motion, ...motionData } = playing.states.motion.state.value
   return {
     ...branchData,
     ...motionData,
-    airJump: playing.states.airJump.state.value._tag
+    airJump: airJumpMode(snapshot)
   }
 }

--- a/examples/playground/src/examples/media-player/schemas.ts
+++ b/examples/playground/src/examples/media-player/schemas.ts
@@ -40,15 +40,7 @@ const soundSettingsFields = {
 }
 
 export const MediaPlayerState = Schema.TaggedUnion({
-  Player: {},
-
-  Transport: {},
-
-  Empty: {},
-
   Loading: { url: Schema.String },
-
-  Ready: {},
 
   Paused: playbackFields,
 
@@ -64,8 +56,6 @@ export const MediaPlayerState = Schema.TaggedUnion({
   Ended: playbackFields,
 
   Failed: { message: Schema.String },
-
-  Settings: {},
 
   Audible: soundSettingsFields,
 
@@ -101,19 +91,16 @@ export const MediaPlayerInternalEvent = Schema.TaggedUnion({
 
 export const MediaPlayerStates = Machine.defineStates({
   Player: {
-    schema: MediaPlayerState.cases.Player,
     type: "parallel",
     states: {
       transport: {
-        schema: MediaPlayerState.cases.Transport,
         initial: "Empty",
         states: {
-          Empty: MediaPlayerState.cases.Empty,
+          Empty: {},
 
           Loading: MediaPlayerState.cases.Loading,
 
           Ready: {
-            schema: MediaPlayerState.cases.Ready,
             initial: "Paused",
             states: {
               Paused: MediaPlayerState.cases.Paused,
@@ -133,7 +120,6 @@ export const MediaPlayerStates = Machine.defineStates({
       },
 
       settings: {
-        schema: MediaPlayerState.cases.Settings,
         initial: "Audible",
         states: {
           Audible: MediaPlayerState.cases.Audible,

--- a/examples/playground/src/examples/microwave/MicrowavePage.tsx
+++ b/examples/playground/src/examples/microwave/MicrowavePage.tsx
@@ -24,6 +24,8 @@ export function MicrowavePage() {
             const cooking = engine.path === "Oven.engine.Cooking"
             const open = door.path === "Oven.door.Open"
             const elapsedSeconds = cooking ? engine.value.elapsedSeconds : 0
+            const engineName = cooking ? "Cooking" : "Idle"
+            const doorName = open ? "Open" : "Closed"
 
             return (
               <div className="machine-demo microwave-demo">
@@ -41,7 +43,7 @@ export function MicrowavePage() {
                   <p className="machine-state-label">Parallel configuration</p>
                   <h2>{cooking ? `Cooking · ${elapsedSeconds}s` : open ? "Idle · door open" : "Idle · door closed"}</h2>
                   <p>
-                    Engine: <code>{engine.value._tag}</code> · Door: <code>{door.value._tag}</code>
+                    Engine: <code>{engineName}</code> · Door: <code>{doorName}</code>
                   </p>
                   <div className="machine-controls">
                     <button

--- a/examples/playground/src/examples/microwave/machine.ts
+++ b/examples/playground/src/examples/microwave/machine.ts
@@ -2,13 +2,7 @@ import { Machine } from "@typeonce/effect-machine"
 import { Schema } from "effect"
 
 export const MicrowaveState = Schema.TaggedUnion({
-  Oven: {},
-  Engine: {},
-  Idle: {},
-  Cooking: { elapsedSeconds: Schema.Number },
-  Door: {},
-  Closed: {},
-  Open: {}
+  Cooking: { elapsedSeconds: Schema.Number }
 })
 
 export const MicrowaveEvent = Schema.TaggedUnion({
@@ -23,23 +17,20 @@ export const MicrowaveInternalEvent = Schema.TaggedUnion({
 
 export const MicrowaveStates = Machine.defineStates({
   Oven: {
-    schema: MicrowaveState.cases.Oven,
     type: "parallel",
     states: {
       engine: {
-        schema: MicrowaveState.cases.Engine,
         initial: "Idle",
         states: {
-          Idle: MicrowaveState.cases.Idle,
+          Idle: {},
           Cooking: MicrowaveState.cases.Cooking
         }
       },
       door: {
-        schema: MicrowaveState.cases.Door,
         initial: "Closed",
         states: {
-          Closed: MicrowaveState.cases.Closed,
-          Open: MicrowaveState.cases.Open
+          Closed: {},
+          Open: {}
         }
       }
     }

--- a/examples/playground/src/examples/traffic-light/TrafficLightPage.tsx
+++ b/examples/playground/src/examples/traffic-light/TrafficLightPage.tsx
@@ -19,7 +19,7 @@ export function TrafficLightPage() {
           Initial: () => <div className="example-message">Starting the signal cycle…</div>,
           Failure: () => <div className="example-message is-error">The traffic light failed to start.</div>,
           Success: ({ value: state }) => {
-            const signal = state.value._tag
+            const signal = state.path
             const red = signal === "Red" || signal === "RedYellow"
             const yellow = signal === "RedYellow" || signal === "Yellow"
             const green = signal === "Green"

--- a/examples/playground/src/examples/traffic-light/machine.ts
+++ b/examples/playground/src/examples/traffic-light/machine.ts
@@ -1,13 +1,6 @@
 import { Machine } from "@typeonce/effect-machine"
 import { Schema } from "effect"
 
-export const TrafficLightState = Schema.TaggedUnion({
-  Red: {},
-  RedYellow: {},
-  Green: {},
-  Yellow: {}
-})
-
 export const TrafficLightEvent = Schema.TaggedUnion({
   Reset: {}
 })
@@ -23,7 +16,12 @@ export const trafficLightDurations = {
   Yellow: 1_500
 } as const
 
-export const TrafficLightStates = Machine.defineStates(TrafficLightState.cases)
+export const TrafficLightStates = Machine.defineStates({
+  Red: {},
+  RedYellow: {},
+  Green: {},
+  Yellow: {}
+})
 
 const elapsed = TrafficLightInternalEvent.cases.TimerElapsed.make({})
 

--- a/examples/playground/src/examples/turnstile/machine.ts
+++ b/examples/playground/src/examples/turnstile/machine.ts
@@ -1,17 +1,15 @@
 import { Machine } from "@typeonce/effect-machine"
 import { Schema } from "effect"
 
-export const TurnstileState = Schema.TaggedUnion({
-  Locked: {},
-  Unlocked: {}
-})
-
 export const TurnstileEvent = Schema.TaggedUnion({
   CoinInserted: {},
   GatePushed: {}
 })
 
-export const TurnstileStates = Machine.defineStates(TurnstileState.cases)
+export const TurnstileStates = Machine.defineStates({
+  Locked: {},
+  Unlocked: {}
+})
 
 export const TurnstileMachine = Machine.make({
   id: "Turnstile",

--- a/examples/pokemon/src/machine.ts
+++ b/examples/pokemon/src/machine.ts
@@ -10,17 +10,13 @@ class ActiveTeam extends Schema.TaggedClass<ActiveTeam>("ActiveTeam")("ActiveTea
   team: Schema.Array(Pokemon)
 }) {}
 
-class Loading extends Schema.TaggedClass<Loading>("Loading")("Loading", {}) {}
-
 class TeamLoaded extends Schema.TaggedClass<TeamLoaded>("TeamLoaded")("TeamLoaded", {
   team: Schema.Array(Pokemon)
 }) {}
 
 class TeamLoadFailed extends Schema.TaggedClass<TeamLoadFailed>("TeamLoadFailed")("TeamLoadFailed", {}) {}
 
-class Failed extends Schema.TaggedClass<Failed>("Failed")("Failed", {}) {}
-
-export const States = Machine.defineStates({ Loading, ActiveTeam, Failed })
+export const States = Machine.defineStates({ Loading: {}, ActiveTeam, Failed: {} })
 
 export const SelectionChild = Machine.child("selection", SelectionMachine)
 export const ReplaceChild = Machine.child("replace", ReplaceMachine)

--- a/examples/pokemon/src/machines/replace.ts
+++ b/examples/pokemon/src/machines/replace.ts
@@ -2,8 +2,6 @@ import { Machine } from "@typeonce/effect-machine"
 import { Effect, Schema } from "effect"
 import { Pokemon, PokemonService, ReplaceInTeam } from "../pokemon.ts"
 
-class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", {}) {}
-
 class Replacing extends Schema.TaggedClass<Replacing>("Replacing")("Replacing", {
   id: Pokemon.fields.id
 }) {}
@@ -35,7 +33,7 @@ const ReplaceWithRandomMachine = Machine.invoke({
     )
 })
 
-export const ReplaceStates = Machine.defineStates({ Idle, Replacing })
+export const ReplaceStates = Machine.defineStates({ Idle: {}, Replacing })
 
 export { ReplacePokemon }
 export const ReplaceMachine = Machine.make({

--- a/examples/pokemon/src/machines/selection.ts
+++ b/examples/pokemon/src/machines/selection.ts
@@ -2,27 +2,17 @@ import { Machine } from "@typeonce/effect-machine"
 import { Effect, Option, Schema } from "effect"
 import { Pokemon, PokemonService, ReplaceInTeam } from "../pokemon.ts"
 
-class Form extends Schema.TaggedClass<Form>("Form")("Form", {}) {}
-
 class Search extends Schema.TaggedClass<Search>("Search")("Search", {
   searchText: Schema.String
 }) {}
-
-class Selection extends Schema.TaggedClass<Selection>("Selection")("Selection", {}) {}
-
-class Unselected extends Schema.TaggedClass<Unselected>("Unselected")("Unselected", {}) {}
 
 class Selected extends Schema.TaggedClass<Selected>("Selected")("Selected", {
   id: Pokemon.fields.id
 }) {}
 
-class NoPokemon extends Schema.TaggedClass<NoPokemon>("NoPokemon")("NoPokemon", {}) {}
-
 class WithPokemon extends Schema.TaggedClass<WithPokemon>("WithPokemon")("WithPokemon", {
   pokemon: Pokemon
 }) {}
-
-class Searching extends Schema.TaggedClass<Searching>("Searching")("Searching", {}) {}
 
 /** Events */
 
@@ -62,23 +52,21 @@ const SearchMachine = ({ searchText }: { searchText: string }) =>
 
 export const SelectionStates = Machine.defineStates({
   form: {
-    schema: Form,
     type: "parallel",
     states: {
       search: {
         schema: Search,
         initial: "NoPokemon",
         states: {
-          NoPokemon,
+          NoPokemon: {},
           WithPokemon,
-          Searching
+          Searching: {}
         }
       },
       selection: {
-        schema: Selection,
         initial: "Unselected",
         states: {
-          Unselected,
+          Unselected: {},
           Selected
         }
       }

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -558,7 +558,7 @@ type ValidateStateNode<Node, AllowHistory extends boolean, Path extends Property
       & ValidatePseudoStateAnnotations<Node, Path>
       & (AllowHistory extends true ? ValidateChoiceStateNode<Node>
         : StateDefinitionError<"Choice states must be declared below an active parent state", Path>)
-  : Node extends { readonly schema: Machine.TaggedSchema } ? ValidateStateNodeConfig<Node, Path>
+  : Node extends Machine.StateNodeConfig ? ValidateStateNodeConfig<Node, Path>
   : StateDefinitionError<"State nodes must be tagged schemas or state node configs", Path>
 
 type ValidateHistoryStateNode<Node extends Machine.HistoryStateNodeConfig> = [
@@ -572,27 +572,31 @@ type ValidateChoiceStateNode<Node extends Machine.ChoiceStateNodeConfig> = [
   : StateDefinitionError<"Choice states cannot declare schemas, children, initial states, output, or history">
 
 type ValidateStateNodeConfig<
-  Node extends { readonly schema: Machine.TaggedSchema },
+  Node extends Machine.StateNodeConfig,
   Path extends PropertyKey
 > = Node extends { readonly type: "parallel" } ?
     & ValidateExactStateNodeProperties<Node, "parallel", Path>
     & ValidateStateNodeWithChildren<Node, Node extends { readonly states: infer Children } ? Children : never, Path>
+    & ValidatePseudoStateAnnotations<Node, Path>
   : Node extends { readonly type: "final" } ?
       & ValidateExactStateNodeProperties<Node, "final", Path>
       & ValidateStateNodeWithoutChildren<Node>
+      & ValidatePseudoStateAnnotations<Node, Path>
   : Node extends { readonly states: infer Children } ?
       & ValidateExactStateNodeProperties<Node, "compound", Path>
       & ValidateStateNodeWithChildren<Node, Children, Path>
+      & ValidatePseudoStateAnnotations<Node, Path>
   :
     & ValidateExactStateNodeProperties<Node, "atomic", Path>
     & ValidateStateNodeWithoutChildren<Node>
+    & ValidatePseudoStateAnnotations<Node, Path>
 
 type ValidateOutputSchema<Node> = "output" extends keyof Node ? Node extends { readonly output: Schema.Top } ? unknown
   : StateDefinitionError<"State output must be a schema">
   : unknown
 
 type ValidateStateNodeWithChildren<
-  Node extends { readonly schema: Machine.TaggedSchema },
+  Node extends Machine.StateNodeConfig,
   Children,
   Path extends PropertyKey
 > = Children extends Machine.StateSchemas ?
@@ -605,7 +609,7 @@ type ValidateStateNodeWithChildren<
   : StateDefinitionError<"Child states must be a state tree">
 
 type ValidateCompoundStateNode<
-  Node extends { readonly schema: Machine.TaggedSchema },
+  Node extends Machine.StateNodeConfig,
   Children extends Machine.StateSchemas,
   Path extends PropertyKey
 > = Node extends { readonly initial: infer Initial } ?
@@ -615,8 +619,8 @@ type ValidateCompoundStateNode<
   : StateDefinitionError<"Compound initial must be one of its direct child keys">
   : StateDefinitionError<"Compound states must declare an initial child">
 
-type ValidateStateNodeWithoutChildren<Node extends { readonly schema: Machine.TaggedSchema }> = "initial" extends
-  keyof Node ? StateDefinitionError<"Atomic states cannot declare an initial child">
+type ValidateStateNodeWithoutChildren<Node extends Machine.StateNodeConfig> = "initial" extends keyof Node ?
+  StateDefinitionError<"Atomic states cannot declare an initial child">
   : Node extends { readonly type: infer Type } ? Type extends "final" ? ValidateOutputSchema<Node>
     : Type extends "active" | undefined ?
       "output" extends keyof Node ? StateDefinitionError<"Only final and parallel states can declare output">
@@ -722,6 +726,56 @@ type ConstructionResult<Result> = Result | Machine.StateConstruction<Result>
 
 type UnwrapConstruction<Result> = Result extends Machine.StateConstruction<infer Value> ? Value : Result
 
+type NodeValue<Node> = [Machine.NodeSchema<Node>] extends [never] ? undefined
+  : Machine.NodeSchema<Node>["Type"]
+
+type NodeMakeInput<Node> = [Machine.NodeSchema<Node>] extends [never] ? never
+  : Machine.NodeSchema<Node>["~type.make.in"]
+
+type WithNodeValue<Node, Rest extends ReadonlyArray<unknown>> = Machine.NodeSchema<Node> extends never ? Rest
+  : readonly [value: NodeValue<Node>, ...Rest]
+
+type WithNodeInput<Node, Rest extends ReadonlyArray<unknown>> = Machine.NodeSchema<Node> extends never ? Rest
+  : readonly [input: NodeMakeInput<Node>, ...Rest]
+
+type NodeBuilderMethod<
+  Node,
+  Arguments extends ReadonlyArray<unknown>,
+  Result,
+  FromArguments extends ReadonlyArray<unknown>,
+  FromResult
+> = Machine.NodeSchema<Node> extends never ? {
+    readonly from: FromCallable<FromArguments, FromResult>
+  }
+  :
+    & ((...args: Arguments) => Result)
+    & { readonly from: FromCallable<FromArguments, FromResult> }
+
+type NodeMethod<
+  Node,
+  Arguments extends ReadonlyArray<unknown>,
+  Result,
+  FromArguments extends ReadonlyArray<unknown>
+> = Machine.NodeSchema<Node> extends never ? FromMethod<FromArguments, Result>
+  : ((...args: Arguments) => Result) & FromMethod<FromArguments, Result>
+
+type NodeConstructionSelectorFromCallable<Node, Builder, Result> = Machine.NodeSchema<Node> extends never ? {
+    <Selected extends ConstructionResult<Result>>(
+      state: (builder: Builder) => Selected
+    ): Machine.StateConstruction<UnwrapConstruction<Selected>>
+  }
+  : ConstructionSelectorFromCallable<NodeMakeInput<Node>, Builder, Result>
+
+type NestedTargetMethod<Node, Builder, Result> = Machine.NodeSchema<Node> extends never ? {
+    readonly from: NodeConstructionSelectorFromCallable<Node, Builder, Result>
+  }
+  :
+    & (<Selected extends ConstructionResult<Result>>(
+      value: NodeValue<Node>,
+      state: (builder: Builder) => Selected
+    ) => Selected)
+    & { readonly from: NodeConstructionSelectorFromCallable<Node, Builder, Result> }
+
 type ConstructionSelectorFromCallable<Input, Builder, Result> = {} extends Input ? {
     <Selected extends ConstructionResult<Result>>(
       state: (builder: Builder) => Selected
@@ -751,14 +805,18 @@ type InitialSnapshotMethod<
   States extends Machine.StateSchemas,
   StateId extends ActiveStateKey<States>,
   Prefix extends string
-> =
-  & ((
-    ...args: InitialSnapshotArguments<States, StateId, Prefix>
-  ) => InitialSnapshotResult<States, StateId, Prefix>)
-  & FromMethod<
+> = Machine.NodeSchema<States[StateId]> extends never ? FromMethod<
     InitialSnapshotFromArguments<States, StateId, Prefix>,
     InitialSnapshotResult<States, StateId, Prefix>
   >
+  :
+    & ((
+      ...args: InitialSnapshotArguments<States, StateId, Prefix>
+    ) => InitialSnapshotResult<States, StateId, Prefix>)
+    & FromMethod<
+      InitialSnapshotFromArguments<States, StateId, Prefix>,
+      InitialSnapshotResult<States, StateId, Prefix>
+    >
 
 type InitialSnapshotArguments<
   States extends Machine.StateSchemas,
@@ -766,21 +824,21 @@ type InitialSnapshotArguments<
   Prefix extends string,
   Path extends string = Machine.JoinPath<Prefix, StateId>
 > = States[StateId] extends infer Node ?
-  Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ? [
-      value: Machine.NodeSchema<Node>["Type"],
+  Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ?
+    WithNodeValue<Node, [
       states: (
         builder: InitialParallelBuilder<Children, Path>
       ) => SnapshotBuilderComplete<InitialSnapshotRegionsWithPrefix<Children, Path>>
-    ]
+    ]>
   : Node extends { readonly states: infer Children extends Machine.StateSchemas } ?
-    Node extends { readonly initial: infer Initial extends ActiveStateKey<Children> | ChoiceStateKey<Children> } ? [
-        value: Machine.NodeSchema<Node>["Type"],
+    Node extends { readonly initial: infer Initial extends ActiveStateKey<Children> | ChoiceStateKey<Children> } ?
+      WithNodeValue<Node, [
         state: (
           builder: Pick<InitialSnapshotBuilderWithPrefix<Children, Path>, Initial>
         ) => InitialSelectableResult<Children, Initial, Path>
-      ]
+      ]>
     : never
-  : [value: Machine.NodeSchema<Node>["Type"]]
+  : WithNodeValue<Node, []>
   : never
 
 type InitialSnapshotFromArguments<
@@ -789,21 +847,21 @@ type InitialSnapshotFromArguments<
   Prefix extends string,
   Path extends string = Machine.JoinPath<Prefix, StateId>
 > = States[StateId] extends infer Node ?
-  Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ? [
-      input: Machine.NodeSchema<Node>["~type.make.in"],
+  Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ?
+    WithNodeInput<Node, [
       states: (
         builder: InitialParallelBuilder<Children, Path>
       ) => SnapshotBuilderComplete<InitialSnapshotRegionsWithPrefix<Children, Path>, boolean>
-    ]
+    ]>
   : Node extends { readonly states: infer Children extends Machine.StateSchemas } ?
-    Node extends { readonly initial: infer Initial extends ActiveStateKey<Children> | ChoiceStateKey<Children> } ? [
-        input: Machine.NodeSchema<Node>["~type.make.in"],
+    Node extends { readonly initial: infer Initial extends ActiveStateKey<Children> | ChoiceStateKey<Children> } ?
+      WithNodeInput<Node, [
         state: (
           builder: Pick<InitialSnapshotBuilderWithPrefix<Children, Path>, Initial>
         ) => ConstructionResult<InitialSelectableResult<Children, Initial, Path>>
-      ]
+      ]>
     : never
-  : [input: Machine.NodeSchema<Node>["~type.make.in"]]
+  : WithNodeInput<Node, []>
   : never
 
 type InitialSnapshotResult<
@@ -815,18 +873,18 @@ type InitialSnapshotResult<
   Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ?
     Machine.ParallelSnapshot<
       Path,
-      Machine.NodeSchema<Node>["Type"],
+      NodeValue<Node>,
       InitialSnapshotRegionsWithPrefix<Children, Path>
     >
   : Node extends { readonly states: infer Children extends Machine.StateSchemas } ?
     Node extends { readonly initial: infer Initial extends ActiveStateKey<Children> | ChoiceStateKey<Children> } ?
       Machine.CompoundSnapshot<
         Path,
-        Machine.NodeSchema<Node>["Type"],
+        NodeValue<Node>,
         InitialSelectableResult<Children, Initial, Path>
       >
     : never
-  : Machine.AtomicSnapshot<Path, Machine.NodeSchema<Node>["Type"]>
+  : Machine.AtomicSnapshot<Path, NodeValue<Node>>
   : never
 
 type InitialSelectableResult<
@@ -853,28 +911,25 @@ type InitialParallelBuilder<
 > =
   & SnapshotBuilderComplete<Regions, Constructed>
   & {
-    readonly [Key in Remaining]:
-      & ((
-        ...args: InitialSnapshotArguments<States, Key, Prefix>
-      ) => InitialParallelBuilder<
+    readonly [Key in Remaining]: NodeBuilderMethod<
+      States[Key],
+      InitialSnapshotArguments<States, Key, Prefix>,
+      InitialParallelBuilder<
         States,
         Prefix,
         Exclude<Remaining, Key>,
         Regions & { readonly [Region in Key]: InitialSnapshotResult<States, Key, Prefix> },
         Constructed
-      >)
-      & {
-        readonly from: FromCallable<
-          InitialSnapshotFromArguments<States, Key, Prefix>,
-          InitialParallelBuilder<
-            States,
-            Prefix,
-            Exclude<Remaining, Key>,
-            Regions & { readonly [Region in Key]: InitialSnapshotResult<States, Key, Prefix> },
-            true
-          >
-        >
-      }
+      >,
+      InitialSnapshotFromArguments<States, Key, Prefix>,
+      InitialParallelBuilder<
+        States,
+        Prefix,
+        Exclude<Remaining, Key>,
+        Regions & { readonly [Region in Key]: InitialSnapshotResult<States, Key, Prefix> },
+        true
+      >
+    >
   }
 
 type FullSnapshotBuilderWithPrefix<
@@ -892,14 +947,18 @@ type FullSnapshotMethod<
   States extends Machine.StateSchemas,
   StateId extends ActiveStateKey<States>,
   Prefix extends string
-> =
-  & ((
-    ...args: FullSnapshotArguments<States, StateId, Prefix>
-  ) => FullSnapshotResult<States, StateId, Prefix>)
-  & FromMethod<
+> = Machine.NodeSchema<States[StateId]> extends never ? FromMethod<
     FullSnapshotFromArguments<States, StateId, Prefix>,
     FullSnapshotResult<States, StateId, Prefix>
   >
+  :
+    & ((
+      ...args: FullSnapshotArguments<States, StateId, Prefix>
+    ) => FullSnapshotResult<States, StateId, Prefix>)
+    & FromMethod<
+      FullSnapshotFromArguments<States, StateId, Prefix>,
+      FullSnapshotResult<States, StateId, Prefix>
+    >
 
 type FullSnapshotArguments<
   States extends Machine.StateSchemas,
@@ -907,21 +966,20 @@ type FullSnapshotArguments<
   Prefix extends string,
   Path extends string = Machine.JoinPath<Prefix, StateId>
 > = States[StateId] extends infer Node ?
-  Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ? [
-      value: Machine.NodeSchema<Node>["Type"],
+  Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ?
+    WithNodeValue<Node, [
       states: (
         builder: FullParallelBuilder<Children, Path>
       ) => SnapshotBuilderComplete<Machine.SnapshotRegionsWithPrefix<Children, Path>>
-    ]
-  : Node extends { readonly states: infer Children extends Machine.StateSchemas } ? [
-      value: Machine.NodeSchema<Node>["Type"],
+    ]>
+  : Node extends { readonly states: infer Children extends Machine.StateSchemas } ? WithNodeValue<Node, [
       state: (
         builder: FullSnapshotBuilderWithPrefix<Children, Path>
       ) =>
         | Machine.SnapshotWithPrefix<Children, Path>
         | Machine.ChoiceTargetInstruction<Machine.ChoiceIdentifierWithPrefix<Children, Path>>
-    ]
-  : [value: Machine.NodeSchema<Node>["Type"]]
+    ]>
+  : WithNodeValue<Node, []>
   : never
 
 type FullSnapshotFromArguments<
@@ -930,22 +988,21 @@ type FullSnapshotFromArguments<
   Prefix extends string,
   Path extends string = Machine.JoinPath<Prefix, StateId>
 > = States[StateId] extends infer Node ?
-  Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ? [
-      input: Machine.NodeSchema<Node>["~type.make.in"],
+  Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ?
+    WithNodeInput<Node, [
       states: (
         builder: FullParallelBuilder<Children, Path>
       ) => SnapshotBuilderComplete<Machine.SnapshotRegionsWithPrefix<Children, Path>, boolean>
-    ]
-  : Node extends { readonly states: infer Children extends Machine.StateSchemas } ? [
-      input: Machine.NodeSchema<Node>["~type.make.in"],
+    ]>
+  : Node extends { readonly states: infer Children extends Machine.StateSchemas } ? WithNodeInput<Node, [
       state: (
         builder: FullSnapshotBuilderWithPrefix<Children, Path>
       ) => ConstructionResult<
         | Machine.SnapshotWithPrefix<Children, Path>
         | Machine.ChoiceTargetInstruction<Machine.ChoiceIdentifierWithPrefix<Children, Path>>
       >
-    ]
-  : [input: Machine.NodeSchema<Node>["~type.make.in"]]
+    ]>
+  : WithNodeInput<Node, []>
   : never
 
 type FullSnapshotResult<
@@ -964,28 +1021,25 @@ type FullParallelBuilder<
 > =
   & SnapshotBuilderComplete<Regions, Constructed>
   & {
-    readonly [Key in Remaining]:
-      & ((
-        ...args: FullSnapshotArguments<States, Key, Prefix>
-      ) => FullParallelBuilder<
+    readonly [Key in Remaining]: NodeBuilderMethod<
+      States[Key],
+      FullSnapshotArguments<States, Key, Prefix>,
+      FullParallelBuilder<
         States,
         Prefix,
         Exclude<Remaining, Key>,
         Regions & { readonly [Region in Key]: FullSnapshotResult<States, Key, Prefix> },
         Constructed
-      >)
-      & {
-        readonly from: FromCallable<
-          FullSnapshotFromArguments<States, Key, Prefix>,
-          FullParallelBuilder<
-            States,
-            Prefix,
-            Exclude<Remaining, Key>,
-            Regions & { readonly [Region in Key]: FullSnapshotResult<States, Key, Prefix> },
-            true
-          >
-        >
-      }
+      >,
+      FullSnapshotFromArguments<States, Key, Prefix>,
+      FullParallelBuilder<
+        States,
+        Prefix,
+        Exclude<Remaining, Key>,
+        Regions & { readonly [Region in Key]: FullSnapshotResult<States, Key, Prefix> },
+        true
+      >
+    >
   }
 
 type HistorySnapshotArguments<
@@ -996,18 +1050,17 @@ type HistorySnapshotArguments<
   Path extends string = Machine.JoinPath<Prefix, StateId>
 > = Path extends Owner ? FullSnapshotArguments<States, StateId, Prefix>
   : States[StateId] extends infer Node ?
-    Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ? [
-        value: Machine.NodeSchema<Node>["Type"],
+    Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ?
+      WithNodeValue<Node, [
         states: (
           builder: HistoryParallelBuilder<Children, Path, Owner>
         ) => SnapshotBuilderComplete<HistorySnapshotRegions<Children, Path, Owner>>
-      ]
-    : Node extends { readonly states: infer Children extends Machine.StateSchemas } ? [
-        value: Machine.NodeSchema<Node>["Type"],
+      ]>
+    : Node extends { readonly states: infer Children extends Machine.StateSchemas } ? WithNodeValue<Node, [
         state: (
           builder: HistorySnapshotBuilderWithPrefix<Children, Owner, Path>
         ) => ConstructionResult<HistorySnapshotWithPrefix<Children, Owner, Path>>
-      ]
+      ]>
     : never
   : never
 
@@ -1019,18 +1072,17 @@ type HistorySnapshotFromArguments<
   Path extends string = Machine.JoinPath<Prefix, StateId>
 > = Path extends Owner ? FullSnapshotFromArguments<States, StateId, Prefix>
   : States[StateId] extends infer Node ?
-    Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ? [
-        input: Machine.NodeSchema<Node>["~type.make.in"],
+    Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ?
+      WithNodeInput<Node, [
         states: (
           builder: HistoryParallelBuilder<Children, Path, Owner>
         ) => SnapshotBuilderComplete<HistorySnapshotRegions<Children, Path, Owner>, boolean>
-      ]
-    : Node extends { readonly states: infer Children extends Machine.StateSchemas } ? [
-        input: Machine.NodeSchema<Node>["~type.make.in"],
+      ]>
+    : Node extends { readonly states: infer Children extends Machine.StateSchemas } ? WithNodeInput<Node, [
         state: (
           builder: HistorySnapshotBuilderWithPrefix<Children, Owner, Path>
         ) => ConstructionResult<HistorySnapshotWithPrefix<Children, Owner, Path>>
-      ]
+      ]>
     : never
   : never
 
@@ -1045,12 +1097,12 @@ type HistorySnapshotResult<
     Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ?
       Machine.ParallelSnapshot<
         Path,
-        Machine.NodeSchema<Node>["Type"],
+        NodeValue<Node>,
         HistorySnapshotRegions<Children, Path, Owner>
       >
     : Node extends { readonly states: infer Children extends Machine.StateSchemas } ? Machine.CompoundSnapshot<
         Path,
-        Machine.NodeSchema<Node>["Type"],
+        NodeValue<Node>,
         HistorySnapshotWithPrefix<Children, Owner, Path>
       >
     : never
@@ -1061,14 +1113,18 @@ type HistorySnapshotMethod<
   StateId extends ActiveStateKey<States>,
   Prefix extends string,
   Owner extends string
-> =
-  & ((
-    ...args: HistorySnapshotArguments<States, StateId, Prefix, Owner>
-  ) => HistorySnapshotResult<States, StateId, Prefix, Owner>)
-  & FromMethod<
+> = Machine.NodeSchema<States[StateId]> extends never ? FromMethod<
     HistorySnapshotFromArguments<States, StateId, Prefix, Owner>,
     HistorySnapshotResult<States, StateId, Prefix, Owner>
   >
+  :
+    & ((
+      ...args: HistorySnapshotArguments<States, StateId, Prefix, Owner>
+    ) => HistorySnapshotResult<States, StateId, Prefix, Owner>)
+    & FromMethod<
+      HistorySnapshotFromArguments<States, StateId, Prefix, Owner>,
+      HistorySnapshotResult<States, StateId, Prefix, Owner>
+    >
 
 type HistorySnapshotWithPrefix<
   States extends Machine.StateSchemas,
@@ -1117,50 +1173,48 @@ type HistoryParallelBuilder<
   & {
     readonly [Key in Remaining]: Owner extends
       | Machine.JoinPath<Prefix, Key>
-      | `${Machine.JoinPath<Prefix, Key>}.${string}` ?
-        & ((...args: HistorySnapshotArguments<States, Key, Prefix, Owner>) => HistoryParallelBuilder<
+      | `${Machine.JoinPath<Prefix, Key>}.${string}` ? NodeBuilderMethod<
+        States[Key],
+        HistorySnapshotArguments<States, Key, Prefix, Owner>,
+        HistoryParallelBuilder<
           States,
           Prefix,
           Owner,
           Exclude<Remaining, Key>,
           Regions & { readonly [Region in Key]: HistorySnapshotResult<States, Key, Prefix, Owner> },
           Constructed
-        >)
-        & {
-          readonly from: FromCallable<
-            HistorySnapshotFromArguments<States, Key, Prefix, Owner>,
-            HistoryParallelBuilder<
-              States,
-              Prefix,
-              Owner,
-              Exclude<Remaining, Key>,
-              Regions & { readonly [Region in Key]: HistorySnapshotResult<States, Key, Prefix, Owner> },
-              true
-            >
-          >
-        }
-      :
-        & ((...args: FullSnapshotArguments<States, Key, Prefix>) => HistoryParallelBuilder<
+        >,
+        HistorySnapshotFromArguments<States, Key, Prefix, Owner>,
+        HistoryParallelBuilder<
+          States,
+          Prefix,
+          Owner,
+          Exclude<Remaining, Key>,
+          Regions & { readonly [Region in Key]: HistorySnapshotResult<States, Key, Prefix, Owner> },
+          true
+        >
+      >
+      : NodeBuilderMethod<
+        States[Key],
+        FullSnapshotArguments<States, Key, Prefix>,
+        HistoryParallelBuilder<
           States,
           Prefix,
           Owner,
           Exclude<Remaining, Key>,
           Regions & { readonly [Region in Key]: FullSnapshotResult<States, Key, Prefix> },
           Constructed
-        >)
-        & {
-          readonly from: FromCallable<
-            FullSnapshotFromArguments<States, Key, Prefix>,
-            HistoryParallelBuilder<
-              States,
-              Prefix,
-              Owner,
-              Exclude<Remaining, Key>,
-              Regions & { readonly [Region in Key]: FullSnapshotResult<States, Key, Prefix> },
-              true
-            >
-          >
-        }
+        >,
+        FullSnapshotFromArguments<States, Key, Prefix>,
+        HistoryParallelBuilder<
+          States,
+          Prefix,
+          Owner,
+          Exclude<Remaining, Key>,
+          Regions & { readonly [Region in Key]: FullSnapshotResult<States, Key, Prefix> },
+          true
+        >
+      >
   }
 
 type ParentPath<Path extends string> = Path extends `${infer Parent}.${infer Child}`
@@ -1245,59 +1299,36 @@ type LocalTargetMethod<
   Path extends string = Machine.JoinPath<Prefix, StateId>
 > = States[StateId] extends infer Node ?
   Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ?
-    Source extends Path | `${Path}.${string}` ?
-        & (<Result extends ConstructionResult<LocalTargetResultWithPrefix<AllStates, Children, Path>>>(
-          value: Machine.NodeSchema<Node>["Type"],
-          state: (
-            builder: LocalTargetBuilderWithPrefix<AllStates, Children, Path, Source>
-          ) => Result
-        ) => Result)
-        & {
-          readonly from: ConstructionSelectorFromCallable<
-            Machine.NodeSchema<Node>["~type.make.in"],
-            LocalTargetBuilderWithPrefix<AllStates, Children, Path, Source>,
-            LocalTargetResultWithPrefix<AllStates, Children, Path>
-          >
-        }
-    :
-      & ((
-        value: Machine.NodeSchema<Node>["Type"],
+    Source extends Path | `${Path}.${string}` ? NestedTargetMethod<
+        Node,
+        LocalTargetBuilderWithPrefix<AllStates, Children, Path, Source>,
+        LocalTargetResultWithPrefix<AllStates, Children, Path>
+      >
+    : NodeMethod<
+      Node,
+      WithNodeValue<Node, [
         states: (
           builder: FullParallelBuilder<Children, Path>
         ) => SnapshotBuilderComplete<Machine.SnapshotRegionsWithPrefix<Children, Path>>
-      ) => Machine.Target<AllStates, StateIdentifierFromPath<AllStates, Path>>)
-      & FromMethod<
-        [
-          input: Machine.NodeSchema<Node>["~type.make.in"],
-          states: (
-            builder: FullParallelBuilder<Children, Path>
-          ) => SnapshotBuilderComplete<Machine.SnapshotRegionsWithPrefix<Children, Path>, boolean>
-        ],
-        Machine.Target<AllStates, StateIdentifierFromPath<AllStates, Path>>
-      >
-  : Node extends { readonly states: infer Children extends Machine.StateSchemas } ?
-      & (<Result extends ConstructionResult<LocalTargetResultWithPrefix<AllStates, Children, Path>>>(
-        value: Machine.NodeSchema<Node>["Type"],
-        state: (
-          builder: LocalTargetBuilderWithPrefix<AllStates, Children, Path, Source>
-        ) => Result
-      ) => Result)
-      & {
-        readonly from: ConstructionSelectorFromCallable<
-          Machine.NodeSchema<Node>["~type.make.in"],
-          LocalTargetBuilderWithPrefix<AllStates, Children, Path, Source>,
-          LocalTargetResultWithPrefix<AllStates, Children, Path>
-        >
-      }
-  :
-    & ((value: Machine.NodeSchema<Node>["Type"]) => Machine.Target<
-      AllStates,
-      StateIdentifierFromPath<AllStates, Path>
-    >)
-    & FromMethod<
-      [input: Machine.NodeSchema<Node>["~type.make.in"]],
-      Machine.Target<AllStates, StateIdentifierFromPath<AllStates, Path>>
+      ]>,
+      Machine.Target<AllStates, StateIdentifierFromPath<AllStates, Path>>,
+      WithNodeInput<Node, [
+        states: (
+          builder: FullParallelBuilder<Children, Path>
+        ) => SnapshotBuilderComplete<Machine.SnapshotRegionsWithPrefix<Children, Path>, boolean>
+      ]>
     >
+  : Node extends { readonly states: infer Children extends Machine.StateSchemas } ? NestedTargetMethod<
+      Node,
+      LocalTargetBuilderWithPrefix<AllStates, Children, Path, Source>,
+      LocalTargetResultWithPrefix<AllStates, Children, Path>
+    >
+  : NodeMethod<
+    Node,
+    WithNodeValue<Node, []>,
+    Machine.Target<AllStates, StateIdentifierFromPath<AllStates, Path>>,
+    WithNodeInput<Node, []>
+  >
   : never
 
 type LocalTargetBuilderForScope<
@@ -1306,28 +1337,29 @@ type LocalTargetBuilderForScope<
   Source extends Machine.StateNodeIdentifier<States>
 > = ChildrenOf<States, Scope> extends infer Children extends Machine.StateSchemas ?
     & LocalTargetBuilderWithPrefix<States, Children, Scope, Source>
-    & {
-      /**
-       * Updates the value of the state containing the local group and moves to
-       * one of the states inside it. Values in other active branches are kept.
-       *
-       * @since 0.4.0
-       */
-      readonly with:
-        & (<Result extends ConstructionResult<LocalTargetResultWithPrefix<States, Children, Scope>>>(
-          value: Machine.StateByIdentifier<States, Scope>,
-          state: (
-            builder: LocalTargetBuilderWithPrefix<States, Children, Scope, Source>
-          ) => Result
-        ) => Result)
-        & {
-          readonly from: ConstructionSelectorFromCallable<
-            Machine.SchemaByIdentifier<States, Scope>["~type.make.in"],
-            LocalTargetBuilderWithPrefix<States, Children, Scope, Source>,
-            LocalTargetResultWithPrefix<States, Children, Scope>
-          >
-        }
-    }
+    & (Scope extends Machine.ValuedStateIdentifier<States> ? {
+        /**
+         * Updates the value of the state containing the local group and moves to
+         * one of the states inside it. Values in other active branches are kept.
+         *
+         * @since 0.4.0
+         */
+        readonly with:
+          & (<Result extends ConstructionResult<LocalTargetResultWithPrefix<States, Children, Scope>>>(
+            value: Machine.StateByIdentifier<States, Scope>,
+            state: (
+              builder: LocalTargetBuilderWithPrefix<States, Children, Scope, Source>
+            ) => Result
+          ) => Result)
+          & {
+            readonly from: ConstructionSelectorFromCallable<
+              Machine.SchemaByIdentifier<States, Scope>["~type.make.in"],
+              LocalTargetBuilderWithPrefix<States, Children, Scope, Source>,
+              LocalTargetResultWithPrefix<States, Children, Scope>
+            >
+          }
+      } :
+      {})
   : {}
 
 type BranchTargetResult<
@@ -1381,60 +1413,39 @@ type BranchTargetMethod<
 > = States[StateId] extends infer Node ?
   Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ?
     Source extends Path | `${Path}.${string}` ?
-        & (<Result extends ConstructionResult<BranchTargetResultWithPrefix<AllStates, Children, Path>>>(
-          value: Machine.NodeSchema<Node>["Type"],
-          state: (
-            builder: BranchTargetBuilderWithPrefix<AllStates, Children, Path, Source>
-          ) => Result
-        ) => Result)
-        & {
-          readonly from: ConstructionSelectorFromCallable<
-            Machine.NodeSchema<Node>["~type.make.in"],
-            BranchTargetBuilderWithPrefix<AllStates, Children, Path, Source>,
-            BranchTargetResultWithPrefix<AllStates, Children, Path>
-          >
-        }
-        & BranchTargetBuilderWithPrefix<AllStates, Children, Path, Source>
-    :
-      & ((
-        value: Machine.NodeSchema<Node>["Type"],
-        states: (
-          builder: FullParallelBuilder<Children, Path>
-        ) => SnapshotBuilderComplete<Machine.SnapshotRegionsWithPrefix<Children, Path>>
-      ) => Machine.Target<AllStates, StateIdentifierFromPath<AllStates, Path>>)
-      & FromMethod<
-        [
-          input: Machine.NodeSchema<Node>["~type.make.in"],
-          states: (
-            builder: FullParallelBuilder<Children, Path>
-          ) => SnapshotBuilderComplete<Machine.SnapshotRegionsWithPrefix<Children, Path>, boolean>
-        ],
-        Machine.Target<AllStates, StateIdentifierFromPath<AllStates, Path>>
-      >
-  : Node extends { readonly states: infer Children extends Machine.StateSchemas } ?
-      & (<Result extends ConstructionResult<BranchTargetResultWithPrefix<AllStates, Children, Path>>>(
-        value: Machine.NodeSchema<Node>["Type"],
-        state: (
-          builder: BranchTargetBuilderWithPrefix<AllStates, Children, Path, Source>
-        ) => Result
-      ) => Result)
-      & {
-        readonly from: ConstructionSelectorFromCallable<
-          Machine.NodeSchema<Node>["~type.make.in"],
+        & NestedTargetMethod<
+          Node,
           BranchTargetBuilderWithPrefix<AllStates, Children, Path, Source>,
           BranchTargetResultWithPrefix<AllStates, Children, Path>
         >
-      }
-      & BranchTargetBuilderWithPrefix<AllStates, Children, Path, Source>
-  :
-    & ((value: Machine.NodeSchema<Node>["Type"]) => Machine.Target<
-      AllStates,
-      StateIdentifierFromPath<AllStates, Path>
-    >)
-    & FromMethod<
-      [input: Machine.NodeSchema<Node>["~type.make.in"]],
-      Machine.Target<AllStates, StateIdentifierFromPath<AllStates, Path>>
+        & BranchTargetBuilderWithPrefix<AllStates, Children, Path, Source>
+    : NodeMethod<
+      Node,
+      WithNodeValue<Node, [
+        states: (
+          builder: FullParallelBuilder<Children, Path>
+        ) => SnapshotBuilderComplete<Machine.SnapshotRegionsWithPrefix<Children, Path>>
+      ]>,
+      Machine.Target<AllStates, StateIdentifierFromPath<AllStates, Path>>,
+      WithNodeInput<Node, [
+        states: (
+          builder: FullParallelBuilder<Children, Path>
+        ) => SnapshotBuilderComplete<Machine.SnapshotRegionsWithPrefix<Children, Path>, boolean>
+      ]>
     >
+  : Node extends { readonly states: infer Children extends Machine.StateSchemas } ?
+      & NestedTargetMethod<
+        Node,
+        BranchTargetBuilderWithPrefix<AllStates, Children, Path, Source>,
+        BranchTargetResultWithPrefix<AllStates, Children, Path>
+      >
+      & BranchTargetBuilderWithPrefix<AllStates, Children, Path, Source>
+  : NodeMethod<
+    Node,
+    WithNodeValue<Node, []>,
+    Machine.Target<AllStates, StateIdentifierFromPath<AllStates, Path>>,
+    WithNodeInput<Node, []>
+  >
   : never
 
 type BranchTargetBuilderForRoot<
@@ -1471,15 +1482,21 @@ type HasDirectShallowHistory<States extends Machine.StateSchemas> = {
   readonly [Key in HistoryStateKey<States>]: States[Key] extends { readonly history: "deep" } ? never : Key
 }[HistoryStateKey<States>] extends never ? false : true
 
+type HasValuedActiveChild<States extends Machine.StateSchemas> = {
+  readonly [Key in ActiveStateKey<States>]: Machine.NodeSchema<States[Key]> extends never ? never : Key
+}[ActiveStateKey<States>] extends never ? false : true
+
 type InitializerClosureForNode<
   AllStates extends Machine.StateSchemas,
   Node,
   Path extends string
 > = Node extends { readonly type: "parallel"; readonly states: infer Children extends Machine.StateSchemas } ?
-    | Extract<Path, Machine.StateIdentifier<AllStates>>
+    | (HasValuedActiveChild<Children> extends true ? Extract<Path, Machine.StateIdentifier<AllStates>> : never)
     | InitializerClosuresForChildren<AllStates, Children, Path>
   : Node extends { readonly states: infer Children extends Machine.StateSchemas; readonly initial: infer Initial } ?
-      | Extract<Path, Machine.StateIdentifier<AllStates>>
+      | (Initial extends ActiveStateKey<Children> ? Machine.NodeSchema<Children[Initial]> extends never ? never
+        : Extract<Path, Machine.StateIdentifier<AllStates>>
+        : never)
       | (Initial extends ActiveStateKey<Children> ? InitializerClosureForNode<
           AllStates,
           Children[Initial],
@@ -2175,8 +2192,9 @@ export declare namespace Machine {
    * Descriptive annotations exposed for compiled state nodes.
    *
    * Schema-backed states resolve their complete Effect Schema annotation map.
-   * Pseudo-states accept only the descriptive fields below. Annotations never
-   * affect state identity, targeting, or runtime behavior.
+   * Schema-less active states and pseudo-states accept only the descriptive
+   * fields below. Annotations never affect state identity, targeting, or
+   * runtime behavior.
    *
    * @category models
    * @since 0.4.0
@@ -2187,14 +2205,18 @@ export declare namespace Machine {
     readonly documentation?: string | undefined
   }
 
-  /** Descriptive annotations accepted by schema-less pseudo-states. */
-  export type PseudoStateAnnotations = Pick<
+  /** Descriptive annotations accepted by schema-less active and pseudo-states. */
+  export type SchemaLessStateAnnotations = Pick<
     StateNodeAnnotations,
     "title" | "description" | "documentation"
   >
 
+  /** @deprecated Use {@link SchemaLessStateAnnotations}. */
+  export type PseudoStateAnnotations = SchemaLessStateAnnotations
+
   /**
-   * Configuration accepted for an atomic object state node.
+   * Configuration accepted for an atomic object state node. Omit `schema` when
+   * the state owns no value; a schema-less final may still declare `output`.
    *
    * @category models
    * @since 0.4.0
@@ -2204,38 +2226,72 @@ export declare namespace Machine {
       readonly schema: TaggedSchema
       readonly type?: "active"
       readonly output?: never
+      readonly annotations?: never
     }
     | {
       readonly schema: TaggedSchema
       readonly type: "final"
       readonly output?: Schema.Top
+      readonly annotations?: never
+    }
+    | {
+      readonly schema?: never
+      readonly type?: "active"
+      readonly output?: never
+      readonly annotations?: SchemaLessStateAnnotations
+    }
+    | {
+      readonly schema?: never
+      readonly type: "final"
+      readonly output?: Schema.Top
+      readonly annotations?: SchemaLessStateAnnotations
     }
 
   /**
-   * Configuration accepted for a compound object state node.
+   * Configuration accepted for a compound object state node. Omit `schema`
+   * when the compound state exists only to own control topology.
    *
    * @category models
    * @since 0.4.0
    */
-  export interface CompoundStateNodeConfig {
-    readonly schema: TaggedSchema
-    readonly type?: "active"
-    readonly initial: string
-    readonly states: StateTree
-  }
+  export type CompoundStateNodeConfig =
+    | {
+      readonly schema: TaggedSchema
+      readonly type?: "active"
+      readonly initial: string
+      readonly states: StateTree
+      readonly annotations?: never
+    }
+    | {
+      readonly schema?: never
+      readonly type?: "active"
+      readonly initial: string
+      readonly states: StateTree
+      readonly annotations?: SchemaLessStateAnnotations
+    }
 
   /**
-   * Configuration accepted for a parallel object state node.
+   * Configuration accepted for a parallel object state node. Omit `schema`
+   * when the parallel state exists only to own its regions.
    *
    * @category models
    * @since 0.4.0
    */
-  export interface ParallelStateNodeConfig {
-    readonly schema: TaggedSchema
-    readonly type: "parallel"
-    readonly output?: Schema.Top
-    readonly states: StateTree
-  }
+  export type ParallelStateNodeConfig =
+    | {
+      readonly schema: TaggedSchema
+      readonly type: "parallel"
+      readonly output?: Schema.Top
+      readonly states: StateTree
+      readonly annotations?: never
+    }
+    | {
+      readonly schema?: never
+      readonly type: "parallel"
+      readonly output?: Schema.Top
+      readonly states: StateTree
+      readonly annotations?: SchemaLessStateAnnotations
+    }
 
   /**
    * Pseudo-state that restores the last active configuration of its parent.
@@ -2253,7 +2309,7 @@ export declare namespace Machine {
     readonly type: "history"
     /** Defaults to shallow history. */
     readonly history?: "shallow" | "deep"
-    readonly annotations?: PseudoStateAnnotations
+    readonly annotations?: SchemaLessStateAnnotations
   }
 
   /**
@@ -2268,7 +2324,7 @@ export declare namespace Machine {
    */
   export interface ChoiceStateNodeConfig {
     readonly type: "choice"
-    readonly annotations?: PseudoStateAnnotations
+    readonly annotations?: SchemaLessStateAnnotations
   }
 
   /**
@@ -2349,13 +2405,13 @@ export declare namespace Machine {
      * @since 0.4.0
      */
     readonly get: {
-      <Path extends StateIdentifier<States>>(
+      <Path extends ValuedStateIdentifier<States>>(
         snapshot: Snapshot<States>,
         path: Path
       ): Option.Option<StateByIdentifier<States, Path>>
       <
         const From extends StateIdentifier<States>,
-        const Path extends StateIdentifier<States>
+        const Path extends ValuedStateIdentifier<States>
       >(
         snapshot: SnapshotByIdentifier<States, From>,
         path: Path & (Path extends NoInfer<From> | `${NoInfer<From>}.${string}` ? unknown : never)
@@ -2372,7 +2428,7 @@ export declare namespace Machine {
      *
      * @since 0.4.0
      */
-    readonly getWithParents: <Path extends StateIdentifier<States>>(
+    readonly getWithParents: <Path extends ValuedStateIdentifier<States>>(
       snapshot: Snapshot<States>,
       path: Path
     ) => Option.Option<StateWithParents<States, Path>>
@@ -2434,7 +2490,7 @@ export declare namespace Machine {
   export interface StateNodeBase<Path extends string = string> {
     readonly path: Path
     readonly key: string
-    /** Resolved Effect Schema annotations, or descriptive pseudo-state annotations. */
+    /** Resolved schema annotations, or descriptive schema-less-state annotations. */
     readonly annotations: Readonly<StateNodeAnnotations> | undefined
     readonly order: number
   }
@@ -2444,7 +2500,7 @@ export declare namespace Machine {
     extends StateNodeBase<OwnPath>
   {
     readonly type: "atomic"
-    readonly schema: TaggedSchema
+    readonly schema: TaggedSchema | undefined
     readonly output: undefined
     readonly history: undefined
     readonly parent: ActivePath | undefined
@@ -2459,7 +2515,7 @@ export declare namespace Machine {
     ChoicePath extends string = ActivePath
   > extends StateNodeBase<OwnPath> {
     readonly type: "compound"
-    readonly schema: TaggedSchema
+    readonly schema: TaggedSchema | undefined
     readonly output: undefined
     readonly history: undefined
     readonly parent: ActivePath | undefined
@@ -2473,7 +2529,7 @@ export declare namespace Machine {
     extends StateNodeBase<OwnPath>
   {
     readonly type: "parallel"
-    readonly schema: TaggedSchema
+    readonly schema: TaggedSchema | undefined
     readonly output: Schema.Top | undefined
     readonly history: undefined
     readonly parent: ActivePath | undefined
@@ -2487,7 +2543,7 @@ export declare namespace Machine {
     extends StateNodeBase<OwnPath>
   {
     readonly type: "final"
-    readonly schema: TaggedSchema
+    readonly schema: TaggedSchema | undefined
     readonly output: Schema.Top | undefined
     readonly history: undefined
     readonly parent: ActivePath | undefined
@@ -2696,6 +2752,19 @@ export declare namespace Machine {
    * @since 0.4.0
    */
   export type StateIdentifier<States extends StateSchemas> = StateIdentifierWithPrefix<States>
+
+  /** Extracts active state paths whose definitions declare a state value schema. */
+  export type ValuedStateIdentifier<States extends StateSchemas> = StateIdentifier<States> extends infer StateId
+    ? StateId extends StateIdentifier<States> ? NodeSchema<NodeByIdentifier<States, StateId>> extends never ? never
+      : StateId
+    : never
+    : never
+
+  /** Extracts active state paths whose definitions intentionally omit a state value schema. */
+  export type StructuralStateIdentifier<States extends StateSchemas> = Exclude<
+    StateIdentifier<States>,
+    ValuedStateIdentifier<States>
+  >
 
   /**
    * Extracts the state path values represented by a state definition under a
@@ -2907,7 +2976,7 @@ export declare namespace Machine {
   export type StateByIdentifier<
     States extends StateSchemas,
     StateId extends StateIdentifier<States>
-  > = Extract<StateOf<States>, SchemaByIdentifier<States, StateId>["Type"]>
+  > = StateId extends ValuedStateIdentifier<States> ? SchemaByIdentifier<States, StateId>["Type"] : undefined
 
   /**
    * Extracts every parent state path from a state identifier.
@@ -2940,7 +3009,7 @@ export declare namespace Machine {
     States extends StateSchemas,
     StateId extends StateIdentifier<States>
   > = StateId extends StateIdentifier<States> ? {
-      readonly [Parent in Extract<ParentStateIdentifier<StateId>, StateIdentifier<States>>]: StateByIdentifier<
+      readonly [Parent in Extract<ParentStateIdentifier<StateId>, ValuedStateIdentifier<States>>]: StateByIdentifier<
         States,
         Parent
       >
@@ -2959,7 +3028,7 @@ export declare namespace Machine {
   > = StateId extends StateIdentifier<States> ?
     Extract<ImmediateParentStateIdentifier<StateId>, StateIdentifier<States>> extends infer Parent
       ? [Parent] extends [never] ? undefined
-      : Parent extends StateIdentifier<States> ? StateByIdentifier<States, Parent>
+      : Parent extends ValuedStateIdentifier<States> ? StateByIdentifier<States, Parent>
       : undefined
     : undefined
     : never
@@ -3144,7 +3213,7 @@ export declare namespace Machine {
    */
   export interface EncodedSnapshotState {
     readonly path: string
-    readonly value: unknown
+    readonly value?: unknown
   }
 
   /**
@@ -3329,17 +3398,17 @@ export declare namespace Machine {
   > = States[StateId] extends { readonly type: "parallel"; readonly states: infer Children }
     ? Children extends StateSchemas ? ParallelSnapshot<
         Path,
-        NodeSchema<States[StateId]>["Type"],
+        NodeValue<States[StateId]>,
         SnapshotRegionsWithPrefix<Children, Path>
       >
-    : AtomicSnapshot<Path, NodeSchema<States[StateId]>["Type"]>
+    : AtomicSnapshot<Path, NodeValue<States[StateId]>>
     : States[StateId] extends { readonly states: infer Children } ? Children extends StateSchemas ? CompoundSnapshot<
           Path,
-          NodeSchema<States[StateId]>["Type"],
+          NodeValue<States[StateId]>,
           SnapshotWithPrefix<Children, Path>
         >
-      : AtomicSnapshot<Path, NodeSchema<States[StateId]>["Type"]>
-    : AtomicSnapshot<Path, NodeSchema<States[StateId]>["Type"]>
+      : AtomicSnapshot<Path, NodeValue<States[StateId]>>
+    : AtomicSnapshot<Path, NodeValue<States[StateId]>>
 
   /**
    * Extracts a complete root snapshot whose selected configuration contains a
@@ -3455,7 +3524,7 @@ export declare namespace Machine {
     readonly value: StateByIdentifier<States, StateId>
     readonly values?: Partial<
       {
-        readonly [AncestorStateId in StateIdentifier<States>]: StateByIdentifier<States, AncestorStateId>
+        readonly [AncestorStateId in ValuedStateIdentifier<States>]: StateByIdentifier<States, AncestorStateId>
       }
     >
   }
@@ -3779,7 +3848,7 @@ export declare namespace Machine {
       Extract<ImmediateParentStateIdentifier<ChoiceId>, StateIdentifier<States>>
     >
     readonly parents: {
-      readonly [Parent in Extract<ParentStateIdentifier<ChoiceId>, StateIdentifier<States>>]: StateByIdentifier<
+      readonly [Parent in Extract<ParentStateIdentifier<ChoiceId>, ValuedStateIdentifier<States>>]: StateByIdentifier<
         States,
         Parent
       >
@@ -4328,10 +4397,14 @@ export declare namespace Machine {
     StateId extends StateIdentifier<States>
   > = NodeByIdentifier<States, StateId> extends infer Node ?
     Node extends { readonly type: "parallel"; readonly states: infer Children extends StateSchemas } ? {
-        readonly [Key in ActiveStateKey<Children>]: NodeSchema<Children[Key]>["Type"]
+        readonly [Key in ActiveStateKey<Children> as NodeSchema<Children[Key]> extends never ? never : Key]: NodeValue<
+          Children[Key]
+        >
       }
     : Node extends { readonly states: infer Children extends StateSchemas; readonly initial: infer Initial } ?
-      Initial extends ActiveStateKey<Children> ? NodeSchema<Children[Initial]>["Type"] : never
+      Initial extends ActiveStateKey<Children> ? NodeSchema<Children[Initial]> extends never ? never
+        : NodeValue<Children[Initial]>
+      : never
     : never
     : never
 
@@ -5303,7 +5376,9 @@ export const isFinal: <
  *
  * The returned `states` property is the same object passed to `defineStates`.
  * The returned `initial` builder creates snapshots without user-authored path
- * strings and enforces compound and parallel initial-state rules.
+ * strings and enforces compound and parallel initial-state rules. Active nodes
+ * may omit `schema` when they own no value; those builders expose `.from(...)`
+ * and still participate fully in targeting, matching, and snapshots.
  *
  * **Example** (Atomic initial snapshot)
  *

--- a/src/internal/machine/atom.ts
+++ b/src/internal/machine/atom.ts
@@ -431,6 +431,13 @@ type SnapshotIdentifier<State> = SnapshotNode<State> extends infer Node ?
   Node extends { readonly path: infer Path extends string } ? Path : never
   : never
 
+type ValuedSnapshotIdentifier<State> = SnapshotNode<State> extends infer Node ?
+  Node extends { readonly path: infer Path extends string; readonly value: infer Value } ?
+    [Value] extends [undefined] ? never
+    : Path
+  : never
+  : never
+
 type SnapshotValueByIdentifier<State, Path extends SnapshotIdentifier<State>> = SnapshotNode<State> extends infer Node ?
   Node extends { readonly path: Path; readonly value: infer Value } ? Value : never
   : never
@@ -443,7 +450,7 @@ type ChildState<Child extends Machine.ChildMachine.Any> = RefState<Machine.Child
 
 const selectValueByPath = <
   State extends Machine.Machine.AtomicSnapshot<string, unknown>,
-  Path extends SnapshotIdentifier<State>
+  Path extends ValuedSnapshotIdentifier<State>
 >(
   snapshot: State,
   path: Path
@@ -467,7 +474,7 @@ export const select = <
   Error,
   Output,
   StartError,
-  const Path extends SnapshotIdentifier<State>
+  const Path extends ValuedSnapshotIdentifier<State>
 >(
   self: MachineAtom<State, Event, Error, Output, StartError>,
   path: Path
@@ -498,7 +505,7 @@ export const selectSnapshot = <
 export const selectChild = <
   Child extends Machine.ChildMachine.Any,
   StartError,
-  const Path extends SnapshotIdentifier<ChildState<Child>>
+  const Path extends ValuedSnapshotIdentifier<ChildState<Child>>
 >(
   self: ChildMachineAtom<Child, StartError>,
   path: Path

--- a/src/internal/machine/configuration.ts
+++ b/src/internal/machine/configuration.ts
@@ -84,7 +84,7 @@ const historyFromSnapshot = (
     const active = new Set<string>()
     const values = new Map<string, unknown>()
     for (const activePath of entry.active) {
-      if (active.has(activePath) || !Object.prototype.hasOwnProperty.call(entry.values, activePath)) {
+      if (active.has(activePath)) {
         throw new Error(`Machine snapshot contains invalid remembered state "${activePath}"`)
       }
       const node = getNode(machine, activePath)
@@ -96,9 +96,15 @@ const historyFromSnapshot = (
         throw new Error(`Machine snapshot contains invalid remembered value for "${activePath}"`)
       }
       active.add(activePath)
-      values.set(activePath, decodeStateValueSync(machine, node, entry.values[activePath]))
+      const hasValue = Object.prototype.hasOwnProperty.call(entry.values, activePath)
+      if (node.schema === undefined) {
+        if (hasValue) throw new Error(`Machine snapshot contains a value for structural state "${activePath}"`)
+      } else {
+        if (!hasValue) throw new Error(`Machine snapshot omits remembered value for "${activePath}"`)
+        values.set(activePath, decodeStateValueSync(machine, node, entry.values[activePath]))
+      }
     }
-    if (!active.has(historyNode.parent) || Object.keys(entry.values).length !== active.size) {
+    if (!active.has(historyNode.parent) || Object.keys(entry.values).length !== values.size) {
       throw new Error(`Machine snapshot contains incomplete history record "${path}"`)
     }
     history.set(path, {
@@ -138,7 +144,6 @@ const historyFromSnapshotEffect = Effect.fnUntraced(function*(
       const node = machine.stateNodes.byPath.get(activePath)
       if (
         active.has(activePath) || node === undefined || node.type === "history" || node.type === "choice" ||
-        !Object.prototype.hasOwnProperty.call(entry.values, activePath) ||
         !(isPathInSubtree(activePath, historyNode.parent) ||
           getPathToRoot(machine, historyNode.parent).includes(activePath))
       ) {
@@ -152,15 +157,39 @@ const historyFromSnapshotEffect = Effect.fnUntraced(function*(
         )
       }
       active.add(activePath)
-      values.set(
-        activePath,
-        yield* decodeBoundary(machine, getStateNodeSchema(node), entry.values[activePath], {
-          boundary: "history",
-          state: activePath
-        })
-      )
+      const hasValue = Object.prototype.hasOwnProperty.call(entry.values, activePath)
+      if (node.schema === undefined) {
+        if (hasValue) {
+          return yield* Effect.fail(
+            new MachineSchemaDecodeError({
+              machineId: machine.id,
+              boundary: "history",
+              state: activePath,
+              cause: Cause.die(new Error(`Machine snapshot contains a value for structural state "${activePath}"`))
+            })
+          )
+        }
+      } else {
+        if (!hasValue) {
+          return yield* Effect.fail(
+            new MachineSchemaDecodeError({
+              machineId: machine.id,
+              boundary: "history",
+              state: activePath,
+              cause: Cause.die(new Error(`Machine snapshot omits remembered value for "${activePath}"`))
+            })
+          )
+        }
+        values.set(
+          activePath,
+          yield* decodeBoundary(machine, getStateNodeSchema(node), entry.values[activePath], {
+            boundary: "history",
+            state: activePath
+          })
+        )
+      }
     }
-    if (!active.has(historyNode.parent) || Object.keys(entry.values).length !== active.size) {
+    if (!active.has(historyNode.parent) || Object.keys(entry.values).length !== values.size) {
       return yield* Effect.fail(
         new MachineSchemaDecodeError({
           machineId: machine.id,
@@ -212,7 +241,7 @@ const historyToSnapshot = (
     entries[path] = {
       mode: record.mode,
       active,
-      values: Object.fromEntries(active.map((path) => [path, record.values.get(path)]))
+      values: Object.fromEntries(record.values)
     }
   }
   return entries
@@ -329,7 +358,9 @@ export const getParentValues = (
   const paths = getPathToRoot(machine, path)
   for (let index = 0; index < paths.length - 1; index++) {
     const parent = paths[index]!
-    parents[parent] = getActiveValue(configuration, parent)
+    if (configuration.values.has(parent)) {
+      parents[parent] = configuration.values.get(parent)
+    }
   }
   return parents
 }
@@ -340,7 +371,7 @@ export const getParentValue = (
   path: string
 ): unknown => {
   const parent = getNode(machine, path).parent
-  return parent === undefined ? undefined : getActiveValue(configuration, parent)
+  return parent === undefined ? undefined : configuration.values.get(parent)
 }
 
 export const getInitialEntryPaths = (
@@ -368,7 +399,7 @@ export const snapshotFromPath = <const States extends Machine.StateSchemas>(
   const node = getNode(machine, path)
   const snapshot: Record<string, unknown> = {
     path,
-    value: getActiveValue(configuration, path)
+    value: configuration.values.get(path)
   }
   if (node.type === "compound") {
     const child = node.children.find((child) => configuration.active.has(child))
@@ -438,9 +469,14 @@ export const configurationFromSnapshot = (
 
   const visit = (current: Machine.AtomicSnapshot<string, unknown>): void => {
     const node = getNode(machine, String(current.path))
-    const value = decodeStateValueSync(machine, node, current.value)
     active.add(node.path)
-    values.set(node.path, value)
+    if (node.schema === undefined) {
+      if (current.value !== undefined) {
+        throw new Error(`Machine structural snapshot "${node.path}" cannot contain a value`)
+      }
+    } else {
+      values.set(node.path, decodeStateValueSync(machine, node, current.value))
+    }
     if (node.type === "compound") {
       if (!hasProperty(current, "state") || !isSnapshot(current.state)) {
         throw new Error(`Machine expected compound snapshot "${node.path}" to include an active child state`)
@@ -520,9 +556,14 @@ export const configurationFromSnapshotEffect = Effect.fnUntraced(function*(
     current: Machine.AtomicSnapshot<string, unknown>
   ) {
     const node = getNode(machine, String(current.path))
-    const value = yield* decodeStateValue(machine, node, current.value)
     active.add(node.path)
-    values.set(node.path, value)
+    if (node.schema === undefined) {
+      if (current.value !== undefined) {
+        throw new Error(`Machine structural snapshot "${node.path}" cannot contain a value`)
+      }
+    } else {
+      values.set(node.path, yield* decodeStateValue(machine, node, current.value))
+    }
     if (node.type === "compound") {
       if (!hasProperty(current, "state") || !isSnapshot(current.state)) {
         throw new Error(`Machine expected compound snapshot "${node.path}" to include an active child state`)
@@ -645,7 +686,9 @@ export const captureHistory = (
     }
     const values = new Map<string, unknown>()
     for (const path of active) {
-      values.set(path, getActiveValue(current, path))
+      if (current.values.has(path)) {
+        values.set(path, current.values.get(path))
+      }
     }
     history.set(node.path, {
       mode,
@@ -722,6 +765,15 @@ export const configurationFromTargetPathEffect = Effect.fnUntraced(function*(
   for (const currentPath of paths) {
     const currentNode = getNode(machine, currentPath)
     active.add(currentPath)
+    if (currentNode.schema === undefined) {
+      const supplied = currentPath === node.path ?
+        value
+        : providedValues !== undefined && hasOwn(providedValues, currentPath) ?
+        providedValues[currentPath]
+        : undefined
+      if (supplied !== undefined) throw new Error(`Machine structural target "${currentPath}" cannot contain a value`)
+      continue
+    }
     if (currentPath === node.path) {
       values.set(currentPath, yield* decodeStateValue(machine, currentNode, value))
     } else if (providedValues !== undefined && hasOwn(providedValues, currentPath)) {
@@ -783,6 +835,12 @@ export const configurationFromTargetSnapshotEffect = Effect.fnUntraced(function*
   for (const ancestor of paths.slice(0, -1)) {
     const node = getNode(machine, ancestor)
     active.add(ancestor)
+    if (node.schema === undefined) {
+      if (providedValues !== undefined && hasOwn(providedValues, ancestor)) {
+        throw new Error(`Machine structural target "${ancestor}" cannot contain a value`)
+      }
+      continue
+    }
     if (providedValues !== undefined && hasOwn(providedValues, ancestor)) {
       values.set(ancestor, yield* decodeStateValue(machine, node, providedValues[ancestor]))
     } else if (current.values.has(ancestor)) {
@@ -816,6 +874,9 @@ export const configurationFromTargetSnapshotEffect = Effect.fnUntraced(function*
             if (!isPathInSubtree(providedPath, child)) continue
             const providedNode = getNode(machine, providedPath)
             active.add(providedPath)
+            if (providedNode.schema === undefined) {
+              throw new Error(`Machine structural target "${providedPath}" cannot contain a value`)
+            }
             values.set(providedPath, yield* decodeStateValue(machine, providedNode, providedValue))
           }
         }
@@ -885,6 +946,15 @@ const configurationFromTargetPathSync = (
   for (const currentPath of paths) {
     const currentNode = getNode(machine, currentPath)
     active.add(currentPath)
+    if (currentNode.schema === undefined) {
+      const supplied = currentPath === node.path ?
+        value
+        : providedValues !== undefined && hasOwn(providedValues, currentPath) ?
+        providedValues[currentPath]
+        : undefined
+      if (supplied !== undefined) throw new Error(`Machine structural target "${currentPath}" cannot contain a value`)
+      continue
+    }
     if (currentPath === node.path) {
       values.set(currentPath, decodeStateValueSync(machine, currentNode, value))
     } else if (providedValues !== undefined && hasOwn(providedValues, currentPath)) {
@@ -932,6 +1002,12 @@ const configurationFromTargetSnapshotSync = (
   for (const ancestor of paths.slice(0, -1)) {
     const node = getNode(machine, ancestor)
     active.add(ancestor)
+    if (node.schema === undefined) {
+      if (providedValues !== undefined && hasOwn(providedValues, ancestor)) {
+        throw new Error(`Machine structural target "${ancestor}" cannot contain a value`)
+      }
+      continue
+    }
     if (providedValues !== undefined && hasOwn(providedValues, ancestor)) {
       values.set(ancestor, decodeStateValueSync(machine, node, providedValues[ancestor]))
     } else if (current.values.has(ancestor)) {
@@ -960,6 +1036,9 @@ const configurationFromTargetSnapshotSync = (
           if (!isPathInSubtree(providedPath, child)) continue
           const providedNode = getNode(machine, providedPath)
           active.add(providedPath)
+          if (providedNode.schema === undefined) {
+            throw new Error(`Machine structural target "${providedPath}" cannot contain a value`)
+          }
           values.set(providedPath, decodeStateValueSync(machine, providedNode, providedValue))
         }
       }
@@ -1098,7 +1177,7 @@ export const resolveFinalOutputEffect: <
 ) {
   const node = getNode(machine, path)
   const output = getStateConfigByPath(machine, path)?.output?.({
-    state: getActiveValue(configuration, path),
+    state: configuration.values.get(path),
     parent: getParentValue(machine, configuration, path),
     parents: getParentValues(machine, configuration, path),
     event,
@@ -1251,7 +1330,7 @@ const resolveFinalOutputSync = <const Events extends ReadonlyArray<Machine.Tagge
 ): unknown => {
   const node = getNode(machine, path)
   const output = getStateConfigByPath(machine, path)?.output?.({
-    state: getActiveValue(configuration, path),
+    state: configuration.values.get(path),
     parent: getParentValue(machine, configuration, path),
     parents: getParentValues(machine, configuration, path),
     event,

--- a/src/internal/machine/executionPlan.ts
+++ b/src/internal/machine/executionPlan.ts
@@ -100,6 +100,12 @@ const compileIndexedExecutionDescriptor = (
     if (node.type === "choice" || node.type === "history") {
       return undefined
     }
+    // Structural active states deliberately use the generic semantic
+    // reference until the indexed value table represents absent values as an
+    // explicit capability rather than an `undefined` slot.
+    if (node.schema === undefined) {
+      return undefined
+    }
     if (node.type === "atomic" || node.type === "final") {
       leafPaths.push(node.path)
     }

--- a/src/internal/machine/invocation.ts
+++ b/src/internal/machine/invocation.ts
@@ -109,7 +109,7 @@ export const startAll = (
     .filter((path) => configuration.active.has(path))
     .flatMap((path) =>
       resolve(Configuration.getStateConfigByPath(machine, path), {
-        state: Configuration.getActiveValue(configuration, path),
+        state: configuration.values.get(path),
         parent: Configuration.getParentValue(machine, configuration, path),
         parents: Configuration.getParentValues(machine, configuration, path),
         event

--- a/src/internal/machine/machine.ts
+++ b/src/internal/machine/machine.ts
@@ -278,10 +278,14 @@ type FromMethodKind = "leaf" | "nested"
 
 const withFrom = <Method extends (value: unknown, ...args: ReadonlyArray<any>) => unknown>(
   method: Method,
-  kind: FromMethodKind
+  kind: FromMethodKind,
+  valued: boolean
 ): Method & { readonly from: (...args: ReadonlyArray<any>) => unknown } => {
   Object.defineProperty(method, "from", {
     value: (...args: ReadonlyArray<any>) => {
+      if (!valued) {
+        return method(undefined, ...args)
+      }
       const omitted = args.length === 0 || (kind === "nested" && args.length === 1 && typeof args[0] === "function")
       const input = omitted ? {} : args[0]
       const rest = omitted ? args : args.slice(1)
@@ -312,7 +316,8 @@ const makeSnapshotBuilder = (
     builder[key] = withFrom(
       (value: unknown, selector?: (builder: unknown) => unknown) =>
         makeSnapshotForNode(definition, key, value, selector, options),
-      node.states === undefined ? "leaf" : "nested"
+      node.states === undefined ? "leaf" : "nested",
+      node.schema !== undefined
     )
   }
   return builder
@@ -339,14 +344,18 @@ const makeParallelSnapshotBuilder = (
     }
     const path = options.prefix === "" ? key : `${options.prefix}.${key}`
     const node = Topology.getStateNodeDefinition(path, definition)
-    builder[key] = withFrom((value: unknown, selector?: (builder: unknown) => unknown) => {
-      const nextRegions: Record<string, unknown> = {}
-      for (const regionKey of Object.keys(regions)) {
-        nextRegions[regionKey] = regions[regionKey]
-      }
-      nextRegions[key] = makeSnapshotForNode(definition, key, value, selector, options)
-      return makeParallelSnapshotBuilder(states, options, nextRegions)
-    }, node.states === undefined ? "leaf" : "nested")
+    builder[key] = withFrom(
+      (value: unknown, selector?: (builder: unknown) => unknown) => {
+        const nextRegions: Record<string, unknown> = {}
+        for (const regionKey of Object.keys(regions)) {
+          nextRegions[regionKey] = regions[regionKey]
+        }
+        nextRegions[key] = makeSnapshotForNode(definition, key, value, selector, options)
+        return makeParallelSnapshotBuilder(states, options, nextRegions)
+      },
+      node.states === undefined ? "leaf" : "nested",
+      node.schema !== undefined
+    )
   }
   return builder
 }
@@ -525,13 +534,25 @@ const makeLocalTargetChildBuilder = (
       builder[child.key] = () => Topology.makeChoiceTarget(child.path, parent.path, values)
       continue
     }
-    builder[child.key] = withFrom((value: unknown, selector?: (builder: unknown) => unknown) => {
-      if (child.type === "atomic" || child.type === "final") {
-        return makeTargetWithValues(child.path, value, values)
-      }
-      if (child.type === "parallel") {
-        if (source !== child.path && !source.startsWith(`${child.path}.`)) {
-          return makeParallelTarget(states, child, value, selector, values)
+    builder[child.key] = withFrom(
+      (value: unknown, selector?: (builder: unknown) => unknown) => {
+        if (child.type === "atomic" || child.type === "final") {
+          return makeTargetWithValues(child.path, value, values)
+        }
+        if (child.type === "parallel") {
+          if (source !== child.path && !source.startsWith(`${child.path}.`)) {
+            return makeParallelTarget(states, child, value, selector, values)
+          }
+          if (selector === undefined) {
+            throw new Error(`Machine expected target "${child.path}" builder to provide an active child state`)
+          }
+          return selector(makeLocalTargetChildBuilder(
+            states,
+            stateNodes,
+            child.path,
+            child.schema === undefined ? values : extendTargetValues(values, child.path, value),
+            source
+          ))
         }
         if (selector === undefined) {
           throw new Error(`Machine expected target "${child.path}" builder to provide an active child state`)
@@ -540,21 +561,13 @@ const makeLocalTargetChildBuilder = (
           states,
           stateNodes,
           child.path,
-          extendTargetValues(values, child.path, value),
+          child.schema === undefined ? values : extendTargetValues(values, child.path, value),
           source
         ))
-      }
-      if (selector === undefined) {
-        throw new Error(`Machine expected target "${child.path}" builder to provide an active child state`)
-      }
-      return selector(makeLocalTargetChildBuilder(
-        states,
-        stateNodes,
-        child.path,
-        extendTargetValues(values, child.path, value),
-        source
-      ))
-    }, child.type === "atomic" || child.type === "final" ? "leaf" : "nested")
+      },
+      child.type === "atomic" || child.type === "final" ? "leaf" : "nested",
+      child.schema !== undefined
+    )
   }
   return builder
 }
@@ -569,12 +582,19 @@ const makeLocalTargetBuilder = (
     return {}
   }
   const builder = makeLocalTargetChildBuilder(states, stateNodes, scope, undefined, source) as Record<string, unknown>
-  builder.with = withFrom((value: unknown, selector?: (builder: unknown) => unknown) => {
-    if (selector === undefined) {
-      throw new Error(`Machine expected target "${scope}" builder to provide an active child state`)
-    }
-    return selector(makeLocalTargetChildBuilder(states, stateNodes, scope, { [scope]: value }, source))
-  }, "nested")
+  const scopeNode = getTargetBuilderNode(stateNodes, scope)
+  if (scopeNode.schema !== undefined) {
+    builder.with = withFrom(
+      (value: unknown, selector?: (builder: unknown) => unknown) => {
+        if (selector === undefined) {
+          throw new Error(`Machine expected target "${scope}" builder to provide an active child state`)
+        }
+        return selector(makeLocalTargetChildBuilder(states, stateNodes, scope, { [scope]: value }, source))
+      },
+      "nested",
+      true
+    )
+  }
   return builder
 }
 
@@ -610,12 +630,31 @@ const makeBranchTargetNodeBuilder = (
 ): unknown => {
   const node = getTargetBuilderNode(stateNodes, path)
   if (node.type === "atomic" || node.type === "final") {
-    return withFrom((value: unknown) => makeTargetWithValues(node.path, value, values), "leaf")
+    return withFrom(
+      (value: unknown) => makeTargetWithValues(node.path, value, values),
+      "leaf",
+      node.schema !== undefined
+    )
   }
-  const builder = withFrom((value: unknown, selector?: (builder: unknown) => unknown) => {
-    if (node.type === "parallel") {
-      if (source !== node.path && !source.startsWith(`${node.path}.`)) {
-        return makeParallelTarget(states, node, value, selector, values)
+  const builder = withFrom(
+    (value: unknown, selector?: (builder: unknown) => unknown) => {
+      if (node.type === "parallel") {
+        if (source !== node.path && !source.startsWith(`${node.path}.`)) {
+          return makeParallelTarget(states, node, value, selector, values)
+        }
+        if (selector === undefined) {
+          throw new Error(`Machine expected target "${node.path}" builder to provide an active child state`)
+        }
+        const nextBuilder: Record<string, unknown> = {}
+        addBranchTargetChildren(
+          nextBuilder,
+          states,
+          stateNodes,
+          node.path,
+          node.schema === undefined ? values : extendTargetValues(values, node.path, value),
+          source
+        )
+        return selector(nextBuilder)
       }
       if (selector === undefined) {
         throw new Error(`Machine expected target "${node.path}" builder to provide an active child state`)
@@ -626,25 +665,14 @@ const makeBranchTargetNodeBuilder = (
         states,
         stateNodes,
         node.path,
-        extendTargetValues(values, node.path, value),
+        node.schema === undefined ? values : extendTargetValues(values, node.path, value),
         source
       )
       return selector(nextBuilder)
-    }
-    if (selector === undefined) {
-      throw new Error(`Machine expected target "${node.path}" builder to provide an active child state`)
-    }
-    const nextBuilder: Record<string, unknown> = {}
-    addBranchTargetChildren(
-      nextBuilder,
-      states,
-      stateNodes,
-      node.path,
-      extendTargetValues(values, node.path, value),
-      source
-    )
-    return selector(nextBuilder)
-  }, "nested") as unknown as Record<string, unknown>
+    },
+    "nested",
+    node.schema !== undefined
+  ) as unknown as Record<string, unknown>
   if (node.type !== "parallel" || source === node.path || source.startsWith(`${node.path}.`)) {
     addBranchTargetChildren(builder, states, stateNodes, node.path, values, source)
   }

--- a/src/internal/machine/planner.ts
+++ b/src/internal/machine/planner.ts
@@ -18,7 +18,6 @@ import {
   configurationFromHistoryRecord,
   getActiveLeafPathFrom,
   getActiveLeafPaths,
-  getActiveValue,
   getHistoryRecord,
   getInitialEntryPaths,
   getLeafPath,
@@ -201,66 +200,76 @@ const completeHistoryConfiguration = (
         if (node.initial === undefined) {
           throw new Error(`Machine shallow history expected compound state "${path}" to have an initial child`)
         }
-        const initializer = machine.handlers[path]?.initial
-        if (initializer === undefined) {
-          throw new Error(`Machine shallow history requires an initial value implementation for state "${path}"`)
-        }
+        const child = getNode(machine, node.initial)
         const current = {
           active,
           values,
           outputs: configuration.outputs,
           history: configuration.history
         } as ActiveConfiguration
-        const initialized = collectStateInitializer(machine, initializer, {
-          state: getActiveValue(current, path),
-          parent: getParentValue(machine, current, path),
-          parents: getParentValues(machine, current, path),
-          event
-        })
-        const child = getNode(machine, node.initial)
         active.add(child.path)
-        values.set(child.path, decodeStateValueSync(machine, child, initialized.value))
-        commands.push(...initialized.commands)
-        raisedEvents.push(...initialized.raisedEvents)
-        emittedEvents.push(...initialized.emittedEvents)
+        if (child.schema !== undefined) {
+          const initializer = machine.handlers[path]?.initial
+          if (initializer === undefined) {
+            throw new Error(`Machine shallow history requires an initial value implementation for state "${path}"`)
+          }
+          const initialized = collectStateInitializer(machine, initializer, {
+            state: current.values.get(path),
+            parent: getParentValue(machine, current, path),
+            parents: getParentValues(machine, current, path),
+            event
+          })
+          values.set(child.path, decodeStateValueSync(machine, child, initialized.value))
+          commands.push(...initialized.commands)
+          raisedEvents.push(...initialized.raisedEvents)
+          emittedEvents.push(...initialized.emittedEvents)
+        }
         changed = true
       }
       if (node.type === "parallel") {
         const missing = node.children.filter((childPath) => !active.has(childPath))
         if (missing.length > 0) {
-          const initializer = machine.handlers[path]?.initial
-          if (initializer === undefined) {
-            throw new Error(`Machine shallow history requires an initial value implementation for state "${path}"`)
-          }
+          const valuedMissing = missing.filter((childPath) => getNode(machine, childPath).schema !== undefined)
           const current = {
             active,
             values,
             outputs: configuration.outputs,
             history: configuration.history
           } as ActiveConfiguration
-          const initialized = collectStateInitializer(machine, initializer, {
-            state: getActiveValue(current, path),
+          const initializer = valuedMissing.length === 0 ? undefined : machine.handlers[path]?.initial
+          if (valuedMissing.length > 0 && initializer === undefined) {
+            throw new Error(`Machine shallow history requires an initial value implementation for state "${path}"`)
+          }
+          const initialized = initializer === undefined ? undefined : collectStateInitializer(machine, initializer, {
+            state: current.values.get(path),
             parent: getParentValue(machine, current, path),
             parents: getParentValues(machine, current, path),
             event
           })
-          if (typeof initialized.value !== "object" || initialized.value === null) {
+          if (initialized !== undefined && (typeof initialized.value !== "object" || initialized.value === null)) {
             throw new Error(`Machine parallel state initializer for "${path}" must return its region values`)
           }
           for (const childPath of missing) {
             const child = getNode(machine, childPath)
-            if (!Object.prototype.hasOwnProperty.call(initialized.value, child.key)) {
-              throw new Error(`Machine parallel state initializer for "${path}" must return region "${child.key}"`)
-            }
             active.add(child.path)
-            values.set(
-              child.path,
-              decodeStateValueSync(machine, child, (initialized.value as Record<string, unknown>)[child.key])
-            )
+            if (child.schema !== undefined) {
+              if (
+                initialized === undefined ||
+                !Object.prototype.hasOwnProperty.call(initialized.value as object, child.key)
+              ) {
+                throw new Error(`Machine parallel state initializer for "${path}" must return region "${child.key}"`)
+              }
+              values.set(
+                child.path,
+                decodeStateValueSync(machine, child, (initialized.value as Record<string, unknown>)[child.key])
+              )
+            }
           }
-          commands.push(...initialized.commands)
-          raisedEvents.push(...initialized.raisedEvents)
-          emittedEvents.push(...initialized.emittedEvents)
+          if (initialized !== undefined) {
+            commands.push(...initialized.commands)
+            raisedEvents.push(...initialized.raisedEvents)
+            emittedEvents.push(...initialized.emittedEvents)
+          }
           changed = true
         }
       }
@@ -495,7 +504,7 @@ const makeStateActionContext = <
   path: string,
   event: Machine.LifecycleEvent<Events>
 ): Machine.StateActionContext<States, Events, Emits, StateId> => ({
-  state: getActiveValue(configuration, path) as Machine.StateByIdentifier<States, StateId>,
+  state: configuration.values.get(path) as Machine.StateByIdentifier<States, StateId>,
   parent: getParentValue(machine, configuration, path) as Machine.ParentStateValue<States, StateId>,
   parents: getParentValues(machine, configuration, path) as Machine.ParentStateValues<States, StateId>,
   event
@@ -514,7 +523,7 @@ const makeTransitionContext = <
   event: Machine.EventByTag<Events, EventTag>,
   snapshot: Machine.Snapshot<States>
 ): Machine.HandlerContext<States, Events, Emits, StateId, EventTag, any, any> => ({
-  state: getActiveValue(configuration, path) as Machine.StateByIdentifier<States, StateId>,
+  state: configuration.values.get(path) as Machine.StateByIdentifier<States, StateId>,
   parent: getParentValue(machine, configuration, path) as Machine.ParentStateValue<States, StateId>,
   parents: getParentValues(machine, configuration, path) as Machine.ParentStateValues<States, StateId>,
   event,
@@ -535,7 +544,7 @@ const makeDoneContext = <
   output: unknown,
   snapshot: Machine.Snapshot<States>
 ): Machine.DoneContext<States, Events, Emits, StateId> => ({
-  state: getActiveValue(configuration, path) as Machine.StateByIdentifier<States, StateId>,
+  state: configuration.values.get(path) as Machine.StateByIdentifier<States, StateId>,
   parent: getParentValue(machine, configuration, path) as Machine.ParentStateValue<States, StateId>,
   parents: getParentValues(machine, configuration, path) as Machine.ParentStateValues<States, StateId>,
   event,
@@ -629,7 +638,7 @@ const selectAlwaysTransitions = <
               Machine.AlwaysContext<States, Events, Emits, Machine.StateIdentifier<States>>
             >,
             context: {
-              state: getActiveValue(configuration, path) as Machine.StateByIdentifier<
+              state: configuration.values.get(path) as Machine.StateByIdentifier<
                 States,
                 Machine.StateIdentifier<States>
               >,
@@ -919,7 +928,9 @@ const choicesFromTarget = (
       return
     }
     if (typeof current !== "object" || current === null || !("path" in current) || !("value" in current)) return
-    values[String(current.path)] = current.value
+    if (current.value !== undefined) {
+      values[String(current.path)] = current.value
+    }
     if ("state" in current) visit(current.state)
     if ("states" in current && typeof current.states === "object" && current.states !== null) {
       for (const state of Object.values(current.states)) visit(state)

--- a/src/internal/machine/serialization.ts
+++ b/src/internal/machine/serialization.ts
@@ -31,7 +31,7 @@ const EncodedSnapshotSchema = Schema.Struct({
   _tag: Schema.Literal("MachineSnapshot"),
   active: Schema.Array(Schema.Struct({
     path: Schema.String,
-    value: Schema.Unknown
+    value: Schema.optional(Schema.Unknown)
   })),
   completed: Schema.optional(Schema.Array(Schema.Struct({
     path: Schema.String,
@@ -220,13 +220,17 @@ export const encodeSnapshot = (
       const path of Array.from(configuration.active).sort((left, right) => compareDocumentOrder(machine, left, right))
     ) {
       const node = getNode(machine, path)
-      active.push({
-        path,
-        value: yield* encodeBoundary(machine, getStateNodeSchema(node), getActiveValue(configuration, path), {
-          boundary: "state",
-          state: path
+      if (node.schema === undefined) {
+        active.push({ path })
+      } else {
+        active.push({
+          path,
+          value: yield* encodeBoundary(machine, getStateNodeSchema(node), getActiveValue(configuration, path), {
+            boundary: "state",
+            state: path
+          })
         })
-      })
+      }
     }
 
     const completed: Array<Machine.EncodedSnapshotCompletion> = []
@@ -290,7 +294,6 @@ export const encodeSnapshot = (
         const stateNode = machine.stateNodes.byPath.get(path)
         if (
           stateNode === undefined || stateNode.type === "history" || stateNode.type === "choice" ||
-          !record.values.has(path) ||
           !(isPathInSubtree(path, record.parent) || getPathToRoot(machine, record.parent).includes(path))
         ) {
           return yield* Effect.fail(
@@ -302,14 +305,23 @@ export const encodeSnapshot = (
             })
           )
         }
-        encodedValues[path] = yield* encodeBoundary(
-          machine,
-          getStateNodeSchema(stateNode),
-          record.values.get(path),
-          { boundary: "history", state: path }
-        )
+        if (stateNode.schema === undefined) {
+          if (record.values.has(path)) {
+            throw new Error(`Machine history record contains a value for structural state "${path}"`)
+          }
+        } else {
+          if (!record.values.has(path)) {
+            throw new Error(`Machine history record omits value for "${path}"`)
+          }
+          encodedValues[path] = yield* encodeBoundary(
+            machine,
+            getStateNodeSchema(stateNode),
+            record.values.get(path),
+            { boundary: "history", state: path }
+          )
+        }
       }
-      if (record.values.size !== record.active.size) {
+      if (Object.keys(encodedValues).length !== record.values.size) {
         return yield* Effect.fail(
           new MachineSchemaEncodeError({
             machineId: machine.id,
@@ -356,13 +368,19 @@ export const decodeSnapshot = (
       }
       const node = getNode(machine, entry.path)
       active.add(entry.path)
-      values.set(
-        entry.path,
-        yield* decodeEncodedBoundary(machine, getStateNodeSchema(node), entry.value, {
-          boundary: "state",
-          state: entry.path
-        })
-      )
+      const hasValue = Object.prototype.hasOwnProperty.call(entry, "value")
+      if (node.schema === undefined) {
+        if (hasValue) throw new Error(`Machine encoded snapshot contains a value for structural state "${entry.path}"`)
+      } else {
+        if (!hasValue) throw new Error(`Machine encoded snapshot omits value for state "${entry.path}"`)
+        values.set(
+          entry.path,
+          yield* decodeEncodedBoundary(machine, getStateNodeSchema(node), entry.value, {
+            boundary: "state",
+            state: entry.path
+          })
+        )
+      }
     }
 
     const history = new Map<string, HistoryRecord>()
@@ -397,7 +415,6 @@ export const decodeSnapshot = (
         const stateNode = machine.stateNodes.byPath.get(path)
         if (
           stateNode === undefined || stateNode.type === "history" || stateNode.type === "choice" ||
-          !Object.prototype.hasOwnProperty.call(encodedRecord.values, path) ||
           !(isPathInSubtree(path, historyNode.parent) || getPathToRoot(machine, historyNode.parent).includes(path))
         ) {
           return yield* Effect.fail(
@@ -410,15 +427,23 @@ export const decodeSnapshot = (
           )
         }
         rememberedActive.add(path)
-        rememberedValues.set(
-          path,
-          yield* decodeEncodedBoundary(machine, getStateNodeSchema(stateNode), encodedRecord.values[path], {
-            boundary: "history",
-            state: path
-          })
-        )
+        const hasValue = Object.prototype.hasOwnProperty.call(encodedRecord.values, path)
+        if (stateNode.schema === undefined) {
+          if (hasValue) {
+            throw new Error(`Machine encoded history contains a value for structural state "${path}"`)
+          }
+        } else {
+          if (!hasValue) throw new Error(`Machine encoded history omits value for state "${path}"`)
+          rememberedValues.set(
+            path,
+            yield* decodeEncodedBoundary(machine, getStateNodeSchema(stateNode), encodedRecord.values[path], {
+              boundary: "history",
+              state: path
+            })
+          )
+        }
       }
-      if (Object.keys(encodedRecord.values).length !== rememberedActive.size) {
+      if (Object.keys(encodedRecord.values).length !== rememberedValues.size) {
         return yield* Effect.fail(
           new MachineSchemaDecodeError({
             machineId: machine.id,

--- a/src/internal/machine/stateDefinition.ts
+++ b/src/internal/machine/stateDefinition.ts
@@ -2,10 +2,10 @@ import * as Schema from "effect/Schema"
 import * as SchemaAST from "effect/SchemaAST"
 
 export const StateNodePropertyPolicy = {
-  atomic: ["schema", "type"],
-  final: ["schema", "type", "output"],
-  compound: ["schema", "type", "initial", "states"],
-  parallel: ["schema", "type", "output", "states"],
+  atomic: ["schema", "type", "annotations"],
+  final: ["schema", "type", "output", "annotations"],
+  compound: ["schema", "type", "initial", "states", "annotations"],
+  parallel: ["schema", "type", "output", "states", "annotations"],
   history: ["type", "history", "annotations"],
   choice: ["type", "annotations"]
 } as const
@@ -152,18 +152,22 @@ const assertAllowedProperties = (
   }
 }
 
-const validatePseudoAnnotations = (
+const validateSchemaLessAnnotations = (
   boundary: StateDefinitionBoundary,
   path: string,
   annotations: unknown
 ): void => {
-  assertPlainRecord(boundary, `${path}.annotations`, annotations, "pseudo-state annotations")
+  assertPlainRecord(boundary, `${path}.annotations`, annotations, "schema-less state annotations")
   for (const property of Reflect.ownKeys(annotations)) {
     if (!(PseudoStateAnnotationProperties as ReadonlyArray<PropertyKey>).includes(property)) {
-      fail(boundary, `${path}.annotations`, `pseudo-state annotations cannot declare property "${String(property)}"`)
+      fail(
+        boundary,
+        `${path}.annotations`,
+        `schema-less state annotations cannot declare property "${String(property)}"`
+      )
     }
     if (typeof annotations[property] !== "string") {
-      fail(boundary, `${path}.annotations.${String(property)}`, "pseudo-state annotation values must be strings")
+      fail(boundary, `${path}.annotations.${String(property)}`, "schema-less state annotation values must be strings")
     }
   }
 }
@@ -211,7 +215,7 @@ const validateStateTree = (
         fail(boundary, path, `${kind} states must be declared below an active parent state`)
       }
       if (hasOwn(node, "annotations")) {
-        validatePseudoAnnotations(boundary, path, node.annotations)
+        validateSchemaLessAnnotations(boundary, path, node.annotations)
       }
       if (kind === "history" && hasOwn(node, "history") && node.history !== "shallow" && node.history !== "deep") {
         fail(boundary, `${path}.history`, "history must be \"shallow\" or \"deep\"")
@@ -219,8 +223,15 @@ const validateStateTree = (
       continue
     }
 
-    if (!hasOwn(node, "schema") || !isTaggedSchema(node.schema)) {
-      fail(boundary, `${path}.schema`, "active states must declare an Effect Schema with a required PropertyKey _tag")
+    const valued = hasOwn(node, "schema")
+    if (valued && !isTaggedSchema(node.schema)) {
+      fail(boundary, `${path}.schema`, "state schemas must decode to an object with a required PropertyKey _tag")
+    }
+    if (valued && hasOwn(node, "annotations")) {
+      fail(boundary, `${path}.annotations`, "schema-backed states must declare annotations on their schema")
+    }
+    if (!valued && hasOwn(node, "annotations")) {
+      validateSchemaLessAnnotations(boundary, path, node.annotations)
     }
     if (kind === "atomic" && hasOwn(node, "type") && node.type !== "active") {
       fail(boundary, `${path}.type`, "atomic state type must be \"active\"")

--- a/src/internal/machine/topology.ts
+++ b/src/internal/machine/topology.ts
@@ -70,7 +70,7 @@ interface NormalizedStateNodeDefinitionBase {
 type NormalizedStateNodeDefinition =
   | (NormalizedStateNodeDefinitionBase & {
     readonly type: "atomic"
-    readonly schema: Machine.TaggedSchema
+    readonly schema: Machine.TaggedSchema | undefined
     readonly output: undefined
     readonly history: undefined
     readonly initial: undefined
@@ -78,7 +78,7 @@ type NormalizedStateNodeDefinition =
   })
   | (NormalizedStateNodeDefinitionBase & {
     readonly type: "compound"
-    readonly schema: Machine.TaggedSchema
+    readonly schema: Machine.TaggedSchema | undefined
     readonly output: undefined
     readonly history: undefined
     readonly initial: string
@@ -86,7 +86,7 @@ type NormalizedStateNodeDefinition =
   })
   | (NormalizedStateNodeDefinitionBase & {
     readonly type: "parallel"
-    readonly schema: Machine.TaggedSchema
+    readonly schema: Machine.TaggedSchema | undefined
     readonly output: Schema.Top | undefined
     readonly history: undefined
     readonly initial: undefined
@@ -94,7 +94,7 @@ type NormalizedStateNodeDefinition =
   })
   | (NormalizedStateNodeDefinitionBase & {
     readonly type: "final"
-    readonly schema: Machine.TaggedSchema
+    readonly schema: Machine.TaggedSchema | undefined
     readonly output: Schema.Top | undefined
     readonly history: undefined
     readonly initial: undefined
@@ -154,9 +154,10 @@ export const getStateNodeDefinition = (
       states: undefined
     }
   }
-  if (!hasProperty(definition, "schema") || !Schema.isSchema(definition.schema)) {
-    throw new Error(`Machine.make expected state "${path}" to be a tagged schema or state node config`)
-  }
+  const schema = hasProperty(definition, "schema") && Schema.isSchema(definition.schema)
+    ? definition.schema as Machine.TaggedSchema
+    : undefined
+  const annotations = schema === undefined ? definition.annotations : Schema.resolveAnnotations(schema)
   if (definition.type === "parallel" && !hasProperty(definition, "states")) {
     throw new Error(`Machine.make expected parallel state "${path}" to declare child regions`)
   }
@@ -167,9 +168,9 @@ export const getStateNodeDefinition = (
     }
     if (definition.type === "parallel") {
       return {
-        schema: definition.schema,
+        schema,
         output: Schema.isSchema(definition.output) ? definition.output : undefined,
-        annotations: Schema.resolveAnnotations(definition.schema),
+        annotations,
         type: "parallel",
         history: undefined,
         initial: undefined,
@@ -180,9 +181,9 @@ export const getStateNodeDefinition = (
       throw new Error(`Machine.make expected compound state "${path}" to declare an initial child`)
     }
     return {
-      schema: definition.schema,
+      schema,
       output: undefined,
-      annotations: Schema.resolveAnnotations(definition.schema),
+      annotations,
       type: "compound",
       history: undefined,
       initial: definition.initial,
@@ -192,18 +193,18 @@ export const getStateNodeDefinition = (
   const output = Schema.isSchema(definition.output) ? definition.output : undefined
   return definition.type === "final"
     ? {
-      schema: definition.schema,
+      schema,
       output,
-      annotations: Schema.resolveAnnotations(definition.schema),
+      annotations,
       type: "final",
       history: undefined,
       initial: undefined,
       states: undefined
     }
     : {
-      schema: definition.schema,
+      schema,
       output: undefined,
-      annotations: Schema.resolveAnnotations(definition.schema),
+      annotations,
       type: "atomic",
       history: undefined,
       initial: undefined,
@@ -405,7 +406,7 @@ export const makeTarget = <
     readonly snapshot?: Machine.SnapshotByIdentifier<States, StateId>
     readonly values?: Partial<
       {
-        readonly [AncestorStateId in Machine.StateIdentifier<States>]: Machine.StateByIdentifier<
+        readonly [AncestorStateId in Machine.ValuedStateIdentifier<States>]: Machine.StateByIdentifier<
           States,
           AncestorStateId
         >
@@ -445,7 +446,9 @@ export const getSnapshotByPath = (
     return Option.none()
   }
   if (parents !== undefined) {
-    parents[snapshot.path] = snapshot.value
+    if (snapshot.value !== undefined) {
+      parents[snapshot.path] = snapshot.value
+    }
   }
   if (hasProperty(snapshot, "state") && isSnapshot(snapshot.state)) {
     return getSnapshotByPath(snapshot.state, path, parents)
@@ -473,7 +476,7 @@ export const getNode = (machine: Machine.Any, path: string): Machine.StateNode =
 
 export const getStateNodeSchema = (node: Machine.StateNode): Machine.TaggedSchema => {
   if (node.schema === undefined) {
-    throw new Error(`Machine pseudo-state "${node.path}" has no active value schema`)
+    throw new Error(`Machine state "${node.path}" has no value schema`)
   }
   return node.schema
 }

--- a/src/internal/testing/machine/verification.ts
+++ b/src/internal/testing/machine/verification.ts
@@ -1114,7 +1114,9 @@ export const verify = <M extends AnyMachine>(
         }
         return
       }
-      if (reportConfiguration && !schemaMatches(node.schema, current.value)) {
+      if (reportConfiguration && node.schema === undefined && current.value !== undefined) {
+        add("configuration.schema", location, `${label} structural state "${path}" contains a value`, path)
+      } else if (reportConfiguration && node.schema !== undefined && !schemaMatches(node.schema, current.value)) {
         add("configuration.schema", location, `${label} value for "${path}" does not match its schema`, path)
       }
 
@@ -1284,9 +1286,17 @@ export const verify = <M extends AnyMachine>(
             path
           )
         }
-        if (!hasOwn(entry.values, path)) {
+        const hasValue = hasOwn(entry.values, path)
+        if (node.schema === undefined && hasValue) {
+          add(
+            "history.value",
+            location,
+            `${label} history record "${historyPath}" values structural state "${path}"`,
+            path
+          )
+        } else if (node.schema !== undefined && !hasValue) {
           add("history.value", location, `${label} history record "${historyPath}" omits value for "${path}"`, path)
-        } else if (!schemaMatches(node.schema, entry.values[path])) {
+        } else if (node.schema !== undefined && !schemaMatches(node.schema, entry.values[path])) {
           add(
             "history.value",
             location,

--- a/src/unstable/reactivity/AtomMachine.ts
+++ b/src/unstable/reactivity/AtomMachine.ts
@@ -291,6 +291,13 @@ type SnapshotIdentifier<State> = SnapshotNode<State> extends infer Node ?
   Node extends { readonly path: infer Path extends string } ? Path : never
   : never
 
+type ValuedSnapshotIdentifier<State> = SnapshotNode<State> extends infer Node ?
+  Node extends { readonly path: infer Path extends string; readonly value: infer Value } ?
+    [Value] extends [undefined] ? never
+    : Path
+  : never
+  : never
+
 type SnapshotValueByIdentifier<State, Path extends SnapshotIdentifier<State>> = SnapshotNode<State> extends infer Node ?
   Node extends { readonly path: Path; readonly value: infer Value } ? Value : never
   : never
@@ -338,7 +345,7 @@ export const select: <
   Error,
   Output,
   StartError,
-  const Path extends SnapshotIdentifier<State>
+  const Path extends ValuedSnapshotIdentifier<State>
 >(self: MachineAtom<State, Event, Error, Output, StartError>, path: Path) => Atom.Atom<
   AsyncResult.AsyncResult<Option.Option<SnapshotValueByIdentifier<State, Path>>, StartError | Error>
 > = internal.select
@@ -384,7 +391,7 @@ export const selectSnapshot: <
 export const selectChild: <
   Child extends Machine.ChildMachine.Any,
   StartError,
-  const Path extends SnapshotIdentifier<ChildState<Child>>
+  const Path extends ValuedSnapshotIdentifier<ChildState<Child>>
 >(self: ChildMachineAtom<Child, StartError>, path: Path) => Atom.Atom<
   AsyncResult.AsyncResult<
     Option.Option<SnapshotValueByIdentifier<ChildState<Child>, Path>>,

--- a/test/internal/machine/strategyDifferential.test.ts
+++ b/test/internal/machine/strategyDifferential.test.ts
@@ -194,6 +194,24 @@ describe("machine planner and runtime strategies", () => {
       })
     }))
 
+  it.effect("fails closed to the generic planner for schema-less active states", () =>
+    Effect.gen(function*() {
+      const states = Machine.defineStates({ Idle: {} })
+      const machine = Machine.make({
+        states: states.states,
+        events: [],
+        initial: () => states.initial.Idle.from()
+      }).handle({ Idle: {} })
+
+      assert.strictEqual(ExecutionPlan.selectExecutionPlanForTesting(machine, "auto").strategy, "generic")
+      yield* verifyPlannerStrategies({
+        machine,
+        events: [],
+        expected: "generic",
+        label: "schema-less fallback"
+      })
+    }))
+
   it("falls back to the generic planner for unknown state semantics", () => {
     const machine = makeFlatMachine()
     const config = machine.handlers.Count as Machine.Machine.AnyStateConfig & Record<PropertyKey, unknown>

--- a/test/machine/StateDefinition.test.ts
+++ b/test/machine/StateDefinition.test.ts
@@ -43,6 +43,43 @@ const makeFromUnknownStates = (states: unknown): unknown =>
   })
 
 describe("exact state-definition runtime validation", () => {
+  it("accepts schema-less active states without confusing them with pseudo-states", () => {
+    const states = Machine.defineStates({
+      Idle: {
+        annotations: { title: "Idle", description: "No state-local data" }
+      },
+      Flow: {
+        initial: "Waiting",
+        states: {
+          Waiting: {},
+          Done: { type: "final", output: Schema.String }
+        }
+      },
+      Regions: {
+        type: "parallel",
+        states: {
+          left: {},
+          right: {}
+        }
+      }
+    })
+    const machine = Machine.make({
+      states: states.states,
+      events: [],
+      initial: () => states.initial.Idle.from()
+    })
+
+    const nodes = Machine.stateNodes(machine)
+    assert.strictEqual(nodes.find(({ path }) => path === "Idle")?.schema, undefined)
+    assert.deepStrictEqual(nodes.find(({ path }) => path === "Idle")?.annotations, {
+      title: "Idle",
+      description: "No state-local data"
+    })
+    assert.strictEqual(nodes.find(({ path }) => path === "Flow")?.type, "compound")
+    assert.strictEqual(nodes.find(({ path }) => path === "Flow.Done")?.type, "final")
+    assert.strictEqual(nodes.find(({ path }) => path === "Regions")?.type, "parallel")
+  })
+
   it("recognizes Effect schemas before inspecting config properties", () => {
     const AnnotatedIdle = Idle.annotate({
       title: "Idle",
@@ -243,5 +280,32 @@ describe("exact state-definition runtime validation", () => {
       "Root.History.annotations.title",
       "must be strings"
     )
+  })
+
+  it("rejects malformed schema-less active states at the runtime boundary", () => {
+    const invalidTrees: ReadonlyArray<readonly [unknown, string, string]> = [
+      [{ Invalid: { schema: undefined } }, "Invalid.schema", "required PropertyKey _tag"],
+      [{ Invalid: { states: { Child: {} } } }, "Invalid.initial", "must declare an initial child"],
+      [{ Invalid: { type: "parallel" } }, "Invalid.states", "must declare child regions"],
+      [
+        { Invalid: { annotations: { executable: "no" } } },
+        "Invalid.annotations",
+        "cannot declare property"
+      ],
+      [
+        { Invalid: { annotations: { title: 1 } } },
+        "Invalid.annotations.title",
+        "must be strings"
+      ]
+    ]
+
+    for (const [states, path, detail] of invalidTrees) {
+      expectDefinitionError(
+        () => Machine.defineStates(states as Machine.Machine.StateSchemas),
+        "Machine.defineStates",
+        path,
+        detail
+      )
+    }
   })
 })

--- a/test/machine/StructuralStates.test.ts
+++ b/test/machine/StructuralStates.test.ts
@@ -1,0 +1,334 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Option, Schema } from "effect"
+import { Machine } from "../../src/index.js"
+
+class Loading extends Schema.TaggedClass<Loading>("StructuralLoading")("Loading", {
+  url: Schema.String
+}) {}
+class Ready extends Schema.TaggedClass<Ready>("StructuralReady")("Ready", {
+  duration: Schema.Number
+}) {}
+class Playing extends Schema.TaggedClass<Playing>("StructuralPlaying")("Playing", {
+  position: Schema.Number
+}) {}
+class Audible extends Schema.TaggedClass<Audible>("StructuralAudible")("Audible", {
+  volume: Schema.Number
+}) {}
+class Muted extends Schema.TaggedClass<Muted>("StructuralMuted")("Muted", {
+  volume: Schema.Number
+}) {}
+
+class SourceSelected extends Schema.TaggedClass<SourceSelected>("StructuralSourceSelected")("SourceSelected", {
+  url: Schema.String
+}) {}
+class Loaded extends Schema.TaggedClass<Loaded>("StructuralLoaded")("Loaded", {
+  duration: Schema.Number
+}) {}
+class Play extends Schema.TaggedClass<Play>("StructuralPlay")("Play", {}) {}
+class Mute extends Schema.TaggedClass<Mute>("StructuralMute")("Mute", {
+  volume: Schema.Number
+}) {}
+class Edit extends Schema.TaggedClass<Edit>("StructuralEdit")("Edit", {
+  draft: Schema.String
+}) {}
+class Leave extends Schema.TaggedClass<Leave>("StructuralLeave")("Leave", {}) {}
+class ResumeShallow extends Schema.TaggedClass<ResumeShallow>("StructuralResumeShallow")("ResumeShallow", {}) {}
+class ResumeDeep extends Schema.TaggedClass<ResumeDeep>("StructuralResumeDeep")("ResumeDeep", {}) {}
+class Editing extends Schema.TaggedClass<Editing>("StructuralEditing")("Editing", {
+  draft: Schema.String
+}) {}
+
+const States = Machine.defineStates({
+  player: {
+    type: "parallel",
+    annotations: { title: "Player" },
+    states: {
+      transport: {
+        initial: "Empty",
+        states: {
+          Empty: {},
+          Loading,
+          Ready: {
+            schema: Ready,
+            initial: "Paused",
+            states: {
+              Paused: {},
+              Playing
+            }
+          }
+        }
+      },
+      settings: {
+        initial: "Audible",
+        states: {
+          Audible,
+          Muted
+        }
+      }
+    }
+  }
+})
+
+const initial = States.initial.player.from((player) =>
+  player
+    .transport.from((transport) => transport.Empty.from())
+    .settings.from((settings) => settings.Audible.from({ volume: 1 }))
+)
+
+const makeMachine = () =>
+  Machine.make({
+    states: States.states,
+    events: [SourceSelected, Loaded, Play, Mute],
+    initial: () => initial
+  }).handle({
+    player: {
+      states: {
+        transport: {
+          states: {
+            Empty: {
+              on: {
+                SourceSelected: ({ event, state, target }) => {
+                  assert.strictEqual(state, undefined)
+                  return target.local.Loading.from({ url: event.url })
+                }
+              }
+            },
+            Loading: {
+              on: {
+                Loaded: ({ event, state, target }) => {
+                  assert.strictEqual(state._tag, "Loading")
+                  return target.local.Ready.from(
+                    { duration: event.duration },
+                    (ready) => ready.Paused.from()
+                  )
+                }
+              }
+            },
+            Ready: {
+              states: {
+                Paused: {
+                  on: {
+                    Play: ({ parent, state, target }) => {
+                      assert.strictEqual(state, undefined)
+                      return target.local.Playing.from({ position: Math.min(0, parent.duration) })
+                    }
+                  }
+                },
+                Playing: {
+                  on: {
+                    Mute: ({ event, target }) => target.branch.player.settings.Muted.from({ volume: event.volume })
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+
+const HistoryStates = Machine.defineStates({
+  flow: {
+    initial: "section",
+    states: {
+      section: {
+        initial: "Idle",
+        states: {
+          Idle: {},
+          Editing
+        }
+      },
+      recent: { type: "history" },
+      exact: { type: "history", history: "deep" }
+    }
+  },
+  away: {}
+})
+
+const historyFallback = () =>
+  HistoryStates.initial.flow.from((flow) => flow.section.from((section) => section.Idle.from()))
+
+const historyMachine = Machine.make({
+  states: HistoryStates.states,
+  events: [Edit, Leave, ResumeShallow, ResumeDeep],
+  initial: historyFallback
+}).handle({
+  flow: {
+    history: {
+      recent: { default: historyFallback },
+      exact: { default: historyFallback }
+    },
+    on: {
+      Leave: ({ target }) => target.full.away.from()
+    },
+    states: {
+      section: {
+        states: {
+          Idle: {
+            on: {
+              Edit: ({ event, target }) => target.local.Editing.from({ draft: event.draft })
+            }
+          }
+        }
+      }
+    }
+  },
+  away: {
+    on: {
+      ResumeShallow: ({ target }) => target.history.flow.recent(),
+      ResumeDeep: ({ target }) => target.history.flow.exact()
+    }
+  }
+})
+
+const FinalStates = Machine.defineStates({
+  Done: {
+    type: "final",
+    output: Schema.String
+  }
+})
+
+describe("structural active states", () => {
+  it.effect("constructs structural atomic, compound, and parallel snapshots without values", () =>
+    Effect.gen(function*() {
+      const planned = yield* Machine.planInitial(makeMachine())
+      const snapshot = planned.state
+      assert.deepStrictEqual(snapshot, {
+        path: "player",
+        value: undefined,
+        states: {
+          transport: {
+            path: "player.transport",
+            value: undefined,
+            state: {
+              path: "player.transport.Empty",
+              value: undefined
+            }
+          },
+          settings: {
+            path: "player.settings",
+            value: undefined,
+            state: {
+              path: "player.settings.Audible",
+              value: new Audible({ volume: 1 })
+            }
+          }
+        }
+      })
+
+      assert.isTrue(States.matches(snapshot, "player.transport"))
+      assert.isTrue(States.matches(snapshot, "player.transport.Empty"))
+      assert.deepStrictEqual(
+        States.get(snapshot, "player.settings.Audible"),
+        Option.some(new Audible({ volume: 1 }))
+      )
+      const transport = States.getSnapshot(snapshot, "player.transport")
+      assert(Option.isSome(transport))
+      assert.strictEqual(transport.value.value, undefined)
+    }))
+
+  it.effect("transitions structural to valued, valued to structural, and across parallel regions", () =>
+    Effect.gen(function*() {
+      const machine = makeMachine()
+      const started = yield* Machine.planInitial(machine)
+
+      const loading = yield* Machine.plan(machine, started.state, new SourceSelected({ url: "/song.mp3" }))
+      assert.deepStrictEqual(
+        States.get(loading.next, "player.transport.Loading"),
+        Option.some(new Loading({ url: "/song.mp3" }))
+      )
+
+      const paused = yield* Machine.plan(machine, loading.next, new Loaded({ duration: 120 }))
+      assert.isTrue(States.matches(paused.next, "player.transport.Ready.Paused"))
+      assert.deepStrictEqual(
+        States.getWithParents(paused.next, "player.transport.Ready"),
+        Option.some({ value: new Ready({ duration: 120 }), parents: {} })
+      )
+
+      const playing = yield* Machine.plan(machine, paused.next, new Play({}))
+      assert.deepStrictEqual(
+        States.getWithParents(playing.next, "player.transport.Ready.Playing"),
+        Option.some({
+          value: new Playing({ position: 0 }),
+          parents: { "player.transport.Ready": new Ready({ duration: 120 }) }
+        })
+      )
+
+      const muted = yield* Machine.plan(machine, playing.next, new Mute({ volume: 0 }))
+      assert.isTrue(States.matches(muted.next, "player.transport.Ready.Playing"))
+      assert.deepStrictEqual(
+        States.get(muted.next, "player.settings.Muted"),
+        Option.some(new Muted({ volume: 0 }))
+      )
+    }))
+
+  it.effect("encodes active structural paths without inventing values", () =>
+    Effect.gen(function*() {
+      const machine = makeMachine()
+      const started = yield* Machine.planInitial(machine)
+      const encoded = yield* Machine.encodeSnapshot(machine, started.state)
+
+      assert.deepStrictEqual(encoded.active, [
+        { path: "player" },
+        { path: "player.transport" },
+        { path: "player.transport.Empty" },
+        { path: "player.settings" },
+        { path: "player.settings.Audible", value: { _tag: "Audible", volume: 1 } }
+      ])
+
+      const decoded = yield* Machine.decodeSnapshot(machine, encoded)
+      assert.deepStrictEqual(decoded, started.state)
+
+      const encodedWithStructuralValue = structuredClone(encoded) as any
+      encodedWithStructuralValue.active[0].value = { _tag: "Invented" }
+      const decodeError = yield* Machine.decodeSnapshot(machine, encodedWithStructuralValue).pipe(Effect.flip)
+      assert.instanceOf(decodeError, Machine.MachineSchemaDecodeError)
+
+      const snapshotWithStructuralValue = { ...started.state, value: { _tag: "Invented" } } as any
+      const encodeError = yield* Machine.encodeSnapshot(machine, snapshotWithStructuralValue).pipe(Effect.flip)
+      assert.instanceOf(encodeError, Machine.MachineSchemaEncodeError)
+    }))
+
+  it.effect("restores structural control through shallow and deep history", () =>
+    Effect.gen(function*() {
+      const started = yield* Machine.planInitial(historyMachine)
+      const editing = yield* Machine.plan(historyMachine, started.state, new Edit({ draft: "saved" }))
+      const away = yield* Machine.plan(historyMachine, editing.next, new Leave({}))
+
+      const shallow = yield* Machine.plan(historyMachine, away.next, new ResumeShallow({}))
+      assert.isTrue(HistoryStates.matches(shallow.next, "flow.section.Idle"))
+      assert.isTrue(Option.isNone(HistoryStates.get(shallow.next, "flow.section.Editing")))
+
+      const deep = yield* Machine.plan(historyMachine, away.next, new ResumeDeep({}))
+      assert.deepStrictEqual(
+        HistoryStates.get(deep.next, "flow.section.Editing"),
+        Option.some(new Editing({ draft: "saved" }))
+      )
+      assert.deepStrictEqual(deep.next.history, away.next.history)
+    }))
+
+  it.effect("keeps final output independent from a state value schema", () =>
+    Effect.gen(function*() {
+      const machine = Machine.make({
+        states: FinalStates.states,
+        events: [],
+        initial: () => FinalStates.initial.Done.from()
+      }).handle({
+        Done: {
+          output: ({ state }) => {
+            assert.strictEqual(state, undefined)
+            return "complete"
+          }
+        }
+      })
+
+      const planned = yield* Machine.planInitial(machine)
+      assert.isTrue(planned.done)
+      assert.strictEqual(planned.output, "complete")
+      assert.deepStrictEqual(planned.state, {
+        path: "Done",
+        value: undefined,
+        completed: [{ path: "Done", output: "complete" }]
+      })
+    }))
+})

--- a/test/testing/Verification.test.ts
+++ b/test/testing/Verification.test.ts
@@ -195,6 +195,38 @@ const historyMachine = Machine.make({
   }
 })
 
+const StructuralHistoryStates = Machine.defineStates({
+  workspace: {
+    initial: "editor",
+    states: {
+      editor: {
+        initial: "idle",
+        states: { idle: {} }
+      },
+      exact: { type: "history", history: "deep" }
+    }
+  },
+  away: {}
+})
+
+const structuralHistoryInitial = () =>
+  StructuralHistoryStates.initial.workspace.from((workspace) => workspace.editor.from((editor) => editor.idle.from()))
+
+const structuralHistoryMachine = Machine.make({
+  states: StructuralHistoryStates.states,
+  events: [Leave],
+  initial: structuralHistoryInitial
+}).handle({
+  workspace: {
+    history: {
+      exact: { default: structuralHistoryInitial }
+    },
+    on: {
+      Leave: ({ target }) => target.full.away.from()
+    }
+  }
+})
+
 class Finished extends Schema.TaggedClass<Finished>("Finished")("Finished", {}) {}
 
 const CompletionStates = Machine.defineStates({
@@ -274,6 +306,45 @@ const laws = (error: MachineTest.VerificationError): ReadonlyArray<MachineTest.V
   error.violations.map((violation) => violation.law)
 
 describe("MachineTest.verify", () => {
+  it.effect("accepts structural configurations and history without invented values", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(structuralHistoryMachine, { events: [new Leave({})] })
+      yield* MachineTest.verify(structuralHistoryMachine, trace)
+
+      const valuedState = {
+        ...trace,
+        final: { ...trace.final, value: { _tag: "Invented" } }
+      } as unknown as typeof trace
+      const stateError = yield* MachineTest.verify(structuralHistoryMachine, valuedState, {
+        laws: ["configuration"]
+      }).pipe(Effect.flip)
+      assert.ok(
+        stateError.violations.some((violation) => violation.law === "configuration.schema" && violation.path === "away")
+      )
+
+      const final = trace.final as any
+      const exact = final.history["workspace.exact"]
+      const valuedHistory = {
+        ...trace,
+        final: {
+          ...final,
+          history: {
+            ...final.history,
+            "workspace.exact": {
+              ...exact,
+              values: { ...exact.values, workspace: { _tag: "Invented" } }
+            }
+          }
+        }
+      } as typeof trace
+      const historyError = yield* MachineTest.verify(structuralHistoryMachine, valuedHistory, {
+        laws: ["history"]
+      }).pipe(Effect.flip)
+      assert.ok(
+        historyError.violations.some((violation) => violation.law === "history.value" && violation.path === "workspace")
+      )
+    }))
+
   it.effect("accepts valid compound, parallel, history, and completion traces", () =>
     Effect.gen(function*() {
       const navigation = yield* MachineTest.run(navigationMachine, { events: [new Go({})] })

--- a/typetest/machine/Inspection.tst.ts
+++ b/typetest/machine/Inspection.tst.ts
@@ -44,7 +44,7 @@ describe("Machine inspection", () => {
     const inspect = (node: Machine.Machine.StateNode<"state">) => {
       switch (node.type) {
         case "atomic":
-          expect(node.schema).type.toBe<Machine.Machine.TaggedSchema>()
+          expect(node.schema).type.toBe<Machine.Machine.TaggedSchema | undefined>()
           expect(node.output).type.toBe<undefined>()
           expect(node.history).type.toBe<undefined>()
           expect(node.children).type.toBe<readonly []>()
@@ -52,7 +52,7 @@ describe("Machine inspection", () => {
           expect(node.parent).type.toBe<"state" | undefined>()
           break
         case "compound":
-          expect(node.schema).type.toBe<Machine.Machine.TaggedSchema>()
+          expect(node.schema).type.toBe<Machine.Machine.TaggedSchema | undefined>()
           expect(node.output).type.toBe<undefined>()
           expect(node.history).type.toBe<undefined>()
           expect(node.children).type.toBe<ReadonlyArray<"state">>()
@@ -60,7 +60,7 @@ describe("Machine inspection", () => {
           expect(node.parent).type.toBe<"state" | undefined>()
           break
         case "parallel":
-          expect(node.schema).type.toBe<Machine.Machine.TaggedSchema>()
+          expect(node.schema).type.toBe<Machine.Machine.TaggedSchema | undefined>()
           expect(node.output).type.toBe<Schema.Top | undefined>()
           expect(node.history).type.toBe<undefined>()
           expect(node.children).type.toBe<ReadonlyArray<"state">>()
@@ -68,7 +68,7 @@ describe("Machine inspection", () => {
           expect(node.parent).type.toBe<"state" | undefined>()
           break
         case "final":
-          expect(node.schema).type.toBe<Machine.Machine.TaggedSchema>()
+          expect(node.schema).type.toBe<Machine.Machine.TaggedSchema | undefined>()
           expect(node.output).type.toBe<Schema.Top | undefined>()
           expect(node.history).type.toBe<undefined>()
           expect(node.children).type.toBe<readonly []>()

--- a/typetest/machine/StructuralStates.tst.ts
+++ b/typetest/machine/StructuralStates.tst.ts
@@ -1,0 +1,207 @@
+import { type Option, Schema } from "effect"
+import { describe, expect, it } from "tstyche"
+import { Machine } from "../../src/index.js"
+
+class Loading extends Schema.TaggedClass<Loading>("StructuralTypeLoading")("Loading", {
+  url: Schema.String
+}) {}
+class Ready extends Schema.TaggedClass<Ready>("StructuralTypeReady")("Ready", {
+  duration: Schema.Number
+}) {}
+class Playing extends Schema.TaggedClass<Playing>("StructuralTypePlaying")("Playing", {
+  position: Schema.Number
+}) {}
+class Audible extends Schema.TaggedClass<Audible>("StructuralTypeAudible")("Audible", {
+  volume: Schema.Number
+}) {}
+class Muted extends Schema.TaggedClass<Muted>("StructuralTypeMuted")("Muted", {
+  volume: Schema.Number
+}) {}
+class Select extends Schema.TaggedClass<Select>("StructuralTypeSelect")("Select", {
+  url: Schema.String
+}) {}
+class Loaded extends Schema.TaggedClass<Loaded>("StructuralTypeLoaded")("Loaded", {
+  duration: Schema.Number
+}) {}
+class Play extends Schema.TaggedClass<Play>("StructuralTypePlay")("Play", {}) {}
+
+const States = Machine.defineStates({
+  player: {
+    type: "parallel",
+    states: {
+      transport: {
+        initial: "Empty",
+        states: {
+          Empty: {},
+          Loading,
+          Ready: {
+            schema: Ready,
+            initial: "Paused",
+            states: {
+              Paused: {},
+              Playing
+            }
+          }
+        }
+      },
+      settings: {
+        initial: "Audible",
+        states: { Audible, Muted }
+      }
+    }
+  }
+})
+
+describe("structural active state types", () => {
+  it("separates active, valued, and structural identifiers", () => {
+    expect<Machine.Machine.ValuedStateIdentifier<typeof States.states>>().type.toBe<
+      | "player.transport.Loading"
+      | "player.transport.Ready"
+      | "player.transport.Ready.Playing"
+      | "player.settings.Audible"
+      | "player.settings.Muted"
+    >()
+    expect<Machine.Machine.StructuralStateIdentifier<typeof States.states>>().type.toBe<
+      | "player"
+      | "player.transport"
+      | "player.transport.Empty"
+      | "player.transport.Ready.Paused"
+      | "player.settings"
+    >()
+  })
+
+  it("requires values only for schema-backed snapshot builders", () => {
+    States.initial.player.from((player) =>
+      player
+        .transport.from((transport) => transport.Empty.from())
+        .settings.from((settings) => settings.Audible.from({ volume: 1 }))
+    )
+
+    expect(States.initial.player.from).type.not.toBeCallableWith({}, () => undefined)
+    expect<typeof States.initial.player extends (...args: ReadonlyArray<any>) => any ? true : false>().type.toBe<
+      false
+    >()
+
+    type PlayerBuilder = Parameters<typeof States.initial.player.from>[0] extends (builder: infer Builder) => unknown
+      ? Builder
+      : never
+    const player = null as unknown as PlayerBuilder
+    expect(player.transport.from).type.not.toBeCallableWith((transport: unknown) => transport)
+
+    type TransportBuilder = Parameters<typeof player.transport.from>[0] extends (builder: infer Builder) => unknown
+      ? Builder
+      : never
+    const transport = null as unknown as TransportBuilder
+    expect(transport.Empty.from).type.toBeCallableWith()
+    expect(transport.Empty.from).type.not.toBeCallableWith({})
+    type SettingsBuilder = Parameters<typeof player.settings.from>[0] extends (builder: infer Builder) => unknown
+      ? Builder
+      : never
+    const settings = null as unknown as SettingsBuilder
+    expect(settings.Audible.from).type.toBeCallableWith({ volume: 1 })
+    expect(settings.Audible.from).type.not.toBeCallableWith()
+  })
+
+  it("restricts value access while retaining structural snapshot queries", () => {
+    type Snapshot = Machine.Machine.Snapshot<typeof States.states>
+    const snapshot = null as unknown as Snapshot
+
+    expect(States.get(snapshot, "player.transport.Loading")).type.toBe<Option.Option<Loading>>()
+    expect(States.get).type.not.toBeCallableWith(snapshot, "player")
+    expect(States.get).type.not.toBeCallableWith(snapshot, "player.transport.Empty")
+    expect(States.getWithParents).type.not.toBeCallableWith(snapshot, "player.transport")
+
+    expect(States.matches).type.toBeCallableWith(snapshot, "player")
+    expect(States.matches).type.toBeCallableWith(snapshot, "player.transport.Empty")
+    expect(States.getSnapshot).type.toBeCallableWith(snapshot, "player.transport")
+    expect(States.getSnapshot(snapshot, "player.transport")).type.toBe<
+      Option.Option<Machine.Machine.SnapshotByIdentifier<typeof States.states, "player.transport">>
+    >()
+  })
+
+  it("types structural handler contexts and targets without fake values", () => {
+    Machine.make({
+      states: States.states,
+      events: [Select, Loaded, Play],
+      initial: () =>
+        States.initial.player.from((player) =>
+          player
+            .transport.from((transport) => transport.Empty.from())
+            .settings.from((settings) => settings.Audible.from({ volume: 1 }))
+        )
+    }).handle({
+      player: {
+        states: {
+          transport: {
+            states: {
+              Empty: {
+                entry: ({ state }) => {
+                  expect(state).type.toBe<undefined>()
+                },
+                invoke: ({ parent, parents, state }) => {
+                  expect(state).type.toBe<undefined>()
+                  expect(parent).type.toBe<undefined>()
+                  expect(parents).type.toBe<{}>()
+                  return []
+                },
+                on: {
+                  Select: ({ parent, parents, state, target }) => {
+                    expect(state).type.toBe<undefined>()
+                    expect(parent).type.toBe<undefined>()
+                    expect(parents).type.toBe<{}>()
+                    expect(target.local).type.not.toHaveProperty("with")
+                    expect(target.local.Empty.from).type.toBeCallableWith()
+                    expect(target.local.Empty.from).type.not.toBeCallableWith({})
+                    expect(target.local.Loading.from).type.toBeCallableWith({ url: "/song.mp3" })
+                    expect(target.local.Loading.from).type.not.toBeCallableWith()
+                    return target.local.Loading.from({ url: "/song.mp3" })
+                  }
+                }
+              },
+              Loading: {
+                on: {
+                  Loaded: ({ event, target }) =>
+                    target.local.Ready.from(
+                      { duration: event.duration },
+                      (ready) => ready.Paused.from()
+                    )
+                }
+              },
+              Ready: {
+                states: {
+                  Paused: {
+                    on: {
+                      Play: ({ parent, parents, state, target }) => {
+                        expect(state).type.toBe<undefined>()
+                        expect(parent).type.toBe<Ready>()
+                        expect(parents).type.toBe<{ readonly "player.transport.Ready": Ready }>()
+                        expect(target.local).type.toHaveProperty("with")
+                        expect(target.local.Playing.from).type.toBeCallableWith({ position: 0 })
+                        return target.local.with.from(
+                          { duration: parent.duration },
+                          (ready) => ready.Playing.from({ position: 0 })
+                        )
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+  })
+
+  it("rejects malformed structural declarations", () => {
+    expect(Machine.defineStates).type.not.toBeCallableWith({
+      invalid: { states: { child: {} } }
+    })
+    expect(Machine.defineStates).type.not.toBeCallableWith({
+      invalid: { type: "parallel" }
+    })
+    expect(Machine.defineStates).type.not.toBeCallableWith({
+      invalid: { schema: undefined }
+    })
+  })
+})

--- a/typetest/unstable/reactivity/AtomMachine.tst.ts
+++ b/typetest/unstable/reactivity/AtomMachine.tst.ts
@@ -90,6 +90,22 @@ const NestedStates = Machine.defineStates({
   }
 })
 
+const StructuralNestedStates = Machine.defineStates({
+  Ready: {
+    type: "parallel",
+    states: {
+      editor: {
+        initial: "Idle",
+        states: {
+          Idle: {},
+          Saving
+        }
+      },
+      network: {}
+    }
+  }
+})
+
 const makeMachine = () =>
   Machine.make({
     states: States.states,
@@ -214,6 +230,30 @@ describe("AtomMachine", () => {
     expect<Atom.Failure<typeof childMatched>>().type.toBe<Atom.Failure<typeof child.result>>()
     expect(AtomMachine.selectChild).type.not.toBeCallableWith(child, "Idle")
     expect(AtomMachine.matchesChild).type.not.toBeCallableWith(child, "Ready.editor.Missing")
+  })
+
+  it("selects values only from schema-backed paths while structural paths remain queryable", () => {
+    type Snapshot = Machine.Machine.Snapshot<typeof StructuralNestedStates.states>
+    type Parent = AtomMachine.MachineAtom<Snapshot, Tick, RuntimeFailure, never, StartFailure>
+    const parent = null as unknown as Parent
+
+    const readySnapshot = AtomMachine.selectSnapshot(parent, "Ready")
+    const editorSnapshot = AtomMachine.selectSnapshot(parent, "Ready.editor")
+    const matched = AtomMachine.matches(parent, "Ready.editor.Idle")
+    const saving = AtomMachine.select(parent, "Ready.editor.Saving")
+
+    expect<Atom.Success<typeof readySnapshot>>().type.toBe<
+      Option.Option<Machine.Machine.SnapshotByIdentifier<typeof StructuralNestedStates.states, "Ready">>
+    >()
+    expect<Atom.Success<typeof editorSnapshot>>().type.toBe<
+      Option.Option<Machine.Machine.SnapshotByIdentifier<typeof StructuralNestedStates.states, "Ready.editor">>
+    >()
+    expect<Atom.Success<typeof matched>>().type.toBe<boolean>()
+    expect<Atom.Success<typeof saving>>().type.toBe<Option.Option<Saving>>()
+    expect(AtomMachine.select).type.not.toBeCallableWith(parent, "Ready")
+    expect(AtomMachine.select).type.not.toBeCallableWith(parent, "Ready.editor")
+    expect(AtomMachine.select).type.not.toBeCallableWith(parent, "Ready.editor.Idle")
+    expect(AtomMachine.select).type.not.toBeCallableWith(parent, "Ready.network")
   })
 
   it("accepts machines without external requirements", () => {


### PR DESCRIPTION
## Summary

- allow atomic, compound, parallel, and final active states to omit `schema` when they own no data
- preserve typed builders, handler contexts, snapshots, history, serialization, and selectors for structural states
- keep optimized execution fail-closed to the generic planner until indexed absent-value semantics are explicit
- migrate eight example machines and teach `MachineTest.verify` to validate structural configurations and history

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required

Local validation included `pnpm check`, `pnpm perf:types`, `pnpm perf:runtime`, and `pnpm check` in the platformer, playground, and Pokémon example packages.