### PR TITLE
Migrate examples to machine event constructors

### DIFF
--- a/examples/platformer/src/machine.test.ts
+++ b/examples/platformer/src/machine.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest"
 import { makeTextRenderer } from "../../../test/machine/visualization/text.ts"
 import {
   airJumpMode,
+  CharacterEvents,
   CharacterMachine,
   type CharacterSnapshot,
   Event,
@@ -100,37 +101,50 @@ const laws = [
   resumeRestoresDeepHistory
 ]
 
+// Exploration scenarios retain decoded events for trace inspection.
+const EventValue = {
+  Resume: () => Machine.event(CharacterMachine, Event.cases.Resume),
+  Pause: (fields: { readonly at: number }) => Machine.event(CharacterMachine, Event.cases.Pause, fields),
+  Reset: () => Machine.event(CharacterMachine, Event.cases.Reset),
+  JumpPressed: (fields: { readonly at: number; readonly y: number; readonly wall: -1 | 0 | 1 }) =>
+    Machine.event(CharacterMachine, Event.cases.JumpPressed, fields),
+  Landed: (fields: { readonly impact: number; readonly axis: -1 | 0 | 1; readonly at: number }) =>
+    Machine.event(CharacterMachine, Event.cases.Landed, fields),
+  ApexReached: (fields: { readonly y: number }) => Machine.event(CharacterMachine, Event.cases.ApexReached, fields),
+  DownPressed: (fields: { readonly at: number }) => Machine.event(CharacterMachine, Event.cases.DownPressed, fields)
+}
+
 const explorationEvents = ({ snapshot }: MachineTest.ExplorationStateContext<typeof CharacterMachine>) => {
   const locomotion = snapshot.states.locomotion.state
   if (locomotion.path === "Character.locomotion.Paused") {
-    return [Event.cases.Resume.make({})]
+    return [EventValue.Resume()]
   }
 
-  const pauseAndReset = [Event.cases.Pause.make({ at: 70 }), Event.cases.Reset.make({})]
+  const pauseAndReset = [EventValue.Pause({ at: 70 }), EventValue.Reset()]
   if (locomotion.state.path === "Character.locomotion.Playing.Grounded") {
     return [
-      Event.cases.JumpPressed.make({ at: 20, y: 100, wall: -1 }),
-      Event.cases.JumpPressed.make({ at: 20, y: 100, wall: 0 }),
-      Event.cases.JumpPressed.make({ at: 20, y: 100, wall: 1 }),
+      EventValue.JumpPressed({ at: 20, y: 100, wall: -1 }),
+      EventValue.JumpPressed({ at: 20, y: 100, wall: 0 }),
+      EventValue.JumpPressed({ at: 20, y: 100, wall: 1 }),
       ...pauseAndReset
     ]
   }
 
   const motion = locomotion.state.states.motion.state
   const airborne = [
-    Event.cases.JumpPressed.make({ at: 30, y: 80, wall: -1 }),
-    Event.cases.JumpPressed.make({ at: 30, y: 80, wall: 1 }),
-    Event.cases.Landed.make({ impact: 12, axis: 0, at: 60 }),
+    EventValue.JumpPressed({ at: 30, y: 80, wall: -1 }),
+    EventValue.JumpPressed({ at: 30, y: 80, wall: 1 }),
+    EventValue.Landed({ impact: 12, axis: 0, at: 60 }),
     ...pauseAndReset
   ]
   return motion.path === "Character.locomotion.Playing.Airborne.motion.Jumping"
     ? [
-      Event.cases.ApexReached.make({ y: 50 }),
-      Event.cases.DownPressed.make({ at: 40 }),
+      EventValue.ApexReached({ y: 50 }),
+      EventValue.DownPressed({ at: 40 }),
       ...airborne
     ]
     : motion.path === "Character.locomotion.Playing.Airborne.motion.Falling"
-    ? [Event.cases.DownPressed.make({ at: 40 }), ...airborne]
+    ? [EventValue.DownPressed({ at: 40 }), ...airborne]
     : airborne
 }
 
@@ -166,20 +180,20 @@ describe("platformer history integration", () => {
       const ducking = yield* Machine.plan(
         CharacterMachine,
         initial.state,
-        Event.cases.DownPressed.make({ at: 10 })
+        CharacterEvents.DownPressed({ at: 10 })
       )
       const beforePause = playingSnapshot(ducking.next)
 
       const paused = yield* Machine.plan(
         CharacterMachine,
         ducking.next,
-        Event.cases.Pause.make({ at: 20 })
+        CharacterEvents.Pause({ at: 20 })
       )
       const pausedLocomotion = paused.next.states.locomotion.state
       expect(pausedLocomotion.path).toBe("Character.locomotion.Paused")
       expect(pausedLocomotion.value).toEqual({ _tag: "Paused", pausedAt: 20 })
 
-      const resumed = yield* Machine.plan(CharacterMachine, paused.next, Event.cases.Resume.make({}))
+      const resumed = yield* Machine.plan(CharacterMachine, paused.next, CharacterEvents.Resume())
       expect(playingSnapshot(resumed.next)).toEqual(beforePause)
       expect(resumed.next.states.facing.state.path).toBe("Character.facing.Right")
       expect(resumed.next.states.contact.state.path).toBe("Character.contact.NoWall")
@@ -192,19 +206,19 @@ describe("platformer history integration", () => {
       const airborne = yield* Machine.plan(
         CharacterMachine,
         initial.state,
-        Event.cases.JumpPressed.make({ at: 100, y: 207, wall: -1 })
+        CharacterEvents.JumpPressed({ at: 100, y: 207, wall: -1 })
       )
       const falling = yield* Machine.plan(
         CharacterMachine,
         airborne.next,
-        Event.cases.ApexReached.make({ y: 91 })
+        CharacterEvents.ApexReached({ y: 91 })
       )
       const beforePause = playingSnapshot(falling.next)
 
       const paused = yield* Machine.plan(
         CharacterMachine,
         falling.next,
-        Event.cases.Pause.make({ at: 180 })
+        CharacterEvents.Pause({ at: 180 })
       )
       expect(paused.next.history?.["Character.locomotion.Playing.resume"]?.active).toEqual([
         "Character",
@@ -217,7 +231,7 @@ describe("platformer history integration", () => {
         "Character.locomotion.Playing.Airborne.airJump.AirJumpGroundLock"
       ])
 
-      const resumed = yield* Machine.plan(CharacterMachine, paused.next, Event.cases.Resume.make({}))
+      const resumed = yield* Machine.plan(CharacterMachine, paused.next, CharacterEvents.Resume())
       const restored = playingSnapshot(resumed.next)
       expect(restored).toEqual(beforePause)
 

--- a/examples/platformer/src/machine.ts
+++ b/examples/platformer/src/machine.ts
@@ -121,13 +121,18 @@ const initialCharacter = () =>
       .contact.from((contact) => contact.NoWall.from())
   )
 
-export const CharacterMachine = Machine.make({
+const definition = Machine.make({
   id: "PlatformerCharacter",
   states: CharacterStates.states,
   events: [Event],
   internalEvents: [InternalEvent],
   initial: initialCharacter
-}).handle({
+})
+
+export const CharacterEvents = Machine.events(definition)
+const InternalEvents = Machine.internalEvents(definition)
+
+export const CharacterMachine = definition.handle({
   Character: {
     on: {
       Reset: {
@@ -223,7 +228,7 @@ export const CharacterMachine = Machine.make({
                     }
                   },
                   Landing: {
-                    invoke: Machine.after("140 millis", InternalEvent.cases.LandingSettled.make({}), {
+                    invoke: Machine.after("140 millis", InternalEvents.LandingSettled(), {
                       id: "landing-settle"
                     }),
                     on: {
@@ -254,8 +259,8 @@ export const CharacterMachine = Machine.make({
                       const push = awayFrom(event.wall)
                       enqueue.raise(
                         push === 0
-                          ? InternalEvent.cases.TryAirJump.make({ at: event.at })
-                          : InternalEvent.cases.WallJump.make({ at: event.at, push })
+                          ? InternalEvents.TryAirJump({ at: event.at })
+                          : InternalEvents.WallJump({ at: event.at, push })
                       )
                     }
                   },
@@ -319,7 +324,7 @@ export const CharacterMachine = Machine.make({
                     },
                     states: {
                       AirJumpGroundLock: {
-                        invoke: Machine.after("120 millis", InternalEvent.cases.AirJumpUnlocked.make({}), {
+                        invoke: Machine.after("120 millis", InternalEvents.AirJumpUnlocked(), {
                           id: "ground-air-jump-unlock"
                         }),
                         on: {
@@ -330,7 +335,7 @@ export const CharacterMachine = Machine.make({
                         }
                       },
                       AirJumpWallLock: {
-                        invoke: Machine.after("240 millis", InternalEvent.cases.AirJumpUnlocked.make({}), {
+                        invoke: Machine.after("240 millis", InternalEvents.AirJumpUnlocked(), {
                           id: "wall-air-jump-unlock"
                         }),
                         on: {
@@ -345,7 +350,7 @@ export const CharacterMachine = Machine.make({
                           TryAirJump: {
                             targets: ["Character.locomotion.Playing.Airborne.airJump.AirJumpSpent"],
                             transition: ({ event, target }, enqueue) => {
-                              enqueue.raise(InternalEvent.cases.DoubleJump.make({ at: event.at }))
+                              enqueue.raise(InternalEvents.DoubleJump({ at: event.at }))
                               return target.local.AirJumpSpent.from()
                             }
                           }

--- a/examples/playground/src/examples/examples.test.ts
+++ b/examples/playground/src/examples/examples.test.ts
@@ -5,17 +5,17 @@ import { Effect } from "effect"
 import { MicrowaveEvent, MicrowaveMachine } from "./microwave/machine.ts"
 import { TrafficLightMachine } from "./traffic-light/machine.ts"
 import { TurnstileEvent, TurnstileMachine } from "./turnstile/machine.ts"
-import { SharedMachine, SharedMachineEvent } from "./worker-tabs/machine.ts"
+import { SharedMachine, SharedTransportEvents } from "./worker-tabs/machine.ts"
 
 describe("playground machines", () => {
   it.effect("accepts only the command enabled by the current turnstile state", () =>
     Effect.gen(function*() {
       const trace = yield* MachineTest.run(TurnstileMachine, {
         events: [
-          TurnstileEvent.cases.GatePushed.make({}),
-          TurnstileEvent.cases.CoinInserted.make({}),
-          TurnstileEvent.cases.CoinInserted.make({}),
-          TurnstileEvent.cases.GatePushed.make({})
+          Machine.event(TurnstileMachine, TurnstileEvent.cases.GatePushed),
+          Machine.event(TurnstileMachine, TurnstileEvent.cases.CoinInserted),
+          Machine.event(TurnstileMachine, TurnstileEvent.cases.CoinInserted),
+          Machine.event(TurnstileMachine, TurnstileEvent.cases.GatePushed)
         ]
       })
 
@@ -46,11 +46,11 @@ describe("playground machines", () => {
     Effect.gen(function*() {
       const trace = yield* MachineTest.run(MicrowaveMachine, {
         events: [
-          MicrowaveEvent.cases.PowerPressed.make({}),
-          MicrowaveEvent.cases.DoorOpened.make({}),
-          MicrowaveEvent.cases.PowerPressed.make({}),
-          MicrowaveEvent.cases.DoorClosed.make({}),
-          MicrowaveEvent.cases.PowerPressed.make({})
+          Machine.event(MicrowaveMachine, MicrowaveEvent.cases.PowerPressed),
+          Machine.event(MicrowaveMachine, MicrowaveEvent.cases.DoorOpened),
+          Machine.event(MicrowaveMachine, MicrowaveEvent.cases.PowerPressed),
+          Machine.event(MicrowaveMachine, MicrowaveEvent.cases.DoorClosed),
+          Machine.event(MicrowaveMachine, MicrowaveEvent.cases.PowerPressed)
         ]
       })
 
@@ -67,9 +67,9 @@ describe("playground machines", () => {
     Effect.gen(function*() {
       const trace = yield* MachineTest.run(SharedMachine, {
         events: [
-          SharedMachineEvent.cases.Started.make({}),
-          SharedMachineEvent.cases.Incremented.make({}),
-          SharedMachineEvent.cases.Synchronized.make({ active: false, count: 12 })
+          SharedTransportEvents.Started(),
+          SharedTransportEvents.Incremented(),
+          SharedTransportEvents.Synchronized({ active: false, count: 12 })
         ]
       })
 

--- a/examples/playground/src/examples/media-player/MediaPlayerPage.tsx
+++ b/examples/playground/src/examples/media-player/MediaPlayerPage.tsx
@@ -3,7 +3,7 @@ import { Match } from "effect"
 import { useCallback, useEffect, useState } from "react"
 import { ExamplePage } from "../../components/ExamplePage.tsx"
 import { mediaPlayerAtom, mediaPlayerViewAtom, registerMediaPlayerElement } from "./atoms.ts"
-import { MediaPlayerEvent } from "./schemas.ts"
+import { MediaPlayerEvents } from "./definition.ts"
 
 interface AudioSource {
   readonly name: string
@@ -75,7 +75,7 @@ export function MediaPlayerPage() {
                           if (file === undefined) return
                           const next = { name: file.name, url: URL.createObjectURL(file) }
                           setSource(next)
-                          send(MediaPlayerEvent.cases.SourceSelected.make({ url: next.url }))
+                          send(MediaPlayerEvents.SourceSelected({ url: next.url }))
                         }}
                       />
                     </label>
@@ -86,16 +86,16 @@ export function MediaPlayerPage() {
                   ref={registerAudioElement}
                   className="media-audio-element"
                   preload="auto"
-                  onWaiting={() => send(MediaPlayerEvent.cases.MediaWaiting.make({}))}
-                  onCanPlay={() => send(MediaPlayerEvent.cases.MediaCanPlay.make({}))}
+                  onWaiting={() => send(MediaPlayerEvents.MediaWaiting())}
+                  onCanPlay={() => send(MediaPlayerEvents.MediaCanPlay())}
                   onError={({ currentTarget }) =>
-                    send(MediaPlayerEvent.cases.MediaFailed.make({
+                    send(MediaPlayerEvents.MediaFailed({
                       message: currentTarget.error?.message ?? "The selected audio file could not be loaded"
                     }))}
                   onTimeUpdate={({ currentTarget }) =>
-                    send(MediaPlayerEvent.cases.TimeUpdated.make({ currentTime: currentTarget.currentTime }))}
+                    send(MediaPlayerEvents.TimeUpdated({ currentTime: currentTarget.currentTime }))}
                   onEnded={({ currentTarget }) =>
-                    send(MediaPlayerEvent.cases.PlaybackEnded.make({ currentTime: currentTarget.currentTime }))}
+                    send(MediaPlayerEvents.PlaybackEnded({ currentTime: currentTarget.currentTime }))}
                 />
 
                 <div className="media-player-layout">
@@ -116,21 +116,21 @@ export function MediaPlayerPage() {
                       <button
                         type="button"
                         disabled={!canPlay || source === undefined}
-                        onClick={() => send(MediaPlayerEvent.cases.PlayRequested.make({}))}
+                        onClick={() => send(MediaPlayerEvents.PlayRequested())}
                       >
                         Play
                       </button>
                       <button
                         type="button"
                         disabled={!canPause}
-                        onClick={() => send(MediaPlayerEvent.cases.PauseRequested.make({}))}
+                        onClick={() => send(MediaPlayerEvents.PauseRequested())}
                       >
                         Pause
                       </button>
                       <button
                         type="button"
                         disabled={!canRestart}
-                        onClick={() => send(MediaPlayerEvent.cases.RestartRequested.make({}))}
+                        onClick={() => send(MediaPlayerEvents.RestartRequested())}
                       >
                         Restart
                       </button>
@@ -164,7 +164,7 @@ export function MediaPlayerPage() {
                           step="0.01"
                           value={settings.volume}
                           onChange={({ currentTarget }) =>
-                            send(MediaPlayerEvent.cases.VolumeChanged.make({
+                            send(MediaPlayerEvents.VolumeChanged({
                               volume: currentTarget.valueAsNumber
                             }))}
                         />
@@ -177,8 +177,8 @@ export function MediaPlayerPage() {
                           onChange={({ currentTarget }) =>
                             send(
                               currentTarget.checked
-                                ? MediaPlayerEvent.cases.MuteRequested.make({})
-                                : MediaPlayerEvent.cases.UnmuteRequested.make({})
+                                ? MediaPlayerEvents.MuteRequested()
+                                : MediaPlayerEvents.UnmuteRequested()
                             )}
                         />
                       </label>
@@ -187,7 +187,7 @@ export function MediaPlayerPage() {
                         <select
                           value={settings.playbackRate}
                           onChange={({ currentTarget }) =>
-                            send(MediaPlayerEvent.cases.PlaybackRateChanged.make({
+                            send(MediaPlayerEvents.PlaybackRateChanged({
                               playbackRate: Number(currentTarget.value)
                             }))}
                         >

--- a/examples/playground/src/examples/media-player/definition.ts
+++ b/examples/playground/src/examples/media-player/definition.ts
@@ -1,0 +1,25 @@
+import { Machine } from "@typeonce/effect-machine"
+import { initialAudioSettings, MediaPlayerEvent, MediaPlayerInternalEvent, MediaPlayerStates } from "./schemas.ts"
+
+const initialPlayer = () =>
+  MediaPlayerStates.initial.Player.from((player) =>
+    player
+      .transport.from((transport) => transport.Empty.from())
+      .settings.from((settings) =>
+        settings.Audible.from({
+          volume: initialAudioSettings.volume,
+          playbackRate: initialAudioSettings.playbackRate
+        })
+      )
+  )
+
+export const MediaPlayerDefinition = Machine.make({
+  id: "MediaPlayer",
+  states: MediaPlayerStates.states,
+  events: [MediaPlayerEvent],
+  internalEvents: [MediaPlayerInternalEvent],
+  initial: initialPlayer
+})
+
+export const MediaPlayerEvents = Machine.events(MediaPlayerDefinition)
+export const MediaPlayerInternalEvents = Machine.internalEvents(MediaPlayerDefinition)

--- a/examples/playground/src/examples/media-player/invocations.ts
+++ b/examples/playground/src/examples/media-player/invocations.ts
@@ -1,6 +1,7 @@
 import { Machine } from "@typeonce/effect-machine"
 import { Data, Effect, Stream } from "effect"
-import { type LoudnessSample, MediaPlayerInternalEvent, type SoundSettings, toAudioSettings } from "./schemas.ts"
+import { MediaPlayerInternalEvents } from "./definition.ts"
+import { type LoudnessSample, type SoundSettings, toAudioSettings } from "./schemas.ts"
 import { MediaPlayer, MediaPlayerError } from "./service.ts"
 
 export const loadAudio = (url: string) =>
@@ -10,8 +11,8 @@ export const loadAudio = (url: string) =>
       const mediaPlayer = yield* MediaPlayer
       yield* mediaPlayer.load(url)
     }),
-    onSuccess: () => MediaPlayerInternalEvent.cases.LoadSucceeded.make({}),
-    onFailure: (failure) => MediaPlayerInternalEvent.cases.OperationFailed.make({ message: failure.message })
+    onSuccess: () => MediaPlayerInternalEvents.LoadSucceeded(),
+    onFailure: (failure) => MediaPlayerInternalEvents.OperationFailed({ message: failure.message })
   })
 
 export const pauseAudio = Machine.invokeEffect({
@@ -21,7 +22,7 @@ export const pauseAudio = Machine.invokeEffect({
     yield* mediaPlayer.pause
   }),
   onSuccess: () => undefined,
-  onFailure: (failure) => MediaPlayerInternalEvent.cases.OperationFailed.make({ message: failure.message })
+  onFailure: (failure) => MediaPlayerInternalEvents.OperationFailed({ message: failure.message })
 })
 
 export const playAudio = Machine.invokeEffect({
@@ -31,7 +32,7 @@ export const playAudio = Machine.invokeEffect({
     yield* mediaPlayer.play
   }),
   onSuccess: () => undefined,
-  onFailure: (failure) => MediaPlayerInternalEvent.cases.OperationFailed.make({ message: failure.message })
+  onFailure: (failure) => MediaPlayerInternalEvents.OperationFailed({ message: failure.message })
 })
 
 export const restartAudio = Machine.invokeEffect({
@@ -40,8 +41,8 @@ export const restartAudio = Machine.invokeEffect({
     const mediaPlayer = yield* MediaPlayer
     yield* mediaPlayer.restart
   }),
-  onSuccess: () => MediaPlayerInternalEvent.cases.RestartSucceeded.make({}),
-  onFailure: (failure) => MediaPlayerInternalEvent.cases.OperationFailed.make({ message: failure.message })
+  onSuccess: () => MediaPlayerInternalEvents.RestartSucceeded(),
+  onFailure: (failure) => MediaPlayerInternalEvents.OperationFailed({ message: failure.message })
 })
 
 export const applyAudioSettings = (settings: SoundSettings, muted: boolean) =>
@@ -82,7 +83,7 @@ export const analyzeAudio = Machine.invoke({
   snapshot: ({ snapshot }) =>
     LoudnessProcessState.$match(snapshot.state, {
       Waiting: () => undefined,
-      Measured: ({ sample }) => MediaPlayerInternalEvent.cases.LoudnessMeasured.make(sample),
-      Failed: ({ failure }) => MediaPlayerInternalEvent.cases.OperationFailed.make({ message: failure.message })
+      Measured: ({ sample }) => MediaPlayerInternalEvents.LoudnessMeasured(sample),
+      Failed: ({ failure }) => MediaPlayerInternalEvents.OperationFailed({ message: failure.message })
     })
 })

--- a/examples/playground/src/examples/media-player/machine.test.ts
+++ b/examples/playground/src/examples/media-player/machine.test.ts
@@ -1,23 +1,26 @@
 import { assert, describe, it } from "@effect/vitest"
+import { Machine } from "@typeonce/effect-machine"
 import { MachineTest } from "@typeonce/effect-machine/testing"
 import { Effect, Graph } from "effect"
 import { MediaPlayerMachine } from "./machine.ts"
 import { MediaPlayerEvent } from "./schemas.ts"
 
 const everyPublicEvent = [
-  MediaPlayerEvent.cases.SourceSelected.make({ url: "https://example.com/audio.mp3" }),
-  MediaPlayerEvent.cases.PlayRequested.make({}),
-  MediaPlayerEvent.cases.PauseRequested.make({}),
-  MediaPlayerEvent.cases.RestartRequested.make({}),
-  MediaPlayerEvent.cases.MediaWaiting.make({}),
-  MediaPlayerEvent.cases.MediaCanPlay.make({}),
-  MediaPlayerEvent.cases.PlaybackEnded.make({ currentTime: 42 }),
-  MediaPlayerEvent.cases.TimeUpdated.make({ currentTime: 21 }),
-  MediaPlayerEvent.cases.MediaFailed.make({ message: "unsupported codec" }),
-  MediaPlayerEvent.cases.VolumeChanged.make({ volume: 0.4 }),
-  MediaPlayerEvent.cases.PlaybackRateChanged.make({ playbackRate: 1.5 }),
-  MediaPlayerEvent.cases.MuteRequested.make({}),
-  MediaPlayerEvent.cases.UnmuteRequested.make({})
+  Machine.event(MediaPlayerMachine, MediaPlayerEvent.cases.SourceSelected, {
+    url: "https://example.com/audio.mp3"
+  }),
+  Machine.event(MediaPlayerMachine, MediaPlayerEvent.cases.PlayRequested),
+  Machine.event(MediaPlayerMachine, MediaPlayerEvent.cases.PauseRequested),
+  Machine.event(MediaPlayerMachine, MediaPlayerEvent.cases.RestartRequested),
+  Machine.event(MediaPlayerMachine, MediaPlayerEvent.cases.MediaWaiting),
+  Machine.event(MediaPlayerMachine, MediaPlayerEvent.cases.MediaCanPlay),
+  Machine.event(MediaPlayerMachine, MediaPlayerEvent.cases.PlaybackEnded, { currentTime: 42 }),
+  Machine.event(MediaPlayerMachine, MediaPlayerEvent.cases.TimeUpdated, { currentTime: 21 }),
+  Machine.event(MediaPlayerMachine, MediaPlayerEvent.cases.MediaFailed, { message: "unsupported codec" }),
+  Machine.event(MediaPlayerMachine, MediaPlayerEvent.cases.VolumeChanged, { volume: 0.4 }),
+  Machine.event(MediaPlayerMachine, MediaPlayerEvent.cases.PlaybackRateChanged, { playbackRate: 1.5 }),
+  Machine.event(MediaPlayerMachine, MediaPlayerEvent.cases.MuteRequested),
+  Machine.event(MediaPlayerMachine, MediaPlayerEvent.cases.UnmuteRequested)
 ]
 
 const generated = MachineTest.scenarios(MediaPlayerMachine, {
@@ -149,8 +152,10 @@ describe("media-player statechart model", () => {
           configuration.includes("Player.settings.Muted")
       )
       assert.deepStrictEqual(loadingAndMuted.trace.scenario.events, [
-        MediaPlayerEvent.cases.SourceSelected.make({ url: "https://example.com/audio.mp3" }),
-        MediaPlayerEvent.cases.MuteRequested.make({})
+        Machine.event(MediaPlayerMachine, MediaPlayerEvent.cases.SourceSelected, {
+          url: "https://example.com/audio.mp3"
+        }),
+        Machine.event(MediaPlayerMachine, MediaPlayerEvent.cases.MuteRequested)
       ])
 
       yield* MachineTest.assertUnreachable(

--- a/examples/playground/src/examples/media-player/machine.ts
+++ b/examples/playground/src/examples/media-player/machine.ts
@@ -1,35 +1,11 @@
 import { Machine } from "@typeonce/effect-machine"
 import { Effect } from "effect"
+import { MediaPlayerDefinition } from "./definition.ts"
 import { analyzeAudio, applyAudioSettings, loadAudio, pauseAudio, playAudio, restartAudio } from "./invocations.ts"
-import {
-  initialAudioSettings,
-  initialPlaybackData,
-  MediaPlayerEvent,
-  MediaPlayerInternalEvent,
-  MediaPlayerStates,
-  updatePlaybackData
-} from "./schemas.ts"
+import { initialPlaybackData, updatePlaybackData } from "./schemas.ts"
 import { MediaPlayer } from "./service.ts"
 
-const initialPlayer = () =>
-  MediaPlayerStates.initial.Player.from((player) =>
-    player
-      .transport.from((transport) => transport.Empty.from())
-      .settings.from((settings) =>
-        settings.Audible.from({
-          volume: initialAudioSettings.volume,
-          playbackRate: initialAudioSettings.playbackRate
-        })
-      )
-  )
-
-export const MediaPlayerMachine = Machine.make({
-  id: "MediaPlayer",
-  states: MediaPlayerStates.states,
-  events: [MediaPlayerEvent],
-  internalEvents: [MediaPlayerInternalEvent],
-  initial: initialPlayer
-}).handle({
+export const MediaPlayerMachine = MediaPlayerDefinition.handle({
   Player: {
     states: {
       transport: {

--- a/examples/playground/src/examples/microwave/MicrowavePage.tsx
+++ b/examples/playground/src/examples/microwave/MicrowavePage.tsx
@@ -2,7 +2,7 @@ import { useAtomSet, useAtomValue } from "@effect/atom-react"
 import { Match } from "effect"
 import { ExamplePage } from "../../components/ExamplePage.tsx"
 import { microwaveAtom } from "./atoms.ts"
-import { MicrowaveEvent } from "./machine.ts"
+import { MicrowaveEvents } from "./machine.ts"
 
 export function MicrowavePage() {
   const stateResult = useAtomValue(microwaveAtom.state)
@@ -49,7 +49,7 @@ export function MicrowavePage() {
                     <button
                       type="button"
                       disabled={open}
-                      onClick={() => send(MicrowaveEvent.cases.PowerPressed.make({}))}
+                      onClick={() => send(MicrowaveEvents.PowerPressed())}
                     >
                       {cooking ? "Stop" : "Start"}
                     </button>
@@ -57,9 +57,7 @@ export function MicrowavePage() {
                       type="button"
                       onClick={() =>
                         send(
-                          open
-                            ? MicrowaveEvent.cases.DoorClosed.make({})
-                            : MicrowaveEvent.cases.DoorOpened.make({})
+                          open ? MicrowaveEvents.DoorClosed() : MicrowaveEvents.DoorOpened()
                         )}
                     >
                       {open ? "Close door" : "Open door"}

--- a/examples/playground/src/examples/microwave/machine.ts
+++ b/examples/playground/src/examples/microwave/machine.ts
@@ -37,9 +37,7 @@ export const MicrowaveStates = Machine.defineStates({
   }
 })
 
-const secondElapsed = MicrowaveInternalEvent.cases.SecondElapsed.make({})
-
-export const MicrowaveMachine = Machine.make({
+const definition = Machine.make({
   id: "Microwave",
   states: MicrowaveStates.states,
   events: [MicrowaveEvent],
@@ -50,7 +48,13 @@ export const MicrowaveMachine = Machine.make({
         .engine.from((engine) => engine.Idle.from())
         .door.from((door) => door.Closed.from())
     )
-}).handle({
+})
+
+export const MicrowaveEvents = Machine.events(definition)
+const InternalEvents = Machine.internalEvents(definition)
+const secondElapsed = InternalEvents.SecondElapsed()
+
+export const MicrowaveMachine = definition.handle({
   Oven: {
     states: {
       engine: {

--- a/examples/playground/src/examples/traffic-light/TrafficLightPage.tsx
+++ b/examples/playground/src/examples/traffic-light/TrafficLightPage.tsx
@@ -2,7 +2,7 @@ import { useAtomSet, useAtomValue } from "@effect/atom-react"
 import { Match } from "effect"
 import { ExamplePage } from "../../components/ExamplePage.tsx"
 import { trafficLightAtom } from "./atoms.ts"
-import { trafficLightDurations, TrafficLightEvent } from "./machine.ts"
+import { trafficLightDurations, TrafficLightEvents } from "./machine.ts"
 
 export function TrafficLightPage() {
   const stateResult = useAtomValue(trafficLightAtom.state)
@@ -43,7 +43,7 @@ export function TrafficLightPage() {
                     <span style={{ animationDuration: `${duration}ms` }} />
                   </div>
                   <div className="machine-controls">
-                    <button type="button" onClick={() => send(TrafficLightEvent.cases.Reset.make({}))}>
+                    <button type="button" onClick={() => send(TrafficLightEvents.Reset())}>
                       Reset cycle
                     </button>
                   </div>

--- a/examples/playground/src/examples/traffic-light/machine.ts
+++ b/examples/playground/src/examples/traffic-light/machine.ts
@@ -23,15 +23,19 @@ export const TrafficLightStates = Machine.defineStates({
   Yellow: {}
 })
 
-const elapsed = TrafficLightInternalEvent.cases.TimerElapsed.make({})
-
-export const TrafficLightMachine = Machine.make({
+const definition = Machine.make({
   id: "TrafficLight",
   states: TrafficLightStates.states,
   events: [TrafficLightEvent],
   internalEvents: [TrafficLightInternalEvent],
   initial: () => TrafficLightStates.initial.Red.from()
-}).handle({
+})
+
+export const TrafficLightEvents = Machine.events(definition)
+const InternalEvents = Machine.internalEvents(definition)
+const elapsed = InternalEvents.TimerElapsed()
+
+export const TrafficLightMachine = definition.handle({
   Red: {
     invoke: Machine.after(trafficLightDurations.Red, elapsed),
     on: {

--- a/examples/playground/src/examples/turnstile/TurnstilePage.tsx
+++ b/examples/playground/src/examples/turnstile/TurnstilePage.tsx
@@ -3,7 +3,7 @@ import { Match } from "effect"
 import { useState } from "react"
 import { ExamplePage } from "../../components/ExamplePage.tsx"
 import { turnstileAtom } from "./atoms.ts"
-import { TurnstileEvent } from "./machine.ts"
+import { TurnstileEvents } from "./machine.ts"
 
 export function TurnstilePage() {
   const stateResult = useAtomValue(turnstileAtom.state)
@@ -39,7 +39,7 @@ export function TurnstilePage() {
                         setLastCommand(
                           locked ? "Coin accepted. Gate unlocked." : "Coin ignored: the gate is already unlocked."
                         )
-                        send(TurnstileEvent.cases.CoinInserted.make({}))
+                        send(TurnstileEvents.CoinInserted())
                       }}
                     >
                       Insert coin
@@ -50,7 +50,7 @@ export function TurnstilePage() {
                         setLastCommand(
                           locked ? "Push ignored: insert a coin first." : "Gate pushed. Turnstile locked again."
                         )
-                        send(TurnstileEvent.cases.GatePushed.make({}))
+                        send(TurnstileEvents.GatePushed())
                       }}
                     >
                       Push gate

--- a/examples/playground/src/examples/turnstile/machine.ts
+++ b/examples/playground/src/examples/turnstile/machine.ts
@@ -11,12 +11,16 @@ export const TurnstileStates = Machine.defineStates({
   Unlocked: {}
 })
 
-export const TurnstileMachine = Machine.make({
+const definition = Machine.make({
   id: "Turnstile",
   states: TurnstileStates.states,
   events: [TurnstileEvent],
   initial: () => TurnstileStates.initial.Locked.from()
-}).handle({
+})
+
+export const TurnstileEvents = Machine.events(definition)
+
+export const TurnstileMachine = definition.handle({
   Locked: {
     on: {
       CoinInserted: ({ target }) => target.full.Unlocked.from()

--- a/examples/playground/src/examples/worker-tabs/WorkerTabsPage.tsx
+++ b/examples/playground/src/examples/worker-tabs/WorkerTabsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import { ExamplePage } from "../../components/ExamplePage.tsx"
-import { type SharedEvent, SharedMachineEvent, type SharedSnapshot } from "./machine.ts"
+import { type SharedEvent, type SharedSnapshot, SharedTransportEvents } from "./machine.ts"
 import type { WorkerResponse } from "./protocol.ts"
 import { createTabChannel } from "./tab-channel.ts"
 import { createMachineWorker, type MachineWorkerClient } from "./worker-client.ts"
@@ -58,9 +58,7 @@ export function WorkerTabsPage() {
         }
         case "SyncState":
           if (message.recipientId === tabId.current) {
-            worker.sendEvent(
-              SharedMachineEvent.cases.Synchronized.make({ active: message.active, count: message.count })
-            )
+            worker.sendEvent(SharedTransportEvents.Synchronized({ active: message.active, count: message.count }))
             setTabMessage(`Synchronized with tab ${message.senderId}.`)
           }
       }
@@ -104,18 +102,18 @@ export function WorkerTabsPage() {
               type="button"
               onClick={() =>
                 send(
-                  active ? SharedMachineEvent.cases.Incremented.make({}) : SharedMachineEvent.cases.Started.make({})
+                  active ? SharedTransportEvents.Incremented() : SharedTransportEvents.Started()
                 )}
             >
               {active ? "Increment" : "Start"}
             </button>
-            <button type="button" onClick={() => send(SharedMachineEvent.cases.Reset.make({}))}>
+            <button type="button" onClick={() => send(SharedTransportEvents.Reset())}>
               Reset
             </button>
             <button
               type="button"
               disabled={!active}
-              onClick={() => send(SharedMachineEvent.cases.Stopped.make({}))}
+              onClick={() => send(SharedTransportEvents.Stopped())}
             >
               Stop
             </button>

--- a/examples/playground/src/examples/worker-tabs/machine.ts
+++ b/examples/playground/src/examples/worker-tabs/machine.ts
@@ -16,12 +16,25 @@ export const SharedMachineEvent = Schema.TaggedUnion({
 
 export const SharedMachineStates = Machine.defineStates(SharedMachineState.cases)
 
-export const SharedMachine = Machine.make({
+const definition = Machine.make({
   id: "WorkerHostedMachine",
   states: SharedMachineStates.states,
   events: [SharedMachineEvent],
   initial: () => SharedMachineStates.initial.Idle.from({ count: 0 })
-}).handle({
+})
+
+// Worker and BroadcastChannel messages need decoded, cloneable data rather
+// than the opaque instructions returned by Machine.events.
+export const SharedTransportEvents = {
+  Started: () => Machine.event(definition, SharedMachineEvent.cases.Started),
+  Incremented: () => Machine.event(definition, SharedMachineEvent.cases.Incremented),
+  Reset: () => Machine.event(definition, SharedMachineEvent.cases.Reset),
+  Stopped: () => Machine.event(definition, SharedMachineEvent.cases.Stopped),
+  Synchronized: (fields: { readonly active: boolean; readonly count: number }) =>
+    Machine.event(definition, SharedMachineEvent.cases.Synchronized, fields)
+}
+
+export const SharedMachine = definition.handle({
   Idle: {
     on: {
       Started: ({ state, target }) => target.full.Active.from({ count: state.count }),


### PR DESCRIPTION
## Summary

- Replace every remaining `Event.cases.<Tag>.make(...)` call under `examples/` with the protocol-bound event construction APIs.
- Use `Machine.events` for public UI and planner delivery and `Machine.internalEvents` for timers, raised events, invoke results, and snapshot mappings.
- Keep decoded `Machine.event` construction at model-trace and Worker/BroadcastChannel boundaries, where events must remain inspectable or structured-cloneable.
- Split the media-player definition from its handlers so invocation helpers can share machine-owned internal constructors without a module cycle.

## Changeset

- [ ] Added or updated for a library or package-metadata change
- [x] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] `examples/platformer`: `pnpm check`
- [x] `examples/playground`: `pnpm check`
- [x] Automated type-performance measurement passed or was not required (`pnpm perf:types` passed locally)
- [x] Automated runtime- and memory-performance measurement passed or was not required (`pnpm perf:runtime` completed locally)