### PR TITLE
Require statically inspectable machine transitions

### DIFF
--- a/.changeset/static-transition-topology.md
+++ b/.changeset/static-transition-topology.md
@@ -1,0 +1,7 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Require `Machine.transition` for every machine transition and capture each possible target as static machine topology. Direct transitions declare `target` and `resolve`; conditional transitions declare titled `cases` whose `when` functions return `Option`, plus an explicit `otherwise` branch. The selected target builder and conditional match value are inferred in each resolver.
+
+Initial state construction now uses the same `target` and `resolve` shape, restricted to the machine's declared initial state. Replace process logic previously created with `Machine.transition` by `Machine.logic`, and replace function handlers, target upper-bound lists, and `States.initial` construction with the explicit transition and initial target selectors.

--- a/README.md
+++ b/README.md
@@ -66,19 +66,31 @@ const CounterDefinition = Machine.make({
   id: "Counter",
   states: States.states,
   events: CounterEvent,
-  initial: () => States.initial.Idle.from()
+  initial: {
+    target: (to) => to.Idle(),
+    resolve: ({ target }) => target.from()
+  }
 })
 
 const Counter = CounterDefinition.handle({
   Idle: {
     on: {
-      Start: ({ target }) => target.full.Running.from({ count: 0 })
+      Start: Machine.transition({
+        target: (to) => to.full.Running(),
+        resolve: ({ target }) => target.from({ count: 0 })
+      })
     }
   },
   Running: {
     on: {
-      Increment: ({ state, target }) => target.full.Running.from({ count: state.count + 1 }),
-      Stop: ({ target }) => target.full.Idle.from()
+      Increment: Machine.transition({
+        target: (to) => to.full.Running(),
+        resolve: ({ state, target }) => target.from({ count: state.count + 1 })
+      }),
+      Stop: Machine.transition({
+        target: (to) => to.full.Idle(),
+        resolve: ({ target }) => target.from()
+      })
     }
   }
 })
@@ -111,8 +123,7 @@ Use this order to preserve inference and keep boundaries explicit:
 Use `.from(...)` when constructing a new state from fields:
 
 ```ts
-target.local.Saving.from({ draft: event.draft })
-States.initial.Form.from({ draft: "" }, (form) => form.Editing.from())
+target.from({ draft: event.draft })
 ```
 
 The machine runs these inputs through the state schema while planning. Schema
@@ -124,10 +135,12 @@ When sibling states share fields, remove the source discriminator and pass the
 remaining fields through the target schema:
 
 ```ts
-Submit: ;
-;(({ state, target }) => {
-  const { _tag: _, ...fields } = state
-  return target.local.Saving.from({ ...fields, attempt: 1 })
+Submit: Machine.transition({
+  target: (to) => to.local.Saving(),
+  resolve: ({ state, target }) => {
+    const { _tag: _, ...fields } = state
+    return target.from({ ...fields, attempt: 1 })
+  }
 })
 ```
 
@@ -144,7 +157,10 @@ const States = Machine.defineStates({
   }
 })
 
-States.initial.Form.from((form) => form.Editing.from())
+initial: {
+  target: (to) => to.Form.initial(),
+  resolve: ({ target }) => target((form) => form.Editing.from())
+}
 ```
 
 Schema-less states remain active, targetable, matchable, and visible through
@@ -181,7 +197,10 @@ const definition = Machine.make({
   events: CommandEvent,
   internalEvents: InternalEvent,
   emittedEvents: Emissions,
-  initial: () => States.initial.Idle.from()
+  initial: {
+    target: (to) => to.Idle(),
+    resolve: ({ target }) => target.from()
+  }
 })
 ```
 
@@ -293,16 +312,22 @@ const child = Machine.make({
   states: ChildStates.states,
   events: ChildEvents,
   parentEvents: ParentEvents,
-  initial: () => ChildStates.initial.Working.from()
+  initial: {
+    target: (to) => to.Working(),
+    resolve: ({ target }) => target.from()
+  }
 }).handle({
   Working: {
     on: {
-      Finish: ({ parent, target }, enqueue) => {
-        if (parent !== undefined) {
-          enqueue.sendTo(parent, ParentEvents.ChildFinished({ id: "job-1" }))
+      Finish: Machine.transition({
+        target: (to) => to.full.Done(),
+        resolve: ({ parent, target }, enqueue) => {
+          if (parent !== undefined) {
+            enqueue.sendTo(parent, ParentEvents.ChildFinished({ id: "job-1" }))
+          }
+          return target.from()
         }
-        return target.full.Done.from()
-      }
+      })
     }
   },
   Done: {}
@@ -377,8 +402,14 @@ Loading: {
   invoke: Machine.invoke({
     id: "save-document",
     effect: () => saveDocument,
-    onDone: ({ output, target }) => target.full.Saved({ id: output.id }),
-    onFailure: ({ error, target }) => target.full.Failed({ message: String(error) })
+    onDone: Machine.transition({
+      target: (to) => to.full.Saved(),
+      resolve: ({ output, target }) => target.from({ id: output.id })
+    }),
+    onFailure: Machine.transition({
+      target: (to) => to.full.Failed(),
+      resolve: ({ error, target }) => target.from({ message: String(error) })
+    })
   })
 }
 
@@ -386,7 +417,10 @@ Waiting: {
   invoke: Machine.invoke({
     id: "save-timeout",
     after: "3 seconds",
-    onDone: ({ target }) => target.full.Failed({ message: "Timed out" })
+    onDone: Machine.transition({
+      target: (to) => to.full.Failed(),
+      resolve: ({ target }) => target.from({ message: "Timed out" })
+    })
   })
 }
 ```
@@ -401,8 +435,14 @@ for state-dependent Effects:
 invoke: Machine.invoke({
   id: "load-document",
   effect: ({ state }) => loadDocument(state.documentId),
-  onDone: ({ output, target }) => target.full.Ready({ document: output }),
-  onFailure: ({ error, target }) => target.full.Failed({ message: error.message })
+  onDone: Machine.transition({
+    target: (to) => to.full.Ready(),
+    resolve: ({ output, target }) => target.from({ document: output })
+  }),
+  onFailure: Machine.transition({
+    target: (to) => to.full.Failed(),
+    resolve: ({ error, target }) => target.from({ message: error.message })
+  })
 })
 ```
 
@@ -428,8 +468,14 @@ const machine = definition.handle({
         parent === undefined
           ? Effect.void
           : parent.send(ParentEvents.SaveStarted()),
-      onDone: ({ target }) => target.none(),
-      onFailure: ({ target }) => target.none()
+      onDone: Machine.transition({
+        target: (to) => to.none(),
+        resolve: () => undefined
+      }),
+      onFailure: Machine.transition({
+        target: (to) => to.none(),
+        resolve: () => undefined
+      })
     })
   }
 })

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -148,8 +148,10 @@ const States = Machine.defineStates({
   }
 })
 
-States.initial.Idle.from()
-States.initial.Form.from((form) => form.Editing.from())
+initial: {
+  target: (to) => to.Form.initial(),
+  resolve: ({ target }) => target((form) => form.Editing.from())
+}
 ```
 
 Schema-less states have the same control semantics as schema-backed states:
@@ -159,10 +161,13 @@ in snapshots. They do not have a state value:
 ```ts
 Idle: {
   on: {
-    Start: ({ state, target }) => {
-      // state: undefined
-      return target.full.Form.from((form) => form.Editing.from())
-    }
+    Start: Machine.transition({
+      target: (to) => to.full.Form.initial(),
+      resolve: ({ state, target }) => {
+        // state: undefined
+        return target.from((form) => form.Editing.from())
+      }
+    })
   }
 }
 
@@ -243,7 +248,10 @@ const States = Machine.defineStates({
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(),
-  initial: () => States.initial.Done.from()
+  initial: {
+    target: (to) => to.Done(),
+    resolve: ({ target }) => target.from()
+  }
 }).handle({
   Done: {
     output: () => "done"
@@ -260,7 +268,10 @@ with `.initial`. This is available on top-level state methods under
 `target.branch`; atomic and final state methods do not expose it:
 
 ```ts
-Open: ({ target }) => target.full.opened.initial.from({ teamId: "team-1" })
+Open: Machine.transition({
+  target: (to) => to.full.opened.initial(),
+  resolve: ({ target }) => target.from({ teamId: "team-1" })
+})
 ```
 
 The selected state's own value is passed directly to `initial(value)` or
@@ -337,7 +348,10 @@ checkout: {
 Target it without a value:
 
 ```ts
-Resume: ({ target }) => target.history.checkout.exact()
+Resume: Machine.transition({
+  target: (to) => to.history.checkout.exact(),
+  resolve: ({ target }) => target()
+})
 ```
 
 Deep history restores the complete remembered subtree and its decoded values.
@@ -400,11 +414,11 @@ sets. A `target.full` result with the same active paths can update values withou
 exiting shared states. To force the source to exit and enter again:
 
 ```ts
-Refresh: {
+Refresh: Machine.transition({
+  target: (to) => to.full.Ready(),
   reenter: true,
-  transition: ({ state, target }) =>
-    target.full.Ready.from({ value: state.value })
-}
+  resolve: ({ state, target }) => target.from({ value: state.value })
+})
 ```
 
 Do not use `target.full` merely because it is easiest to discover. Prefer the
@@ -413,8 +427,8 @@ narrowest builder that expresses the intended configuration change.
 Every state builder method has two construction forms:
 
 ```ts
-target.local.Ready(decodedReady)
-target.local.Ready.from({ value: event.value })
+target(decodedReady)
+target.from({ value: event.value })
 ```
 
 The direct call accepts the schema's decoded `Type`. `.from` accepts its
@@ -429,8 +443,8 @@ builders.
 If `{}` satisfies the schema's constructor input, omit it:
 
 ```ts
-target.local.Idle.from()
-target.local.Flow.from((flow) => flow.Idle.from())
+target.from()
+target.from((flow) => flow.Idle.from())
 ```
 
 This shorthand also applies to schemas whose constructor fields are all
@@ -481,10 +495,21 @@ Event, `always`, and `onDone` transition contexts include a fully typed
 microstep, before any selected transition is applied:
 
 ```ts
-BufferReady: ({ snapshot, target }) =>
-  States.matches(snapshot, "Player.Network.Online")
-    ? target.local.Playing.from()
-    : target.none()
+BufferReady: Machine.transition({
+  cases: [{
+    title: "online",
+    when: ({ snapshot }) =>
+      States.matches(snapshot, "Player.Network.Online")
+        ? Option.some(undefined)
+        : Option.none(),
+    target: (to) => to.local.Playing(),
+    resolve: ({ target }) => target.from()
+  }],
+  otherwise: {
+    target: (to) => to.none(),
+    resolve: () => undefined
+  }
+})
 ```
 
 Use the existing `States.matches`, `States.get`, `States.getWithParents`, and
@@ -519,10 +544,13 @@ When sibling state payloads share fields, destructure away the source
 discriminator and construct the destination through its target builder:
 
 ```ts
-Submit: ({ state, target }) => {
-  const { _tag: _, ...fields } = state
-  return target.local.Saving.from({ ...fields, attempt: 1 })
-}
+Submit: Machine.transition({
+  target: (to) => to.local.Saving(),
+  resolve: ({ state, target }) => {
+    const { _tag: _, ...fields } = state
+    return target.from({ ...fields, attempt: 1 })
+  }
+})
 ```
 
 The target schema remains responsible for defaults, transforms, refinements,
@@ -531,30 +559,44 @@ rather than copying it through every phase.
 
 ## Planning, actions, raised events, and emissions
 
-A transition returns a target synchronously:
+A transition declares every possible branch and resolves the selected target
+synchronously:
 
 ```ts
-Submit: ({ state, target }) =>
-  state.valid ? target.local.Saving.from({ draft: state.draft }) : target.none()
+Submit: Machine.transition({
+  cases: [{
+    title: "valid",
+    when: ({ state }) => state.valid ? Option.some(state.draft) : Option.none(),
+    target: (to) => to.local.Saving(),
+    resolve: ({ match, target }) => target.from({ draft: match })
+  }],
+  otherwise: {
+    target: (to) => to.none(),
+    resolve: () => undefined
+  }
+})
 ```
 
-Every installed event, `always`, `onDone`, and invoke lifecycle handler must
-return a concrete target or `target.none()`. An absent event handler means the
-event is ignored. Returning `target.none()` means it was handled without a
-destination, so queued commands, raised events, and emitted events are still
-retained. It remains valid when a transition declares `targets`: those paths
-are an upper bound on concrete destinations, not an exhaustive result set.
+Every installed event, `always`, `onDone`, choice, and invoke lifecycle handler
+must use `Machine.transition`. Each direct branch declares one `target`; a
+conditional transition declares ordered `cases` and a required `otherwise`.
+`when` returns `Option.some(match)` to select a case and infer `match` in its
+resolver. Selecting `to.none()` handles the transition without a destination,
+while retaining queued commands, raised events, and emitted events.
 
-`reenter: true` remains meaningful with `target.none()`: the source exits and
+`reenter: true` remains meaningful with `to.none()`: the source exits and
 enters again while its logical configuration is retained.
 
 Closed statechart and machine operations use `enqueue`:
 
 ```ts
-Submit: ({ target }, enqueue) => {
-  enqueue.emit(Emissions.SaveRequested())
-  return target.local.Saving.from()
-}
+Submit: Machine.transition({
+  target: (to) => to.local.Saving(),
+  resolve: ({ target }, enqueue) => {
+    enqueue.emit(Emissions.SaveRequested())
+    return target.from()
+  }
+})
 ```
 
 Declare emission constructors separately from machine inputs:
@@ -648,11 +690,15 @@ const child = Machine.make({
 }).handle({
   Working: {
     on: {
-      Finish: ({ parent }, enqueue) => {
-        if (parent !== undefined) {
-          enqueue.sendTo(parent, ParentEvents.ChildFinished())
+      Finish: Machine.transition({
+        target: (to) => to.none(),
+        resolve: ({ parent }, enqueue) => {
+          if (parent !== undefined) {
+            enqueue.sendTo(parent, ParentEvents.ChildFinished())
+          }
+          return undefined
         }
-      }
+      })
     }
   }
 })
@@ -718,7 +764,10 @@ const definition = Machine.make({
   states: States.states,
   events: Events,
   internalEvents: InternalEvents,
-  initial: () => States.initial.Idle.from()
+  initial: {
+    target: (to) => to.Idle(),
+    resolve: ({ target }) => target.from()
+  }
 })
 ```
 
@@ -774,9 +823,14 @@ receive the typed Effect channels and can transition directly:
 invoke: Machine.invoke({
   id: "save",
   effect: () => SaveService.save(draft),
-  onDone: ({ output, target }) => target.full.Saved({ entry: output }),
-  onFailure: ({ error, target }) =>
-    target.full.SaveFailed({ message: error.message })
+  onDone: Machine.transition({
+    target: (to) => to.full.Saved(),
+    resolve: ({ output, target }) => target.from({ entry: output })
+  }),
+  onFailure: Machine.transition({
+    target: (to) => to.full.SaveFailed(),
+    resolve: ({ error, target }) => target.from({ message: error.message })
+  })
 })
 ```
 
@@ -799,8 +853,14 @@ error, and service channels together. No return annotation is needed:
 invoke: Machine.invoke({
   id: "load",
   effect: ({ state }) => LoadService.load(state.userId),
-  onDone: ({ output, target }) => target.full.Loaded({ user: output }),
-  onFailure: ({ error, target }) => target.full.LoadFailed({ error })
+  onDone: Machine.transition({
+    target: (to) => to.full.Loaded(),
+    resolve: ({ output, target }) => target.from({ user: output })
+  }),
+  onFailure: Machine.transition({
+    target: (to) => to.full.LoadFailed(),
+    resolve: ({ error, target }) => target.from({ error })
+  })
 })
 ```
 
@@ -824,8 +884,14 @@ const machine = definition.handle({
         parent === undefined
           ? Effect.void
           : parent.send(ParentEvents.SaveStarted()),
-      onDone: ({ target }) => target.none(),
-      onFailure: ({ target }) => target.none()
+      onDone: Machine.transition({
+        target: (to) => to.none(),
+        resolve: () => undefined
+      }),
+      onFailure: Machine.transition({
+        target: (to) => to.none(),
+        resolve: () => undefined
+      })
     })
   }
 })
@@ -840,7 +906,10 @@ A cancellable timer uses the same object:
 invoke: Machine.invoke({
   id: "clear-status",
   after: "3 seconds",
-  onDone: ({ target }) => target.full.Clear()
+  onDone: Machine.transition({
+    target: (to) => to.full.Clear(),
+    resolve: ({ target }) => target()
+  })
 })
 ```
 
@@ -867,7 +936,10 @@ Invoke it from its owning state:
 invoke: Machine.invoke({
   child: Editor,
   input: editorInput,
-  onDone: ({ output, target }) => target.full.EditorDone({ output })
+  onDone: Machine.transition({
+    target: (to) => to.full.EditorDone(),
+    resolve: ({ output, target }) => target.from({ output })
+  })
 })
 ```
 
@@ -1182,12 +1254,15 @@ reference model when correctness of the expected behavior matters.
 
 ## Common compiler errors
 
-### `initial` is not callable
+### `initial` requires a static target
 
-Wrap the initial builder result:
+Select the initial root separately from constructing its value:
 
 ```ts
-initial: () => States.initial.Idle.from()
+initial: {
+  target: (to) => to.Idle(),
+  resolve: ({ target }) => target.from()
+}
 ```
 
 ### Invoked child expects events not accepted by the parent

--- a/examples/platformer/src/machine.test.ts
+++ b/examples/platformer/src/machine.test.ts
@@ -157,17 +157,17 @@ describe("platformer history integration", () => {
       const definitions = Machine.transitionDefinitions(CharacterMachine)
       const rendered = renderMachine(CharacterMachine, initial.state)
 
-      expect(definitions).toHaveLength(27)
+      expect(definitions).toHaveLength(28)
       expect(definitions).toContainEqual({
         source: "Character.locomotion.Playing.Airborne.airJump",
         trigger: { type: "event", event: "WallJump" },
         reenter: true,
-        targets: {
-          type: "declared",
-          paths: ["Character.locomotion.Playing.Airborne.airJump.AirJumpWallLock"]
-        }
+        branches: [{
+          type: "direct",
+          target: "Character.locomotion.Playing.Airborne.airJump.AirJumpWallLock"
+        }]
       })
-      expect(definitions.every(({ targets }) => targets.type === "declared")).toBe(true)
+      expect(definitions.every(({ branches }) => branches.length > 0)).toBe(true)
       expect(rendered).toContain("◇ on: WallJump [reenter] → AirJumpWallLock")
       expect(rendered).toContain(
         "Candidate events: Move, DownPressed, JumpPressed, Pause, WallJump, WallContact, Reset"

--- a/examples/platformer/src/machine.ts
+++ b/examples/platformer/src/machine.ts
@@ -1,5 +1,5 @@
 import { Machine } from "@typeonce/effect-machine"
-import { Schema } from "effect"
+import { Option, Schema } from "effect"
 
 // Domain schemas are shared by state payloads and the public physics protocol.
 export const Axis = Schema.Literals([-1, 0, 1])
@@ -114,31 +114,40 @@ export const CharacterStates = Machine.defineStates({
   }
 })
 
-const initialCharacter = () =>
-  CharacterStates.initial.Character.from((character) =>
-    character
-      .locomotion.from((locomotion) =>
-        locomotion.Playing.from((playing) => playing.Grounded.from((grounded) => grounded.Standing.from()))
-      )
-      .facing.from((facing) => facing.Right.from())
-      .contact.from((contact) => contact.NoWall.from())
-  )
-
 const definition = Machine.make({
   id: "PlatformerCharacter",
   states: CharacterStates.states,
   events: CharacterEvents,
   internalEvents: InternalEvents,
-  initial: initialCharacter
+  initial: {
+    target: (to) => to.Character.initial(),
+    resolve: ({ target }) =>
+      target.from((character) =>
+        character
+          .locomotion.from((locomotion) =>
+            locomotion.Playing.from((playing) => playing.Grounded.from((grounded) => grounded.Standing.from()))
+          )
+          .facing.from((facing) => facing.Right.from())
+          .contact.from((contact) => contact.NoWall.from())
+      )
+  }
 })
 
 export const CharacterMachine = definition.handle({
   Character: {
     on: {
-      Reset: {
-        targets: ["Character"],
-        transition: initialCharacter
-      }
+      Reset: Machine.transition({
+        target: (to) => to.full.Character(),
+        resolve: ({ target }) =>
+          target.from((character) =>
+            character
+              .locomotion.from((locomotion) =>
+                locomotion.Playing.from((playing) => playing.Grounded.from((grounded) => grounded.Standing.from()))
+              )
+              .facing.from((facing) => facing.Right.from())
+              .contact.from((contact) => contact.NoWall.from())
+          )
+      })
     },
     states: {
       locomotion: {
@@ -146,23 +155,32 @@ export const CharacterMachine = definition.handle({
           Playing: {
             history: {
               resume: {
-                default: initialCharacter
+                default: ({ target }) =>
+                  target.Character.from((character) =>
+                    character
+                      .locomotion.from((locomotion) =>
+                        locomotion.Playing.from((playing) =>
+                          playing.Grounded.from((grounded) => grounded.Standing.from())
+                        )
+                      )
+                      .facing.from((facing) => facing.Right.from())
+                      .contact.from((contact) => contact.NoWall.from())
+                  )
               }
             },
             on: {
-              Pause: {
-                targets: ["Character.locomotion.Paused"],
-                transition: ({ event, target }) =>
-                  target.branch.Character.locomotion.Paused.from({ pausedAt: event.at })
-              }
+              Pause: Machine.transition({
+                target: (to) => to.branch.Character.locomotion.Paused(),
+                resolve: ({ event, target }) => target.from({ pausedAt: event.at })
+              })
             },
             states: {
               Grounded: {
                 on: {
-                  JumpPressed: {
-                    targets: ["Character"],
-                    transition: ({ event, target }) =>
-                      target.full.Character.from((character) =>
+                  JumpPressed: Machine.transition({
+                    target: (to) => to.full.Character(),
+                    resolve: ({ event, target }) =>
+                      target.from((character) =>
                         character
                           .locomotion.from((locomotion) =>
                             locomotion.Playing.from((playing) =>
@@ -183,137 +201,159 @@ export const CharacterMachine = definition.handle({
                               : contact.NoWall.from()
                           )
                       )
-                  }
+                  })
                 },
                 states: {
                   Standing: {
                     on: {
-                      Move: {
-                        targets: ["Character.locomotion.Playing.Grounded.Running"],
-                        transition: ({ event, target }) =>
-                          event.axis === 0
-                            ? target.none()
-                            : target.local.Running.from({ startedAt: event.at })
-                      },
-                      DownPressed: {
-                        targets: ["Character.locomotion.Playing.Grounded.Ducking"],
-                        transition: ({ event, target }) => target.local.Ducking.from({ startedAt: event.at })
-                      }
+                      Move: Machine.transition({
+                        cases: [{
+                          title: "moving",
+                          when: ({ event }) => event.axis === 0 ? Option.none() : Option.some(event),
+                          target: (to) => to.local.Running(),
+                          resolve: ({ match, target }) => target.from({ startedAt: match.at })
+                        }],
+                        otherwise: {
+                          target: (to) => to.none(),
+                          resolve: () => undefined
+                        }
+                      }),
+                      DownPressed: Machine.transition({
+                        target: (to) => to.local.Ducking(),
+                        resolve: ({ event, target }) => target.from({ startedAt: event.at })
+                      })
                     }
                   },
                   Running: {
                     on: {
-                      Move: {
-                        targets: ["Character.locomotion.Playing.Grounded.Standing"],
-                        transition: ({ event, target }) =>
-                          event.axis === 0 ? target.local.Standing.from() : target.none()
-                      },
-                      DownPressed: {
-                        targets: ["Character.locomotion.Playing.Grounded.Ducking"],
-                        transition: ({ event, target }) => target.local.Ducking.from({ startedAt: event.at })
-                      }
+                      Move: Machine.transition({
+                        cases: [{
+                          title: "stopped",
+                          when: ({ event }) => event.axis === 0 ? Option.some(undefined) : Option.none(),
+                          target: (to) => to.local.Standing(),
+                          resolve: ({ target }) => target.from()
+                        }],
+                        otherwise: {
+                          target: (to) => to.none(),
+                          resolve: () => undefined
+                        }
+                      }),
+                      DownPressed: Machine.transition({
+                        target: (to) => to.local.Ducking(),
+                        resolve: ({ event, target }) => target.from({ startedAt: event.at })
+                      })
                     }
                   },
                   Ducking: {
                     on: {
-                      DownReleased: {
-                        targets: [
-                          "Character.locomotion.Playing.Grounded.Standing",
-                          "Character.locomotion.Playing.Grounded.Running"
-                        ],
-                        transition: ({ event, target }) =>
-                          event.axis === 0
-                            ? target.local.Standing.from()
-                            : target.local.Running.from({ startedAt: event.at })
-                      }
+                      DownReleased: Machine.transition({
+                        cases: [{
+                          title: "stopped",
+                          when: ({ event }) => event.axis === 0 ? Option.some(undefined) : Option.none(),
+                          target: (to) => to.local.Standing(),
+                          resolve: ({ target }) => target.from()
+                        }],
+                        otherwise: {
+                          target: (to) => to.local.Running(),
+                          resolve: ({ event, target }) => target.from({ startedAt: event.at })
+                        }
+                      })
                     }
                   },
                   Landing: {
-                    invoke: Machine.invoke({
+                    invoke: definition.invoke({
                       id: "landing-settle",
                       after: "140 millis",
-                      onDone: {
-                        targets: [
-                          "Character.locomotion.Playing.Grounded.Standing",
-                          "Character.locomotion.Playing.Grounded.Running"
-                        ],
-                        transition: ({ state, target }) =>
-                          state.resumeAxis === 0
-                            ? target.local.Standing.from()
-                            : target.local.Running.from({ startedAt: state.landedAt + 140 })
-                      }
+                      onDone: Machine.transition({
+                        target: (to) => to.none(),
+                        resolve: (_, enqueue) => {
+                          enqueue.raise(InternalEvents.LandingSettled())
+                          return undefined
+                        }
+                      })
                     }),
                     on: {
-                      Move: {
-                        targets: ["Character.locomotion.Playing.Grounded.Landing"],
-                        transition: ({ event, state, target }) => {
-                          const { _tag: _, ...fields } = state
-                          return target.local.Landing.from({ ...fields, resumeAxis: event.axis })
+                      LandingSettled: Machine.transition({
+                        cases: [{
+                          title: "stopped",
+                          when: ({ state }) => state.resumeAxis === 0 ? Option.some(undefined) : Option.none(),
+                          target: (to) => to.local.Standing(),
+                          resolve: ({ target }) => target.from()
+                        }],
+                        otherwise: {
+                          target: (to) => to.local.Running(),
+                          resolve: ({ state, target }) => target.from({ startedAt: state.landedAt + 140 })
                         }
-                      }
+                      }),
+                      Move: Machine.transition({
+                        target: (to) => to.local.Landing(),
+                        resolve: ({ event, state, target }) => {
+                          const { _tag: _, ...fields } = state
+                          return target.from({ ...fields, resumeAxis: event.axis })
+                        }
+                      })
                     }
                   }
                 }
               },
               Airborne: {
                 on: {
-                  JumpPressed: {
-                    targets: [],
-                    transition: ({ event, target }, enqueue) => {
+                  JumpPressed: Machine.transition({
+                    target: (to) => to.none(),
+                    resolve: ({ event }, enqueue) => {
                       const push = awayFrom(event.wall)
                       enqueue.raise(
                         push === 0
                           ? InternalEvents.TryAirJump({ at: event.at })
                           : InternalEvents.WallJump({ at: event.at, push })
                       )
-                      return target.none()
+                      return undefined
                     }
-                  },
-                  Landed: {
-                    targets: ["Character.locomotion.Playing.Grounded.Landing"],
-                    transition: ({ event, target }) =>
-                      target.branch.Character.locomotion.Playing.Grounded.from((grounded) =>
+                  }),
+                  Landed: Machine.transition({
+                    target: (to) => to.branch.Character.locomotion.Playing.Grounded(),
+                    resolve: ({ event, target }) =>
+                      target.from((grounded) =>
                         grounded.Landing.from({
                           impact: event.impact,
                           resumeAxis: event.axis,
                           landedAt: event.at
                         })
                       )
-                  }
+                  })
                 },
                 states: {
                   motion: {
                     on: {
-                      DoubleJump: {
-                        targets: ["Character.locomotion.Playing.Airborne.motion.Jumping"],
-                        transition: ({ event, target }) =>
-                          target.local.Jumping.from({ startedAt: event.at, push: 0, kind: "Double" })
-                      },
-                      WallJump: {
-                        targets: ["Character.locomotion.Playing.Airborne.motion.Jumping"],
-                        transition: ({ event, target }) =>
-                          target.local.Jumping.from({ startedAt: event.at, push: event.push, kind: "Wall" })
-                      }
+                      DoubleJump: Machine.transition({
+                        target: (to) => to.local.Jumping(),
+                        resolve: ({ event, target }) => target.from({ startedAt: event.at, push: 0, kind: "Double" })
+                      }),
+                      WallJump: Machine.transition({
+                        target: (to) => to.local.Jumping(),
+                        resolve: ({ event, target }) =>
+                          target.from({ startedAt: event.at, push: event.push, kind: "Wall" })
+                      })
                     },
                     states: {
                       Jumping: {
                         on: {
-                          ApexReached: {
-                            targets: ["Character.locomotion.Playing.Airborne.motion.Falling"],
-                            transition: ({ event, target }) => target.local.Falling.from({ apexY: event.y })
-                          },
-                          DownPressed: {
-                            targets: ["Character.locomotion.Playing.Airborne.motion.Diving"],
-                            transition: ({ event, target }) => target.local.Diving.from({ startedAt: event.at })
-                          }
+                          ApexReached: Machine.transition({
+                            target: (to) => to.local.Falling(),
+                            resolve: ({ event, target }) => target.from({ apexY: event.y })
+                          }),
+                          DownPressed: Machine.transition({
+                            target: (to) => to.local.Diving(),
+                            resolve: ({ event, target }) => target.from({ startedAt: event.at })
+                          })
                         }
                       },
                       Falling: {
                         on: {
-                          DownPressed: {
-                            targets: ["Character.locomotion.Playing.Airborne.motion.Diving"],
-                            transition: ({ event, target }) => target.local.Diving.from({ startedAt: event.at })
-                          }
+                          DownPressed: Machine.transition({
+                            target: (to) => to.local.Diving(),
+                            resolve: ({ event, target }) => target.from({ startedAt: event.at })
+                          })
                         }
                       },
                       Diving: {}
@@ -321,21 +361,21 @@ export const CharacterMachine = definition.handle({
                   },
                   airJump: {
                     on: {
-                      WallJump: {
-                        reenter: true,
-                        targets: ["Character.locomotion.Playing.Airborne.airJump.AirJumpWallLock"],
-                        transition: ({ target }) => target.local.AirJumpWallLock.from()
-                      }
+                      WallJump: Machine.transition({
+                        target: (to) => to.local.AirJumpWallLock(),
+                        resolve: ({ target }) => target.from(),
+                        reenter: true
+                      })
                     },
                     states: {
                       AirJumpGroundLock: {
                         invoke: Machine.invoke({
                           id: "ground-air-jump-unlock",
                           after: "120 millis",
-                          onDone: {
-                            targets: ["Character.locomotion.Playing.Airborne.airJump.AirJumpReady"],
-                            transition: ({ target }) => target.local.AirJumpReady.from()
-                          }
+                          onDone: Machine.transition({
+                            target: (to) => to.local.AirJumpReady(),
+                            resolve: ({ target }) => target.from()
+                          })
                         }),
                         on: {}
                       },
@@ -343,22 +383,22 @@ export const CharacterMachine = definition.handle({
                         invoke: Machine.invoke({
                           id: "wall-air-jump-unlock",
                           after: "240 millis",
-                          onDone: {
-                            targets: ["Character.locomotion.Playing.Airborne.airJump.AirJumpReady"],
-                            transition: ({ target }) => target.local.AirJumpReady.from()
-                          }
+                          onDone: Machine.transition({
+                            target: (to) => to.local.AirJumpReady(),
+                            resolve: ({ target }) => target.from()
+                          })
                         }),
                         on: {}
                       },
                       AirJumpReady: {
                         on: {
-                          TryAirJump: {
-                            targets: ["Character.locomotion.Playing.Airborne.airJump.AirJumpSpent"],
-                            transition: ({ event, target }, enqueue) => {
+                          TryAirJump: Machine.transition({
+                            target: (to) => to.local.AirJumpSpent(),
+                            resolve: ({ event, target }, enqueue) => {
                               enqueue.raise(InternalEvents.DoubleJump({ at: event.at }))
-                              return target.local.AirJumpSpent.from()
+                              return target.from()
                             }
-                          }
+                          })
                         }
                       },
                       AirJumpSpent: {}
@@ -370,10 +410,10 @@ export const CharacterMachine = definition.handle({
           },
           Paused: {
             on: {
-              Resume: {
-                targets: ["Character.locomotion.Playing.resume"],
-                transition: ({ target }) => target.history.Character.locomotion.Playing.resume()
-              }
+              Resume: Machine.transition({
+                target: (to) => to.history.Character.locomotion.Playing.resume(),
+                resolve: ({ target }) => target()
+              })
             }
           }
         }
@@ -382,41 +422,69 @@ export const CharacterMachine = definition.handle({
         states: {
           Left: {
             on: {
-              Move: {
-                targets: ["Character.facing.Right"],
-                transition: ({ event, target }) => event.axis === 1 ? target.local.Right.from() : target.none()
-              },
-              WallJump: {
-                targets: ["Character.facing.Right"],
-                transition: ({ event, target }) => event.push === 1 ? target.local.Right.from() : target.none()
-              }
+              Move: Machine.transition({
+                cases: [{
+                  title: "right",
+                  when: ({ event }) => event.axis === 1 ? Option.some(undefined) : Option.none(),
+                  target: (to) => to.local.Right(),
+                  resolve: ({ target }) => target.from()
+                }],
+                otherwise: { target: (to) => to.none(), resolve: () => undefined }
+              }),
+              WallJump: Machine.transition({
+                cases: [{
+                  title: "right",
+                  when: ({ event }) => event.push === 1 ? Option.some(undefined) : Option.none(),
+                  target: (to) => to.local.Right(),
+                  resolve: ({ target }) => target.from()
+                }],
+                otherwise: { target: (to) => to.none(), resolve: () => undefined }
+              })
             }
           },
           Right: {
             on: {
-              Move: {
-                targets: ["Character.facing.Left"],
-                transition: ({ event, target }) => event.axis === -1 ? target.local.Left.from() : target.none()
-              },
-              WallJump: {
-                targets: ["Character.facing.Left"],
-                transition: ({ event, target }) => event.push === -1 ? target.local.Left.from() : target.none()
-              }
+              Move: Machine.transition({
+                cases: [{
+                  title: "left",
+                  when: ({ event }) => event.axis === -1 ? Option.some(undefined) : Option.none(),
+                  target: (to) => to.local.Left(),
+                  resolve: ({ target }) => target.from()
+                }],
+                otherwise: { target: (to) => to.none(), resolve: () => undefined }
+              }),
+              WallJump: Machine.transition({
+                cases: [{
+                  title: "left",
+                  when: ({ event }) => event.push === -1 ? Option.some(undefined) : Option.none(),
+                  target: (to) => to.local.Left(),
+                  resolve: ({ target }) => target.from()
+                }],
+                otherwise: { target: (to) => to.none(), resolve: () => undefined }
+              })
             }
           }
         }
       },
       contact: {
         on: {
-          WallContact: {
-            targets: ["Character.contact.NoWall", "Character.contact.LeftWall", "Character.contact.RightWall"],
-            transition: ({ event, target }) =>
-              event.wall === -1
-                ? target.local.LeftWall.from()
-                : event.wall === 1
-                ? target.local.RightWall.from()
-                : target.local.NoWall.from()
-          }
+          WallContact: Machine.transition({
+            cases: [{
+              title: "left wall",
+              when: ({ event }) => event.wall === -1 ? Option.some(undefined) : Option.none(),
+              target: (to) => to.local.LeftWall(),
+              resolve: ({ target }) => target.from()
+            }, {
+              title: "right wall",
+              when: ({ event }) => event.wall === 1 ? Option.some(undefined) : Option.none(),
+              target: (to) => to.local.RightWall(),
+              resolve: ({ target }) => target.from()
+            }],
+            otherwise: {
+              target: (to) => to.local.NoWall(),
+              resolve: ({ target }) => target.from()
+            }
+          })
         },
         states: {
           NoWall: {},

--- a/examples/playground/src/examples/media-player/definition.ts
+++ b/examples/playground/src/examples/media-player/definition.ts
@@ -3,22 +3,23 @@ import { initialAudioSettings, MediaPlayerEvents, MediaPlayerInternalEvents, Med
 
 export { MediaPlayerEvents, MediaPlayerInternalEvents } from "./schemas.ts"
 
-const initialPlayer = () =>
-  MediaPlayerStates.initial.Player.from((player) =>
-    player
-      .transport.from((transport) => transport.Empty.from())
-      .settings.from((settings) =>
-        settings.Audible.from({
-          volume: initialAudioSettings.volume,
-          playbackRate: initialAudioSettings.playbackRate
-        })
-      )
-  )
-
 export const MediaPlayerDefinition = Machine.make({
   id: "MediaPlayer",
   states: MediaPlayerStates.states,
   events: MediaPlayerEvents,
   internalEvents: MediaPlayerInternalEvents,
-  initial: initialPlayer
+  initial: {
+    target: (to) => to.Player.initial(),
+    resolve: ({ target }) =>
+      target.from((player) =>
+        player
+          .transport.from((transport) => transport.Empty.from())
+          .settings.from((settings) =>
+            settings.Audible.from({
+              volume: initialAudioSettings.volume,
+              playbackRate: initialAudioSettings.playbackRate
+            })
+          )
+      )
+  }
 })

--- a/examples/playground/src/examples/media-player/machine.ts
+++ b/examples/playground/src/examples/media-player/machine.ts
@@ -13,175 +13,305 @@ import {
 import { initialPlaybackData, updatePlaybackData } from "./schemas.ts"
 import { MediaPlayer } from "./service.ts"
 
+type Definition = typeof MediaPlayerDefinition
+type States = Machine.Machine.States<Definition>
+type Events = Machine.Machine.Events<Definition>
+type Emits = Machine.Machine.Emits<Definition>
+type InputEvents = Machine.Machine.InputEvents<Definition>
+type ParentEvents = Machine.Machine.ParentEvents<Definition>
+type PlayingStateId = "Player.transport.Ready.Playing"
+type AnalyzeDone = Machine.Machine.InvokeTransition<
+  States,
+  Events,
+  Emits,
+  PlayingStateId,
+  Machine.Machine.InvokeDoneContext<States, Events, Emits, PlayingStateId, void, InputEvents, ParentEvents>
+>
+type AnalyzeSnapshot = Machine.Machine.InvokeTransition<
+  States,
+  Events,
+  Emits,
+  PlayingStateId,
+  Machine.Machine.InvokeSnapshotContext<
+    States,
+    Events,
+    Emits,
+    PlayingStateId,
+    Machine.Machine.LogicStateOf<typeof analyzeAudio>,
+    Machine.Machine.LogicErrorOf<typeof analyzeAudio>,
+    Machine.Machine.LogicOutputOf<typeof analyzeAudio>,
+    InputEvents,
+    ParentEvents
+  >
+>
+
+const analyzeDone: AnalyzeDone = Machine.transition({
+  target: (to) => to.none(),
+  resolve: () => undefined
+})
+
+const analyzeSnapshot: AnalyzeSnapshot = Machine.transition({
+  target: (to) => to.none(),
+  resolve: ({ snapshot }, enqueue) => {
+    const event = loudnessEvent(snapshot.state)
+    if (event !== undefined) enqueue.raise(event)
+    return undefined
+  }
+})
+
 export const MediaPlayerMachine = MediaPlayerDefinition.handle({
   Player: {
     states: {
       transport: {
         on: {
-          SourceSelected: {
-            reenter: true,
-            transition: ({ event, target }) => target.local.Loading.from({ url: event.url })
-          },
+          SourceSelected: Machine.transition({
+            target: (to) => to.local.Loading(),
+            resolve: ({ event, target }) => target.from({ url: event.url }),
+            reenter: true
+          }),
 
-          MediaFailed: ({ event, target }) => target.local.Failed.from({ message: event.message }),
+          MediaFailed: Machine.transition({
+            target: (to) => to.local.Failed(),
+            resolve: ({ event, target }) => target.from({ message: event.message })
+          }),
 
-          OperationFailed: ({ event, target }) => target.local.Failed.from({ message: event.message })
+          OperationFailed: Machine.transition({
+            target: (to) => to.local.Failed(),
+            resolve: ({ event, target }) => target.from({ message: event.message })
+          })
         },
         states: {
           Empty: {},
 
           Loading: {
-            invoke: Machine.invoke({
+            invoke: MediaPlayerDefinition.invoke({
               id: "load-audio",
               effect: ({ state }) => loadAudio(state.url),
-              onDone: ({ target }, enqueue) => {
-                enqueue.raise(MediaPlayerInternalEvents.LoadSucceeded())
-                return target.none()
-              },
-              onFailure: ({ error, target }, enqueue) => {
-                enqueue.raise(MediaPlayerInternalEvents.OperationFailed({ message: error.message }))
-                return target.none()
-              }
+              onDone: Machine.transition({
+                target: (to) => to.none(),
+                resolve: (_, enqueue) => {
+                  enqueue.raise(MediaPlayerInternalEvents.LoadSucceeded())
+                  return undefined
+                }
+              }),
+              onFailure: Machine.transition({
+                target: (to) => to.none(),
+                resolve: ({ error }, enqueue) => {
+                  enqueue.raise(MediaPlayerInternalEvents.OperationFailed({ message: error.message }))
+                  return undefined
+                }
+              })
             }),
             on: {
-              LoadSucceeded: ({ target }) => target.local.Ready.from((ready) => ready.Paused.from(initialPlaybackData))
+              LoadSucceeded: Machine.transition({
+                target: (to) => to.local.Ready(),
+                resolve: ({ target }) => target.from((ready) => ready.Paused.from(initialPlaybackData))
+              })
             }
           },
 
           Ready: {
             states: {
               Paused: {
-                invoke: Machine.invoke({
+                invoke: MediaPlayerDefinition.invoke({
                   id: "pause-audio",
                   effect: () => pauseAudio,
-                  onDone: ({ target }) => target.none(),
-                  onFailure: ({ error, target }, enqueue) => {
-                    enqueue.raise(MediaPlayerInternalEvents.OperationFailed({ message: error.message }))
-                    return target.none()
-                  }
+                  onDone: Machine.transition({
+                    target: (to) => to.none(),
+                    resolve: () => undefined
+                  }),
+                  onFailure: Machine.transition({
+                    target: (to) => to.none(),
+                    resolve: ({ error }, enqueue) => {
+                      enqueue.raise(MediaPlayerInternalEvents.OperationFailed({ message: error.message }))
+                      return undefined
+                    }
+                  })
                 }),
                 on: {
-                  PlayRequested: ({ state, target }) =>
-                    target.local.Playing.from({
-                      ...updatePlaybackData(state, {}),
-                      loudness: null
-                    }),
+                  PlayRequested: Machine.transition({
+                    target: (to) => to.local.Playing(),
+                    resolve: ({ state, target }) =>
+                      target.from({
+                        ...updatePlaybackData(state, {}),
+                        loudness: null
+                      })
+                  }),
 
-                  RestartRequested: ({ state, target }) => target.local.Restarting.from(updatePlaybackData(state, {}))
+                  RestartRequested: Machine.transition({
+                    target: (to) => to.local.Restarting(),
+                    resolve: ({ state, target }) => target.from(updatePlaybackData(state, {}))
+                  })
                 }
               },
 
               Playing: {
                 invoke: [
-                  Machine.invoke({
+                  MediaPlayerDefinition.invoke({
                     id: "play-audio",
                     effect: () => playAudio,
-                    onDone: ({ target }) => target.none(),
-                    onFailure: ({ error, target }, enqueue) => {
-                      enqueue.raise(MediaPlayerInternalEvents.OperationFailed({ message: error.message }))
-                      return target.none()
-                    }
+                    onDone: Machine.transition({
+                      target: (to) => to.none(),
+                      resolve: () => undefined
+                    }),
+                    onFailure: Machine.transition({
+                      target: (to) => to.none(),
+                      resolve: ({ error }, enqueue) => {
+                        enqueue.raise(MediaPlayerInternalEvents.OperationFailed({ message: error.message }))
+                        return undefined
+                      }
+                    })
                   }),
-                  Machine.invoke({
+                  MediaPlayerDefinition.invoke({
                     id: "analyze-audio",
                     address: Machine.childAddress("analyze-audio"),
                     logic: analyzeAudio,
-                    onDone: ({ target }) => target.none(),
-                    onSnapshot: ({ snapshot, target }, enqueue) => {
-                      const event = loudnessEvent(snapshot.state)
-                      if (event !== undefined) enqueue.raise(event)
-                      return target.none()
-                    }
+                    onDone: analyzeDone,
+                    onSnapshot: analyzeSnapshot
                   })
                 ],
                 on: {
-                  PauseRequested: ({ state, target }) => target.local.Paused.from(updatePlaybackData(state, {})),
+                  PauseRequested: Machine.transition({
+                    target: (to) => to.local.Paused(),
+                    resolve: ({ state, target }) => target.from(updatePlaybackData(state, {}))
+                  }),
 
-                  RestartRequested: ({ state, target }) => target.local.Restarting.from(updatePlaybackData(state, {})),
+                  RestartRequested: Machine.transition({
+                    target: (to) => to.local.Restarting(),
+                    resolve: ({ state, target }) => target.from(updatePlaybackData(state, {}))
+                  }),
 
-                  MediaWaiting: ({ state, target }) => target.local.Buffering.from(updatePlaybackData(state, {})),
+                  MediaWaiting: Machine.transition({
+                    target: (to) => to.local.Buffering(),
+                    resolve: ({ state, target }) => target.from(updatePlaybackData(state, {}))
+                  }),
 
-                  PlaybackEnded: ({ event, state, target }) =>
-                    target.local.Ended.from(updatePlaybackData(state, { currentTime: event.currentTime })),
+                  PlaybackEnded: Machine.transition({
+                    target: (to) => to.local.Ended(),
+                    resolve: ({ event, state, target }) =>
+                      target.from(updatePlaybackData(state, { currentTime: event.currentTime }))
+                  }),
 
-                  TimeUpdated: ({ event, state, target }) =>
-                    target.local.Playing.from({
-                      currentTime: event.currentTime,
-                      loudness: state.loudness
-                    }),
+                  TimeUpdated: Machine.transition({
+                    target: (to) => to.local.Playing(),
+                    resolve: ({ event, state, target }) =>
+                      target.from({
+                        currentTime: event.currentTime,
+                        loudness: state.loudness
+                      })
+                  }),
 
-                  LoudnessMeasured: ({ event, state, target }) =>
-                    target.local.Playing.from({
-                      currentTime: state.currentTime,
-                      loudness: {
-                        rms: event.rms,
-                        peak: event.peak,
-                        decibels: event.decibels
-                      }
-                    })
+                  LoudnessMeasured: Machine.transition({
+                    target: (to) => to.local.Playing(),
+                    resolve: ({ event, state, target }) =>
+                      target.from({
+                        currentTime: state.currentTime,
+                        loudness: {
+                          rms: event.rms,
+                          peak: event.peak,
+                          decibels: event.decibels
+                        }
+                      })
+                  })
                 }
               },
 
               Buffering: {
                 on: {
-                  MediaCanPlay: ({ state, target }) =>
-                    target.local.Playing.from({
-                      ...updatePlaybackData(state, {}),
-                      loudness: null
-                    }),
+                  MediaCanPlay: Machine.transition({
+                    target: (to) => to.local.Playing(),
+                    resolve: ({ state, target }) =>
+                      target.from({
+                        ...updatePlaybackData(state, {}),
+                        loudness: null
+                      })
+                  }),
 
-                  PauseRequested: ({ state, target }) => target.local.Paused.from(updatePlaybackData(state, {})),
+                  PauseRequested: Machine.transition({
+                    target: (to) => to.local.Paused(),
+                    resolve: ({ state, target }) => target.from(updatePlaybackData(state, {}))
+                  }),
 
-                  RestartRequested: ({ state, target }) => target.local.Restarting.from(updatePlaybackData(state, {})),
+                  RestartRequested: Machine.transition({
+                    target: (to) => to.local.Restarting(),
+                    resolve: ({ state, target }) => target.from(updatePlaybackData(state, {}))
+                  }),
 
-                  PlaybackEnded: ({ event, state, target }) =>
-                    target.local.Ended.from(updatePlaybackData(state, { currentTime: event.currentTime })),
+                  PlaybackEnded: Machine.transition({
+                    target: (to) => to.local.Ended(),
+                    resolve: ({ event, state, target }) =>
+                      target.from(updatePlaybackData(state, { currentTime: event.currentTime }))
+                  }),
 
-                  TimeUpdated: ({ event, state, target }) =>
-                    target.local.Buffering.from(updatePlaybackData(state, { currentTime: event.currentTime }))
+                  TimeUpdated: Machine.transition({
+                    target: (to) => to.local.Buffering(),
+                    resolve: ({ event, state, target }) =>
+                      target.from(updatePlaybackData(state, { currentTime: event.currentTime }))
+                  })
                 }
               },
 
               Restarting: {
-                invoke: Machine.invoke({
+                invoke: MediaPlayerDefinition.invoke({
                   id: "restart-audio",
                   effect: () => restartAudio,
-                  onDone: ({ target }, enqueue) => {
-                    enqueue.raise(MediaPlayerInternalEvents.RestartSucceeded())
-                    return target.none()
-                  },
-                  onFailure: ({ error, target }, enqueue) => {
-                    enqueue.raise(MediaPlayerInternalEvents.OperationFailed({ message: error.message }))
-                    return target.none()
-                  }
+                  onDone: Machine.transition({
+                    target: (to) => to.none(),
+                    resolve: (_, enqueue) => {
+                      enqueue.raise(MediaPlayerInternalEvents.RestartSucceeded())
+                      return undefined
+                    }
+                  }),
+                  onFailure: Machine.transition({
+                    target: (to) => to.none(),
+                    resolve: ({ error }, enqueue) => {
+                      enqueue.raise(MediaPlayerInternalEvents.OperationFailed({ message: error.message }))
+                      return undefined
+                    }
+                  })
                 }),
                 on: {
-                  RestartSucceeded: ({ target }) => target.local.Playing.from({ currentTime: 0, loudness: null }),
+                  RestartSucceeded: Machine.transition({
+                    target: (to) => to.local.Playing(),
+                    resolve: ({ target }) => target.from({ currentTime: 0, loudness: null })
+                  }),
 
-                  TimeUpdated: ({ event, state, target }) =>
-                    target.local.Restarting.from(updatePlaybackData(state, { currentTime: event.currentTime }))
+                  TimeUpdated: Machine.transition({
+                    target: (to) => to.local.Restarting(),
+                    resolve: ({ event, state, target }) =>
+                      target.from(updatePlaybackData(state, { currentTime: event.currentTime }))
+                  })
                 }
               },
 
               Ended: {
                 on: {
-                  PlayRequested: ({ state, target }) => target.local.Restarting.from(updatePlaybackData(state, {})),
+                  PlayRequested: Machine.transition({
+                    target: (to) => to.local.Restarting(),
+                    resolve: ({ state, target }) => target.from(updatePlaybackData(state, {}))
+                  }),
 
-                  RestartRequested: ({ state, target }) => target.local.Restarting.from(updatePlaybackData(state, {}))
+                  RestartRequested: Machine.transition({
+                    target: (to) => to.local.Restarting(),
+                    resolve: ({ state, target }) => target.from(updatePlaybackData(state, {}))
+                  })
                 }
               }
             }
           },
 
           Failed: {
-            invoke: Machine.invoke({
+            invoke: MediaPlayerDefinition.invoke({
               id: "report-error",
               effect: ({ state }) =>
                 Effect.gen(function*() {
                   const mediaPlayer = yield* MediaPlayer
                   yield* mediaPlayer.reportError(state.message)
                 }),
-              onDone: ({ target }) => target.none()
+              onDone: Machine.transition({
+                target: (to) => to.none(),
+                resolve: () => undefined
+              })
             })
           }
         }
@@ -190,68 +320,84 @@ export const MediaPlayerMachine = MediaPlayerDefinition.handle({
       settings: {
         states: {
           Audible: {
-            invoke: Machine.invoke({
+            invoke: MediaPlayerDefinition.invoke({
               id: "apply-audio-settings",
               effect: ({ state }) => applyAudioSettings(state, false),
-              onDone: ({ target }) => target.none()
+              onDone: Machine.transition({
+                target: (to) => to.none(),
+                resolve: () => undefined
+              })
             }),
             on: {
-              VolumeChanged: {
-                reenter: true,
-                transition: ({ event, state, target }) =>
-                  target.local.Audible.from({
+              VolumeChanged: Machine.transition({
+                target: (to) => to.local.Audible(),
+                resolve: ({ event, state, target }) =>
+                  target.from({
                     volume: event.volume,
                     playbackRate: state.playbackRate
-                  })
-              },
+                  }),
+                reenter: true
+              }),
 
-              PlaybackRateChanged: {
-                reenter: true,
-                transition: ({ event, state, target }) =>
-                  target.local.Audible.from({
+              PlaybackRateChanged: Machine.transition({
+                target: (to) => to.local.Audible(),
+                resolve: ({ event, state, target }) =>
+                  target.from({
                     volume: state.volume,
                     playbackRate: event.playbackRate
-                  })
-              },
+                  }),
+                reenter: true
+              }),
 
-              MuteRequested: ({ state, target }) =>
-                target.local.Muted.from({
-                  volume: state.volume,
-                  playbackRate: state.playbackRate
-                })
+              MuteRequested: Machine.transition({
+                target: (to) => to.local.Muted(),
+                resolve: ({ state, target }) =>
+                  target.from({
+                    volume: state.volume,
+                    playbackRate: state.playbackRate
+                  })
+              })
             }
           },
 
           Muted: {
-            invoke: Machine.invoke({
+            invoke: MediaPlayerDefinition.invoke({
               id: "apply-audio-settings",
               effect: ({ state }) => applyAudioSettings(state, true),
-              onDone: ({ target }) => target.none()
+              onDone: Machine.transition({
+                target: (to) => to.none(),
+                resolve: () => undefined
+              })
             }),
             on: {
-              VolumeChanged: {
-                reenter: true,
-                transition: ({ event, state, target }) =>
-                  target.local.Muted.from({
+              VolumeChanged: Machine.transition({
+                target: (to) => to.local.Muted(),
+                resolve: ({ event, state, target }) =>
+                  target.from({
                     volume: event.volume,
                     playbackRate: state.playbackRate
-                  })
-              },
+                  }),
+                reenter: true
+              }),
 
-              PlaybackRateChanged: {
-                reenter: true,
-                transition: ({ event, state, target }) =>
-                  target.local.Muted.from({
+              PlaybackRateChanged: Machine.transition({
+                target: (to) => to.local.Muted(),
+                resolve: ({ event, state, target }) =>
+                  target.from({
                     volume: state.volume,
                     playbackRate: event.playbackRate
-                  })
-              },
+                  }),
+                reenter: true
+              }),
 
-              UnmuteRequested: ({ state, target }) =>
-                target.local.Audible.from({
-                  volume: state.volume,
-                  playbackRate: state.playbackRate
-                })
+              UnmuteRequested: Machine.transition({
+                target: (to) => to.local.Audible(),
+                resolve: ({ state, target }) =>
+                  target.from({
+                    volume: state.volume,
+                    playbackRate: state.playbackRate
+                  })
+              })
             }
           }
         }

--- a/examples/playground/src/examples/microwave/machine.ts
+++ b/examples/playground/src/examples/microwave/machine.ts
@@ -1,5 +1,5 @@
 import { Machine } from "@typeonce/effect-machine"
-import { Schema } from "effect"
+import { Option, Schema } from "effect"
 
 export const MicrowaveState = Schema.TaggedUnion({
   Cooking: { elapsedSeconds: Schema.Number }
@@ -39,12 +39,15 @@ const definition = Machine.make({
   id: "Microwave",
   states: MicrowaveStates.states,
   events: MicrowaveEvents,
-  initial: () =>
-    MicrowaveStates.initial.Oven.from((oven) =>
-      oven
-        .engine.from((engine) => engine.Idle.from())
-        .door.from((door) => door.Closed.from())
-    )
+  initial: {
+    target: (to) => to.Oven.initial(),
+    resolve: ({ target }) =>
+      target.from((oven) =>
+        oven
+          .engine.from((engine) => engine.Idle.from())
+          .door.from((door) => door.Closed.from())
+      )
+  }
 })
 
 export const MicrowaveMachine = definition.handle({
@@ -54,21 +57,38 @@ export const MicrowaveMachine = definition.handle({
         states: {
           Idle: {
             on: {
-              PowerPressed: ({ snapshot, target }) =>
-                MicrowaveStates.matches(snapshot, "Oven.door.Closed")
-                  ? target.local.Cooking.from({ elapsedSeconds: 0 })
-                  : target.none()
+              PowerPressed: Machine.transition({
+                cases: [{
+                  title: "door closed",
+                  when: ({ snapshot }) =>
+                    MicrowaveStates.matches(snapshot, "Oven.door.Closed")
+                      ? Option.some(undefined)
+                      : Option.none(),
+                  target: (to) => to.local.Cooking(),
+                  resolve: ({ target }) => target.from({ elapsedSeconds: 0 })
+                }],
+                otherwise: { target: (to) => to.none(), resolve: () => undefined }
+              })
             }
           },
           Cooking: {
             invoke: Machine.invoke({
               id: "cooking-second",
               after: "1 second",
-              onDone: ({ state, target }) => target.local.Cooking.from({ elapsedSeconds: state.elapsedSeconds + 1 })
+              onDone: Machine.transition({
+                target: (to) => to.local.Cooking(),
+                resolve: ({ state, target }) => target.from({ elapsedSeconds: state.elapsedSeconds + 1 })
+              })
             }),
             on: {
-              PowerPressed: ({ target }) => target.local.Idle.from(),
-              DoorOpened: ({ target }) => target.local.Idle.from()
+              PowerPressed: Machine.transition({
+                target: (to) => to.local.Idle(),
+                resolve: ({ target }) => target.from()
+              }),
+              DoorOpened: Machine.transition({
+                target: (to) => to.local.Idle(),
+                resolve: ({ target }) => target.from()
+              })
             }
           }
         }
@@ -77,12 +97,18 @@ export const MicrowaveMachine = definition.handle({
         states: {
           Closed: {
             on: {
-              DoorOpened: ({ target }) => target.local.Open.from()
+              DoorOpened: Machine.transition({
+                target: (to) => to.local.Open(),
+                resolve: ({ target }) => target.from()
+              })
             }
           },
           Open: {
             on: {
-              DoorClosed: ({ target }) => target.local.Closed.from()
+              DoorClosed: Machine.transition({
+                target: (to) => to.local.Closed(),
+                resolve: ({ target }) => target.from()
+              })
             }
           }
         }

--- a/examples/playground/src/examples/traffic-light/machine.ts
+++ b/examples/playground/src/examples/traffic-light/machine.ts
@@ -25,7 +25,10 @@ const definition = Machine.make({
   id: "TrafficLight",
   states: TrafficLightStates.states,
   events: TrafficLightEvents,
-  initial: () => TrafficLightStates.initial.Red.from()
+  initial: {
+    target: (to) => to.Red(),
+    resolve: ({ target }) => target.from()
+  }
 })
 
 export const TrafficLightMachine = definition.handle({
@@ -33,43 +36,65 @@ export const TrafficLightMachine = definition.handle({
     invoke: Machine.invoke({
       id: "red-timer",
       after: trafficLightDurations.Red,
-      onDone: ({ target }) => target.full.RedYellow.from()
+      onDone: Machine.transition({
+        target: (to) => to.full.RedYellow(),
+        resolve: ({ target }) => target.from()
+      })
     }),
     on: {
-      Reset: {
-        reenter: true,
-        transition: ({ target }) => target.full.Red.from()
-      }
+      Reset: Machine.transition({
+        target: (to) => to.full.Red(),
+        resolve: ({ target }) => target.from(),
+        reenter: true
+      })
     }
   },
   RedYellow: {
     invoke: Machine.invoke({
       id: "red-yellow-timer",
       after: trafficLightDurations.RedYellow,
-      onDone: ({ target }) => target.full.Green.from()
+      onDone: Machine.transition({
+        target: (to) => to.full.Green(),
+        resolve: ({ target }) => target.from()
+      })
     }),
     on: {
-      Reset: ({ target }) => target.full.Red.from()
+      Reset: Machine.transition({
+        target: (to) => to.full.Red(),
+        resolve: ({ target }) => target.from()
+      })
     }
   },
   Green: {
     invoke: Machine.invoke({
       id: "green-timer",
       after: trafficLightDurations.Green,
-      onDone: ({ target }) => target.full.Yellow.from()
+      onDone: Machine.transition({
+        target: (to) => to.full.Yellow(),
+        resolve: ({ target }) => target.from()
+      })
     }),
     on: {
-      Reset: ({ target }) => target.full.Red.from()
+      Reset: Machine.transition({
+        target: (to) => to.full.Red(),
+        resolve: ({ target }) => target.from()
+      })
     }
   },
   Yellow: {
     invoke: Machine.invoke({
       id: "yellow-timer",
       after: trafficLightDurations.Yellow,
-      onDone: ({ target }) => target.full.Red.from()
+      onDone: Machine.transition({
+        target: (to) => to.full.Red(),
+        resolve: ({ target }) => target.from()
+      })
     }),
     on: {
-      Reset: ({ target }) => target.full.Red.from()
+      Reset: Machine.transition({
+        target: (to) => to.full.Red(),
+        resolve: ({ target }) => target.from()
+      })
     }
   }
 })

--- a/examples/playground/src/examples/turnstile/machine.ts
+++ b/examples/playground/src/examples/turnstile/machine.ts
@@ -17,18 +17,27 @@ const definition = Machine.make({
   id: "Turnstile",
   states: TurnstileStates.states,
   events: TurnstileEvents,
-  initial: () => TurnstileStates.initial.Locked.from()
+  initial: {
+    target: (to) => to.Locked(),
+    resolve: ({ target }) => target.from()
+  }
 })
 
 export const TurnstileMachine = definition.handle({
   Locked: {
     on: {
-      CoinInserted: ({ target }) => target.full.Unlocked.from()
+      CoinInserted: Machine.transition({
+        target: (to) => to.full.Unlocked(),
+        resolve: ({ target }) => target.from()
+      })
     }
   },
   Unlocked: {
     on: {
-      GatePushed: ({ target }) => target.full.Locked.from()
+      GatePushed: Machine.transition({
+        target: (to) => to.full.Locked(),
+        resolve: ({ target }) => target.from()
+      })
     }
   }
 })

--- a/examples/playground/src/examples/worker-tabs/machine.ts
+++ b/examples/playground/src/examples/worker-tabs/machine.ts
@@ -1,5 +1,5 @@
 import { Machine } from "@typeonce/effect-machine"
-import { Schema } from "effect"
+import { Option, Schema } from "effect"
 import { type SharedEvent, SharedMachineEvents } from "./protocol.ts"
 
 export type { SharedEvent } from "./protocol.ts"
@@ -15,7 +15,10 @@ const definition = Machine.make({
   id: "WorkerHostedMachine",
   states: SharedMachineStates.states,
   events: SharedMachineEvents,
-  initial: () => SharedMachineStates.initial.Idle.from({ count: 0 })
+  initial: {
+    target: (to) => to.Idle(),
+    resolve: ({ target }) => target.from({ count: 0 })
+  }
 })
 
 // Worker and BroadcastChannel messages need decoded, cloneable data rather
@@ -34,23 +37,54 @@ export const SharedTransportEvents = {
 export const SharedMachine = definition.handle({
   Idle: {
     on: {
-      Started: ({ state, target }) => target.full.Active.from({ count: state.count }),
-      Reset: ({ target }) => target.full.Idle.from({ count: 0 }),
-      Synchronized: ({ event, target }) =>
-        event.active
-          ? target.full.Active.from({ count: event.count })
-          : target.full.Idle.from({ count: event.count })
+      Started: Machine.transition({
+        target: (to) => to.full.Active(),
+        resolve: ({ state, target }) => target.from({ count: state.count })
+      }),
+      Reset: Machine.transition({
+        target: (to) => to.full.Idle(),
+        resolve: ({ target }) => target.from({ count: 0 })
+      }),
+      Synchronized: Machine.transition({
+        cases: [{
+          title: "active",
+          when: ({ event }) => event.active ? Option.some(event.count) : Option.none(),
+          target: (to) => to.full.Active(),
+          resolve: ({ match, target }) => target.from({ count: match })
+        }],
+        otherwise: {
+          target: (to) => to.full.Idle(),
+          resolve: ({ event, target }) => target.from({ count: event.count })
+        }
+      })
     }
   },
   Active: {
     on: {
-      Incremented: ({ state, target }) => target.full.Active.from({ count: state.count + 1 }),
-      Reset: ({ target }) => target.full.Active.from({ count: 0 }),
-      Stopped: ({ state, target }) => target.full.Idle.from({ count: state.count }),
-      Synchronized: ({ event, target }) =>
-        event.active
-          ? target.full.Active.from({ count: event.count })
-          : target.full.Idle.from({ count: event.count })
+      Incremented: Machine.transition({
+        target: (to) => to.full.Active(),
+        resolve: ({ state, target }) => target.from({ count: state.count + 1 })
+      }),
+      Reset: Machine.transition({
+        target: (to) => to.full.Active(),
+        resolve: ({ target }) => target.from({ count: 0 })
+      }),
+      Stopped: Machine.transition({
+        target: (to) => to.full.Idle(),
+        resolve: ({ state, target }) => target.from({ count: state.count })
+      }),
+      Synchronized: Machine.transition({
+        cases: [{
+          title: "active",
+          when: ({ event }) => event.active ? Option.some(event.count) : Option.none(),
+          target: (to) => to.full.Active(),
+          resolve: ({ match, target }) => target.from({ count: match })
+        }],
+        otherwise: {
+          target: (to) => to.full.Idle(),
+          resolve: ({ event, target }) => target.from({ count: event.count })
+        }
+      })
     }
   }
 })

--- a/examples/pokemon/src/machine.ts
+++ b/examples/pokemon/src/machine.ts
@@ -15,37 +15,63 @@ export const States = Machine.defineStates({ Loading: {}, ActiveTeam, Failed: {}
 export const SelectionChild = Machine.child("selection", SelectionMachine)
 export const ReplaceChild = Machine.child("replace", ReplaceMachine)
 
-const machine = Machine.make({
+const definition = Machine.make({
   states: States.states,
   events: TeamEvents,
-  initial: () => States.initial.Loading.from()
-}).handle({
+  initial: {
+    target: (to) => to.Loading(),
+    resolve: ({ target }) => target.from()
+  }
+})
+
+const machine = definition.handle({
   Loading: {
-    invoke: Machine.invoke({
+    invoke: definition.invoke({
       id: "load-team",
       effect: () =>
         Effect.gen(function*() {
           const service = yield* PokemonService
           return yield* service.getRandomTeam()
         }),
-      onDone: ({ output, target }) => target.full.ActiveTeam.from({ team: output }),
-      onFailure: ({ target }) => target.full.Failed.from()
+      onDone: Machine.transition({
+        target: (to) => to.full.ActiveTeam(),
+        resolve: ({ output, target }) => target.from({ team: output })
+      }),
+      onFailure: Machine.transition({
+        target: (to) => to.full.Failed(),
+        resolve: ({ target }) => target.from()
+      })
     })
   },
   ActiveTeam: {
     invoke: [
-      Machine.invoke({
+      definition.invoke({
         child: SelectionChild,
-        onDone: ({ target }) => target.none(),
-        onFailure: ({ target }) => target.full.Failed.from()
+        onDone: Machine.transition({
+          target: (to) => to.none(),
+          resolve: () => undefined
+        }),
+        onFailure: Machine.transition({
+          target: (to) => to.full.Failed(),
+          resolve: ({ target }) => target.from()
+        })
       }),
-      Machine.invoke({ child: ReplaceChild, onFailure: ({ target }) => target.full.Failed.from() })
+      definition.invoke({
+        child: ReplaceChild,
+        onFailure: Machine.transition({
+          target: (to) => to.full.Failed(),
+          resolve: ({ target }) => target.from()
+        })
+      })
     ],
     on: {
-      ReplaceInTeam: ({ event, target, state }) =>
-        target.full.ActiveTeam.from({
-          team: state.team.map((pokemon) => (pokemon.id === event.id ? event.pokemon : pokemon))
-        })
+      ReplaceInTeam: Machine.transition({
+        target: (to) => to.full.ActiveTeam(),
+        resolve: ({ event, target, state }) =>
+          target.from({
+            team: state.team.map((pokemon) => (pokemon.id === event.id ? event.pokemon : pokemon))
+          })
+      })
     }
   },
   Failed: {}

--- a/examples/pokemon/src/machines/replace.ts
+++ b/examples/pokemon/src/machines/replace.ts
@@ -36,30 +36,45 @@ export const ReplaceMachine = Machine.make({
   events: ReplaceEvents,
   internalEvents: ReplaceInternalEvents,
   parentEvents: TeamEvents,
-  initial: () => ReplaceStates.initial.Idle.from()
+  initial: {
+    target: (to) => to.Idle(),
+    resolve: ({ target }) => target.from()
+  }
 }).handle({
   Idle: {
     on: {
-      ReplacePokemon: ({ event, target }) => target.full.Replacing.from({ id: event.id })
+      ReplacePokemon: Machine.transition({
+        target: (to) => to.full.Replacing(),
+        resolve: ({ event, target }) => target.from({ id: event.id })
+      })
     }
   },
   Replacing: {
     invoke: Machine.invoke({
       id: "replaceWithRandom",
       effect: () => replaceWithRandom,
-      onDone: ({ output, target }, enqueue) => {
-        enqueue.raise(ReplaceInternalEvents.Replaced({ pokemon: output.pokemon }))
-        return target.none()
-      },
-      onFailure: ({ target }) => target.full.Idle.from()
+      onDone: Machine.transition({
+        target: (to) => to.none(),
+        resolve: ({ output }, enqueue) => {
+          enqueue.raise(ReplaceInternalEvents.Replaced({ pokemon: output.pokemon }))
+          return undefined
+        }
+      }),
+      onFailure: Machine.transition({
+        target: (to) => to.full.Idle(),
+        resolve: ({ target }) => target.from()
+      })
     }),
     on: {
-      Replaced: ({ event, parent, state, target }, enqueue) => {
-        if (parent !== undefined) {
-          enqueue.sendTo(parent, TeamEvents.ReplaceInTeam({ id: state.id, pokemon: event.pokemon }))
+      Replaced: Machine.transition({
+        target: (to) => to.full.Idle(),
+        resolve: ({ event, parent, state, target }, enqueue) => {
+          if (parent !== undefined) {
+            enqueue.sendTo(parent, TeamEvents.ReplaceInTeam({ id: state.id, pokemon: event.pokemon }))
+          }
+          return target.from()
         }
-        return target.full.Idle.from()
-      }
+      })
     }
   }
 })

--- a/examples/pokemon/src/machines/selection.ts
+++ b/examples/pokemon/src/machines/selection.ts
@@ -69,55 +69,81 @@ export const SelectionStates = Machine.defineStates({
 })
 
 export const SelectionEvents = Machine.events(SelectPokemon, UpdateSearchText, SearchResult, ReplacePokemon)
-export const SelectionMachine = Machine.make({
+const definition = Machine.make({
   states: SelectionStates.states,
   events: SelectionEvents,
   parentEvents: TeamEvents,
-  initial: () =>
-    SelectionStates.initial.form.from((form) =>
-      form
-        .search.from({ searchText: "" }, (search) => search.NoPokemon.from())
-        .selection.from((selection) => selection.Unselected.from())
-    )
-}).handle({
+  initial: {
+    target: (to) => to.form.initial(),
+    resolve: ({ target }) =>
+      target.from((form) =>
+        form
+          .search.from({ searchText: "" }, (search) => search.NoPokemon.from())
+          .selection.from((selection) => selection.Unselected.from())
+      )
+  }
+})
+
+export const SelectionMachine = definition.handle({
   form: {
     states: {
       search: {
         on: {
-          UpdateSearchText: {
-            reenter: true,
-            transition: ({ event, target }) =>
-              target.local.with.from({ searchText: event.value }, (search) => search.Searching.from())
-          }
+          UpdateSearchText: Machine.transition({
+            target: (to) => to.local.with(),
+            resolve: ({ event, target }) =>
+              target.from({ searchText: event.value }, (search) => search.Searching.from()),
+            reenter: true
+          })
         },
         states: {
           WithPokemon: {
             on: {
-              ReplacePokemon: ({ event, parent, state, target }, enqueue) => {
-                if (parent !== undefined) {
-                  enqueue.sendTo(parent, TeamEvents.ReplaceInTeam({ id: event.id, pokemon: state.pokemon }))
+              ReplacePokemon: Machine.transition({
+                target: (to) => to.full.form(),
+                resolve: ({ event, parent, state, target }, enqueue) => {
+                  if (parent !== undefined) {
+                    enqueue.sendTo(parent, TeamEvents.ReplaceInTeam({ id: event.id, pokemon: state.pokemon }))
+                  }
+                  return target.from((form) =>
+                    form
+                      .search.from({ searchText: "" }, (search) => search.NoPokemon.from())
+                      .selection.from((selection) => selection.Unselected.from())
+                  )
                 }
-                return target.full.form.from((form) =>
-                  form
-                    .search.from({ searchText: "" }, (search) => search.NoPokemon.from())
-                    .selection.from((selection) => selection.Unselected.from())
-                )
-              }
+              })
             }
           },
           Searching: {
-            invoke: Machine.invoke({
+            invoke: definition.invoke({
               id: "search",
               effect: ({ ancestors }) => searchPokemon(ancestors["form.search"].searchText),
-              onDone: ({ output, target }) =>
-                output.result.pipe(
-                  Option.match({
-                    onNone: () => target.local.NoPokemon.from(),
-                    onSome: (pokemon) => target.local.WithPokemon.from({ pokemon })
-                  })
-                ),
-              onFailure: ({ target }) => target.local.NoPokemon.from()
-            })
+              onDone: Machine.transition({
+                target: (to) => to.none(),
+                resolve: ({ output }, enqueue) => {
+                  enqueue.raise(output)
+                  return undefined
+                }
+              }),
+              onFailure: Machine.transition({
+                target: (to) => to.local.NoPokemon(),
+                resolve: ({ target }) => target.from()
+              })
+            }),
+            on: {
+              SearchResult: Machine.transition({
+                cases: [{
+                  title: "found",
+                  when: ({ event }) => event.result,
+                  target: (to) => to.local.WithPokemon(),
+                  resolve: ({ match, target }) => target.from({ pokemon: match })
+                }],
+                otherwise: {
+                  target: (to) => to.local.NoPokemon(),
+                  resolve: ({ target }) => target.from()
+                }
+              })
+            }
           }
         }
       },
@@ -125,15 +151,26 @@ export const SelectionMachine = Machine.make({
         states: {
           Unselected: {
             on: {
-              SelectPokemon: ({ event, target }) => target.local.Selected.from({ id: event.id })
+              SelectPokemon: Machine.transition({
+                target: (to) => to.local.Selected(),
+                resolve: ({ event, target }) => target.from({ id: event.id })
+              })
             }
           },
           Selected: {
             on: {
-              SelectPokemon: ({ event, target, state }) =>
-                state.id === event.id
-                  ? target.local.Unselected.from()
-                  : target.local.Selected.from({ id: event.id })
+              SelectPokemon: Machine.transition({
+                cases: [{
+                  title: "already selected",
+                  when: ({ event, state }) => state.id === event.id ? Option.some(undefined) : Option.none(),
+                  target: (to) => to.local.Unselected(),
+                  resolve: ({ target }) => target.from()
+                }],
+                otherwise: {
+                  target: (to) => to.local.Selected(),
+                  resolve: ({ event, target }) => target.from({ id: event.id })
+                }
+              })
             }
           }
         }

--- a/perf/runtime/counter.mjs
+++ b/perf/runtime/counter.mjs
@@ -50,13 +50,21 @@ export const counterMachine = Machine.make({
   id: "RuntimeBenchmarkCounter",
   states: CounterStates.states,
   events: benchmarkApi.events(CounterEvent.cases.Increment, CounterEvent.cases.Finish),
-  initial: () => CounterStates.initial.Count.from({ value: 0 })
+  initial: benchmarkApi.initial({
+    target: (to) => to.Count(),
+    resolve: ({ target }) => target(CounterState.cases.Count.make({ value: 0 }))
+  }, () => CounterStates.initial.Count.from({ value: 0 }))
 }).handle({
   Count: {
     on: {
-      Increment: ({ state, target }) =>
-        target.full.Count.from({ value: state.value + 1 }),
-      Finish: ({ state, target }) => target.full.Done.from({ value: state.value })
+      Increment: benchmarkApi.transition({
+        target: (to) => to.full.Count(),
+        resolve: ({ state, target }) => target.from({ value: state.value + 1 })
+      }, ({ state, target }) => target.full.Count.from({ value: state.value + 1 })),
+      Finish: benchmarkApi.transition({
+        target: (to) => to.full.Done(),
+        resolve: ({ state, target }) => target.from({ value: state.value })
+      }, ({ state, target }) => target.full.Done.from({ value: state.value }))
     }
   },
   Done: {
@@ -71,7 +79,10 @@ const counterParentMachine = Machine.make({
   id: "RuntimeBenchmarkCounterParent",
   states: ParentStates.states,
   events: benchmarkApi.events(),
-  initial: () => ParentStates.initial.Active.from()
+  initial: benchmarkApi.initial({
+    target: (to) => to.Active(),
+    resolve: ({ target }) => target.from()
+  }, () => ParentStates.initial.Active.from())
 }).handle({
   Active: {
     invoke: benchmarkApi.invokeChild({ child: CounterChild, onDone: benchmarkApi.targetless })
@@ -82,7 +93,10 @@ const counterSnapshotParentMachine = Machine.make({
   id: "RuntimeBenchmarkSnapshotCounterParent",
   states: ParentStates.states,
   events: benchmarkApi.events(),
-  initial: () => ParentStates.initial.Active.from()
+  initial: benchmarkApi.initial({
+    target: (to) => to.Active(),
+    resolve: ({ target }) => target.from()
+  }, () => ParentStates.initial.Active.from())
 }).handle({
   Active: {
     invoke: benchmarkApi.invokeChild({
@@ -125,19 +139,26 @@ const hierarchicalCounterMachine = Machine.make({
   id: "RuntimeBenchmarkHierarchicalCounter",
   states: HierarchicalStates.states,
   events: benchmarkApi.events(HierarchicalEvent.cases.Increment, HierarchicalEvent.cases.Finish),
-  initial: () =>
+  initial: benchmarkApi.initial({
+    target: (to) => to.Active.initial(),
+    resolve: ({ target }) => target.from((active) => active.Count.from({ value: 0 }))
+  }, () =>
     HierarchicalStates.initial.Active.from(
       (active) => active.Count.from({ value: 0 })
-    )
+    ))
 }).handle({
   Active: {
     states: {
       Count: {
         on: {
-          Increment: ({ state, target }) =>
-            target.local.Count.from({ value: state.value + 1 }),
-          Finish: ({ state, target }) =>
-            target.full.Complete.from({ value: state.value })
+          Increment: benchmarkApi.transition({
+            target: (to) => to.local.Count(),
+            resolve: ({ state, target }) => target.from({ value: state.value + 1 })
+          }, ({ state, target }) => target.local.Count.from({ value: state.value + 1 })),
+          Finish: benchmarkApi.transition({
+            target: (to) => to.full.Complete(),
+            resolve: ({ state, target }) => target.from({ value: state.value })
+          }, ({ state, target }) => target.full.Complete.from({ value: state.value }))
         }
       }
     }
@@ -174,32 +195,48 @@ const parallelCounterMachine = Machine.make({
   id: "RuntimeBenchmarkParallelCounter",
   states: ParallelStates.states,
   events: benchmarkApi.events(HierarchicalEvent.cases.IncrementLeft, HierarchicalEvent.cases.IncrementRight, HierarchicalEvent.cases.Finish),
-  initial: () =>
+  initial: benchmarkApi.initial({
+    target: (to) => to.Active.initial(),
+    resolve: ({ target }) =>
+      target.from((active) =>
+        active
+          .Left.from({ value: 0 })
+          .Right.from({ value: 0 }))
+  }, () =>
     ParallelStates.initial.Active.from(
       (active) =>
         active
           .Left.from({ value: 0 })
           .Right.from({ value: 0 })
-    )
+    ))
 }).handle({
   Active: {
     on: {
-      Finish: ({ snapshot, target }) =>
-        target.full.Complete.from({
+      Finish: benchmarkApi.transition({
+        target: (to) => to.full.Complete(),
+        resolve: ({ snapshot, target }) => target.from({
           value: snapshot.states.Left.value.value + snapshot.states.Right.value.value
         })
+      }, ({ snapshot, target }) =>
+        target.full.Complete.from({
+          value: snapshot.states.Left.value.value + snapshot.states.Right.value.value
+        }))
     },
     states: {
       Left: {
         on: {
-          IncrementLeft: ({ state, target }) =>
-            target.branch.Active.Left.from({ value: state.value + 1 })
+          IncrementLeft: benchmarkApi.transition({
+            target: (to) => to.branch.Active.Left(),
+            resolve: ({ state, target }) => target.from({ value: state.value + 1 })
+          }, ({ state, target }) => target.branch.Active.Left.from({ value: state.value + 1 }))
         }
       },
       Right: {
         on: {
-          IncrementRight: ({ state, target }) =>
-            target.branch.Active.Right.from({ value: state.value + 1 })
+          IncrementRight: benchmarkApi.transition({
+            target: (to) => to.branch.Active.Right(),
+            resolve: ({ state, target }) => target.from({ value: state.value + 1 })
+          }, ({ state, target }) => target.branch.Active.Right.from({ value: state.value + 1 }))
         }
       }
     }

--- a/perf/runtime/effect-machine-compatibility.mjs
+++ b/perf/runtime/effect-machine-compatibility.mjs
@@ -5,21 +5,32 @@
  * base and head packages. Public API migrations therefore belong at this one
  * capability boundary instead of leaking version checks into benchmark cases.
  */
-export const makeEffectMachineBenchmarkApi = (Machine) => ({
-  events: typeof Machine.event === "function"
-    ? (...schemas) => schemas
-    : (...schemas) => Machine.events(...schemas),
-  targetless: ({ target }) => typeof target.none === "function" ? target.none() : undefined,
-  invokeChild: typeof Machine.invokeMachine === "function"
-    ? ({ onSnapshot, onFailure, ...config }) => {
-      if (onFailure !== undefined) {
-        throw new Error("The legacy child invocation API cannot handle failures as parent transitions")
-      }
+export const makeEffectMachineBenchmarkApi = (Machine) => {
+  // The legacy process constructor takes `(initial, transition)`. The static
+  // definition constructor is deliberately unary and returns its config.
+  const hasStaticTransitions = typeof Machine.transition === "function" && Machine.transition.length === 1
+  const targetless = ({ target }) => typeof target.none === "function" ? target.none() : undefined
 
-      return Machine.invokeMachine({
-        ...config,
-        ...(onSnapshot === undefined ? {} : { snapshot: onSnapshot })
-      })
-    }
-    : (config) => Machine.invoke(config)
-})
+  return {
+    events: typeof Machine.event === "function"
+      ? (...schemas) => schemas
+      : (...schemas) => Machine.events(...schemas),
+    initial: (definition, legacy) => hasStaticTransitions ? definition : legacy,
+    transition: (definition, legacy) => hasStaticTransitions ? Machine.transition(definition) : legacy,
+    targetless: hasStaticTransitions
+      ? Machine.transition({ target: (to) => to.none(), resolve: () => undefined })
+      : targetless,
+    invokeChild: typeof Machine.invokeMachine === "function"
+      ? ({ onSnapshot, onFailure, ...config }) => {
+        if (onFailure !== undefined) {
+          throw new Error("The legacy child invocation API cannot handle failures as parent transitions")
+        }
+
+        return Machine.invokeMachine({
+          ...config,
+          ...(onSnapshot === undefined ? {} : { snapshot: onSnapshot })
+        })
+      }
+      : (config) => Machine.invoke(config)
+  }
+}

--- a/perf/types/adapter-readiness-control.ts
+++ b/perf/types/adapter-readiness-control.ts
@@ -23,13 +23,16 @@ export const States = Machine.defineStates({
   Ready
 })
 
-export const snapshot = States.initial.Ready(Ready.make({}))
+export const snapshot = { path: "Ready" as const, value: Ready.make({}) }
 
 export const machine = Machine.make({
   id: "perf-readiness",
   states: States.states,
   events: Machine.events(),
-  initial: () => snapshot
+  initial: {
+    target: (to) => to.Ready(),
+    resolve: ({ target }) => target(Ready.make({}))
+  }
 }).handle({
   Flow: {
     history: {
@@ -40,10 +43,10 @@ export const machine = Machine.make({
     states: {
       Idle: {},
       Route: {
-        choice: {
-          targets: ["Ready"],
-          transition: ({ target }) => target.full.Ready(Ready.make({}))
-        }
+        choice: Machine.transition({
+          target: (to) => to.full.Ready(),
+          resolve: ({ target }) => target(Ready.make({}))
+        })
       }
     }
   },

--- a/perf/types/composition-control.ts
+++ b/perf/types/composition-control.ts
@@ -62,18 +62,19 @@ export const States = Machine.defineStates({
   }
 })
 
-export const initialWorkspace = () =>
-  States.initial.App(App.make({}), (app) =>
-    app.Workspace(
-      Workspace.make({}),
-      (workspace) =>
-        workspace
-          .Editor(Editor.make({}), (editor) => editor.Editing(Editing.make({})))
-          .Sync(Sync.make({}), (sync) => sync.Idle(SyncIdle.make({})))
-    ))
-
 export const machine = Machine.make({
   states: States.states,
   events: Machine.events(),
-  initial: initialWorkspace
+  initial: {
+    target: (to) => to.App.initial(),
+    resolve: ({ target }) =>
+      target(App.make({}), (app) =>
+        app.Workspace(
+          Workspace.make({}),
+          (workspace) =>
+            workspace
+              .Editor(Editor.make({}), (editor) => editor.Editing(Editing.make({})))
+              .Sync(Sync.make({}), (sync) => sync.Idle(SyncIdle.make({})))
+        ))
+  }
 })

--- a/perf/types/composition.ts
+++ b/perf/types/composition.ts
@@ -5,7 +5,6 @@ import {
   Editing,
   Editor,
   EditorDone,
-  initialWorkspace,
   machine,
   States,
   Sync,
@@ -31,7 +30,15 @@ const handled = machine.handle({
       Workspace: {
         history: {
           recent: {
-            default: () => initialWorkspace()
+            default: ({ target }) =>
+              target.App(App.make({}), (app) =>
+                app.Workspace(
+                  Workspace.make({}),
+                  (workspace) =>
+                    workspace
+                      .Editor(Editor.make({}), (editor) => editor.Editing(Editing.make({})))
+                      .Sync(Sync.make({}), (sync) => sync.Idle(SyncIdle.make({})))
+                ))
           }
         },
         output: ({ outputs }) => ({
@@ -60,10 +67,10 @@ const handled = machine.handle({
         }
       },
       Route: {
-        choice: {
-          targets: ["App"],
-          transition: ({ target }) =>
-            target.full.App(App.make({}), (app) =>
+        choice: Machine.transition({
+          target: (to) => to.full.App(),
+          resolve: ({ target }) =>
+            target(App.make({}), (app) =>
               app.Workspace(
                 Workspace.make({}),
                 (workspace) =>
@@ -71,7 +78,7 @@ const handled = machine.handle({
                     .Editor(Editor.make({}), (editor) => editor.Editing(Editing.make({})))
                     .Sync(Sync.make({}), (sync) => sync.Idle(SyncIdle.make({})))
               ))
-        }
+        })
       }
     }
   }

--- a/perf/types/dynamic-invoke-control.ts
+++ b/perf/types/dynamic-invoke-control.ts
@@ -14,5 +14,8 @@ export const loadUser = (userId: string) => Effect.fail(new LoadError()).pipe(Ef
 export const machine = Machine.make({
   states: States.states,
   events: Machine.events(),
-  initial: () => States.initial.Loading(Loading.make({ userId: "user-1" }))
+  initial: {
+    target: (to) => to.Loading(),
+    resolve: ({ target }) => target(Loading.make({ userId: "user-1" }))
+  }
 })

--- a/perf/types/dynamic-invoke.ts
+++ b/perf/types/dynamic-invoke.ts
@@ -11,16 +11,22 @@ const invoked = machine.handle({
     invoke: Machine.invoke({
       id: "load-user",
       effect: ({ state }) => loadUser(state.userId),
-      onDone: ({ output, target }) => {
-        const user: User = output
-        void user
-        return target.none()
-      },
-      onFailure: ({ error, target }) => {
-        const loadError: LoadError = error
-        void loadError
-        return target.none()
-      }
+      onDone: Machine.transition({
+        target: (to) => to.none(),
+        resolve: ({ output }) => {
+          const user: User = output
+          void user
+          return undefined
+        }
+      }),
+      onFailure: Machine.transition({
+        target: (to) => to.none(),
+        resolve: ({ error }) => {
+          const loadError: LoadError = error
+          void loadError
+          return undefined
+        }
+      })
     })
   }
 })

--- a/perf/types/exact-channels-control.ts
+++ b/perf/types/exact-channels-control.ts
@@ -23,5 +23,8 @@ export const machine = Machine.make({
   internalEvents: Machine.internalEvents(Loaded),
   emittedEvents: Machine.emittedEvents(Notice),
   input: Input,
-  initial: (input) => States.initial.Idle(Idle.make({ value: input.seed }))
+  initial: {
+    target: (to) => to.Idle(),
+    resolve: ({ input, target }) => target(Idle.make({ value: input.seed }))
+  }
 })

--- a/perf/types/exact-channels.ts
+++ b/perf/types/exact-channels.ts
@@ -12,11 +12,17 @@ const complete = machine.handle({
   Idle: {
     entry: () => {},
     on: {
-      Start: ({ event, target }, enqueue) => {
-        enqueue.emit(Notice.make({ value: event.value }))
-        return target.full.Done(Done.make({ value: event.value }))
-      },
-      Loaded: ({ event, target }) => target.full.Done(Done.make({ value: event.value }))
+      Start: Machine.transition({
+        target: (to) => to.full.Done(),
+        resolve: ({ event, target }, enqueue) => {
+          enqueue.emit(Notice.make({ value: event.value }))
+          return target(Done.make({ value: event.value }))
+        }
+      }),
+      Loaded: Machine.transition({
+        target: (to) => to.full.Done(),
+        resolve: ({ event, target }) => target(Done.make({ value: event.value }))
+      })
     }
   },
   Done: {

--- a/perf/types/handle-depth-24-control.ts
+++ b/perf/types/handle-depth-24-control.ts
@@ -159,7 +159,10 @@ export const States = Machine.defineStates({
 export const machine = Machine.make({
   states: States.states,
   events: Machine.events(),
-  initial: (): never => {
-    throw new Error("type-performance fixture")
+  initial: {
+    target: (to) => to.n0.initial(),
+    resolve: (): never => {
+      throw new Error("type-performance fixture")
+    }
   }
 })

--- a/perf/types/handle-depth-wide-16-control.ts
+++ b/perf/types/handle-depth-wide-16-control.ts
@@ -142,7 +142,10 @@ export const States = Machine.defineStates({
 export const machine = Machine.make({
   states: States.states,
   events: Machine.events(),
-  initial: (): never => {
-    throw new Error("type-performance fixture")
+  initial: {
+    target: (to) => to.n0.initial(),
+    resolve: (): never => {
+      throw new Error("type-performance fixture")
+    }
   }
 })

--- a/perf/types/handle.ts
+++ b/perf/types/handle.ts
@@ -17,16 +17,25 @@ const States = Machine.defineStates(State.cases)
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(Event.cases.Start, Event.cases.Finish),
-  initial: () => States.initial.Idle(State.cases.Idle.make({}))
+  initial: {
+    target: (to) => to.Idle(),
+    resolve: ({ target }) => target(State.cases.Idle.make({}))
+  }
 }).handle({
   Idle: {
     on: {
-      Start: ({ target }) => target.full.Running(State.cases.Running.make({}))
+      Start: Machine.transition({
+        target: (to) => to.full.Running(),
+        resolve: ({ target }) => target(State.cases.Running.make({}))
+      })
     }
   },
   Running: {
     on: {
-      Finish: ({ event, target }) => target.full.Done(State.cases.Done.make({ value: event.value }))
+      Finish: Machine.transition({
+        target: (to) => to.full.Done(),
+        resolve: ({ event, target }) => target(State.cases.Done.make({ value: event.value }))
+      })
     }
   },
   Done: {}

--- a/perf/types/make.ts
+++ b/perf/types/make.ts
@@ -17,7 +17,10 @@ const States = Machine.defineStates(State.cases)
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(Event.cases.Start, Event.cases.Finish),
-  initial: () => States.initial.Idle(State.cases.Idle.make({}))
+  initial: {
+    target: (to) => to.Idle(),
+    resolve: ({ target }) => target(State.cases.Idle.make({}))
+  }
 })
 
 void machine

--- a/perf/types/successive-handle-control.ts
+++ b/perf/types/successive-handle-control.ts
@@ -31,10 +31,11 @@ export const States = Machine.defineStates({
   }
 })
 
-export const initialIdle = () => States.initial.Flow(Flow.make({}), (flow) => flow.Idle(Idle.make({})))
-
 export const machine = Machine.make({
   states: States.states,
   events: Machine.events(Start, Finish),
-  initial: initialIdle
+  initial: {
+    target: (to) => to.Flow.initial(),
+    resolve: ({ target }) => target(Flow.make({}), (flow) => flow.Idle(Idle.make({})))
+  }
 })

--- a/perf/types/successive-handle.ts
+++ b/perf/types/successive-handle.ts
@@ -1,6 +1,6 @@
 import { Machine } from "@typeonce/effect-machine"
 import { Context, Data, Effect } from "effect"
-import { Done, Flow, Idle, initialIdle, machine, Running } from "./successive-handle-control.js"
+import { Done, Flow, Idle, machine, Running } from "./successive-handle-control.js"
 
 type Equal<Left, Right> = (<Type>() => Type extends Left ? 1 : 2) extends (<Type>() => Type extends Right ? 1 : 2) ?
   true :
@@ -17,15 +17,15 @@ const withFlow = machine.handle({
   Flow: {
     history: {
       recent: {
-        default: () => initialIdle()
+        default: ({ target }) => target.Flow(Flow.make({}), (flow) => flow.Idle(Idle.make({})))
       }
     },
     states: {
       Route: {
-        choice: {
-          targets: ["Flow.Idle"],
-          transition: ({ target }) => target.local.Idle(Idle.make({}))
-        }
+        choice: Machine.transition({
+          target: (to) => to.local.Idle(),
+          resolve: ({ target }) => target(Idle.make({}))
+        })
       }
     }
   }
@@ -36,7 +36,10 @@ const withIdle = withFlow.handle({
     states: {
       Idle: {
         on: {
-          Start: ({ target }) => target.local.Running(Running.make({}))
+          Start: Machine.transition({
+            target: (to) => to.local.Running(),
+            resolve: ({ target }) => target(Running.make({}))
+          })
         }
       }
     }
@@ -48,7 +51,10 @@ const withRunning = withIdle.handle({
     states: {
       Running: {
         on: {
-          Finish: ({ event, target }) => target.local.Done(Done.make({ value: event.value }))
+          Finish: Machine.transition({
+            target: (to) => to.local.Done(),
+            resolve: ({ event, target }) => target(Done.make({ value: event.value }))
+          })
         }
       }
     }

--- a/scripts/fixtures/consumer/consumer.ts
+++ b/scripts/fixtures/consumer/consumer.ts
@@ -27,16 +27,25 @@ const machine = Machine.make({
   states: States.states,
   events: PublicEvents,
   internalEvents: InternalEvents,
-  initial: () => States.initial.Idle(State.cases.Idle.make({}))
+  initial: {
+    target: (to) => to.Idle(),
+    resolve: ({ target }) => target(State.cases.Idle.make({}))
+  }
 }).handle({
   Idle: {
     on: {
-      Start: ({ target }) => target.full.Loading(State.cases.Loading.make({}))
+      Start: Machine.transition({
+        target: (to) => to.full.Loading(),
+        resolve: ({ target }) => target(State.cases.Loading.make({}))
+      })
     }
   },
   Loading: {
     on: {
-      Loaded: ({ event, target }) => target.full.Done(State.cases.Done.make({ value: event.value }))
+      Loaded: Machine.transition({
+        target: (to) => to.full.Done(),
+        resolve: ({ event, target }) => target(State.cases.Done.make({ value: event.value }))
+      })
     }
   },
   Done: {}
@@ -53,12 +62,12 @@ const cluster = ClusterMachine.make("ConsumerEntity", machine, {
 const invoked = Machine.invoke({
   id: "fixture-load",
   effect: () => Effect.succeed("ready"),
-  onDone: ({ target }) => target.none()
+  onDone: Machine.transition({ target: (to) => to.none(), resolve: () => undefined })
 })
 const delayed = Machine.invoke({
   id: "fixture-delay",
   after: "1 second",
-  onDone: ({ target }) => target.none()
+  onDone: Machine.transition({ target: (to) => to.none(), resolve: () => undefined })
 })
 const generated = MachineTest.scenarios(machine, { minEvents: 1, maxEvents: 2 })
 

--- a/scripts/fixtures/consumer/deep-bound.ts
+++ b/scripts/fixtures/consumer/deep-bound.ts
@@ -49,7 +49,10 @@ const childMachine = Machine.make({
   events: Machine.events(),
   parentEvents: ChildParentEvents,
   input: Schema.Struct({ value: Schema.String }),
-  initial: ({ value }) => ChildStates.initial.Done(ChildState.cases.Done.make({ value }))
+  initial: {
+    target: (to) => to.Done(),
+    resolve: ({ input, target }) => target(ChildState.cases.Done.make({ value: input.value }))
+  }
 }).handle({
   Done: {
     entry: ({ parent, state }, enqueue) => {
@@ -92,23 +95,29 @@ const definition = Machine.make({
   internalEvents: Machine.internalEvents(Internal.cases.Loaded, Internal.cases.ChildCompleted),
   emittedEvents: Emissions,
   input: Schema.Struct({ seed: Schema.String }),
-  initial: ({ seed: _seed }) => States.initial.Idle(State.cases.Idle.make({}))
+  initial: {
+    target: (to) => to.Idle(),
+    resolve: ({ input: { seed: _seed }, target }) => target(State.cases.Idle.make({}))
+  }
 })
 const machine = definition.handle({
   Idle: {
     invoke: definition.invoke({
       id: "deep-inline-invoke",
       effect: () => Effect.asVoid(ExternalService),
-      onDone: ({ target }) => target.none()
+      onDone: Machine.transition({ target: (to) => to.none(), resolve: () => undefined })
     }),
     on: {
-      Begin: ({ target }) =>
-        target.full.Ready(
-          State.cases.Ready.make({}),
-          (ready) =>
-            ready.Editor(State.cases.Editor.make({}), (editor) =>
-              editor.Editing(State.cases.Editing.make({ value: "ready" })))
-        )
+      Begin: Machine.transition({
+        target: (to) => to.full.Ready(),
+        resolve: ({ target }) =>
+          target(
+            State.cases.Ready.make({}),
+            (ready) =>
+              ready.Editor(State.cases.Editor.make({}), (editor) =>
+                editor.Editing(State.cases.Editing.make({ value: "ready" })))
+          )
+      })
     }
   },
   Ready: {
@@ -117,22 +126,31 @@ const machine = definition.handle({
         states: {
           Editing: {
             on: {
-              Save: ({ event, target }) => target.local.Saving(State.cases.Saving.make({ value: event.value })),
-              Loaded: ({ target }) => target.none()
+              Save: Machine.transition({
+                target: (to) => to.local.Saving(),
+                resolve: ({ event, target }) => target(State.cases.Saving.make({ value: event.value }))
+              }),
+              Loaded: Machine.transition({ target: (to) => to.none(), resolve: () => undefined })
             }
           },
           Saving: {
             invoke: definition.invoke({
               child: Child,
               input: ({ state }) => ({ value: state.value }),
-              onDone: ({ target }) => target.none()
+              onDone: Machine.transition({ target: (to) => to.none(), resolve: () => undefined })
             }),
             on: {
-              ChildNotice: ({ event, target }, enqueue) => {
-                enqueue.emit(Emissions.Notice({ value: event.value }))
-                return target.local.Saving(State.cases.Saving.make({ value: event.value }))
-              },
-              ChildCompleted: ({ event, target }) => target.full.Done(State.cases.Done.make({ value: event.value }))
+              ChildNotice: Machine.transition({
+                target: (to) => to.local.Saving(),
+                resolve: ({ event, target }, enqueue) => {
+                  enqueue.emit(Emissions.Notice({ value: event.value }))
+                  return target(State.cases.Saving.make({ value: event.value }))
+                }
+              }),
+              ChildCompleted: Machine.transition({
+                target: (to) => to.full.Done(),
+                resolve: ({ event, target }) => target(State.cases.Done.make({ value: event.value }))
+              })
             }
           }
         }
@@ -227,8 +245,11 @@ const PackagedDeepStates = Machine.defineStates({
 const packagedDeepMachine = Machine.make({
   states: PackagedDeepStates.states,
   events: Machine.events(),
-  initial: (): never => {
-    throw new Error("type-only packaged consumer fixture")
+  initial: {
+    target: (to) => to.n0.initial(),
+    resolve: (): never => {
+      throw new Error("type-only packaged consumer fixture")
+    }
   }
 }).handle({
   n0: {

--- a/scripts/invoke-autocomplete.test.mjs
+++ b/scripts/invoke-autocomplete.test.mjs
@@ -7,14 +7,14 @@ import ts from "typescript"
 const projectRoot = path.resolve(import.meta.dirname, "..")
 const virtualFile = path.join(projectRoot, "invoke-autocomplete.fixture.ts")
 const source = `
-import { Effect } from "effect"
+import { Effect, Option } from "effect"
 import { Machine } from "./src/index.js"
 
 const States = Machine.defineStates({ Loading: {}, Done: {}, Failed: {} })
 const definition = Machine.make({
   states: States.states,
   events: Machine.events(),
-  initial: () => States.initial.Loading.from()
+  initial: { target: (to) => to.Loading(), resolve: ({ target }) => target.from() }
 })
 
 definition.handle({
@@ -22,8 +22,14 @@ definition.handle({
     invoke: Machine.invoke({
       id: "load",
       effect: () => Effect.fail("offline").pipe(Effect.as(1)),
-      onDone: ({ /*done-context*/ }) => States.initial.Done.from(),
-      onFailure: ({ /*failure-context*/ }) => States.initial.Failed.from()
+      onDone: Machine.transition({
+        target: (to) => to.full./*done-target*/Done(),
+        resolve: ({ /*done-context*/ ...context }) => context.target.from()
+      }),
+      onFailure: Machine.transition({
+        target: (to) => to.full.Failed(),
+        resolve: ({ /*failure-context*/ ...context }) => context.target.from()
+      })
     })
   },
   Done: {},
@@ -40,6 +46,52 @@ definition.handle({
   },
   Done: {},
   Failed: {}
+})
+
+definition.handle({
+  Loading: {
+    always: Machine.transition({
+      /*transition-properties*/
+    })
+  }
+})
+
+definition.handle({
+  Loading: {
+    always: Machine.transition({
+      target: (to) => to.none(),
+      resolve: ({ /*targetless-context*/ }) => undefined
+    })
+  }
+})
+
+definition.handle({
+  Loading: {
+    always: Machine.transition({
+      target: (to) => to./*target-scopes*/full.Done(),
+      resolve: ({ /*transition-context*/ ...context }) => context.target.from()
+    })
+  }
+})
+
+definition.handle({
+  Loading: {
+    always: Machine.transition({
+      cases: [{
+        title: "ready",
+        when: ({ /*case-when-context*/ }) => Option.some("ready" as const),
+        target: (to) => to.full.Done(),
+        resolve: ({ /*case-resolve-context*/ ...context }) => {
+          const exact: "ready" = context.match
+          return context.target.from()
+        }
+      }],
+      otherwise: {
+        target: (to) => to.none(),
+        resolve: () => undefined
+      }
+    })
+  }
 })
 `
 
@@ -81,6 +133,10 @@ test("contextually completes Effect invocation factories while authoring", () =>
   assert.equal(done.has("state"), true)
   assert.equal(done.has("target"), true)
 
+  const doneTarget = completions("done-target")
+  assert.equal(doneTarget.has("Done"), true)
+  assert.equal(doneTarget.has("Failed"), true)
+
   const failure = completions("failure-context")
   assert.equal(failure.has("error"), true)
   assert.equal(failure.has("state"), true)
@@ -89,4 +145,38 @@ test("contextually completes Effect invocation factories while authoring", () =>
   const properties = completions("invoke-properties")
   assert.equal(properties.has("onDone"), true)
   assert.equal(properties.has("onFailure"), true)
+})
+
+test("contextually completes transition definitions while authoring", () => {
+  const properties = completions("transition-properties")
+  assert.equal(properties.has("target"), true)
+  assert.equal(properties.has("resolve"), true)
+  assert.equal(properties.has("cases"), true)
+  assert.equal(properties.has("reenter"), true)
+
+  const scopes = completions("target-scopes")
+  assert.equal(scopes.has("none"), true)
+  assert.equal(scopes.has("local"), true)
+  assert.equal(scopes.has("branch"), true)
+  assert.equal(scopes.has("full"), true)
+  assert.equal(scopes.has("history"), true)
+
+  const context = completions("transition-context")
+  assert.equal(context.has("state"), true)
+  assert.equal(context.has("ancestors"), true)
+  assert.equal(context.has("snapshot"), true)
+  assert.equal(context.has("target"), true)
+
+  const targetless = completions("targetless-context")
+  assert.equal(targetless.has("state"), true)
+  assert.equal(targetless.has("target"), false)
+
+  const when = completions("case-when-context")
+  assert.equal(when.has("state"), true)
+  assert.equal(when.has("target"), false)
+
+  const resolve = completions("case-resolve-context")
+  assert.equal(resolve.has("match"), true)
+  assert.equal(resolve.has("target"), true)
+
 })

--- a/scripts/runtime-performance-compatibility.test.mjs
+++ b/scripts/runtime-performance-compatibility.test.mjs
@@ -2,6 +2,30 @@ import { strict as assert } from "node:assert"
 import { test } from "node:test"
 import { makeEffectMachineBenchmarkApi } from "../perf/runtime/effect-machine-compatibility.mjs"
 
+test("adapts static transition definitions only when the new capability is present", () => {
+  const calls = []
+  const Machine = {
+    logic: () => undefined,
+    transition: (definition) => {
+      calls.push(definition)
+      return { static: definition }
+    },
+    invoke: (config) => config,
+    events: (...schemas) => schemas
+  }
+  const api = makeEffectMachineBenchmarkApi(Machine)
+  const definition = { target: "selected", resolve: "resolved" }
+  const legacy = () => undefined
+
+  assert.equal(api.initial(definition, legacy), definition)
+  assert.deepEqual(api.transition(definition, legacy), { static: definition })
+  assert.equal(typeof api.targetless.static.target, "function")
+  assert.equal(typeof api.targetless.static.resolve, "function")
+  assert.equal(api.targetless.static.target({ none: () => "none" }), "none")
+  assert.equal(api.targetless.static.resolve(), undefined)
+  assert.equal(calls.length, 2)
+})
+
 test("uses the current child invocation capability when available", () => {
   const calls = []
   const noTarget = Symbol("no-target")
@@ -33,6 +57,9 @@ test("adapts lifecycle names for the legacy child invocation capability", () => 
   const onSnapshot = () => undefined
   const Machine = {
     event: () => undefined,
+    transition: (_initial, _transition) => {
+      throw new Error("legacy process constructor must not capture state transitions")
+    },
     invokeMachine: (config) => {
       calls.push(config)
       return { api: "legacy", config }
@@ -40,6 +67,8 @@ test("adapts lifecycle names for the legacy child invocation capability", () => 
   }
 
   assert.deepEqual(makeEffectMachineBenchmarkApi(Machine).events("Increment", "Finish"), ["Increment", "Finish"])
+  assert.equal(makeEffectMachineBenchmarkApi(Machine).initial("static", onDone), onDone)
+  assert.equal(makeEffectMachineBenchmarkApi(Machine).transition("static", onDone), onDone)
 
   assert.deepEqual(
     makeEffectMachineBenchmarkApi(Machine).invokeChild({

--- a/scripts/type-performance.mjs
+++ b/scripts/type-performance.mjs
@@ -71,8 +71,10 @@ const scenarios = [
     label: "machine.handle (3 states, 2 transitions)",
     file: "handle.ts",
     control: "make",
-    maxInstantiations: 40_000,
-    maxMarginalInstantiations: 23_000
+    // The first statically captured transition pays the one-time constructor
+    // inference cost. Deeper and successive-handler scenarios gate scaling.
+    maxInstantiations: 70_000,
+    maxMarginalInstantiations: 56_000
   },
   {
     id: "dynamic-invoke-control",

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -537,6 +537,7 @@ type IncompatibleRuntime<Requirements, Events, Emits> = Requirements extends Run
   : never
 
 const InvokeTypeId: typeof internal.InvokeTypeId = internal.InvokeTypeId
+const TransitionTypeId: typeof internal.TransitionTypeId = internal.TransitionTypeId
 
 type StateDefinitionError<
   Message extends string,
@@ -2891,15 +2892,15 @@ export declare namespace Machine {
    * @category utility types
    * @since 0.4.0
    */
-  export type InitialBuilder<States extends StateSchemas> = InitialSnapshotBuilderWithPrefix<States>
+  type InitialBuilder<States extends StateSchemas> = InitialSnapshotBuilderWithPrefix<States>
 
   /**
-   * State definitions and snapshot builders returned by `defineStates`.
+   * State definitions and snapshot access helpers returned by `defineStates`.
    *
    * **Details**
    *
    * The `states` property is the original state tree and can be passed directly
-   * to `make`. The `initial` property builds path-safe snapshots for the same
+   * to `make`. The remaining helpers match and read snapshots for the same
    * state tree.
    *
    * @category models
@@ -2908,9 +2909,6 @@ export declare namespace Machine {
   export interface DefinedStates<States extends StateSchemas> {
     /** Original state tree supplied to {@link defineStates}. */
     readonly states: States
-
-    /** Type-safe builders for constructing valid initial snapshots. */
-    readonly initial: InitialBuilder<States>
 
     /**
      * Returns the decoded value for an active state path. The supplied
@@ -3158,20 +3156,20 @@ export declare namespace Machine {
       readonly outcome: "done" | "failure" | "snapshot"
     }
 
-  /**
-   * Statically inspectable destination paths for a transition handler.
-   * A declared parent path covers every descendant below that state.
-   *
-   * @category models
-   * @since 0.4.0
-   */
-  export type TransitionTargets<Path extends string = string> =
+  /** One statically captured branch of a transition definition. */
+  export type TransitionBranch<Path extends string = string> =
     | {
-      readonly type: "dynamic"
+      readonly type: "direct"
+      readonly target: Path | undefined
     }
     | {
-      readonly type: "declared"
-      readonly paths: ReadonlyArray<Path>
+      readonly type: "case"
+      readonly title: string
+      readonly target: Path | undefined
+    }
+    | {
+      readonly type: "otherwise"
+      readonly target: Path | undefined
     }
 
   /**
@@ -3179,10 +3177,9 @@ export declare namespace Machine {
    *
    * **Details**
    *
-   * Event, eventless, completion, and invocation lifecycle handlers may
-   * declare an upper bound of possible target paths. A handler without that
-   * declaration is explicitly reported as dynamic. The source, trigger, and
-   * reentry behavior are available without executing the handler.
+   * Every branch exposes its selected target without executing its predicate
+   * or resolver. A compound local or branch target covers its descendants;
+   * `undefined` identifies an explicitly targetless branch.
    *
    * @category models
    * @since 0.4.0
@@ -3195,7 +3192,7 @@ export declare namespace Machine {
     readonly source: SourcePath
     readonly trigger: TransitionTrigger<EventTag>
     readonly reenter: boolean
-    readonly targets: TransitionTargets<TargetPath>
+    readonly branches: ReadonlyArray<TransitionBranch<TargetPath>>
   }
 
   /**
@@ -4057,9 +4054,7 @@ export declare namespace Machine {
    * Opaque result returned by an explicitly targetless transition.
    *
    * The transition remains handled and retains its queued commands, raised
-   * events, and emitted events, but selects no concrete destination. Declared
-   * `targets` constrain only concrete destinations, so this result is always
-   * permitted from ordinary transition handlers.
+   * events, and emitted events, but selects no concrete destination.
    *
    * @category models
    * @since 0.10.0
@@ -4216,8 +4211,7 @@ export declare namespace Machine {
      *
      * The event or lifecycle outcome is handled and queued operations are
      * retained, while the current state configuration remains the transition
-     * result. This remains valid when the handler declares concrete `targets`,
-     * because those paths are an upper bound rather than an exhaustive result.
+     * result.
      *
      * @since 0.10.0
      */
@@ -4256,6 +4250,159 @@ export declare namespace Machine {
 
     /** Restores a declared shallow or deep history pseudo-state. */
     readonly history: HistoryTargetBuilder<States>
+  }
+
+  /**
+   * Opaque exact destination selected while a machine definition is captured.
+   * The selection contains topology only; state values are constructed later
+   * by the selected branch's resolver.
+   *
+   * @category models
+   * @since 0.14.0
+   */
+  export interface TargetSelection<
+    out Result,
+    out Path extends string | undefined = string | undefined,
+    out Kind extends Topology.TargetSelectionKind = Topology.TargetSelectionKind
+  > {
+    readonly [Topology.TargetSelectionTypeId]: typeof Topology.TargetSelectionTypeId
+    readonly kind: Kind
+    readonly scope: Topology.TargetSelectionScope | undefined
+    readonly path: Path
+    readonly "~effect/Machine/TargetSelectionResult"?: Types.Covariant<Result>
+  }
+
+  type SelectionMethod<Builder, Path extends string, Kind extends Topology.TargetSelectionKind = "state"> = () =>
+    TargetSelection<Builder, Path, Kind>
+
+  type InitialSelectionMethod<Builder, Path extends string> = Builder extends { readonly initial: infer Initial } ? {
+      readonly initial: SelectionMethod<Initial, Path, "initial">
+    }
+    : {}
+
+  type SelectionTreeWithPrefix<
+    AllStates extends StateSchemas,
+    States extends StateSchemas,
+    Prefix extends string,
+    Scope extends "local" | "branch",
+    Builder
+  > = {
+    readonly [Key in Extract<ActiveStateKey<States> | ChoiceStateKey<States>, keyof Builder>]: SelectionNode<
+      AllStates,
+      States[Key],
+      JoinPath<Prefix, Key>,
+      Scope,
+      Builder[Key]
+    >
+  }
+
+  type SelectionNode<
+    AllStates extends StateSchemas,
+    Node,
+    Path extends string,
+    Scope extends "local" | "branch",
+    Builder
+  > = Node extends ChoiceStateNodeConfig ? SelectionMethod<
+      Builder,
+      Path,
+      "choice"
+    >
+    : Node extends { readonly states: infer Children extends StateSchemas } ?
+        & SelectionMethod<Builder, Path>
+        & InitialSelectionMethod<Builder, Path>
+        & SelectionTreeWithPrefix<AllStates, Children, Path, Scope, Builder>
+    : SelectionMethod<Builder, Path>
+
+  type FullSelectionNode<
+    AllStates extends StateSchemas,
+    Node,
+    Path extends StateIdentifier<AllStates>,
+    Builder
+  > = Node extends { readonly states: StateSchemas } ?
+      & SelectionMethod<Builder, Path>
+      & InitialSelectionMethod<Builder, Path>
+    : SelectionMethod<Builder, Path>
+
+  type FullTargetSelector<States extends StateSchemas> = {
+    readonly [Key in Extract<ActiveStateKey<States>, keyof FullTargetBuilder<States>>]: FullSelectionNode<
+      States,
+      States[Key],
+      Extract<Key, StateIdentifier<States>>,
+      FullTargetBuilder<States>[Key]
+    >
+  }
+
+  type BranchTargetSelector<
+    States extends StateSchemas,
+    Source extends StateNodeIdentifier<States>,
+    Root extends string = Source extends `${infer Head}.${string}` ? Head : Source
+  > = Root extends ActiveStateKey<States> ? Root extends keyof BranchTargetBuilder<States, Source> ? {
+        readonly [Key in Root]: SelectionNode<
+          States,
+          States[Key],
+          Key,
+          "branch",
+          BranchTargetBuilder<States, Source>[Key]
+        >
+      }
+    : {}
+    : {}
+
+  type LocalTargetSelector<
+    States extends StateSchemas,
+    Source extends StateNodeIdentifier<States>
+  > = NearestCompoundScope<States, Source> extends infer Scope extends StateIdentifier<States> ?
+    ChildrenOf<States, Scope> extends infer Children extends StateSchemas ?
+      LocalTargetBuilder<States, Source> extends infer Builder ?
+          & SelectionTreeWithPrefix<States, Children, Scope, "local", Builder>
+          & ("with" extends keyof Builder ? {
+              readonly with: SelectionMethod<Builder["with"], Scope>
+            }
+            : {})
+      : {}
+    : {}
+    : {}
+
+  type HistorySelectionTree<
+    AllStates extends StateSchemas,
+    States extends StateSchemas,
+    Prefix extends string,
+    Builder
+  > = {
+    readonly [Key in Extract<HistoryContainingKey<States>, keyof Builder>]: States[Key] extends HistoryStateNodeConfig ?
+      SelectionMethod<
+        Builder[Key],
+        JoinPath<Prefix, Key>,
+        "history"
+      >
+      : States[Key] extends { readonly states: infer Children extends StateSchemas } ? HistorySelectionTree<
+          AllStates,
+          Children,
+          JoinPath<Prefix, Key>,
+          Builder[Key]
+        >
+      : never
+  }
+
+  /** Definition-time topology selector available to an ordinary transition. */
+  export interface TargetSelector<
+    States extends StateSchemas,
+    Source extends StateNodeIdentifier<States>
+  > {
+    readonly none: SelectionMethod<TargetBuilder<States, Source>["none"], never, "none">
+    readonly local: LocalTargetSelector<States, Source>
+    readonly branch: BranchTargetSelector<States, Source>
+    readonly full: FullTargetSelector<States>
+    readonly history: HistorySelectionTree<States, States, "", HistoryTargetBuilder<States>>
+  }
+
+  /** Definition-time selector that can choose only a valid top-level initial entry. */
+  export type InitialSelector<States extends StateSchemas> = {
+    readonly [Key in Extract<ActiveStateKey<States>, keyof InitialBuilder<States>>]: States[Key] extends
+      { readonly states: StateSchemas } ? {
+        readonly initial: SelectionMethod<InitialBuilder<States>[Key], Key, "initial">
+      }
+      : SelectionMethod<InitialBuilder<States>[Key], Key>
   }
 
   /**
@@ -4555,7 +4702,8 @@ export declare namespace Machine {
   export type InitialResult<States extends StateSchemas, E, R> =
     | Snapshot<States>
     | InitialSnapshot<States>
-    | StateConstruction<Snapshot<States> | InitialSnapshot<States>>
+    | InitialTarget<StateIdentifier<States>>
+    | StateConstruction<Snapshot<States> | InitialSnapshot<States> | InitialTarget<StateIdentifier<States>>>
 
   /** Initial snapshots may transiently terminate in a declared choice node. */
   export type InitialSnapshot<States extends StateSchemas> = {
@@ -4651,19 +4799,22 @@ export declare namespace Machine {
     }[keyof NonNullable<History>]
     : never
   /** Extracts the return value from a choice resolver. */
-  export type ChoiceReturn<Config> = Config extends {
-    readonly choice: { readonly transition: (...args: any) => infer Ret }
-  } ? Ret :
-    never
+  export type ChoiceReturn<Config> = Config extends { readonly choice: infer Choice } ? EventTransitionReturn<Choice>
+    : never
   /**
    * Extracts the return value from an event transition config.
    *
    * @category utility types
    * @since 0.4.0
    */
-  export type EventTransitionReturn<Transition> = Transition extends (...args: any) => infer Ret ? Ret
-    : Transition extends { readonly transition: (...args: any) => infer Ret } ? Ret
-    : never
+  export type EventTransitionReturn<Transition> =
+    | (Transition extends { readonly resolve?: infer Resolve } ?
+      NonNullable<Resolve> extends (...args: any) => infer Ret ? Ret : never
+      : never)
+    | (Transition extends { readonly cases: infer Cases extends ReadonlyArray<unknown> } ?
+      EventTransitionReturn<Cases[number]>
+      : never)
+    | (Transition extends { readonly otherwise: infer Otherwise } ? EventTransitionReturn<Otherwise> : never)
   /**
    * Extracts the return value from a state's event handlers.
    *
@@ -4869,28 +5020,141 @@ export declare namespace Machine {
     | Effect.Services<ChoiceReturn<Config>>
     | InvokeRequirements<Config>
 
+  type TransitionWhenContext<Context> = Omit<Context, "target">
+
+  /** Type evidence retained by {@link transition} without affecting runtime data. */
+  export interface TransitionTyped<
+    States extends StateSchemas,
+    Events extends ReadonlyArray<TaggedSchema>,
+    Emits extends ReadonlyArray<TaggedSchema>,
+    StateId extends StateNodeIdentifier<States>,
+    Context,
+    Reenter extends boolean
+  > {
+    readonly [TransitionTypeId]: {
+      readonly owner: Types.Covariant<readonly [States, Events, Emits, StateId, Context]>
+    }
+  }
+
+  /** Type evidence for a targetless transition reusable in every owning context. */
+  export interface TargetlessTransitionTyped {
+    readonly [TransitionTypeId]: {
+      readonly targetless: true
+    }
+  }
+
+  /** The only transition value accepted by machine handler APIs. */
+  export type TransitionConfig<
+    States extends StateSchemas,
+    Events extends ReadonlyArray<TaggedSchema>,
+    Emits extends ReadonlyArray<TaggedSchema>,
+    StateId extends StateNodeIdentifier<States>,
+    Context,
+    Reenter extends boolean = false
+  > =
+    & (TransitionTyped<States, Events, Emits, StateId, Context, Reenter> | TargetlessTransitionTyped)
+    & {
+      readonly reenter?: [Reenter] extends [true] ? boolean : never
+    }
+
+  export type SelectionBuilder<Selection> = Selection extends TargetSelection<infer Builder, any, any> ? Builder : never
+  export type SelectionKind<Selection> = Selection extends TargetSelection<any, any, infer Kind> ? Kind : never
+  export type SelectionPath<Selection> = Selection extends TargetSelection<any, infer Path, any> ? Path : never
+  export type TargetBuilderResult<Builder> =
+    | (Builder extends (...args: any) => infer Result ? Result : never)
+    | (Builder extends { readonly from: (...args: any) => infer Result } ? Result : never)
+  export type SelectedTargetResult<Selection> = SelectionBuilder<Selection> extends infer Builder ?
+    TargetBuilderResult<Builder>
+    : never
+
+  export type TransitionResolveContext<
+    Context,
+    Selection,
+    Match = never
+  > =
+    & Omit<Context, "target">
+    & ([Match] extends [never] ? {} : { readonly match: Match })
+    & (SelectionKind<Selection> extends "none" ? {} : { readonly target: SelectionBuilder<Selection> })
+
+  export type TransitionResolver<
+    Events extends ReadonlyArray<TaggedSchema>,
+    Emits extends ReadonlyArray<TaggedSchema>,
+    Context,
+    Selection,
+    Match = never
+  > = (
+    context: TransitionResolveContext<Context, Selection, Match>,
+    enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
+  ) => SelectionKind<Selection> extends "none" ? undefined : SelectedTargetResult<Selection> | undefined
+
+  export type TransitionDirectInput<
+    States extends StateSchemas,
+    Events extends ReadonlyArray<TaggedSchema>,
+    Emits extends ReadonlyArray<TaggedSchema>,
+    StateId extends StateNodeIdentifier<States>,
+    Context,
+    Reenter extends boolean,
+    Selection extends TargetSelection<any, any, any>
+  > = {
+    readonly target: (to: TargetSelector<States, StateId>) => Selection
+    readonly resolve?: TransitionResolver<Events, Emits, Context, Selection>
+    readonly cases?: never
+    readonly otherwise?: never
+    readonly reenter?: Reenter
+  }
+
+  export type TransitionCaseInput<
+    States extends StateSchemas,
+    Events extends ReadonlyArray<TaggedSchema>,
+    Emits extends ReadonlyArray<TaggedSchema>,
+    StateId extends StateNodeIdentifier<States>,
+    Context,
+    Selection extends TargetSelection<any, any, any>,
+    Match
+  > = {
+    readonly title: string
+    readonly when: (context: TransitionWhenContext<Context>) => Option.Option<Match>
+    readonly target: (to: TargetSelector<States, StateId>) => Selection
+    readonly resolve?: TransitionResolver<Events, Emits, Context, Selection, NoInfer<Match>>
+    readonly cases?: never
+    readonly otherwise?: never
+    readonly reenter?: never
+  }
+
+  export type TransitionConditionalInput<
+    States extends StateSchemas,
+    Events extends ReadonlyArray<TaggedSchema>,
+    Emits extends ReadonlyArray<TaggedSchema>,
+    StateId extends StateNodeIdentifier<States>,
+    Context,
+    Reenter extends boolean,
+    Cases extends readonly [object, ...ReadonlyArray<object>],
+    OtherwiseSelection extends TargetSelection<any, any, any>
+  > = {
+    readonly target?: never
+    readonly resolve?: never
+    readonly cases: Cases
+    readonly otherwise: TransitionDirectInput<
+      States,
+      Events,
+      Emits,
+      StateId,
+      Context,
+      never,
+      OtherwiseSelection
+    >
+    readonly reenter?: Reenter
+  }
+
   export type InvokeTransition<
     States extends StateSchemas,
     Events extends ReadonlyArray<TaggedSchema>,
     Emits extends ReadonlyArray<TaggedSchema>,
+    StateId extends StateNodeIdentifier<States>,
     Context
-  > =
-    | ((context: NoInfer<Context>, enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>) => HandlerResult<States, any, any>)
-    | {
-      readonly reenter?: boolean
-      readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
-      readonly transition: (
-        context: NoInfer<Context>,
-        enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-      ) => HandlerResult<States, any, any>
-    }
+  > = TransitionConfig<States, Events, Emits, StateId, Context, true>
 
   export type InvokeSource<Value, Context> = Value | ((context: Context) => Value)
-
-  interface AnyLogicSource {
-    initial(...args: ReadonlyArray<any>): Effect.Effect<any, any, any>
-    run(...args: ReadonlyArray<any>): Effect.Effect<any, any, any>
-  }
 
   /** Inline state-owned work that runs for the lifetime of its active state. */
   export interface InvokeOwned<
@@ -4955,7 +5219,7 @@ export declare namespace Machine {
         readonly id: string
         readonly address: string
         readonly logic: InvokeSource<
-          AnyLogicSource,
+          Logic<any, any, any, any, any, any>,
           InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
         >
         readonly effect?: never
@@ -5035,6 +5299,7 @@ export declare namespace Machine {
       States,
       Events,
       Emits,
+      StateId,
       InvokeDoneContext<States, Events, Emits, StateId, void, InputEvents, ParentEvents>
     >
   }
@@ -5066,35 +5331,38 @@ export declare namespace Machine {
         States,
         Events,
         Emits,
+        StateId,
         InvokeSnapshotContext<
           States,
           Events,
           Emits,
           StateId,
-          ChildState,
-          ChildError,
-          ChildOutput,
+          NoInfer<ChildState>,
+          NoInfer<ChildError>,
+          NoInfer<ChildOutput>,
           InputEvents,
           ParentEvents
         >
       >
     }
     & InvokeDoneRequirement<
-      ChildOutput,
+      NoInfer<ChildOutput>,
       InvokeTransition<
         States,
         Events,
         Emits,
-        InvokeDoneContext<States, Events, Emits, StateId, ChildOutput, InputEvents, ParentEvents>
+        StateId,
+        InvokeDoneContext<States, Events, Emits, StateId, NoInfer<ChildOutput>, InputEvents, ParentEvents>
       >
     >
     & InvokeFailureRequirement<
-      ChildError,
+      NoInfer<ChildError>,
       InvokeTransition<
         States,
         Events,
         Emits,
-        InvokeFailureContext<States, Events, Emits, StateId, ChildError, InputEvents, ParentEvents>
+        StateId,
+        InvokeFailureContext<States, Events, Emits, StateId, NoInfer<ChildError>, InputEvents, ParentEvents>
       >
     >
 
@@ -5126,6 +5394,7 @@ export declare namespace Machine {
         States,
         Events,
         Emits,
+        StateId,
         InvokeSnapshotContext<
           States,
           Events,
@@ -5151,6 +5420,7 @@ export declare namespace Machine {
         States,
         Events,
         Emits,
+        StateId,
         InvokeDoneContext<
           States,
           Events,
@@ -5168,6 +5438,7 @@ export declare namespace Machine {
         States,
         Events,
         Emits,
+        StateId,
         InvokeFailureContext<
           States,
           Events,
@@ -5180,12 +5451,24 @@ export declare namespace Machine {
       >
     >
 
-  export type LogicStateOf<Value> = Value extends Logic<infer State, any, any, any, any, any> ? State : never
-  export type LogicEventOf<Value> = Value extends Logic<any, infer Event, any, any, any, any> ? Event : never
-  export type LogicErrorOf<Value> = Value extends Logic<any, any, infer Error, any, any, any> ? Error : never
-  export type LogicServicesOf<Value> = Value extends Logic<any, any, any, infer Services, any, any> ? Services : never
-  export type LogicOutputOf<Value> = Value extends Logic<any, any, any, any, infer Output, any> ? Output : never
-  export type LogicInitialErrorOf<Value> = Value extends Logic<any, any, any, any, any, infer Error> ? Error : never
+  type LogicInitialEffectOf<Value> = Value extends { readonly initial: infer Initial } ?
+    Initial extends (...args: ReadonlyArray<any>) => infer Result ? Result : never
+    : never
+
+  type LogicRunEffectOf<Value> = Value extends { readonly run: infer Run } ?
+    Run extends (...args: ReadonlyArray<any>) => infer Result ? Result : never
+    : never
+
+  export type LogicStateOf<Value> = Effect.Success<LogicInitialEffectOf<Value>>
+  export type LogicEventOf<Value> = Value extends { readonly initial: infer Initial } ?
+    Initial extends (scope: infer LogicScope, ...args: ReadonlyArray<any>) => any ?
+      LogicScope extends Logic.Scope<infer Event> ? Event : never
+    : never
+    : never
+  export type LogicErrorOf<Value> = Effect.Error<LogicRunEffectOf<Value>>
+  export type LogicServicesOf<Value> = Effect.Services<LogicInitialEffectOf<Value> | LogicRunEffectOf<Value>>
+  export type LogicOutputOf<Value> = Effect.Success<LogicRunEffectOf<Value>>
+  export type LogicInitialErrorOf<Value> = Effect.Error<LogicInitialEffectOf<Value>>
 
   type ContextualInvokeConfig<
     States extends StateSchemas,
@@ -5204,6 +5487,7 @@ export declare namespace Machine {
               States,
               Events,
               Emits,
+              StateId,
               InvokeDoneContext<States, Events, Emits, StateId, Effect.Success<Fx>, InputEvents, ParentEvents>
             >
           >
@@ -5213,6 +5497,7 @@ export declare namespace Machine {
               States,
               Events,
               Emits,
+              StateId,
               InvokeFailureContext<States, Events, Emits, StateId, Effect.Error<Fx>, InputEvents, ParentEvents>
             >
           >
@@ -5223,6 +5508,7 @@ export declare namespace Machine {
           States,
           Events,
           Emits,
+          StateId,
           InvokeDoneContext<States, Events, Emits, StateId, void, InputEvents, ParentEvents>
         >
         readonly onFailure?: never
@@ -5236,6 +5522,7 @@ export declare namespace Machine {
               States,
               Events,
               Emits,
+              StateId,
               InvokeDoneContext<States, Events, Emits, StateId, InvokeOutput<Raw>, InputEvents, ParentEvents>
             >
           >
@@ -5245,6 +5532,7 @@ export declare namespace Machine {
               States,
               Events,
               Emits,
+              StateId,
               InvokeFailureContext<
                 States,
                 Events,
@@ -5267,6 +5555,7 @@ export declare namespace Machine {
               States,
               Events,
               Emits,
+              StateId,
               InvokeSnapshotContext<
                 States,
                 Events,
@@ -5289,6 +5578,7 @@ export declare namespace Machine {
               States,
               Events,
               Emits,
+              StateId,
               InvokeDoneContext<
                 States,
                 Events,
@@ -5306,6 +5596,7 @@ export declare namespace Machine {
               States,
               Events,
               Emits,
+              StateId,
               InvokeFailureContext<
                 States,
                 Events,
@@ -5328,6 +5619,7 @@ export declare namespace Machine {
               States,
               Events,
               Emits,
+              StateId,
               InvokeSnapshotContext<
                 States,
                 Events,
@@ -5418,51 +5710,29 @@ export declare namespace Machine {
     readonly invoke?:
       | InvokeDefinition<States, Events, Emits, StateId, InputEvents, ParentEvents>
       | TypedInvokeDefinition
-    readonly always?:
-      | ((
-        context: AlwaysContext<States, Events, Emits, StateId, InputEvents, ParentEvents>,
-        enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-      ) => HandlerResult<States, any, any>)
-      | {
-        /** Statically declared upper bound of possible target paths. */
-        readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
-        readonly transition: (
-          context: AlwaysContext<States, Events, Emits, StateId, InputEvents, ParentEvents>,
-          enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-        ) => HandlerResult<States, any, any>
-      }
-    readonly onDone?:
-      | ((
-        context: DoneContext<States, Events, Emits, StateId, InputEvents, ParentEvents>,
-        enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-      ) => HandlerResult<States, any, any>)
-      | {
-        /** Statically declared upper bound of possible target paths. */
-        readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
-        readonly transition: (
-          context: DoneContext<States, Events, Emits, StateId, InputEvents, ParentEvents>,
-          enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-        ) => HandlerResult<States, any, any>
-      }
+    readonly always?: TransitionConfig<
+      States,
+      Events,
+      Emits,
+      StateId,
+      AlwaysContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    >
+    readonly onDone?: TransitionConfig<
+      States,
+      Events,
+      Emits,
+      StateId,
+      DoneContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    >
     readonly on?: {
-      readonly [EventTag in TagOf<Events[number]>]?:
-        | ((
-          context: HandlerContext<States, Events, Emits, StateId, EventTag, E, R, InputEvents, ParentEvents>,
-          enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-        ) => HandlerResult<States, any, any>)
-        | {
-          readonly reenter?: boolean
-          /**
-           * Upper bound of state or history paths this handler may target.
-           * Returning `target.none()` is always permitted. Declaring a parent state also
-           * permits concrete descendant targets below it.
-           */
-          readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
-          readonly transition: (
-            context: HandlerContext<States, Events, Emits, StateId, EventTag, E, R, InputEvents, ParentEvents>,
-            enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-          ) => HandlerResult<States, any, any>
-        }
+      readonly [EventTag in TagOf<Events[number]>]?: TransitionConfig<
+        States,
+        Events,
+        Emits,
+        StateId,
+        HandlerContext<States, Events, Emits, StateId, EventTag, E, R, InputEvents, ParentEvents>,
+        true
+      >
     }
     readonly initialize?: StateInitializeHandler<States, Events, Emits, StateId, InputEvents, ParentEvents>
   } & ActiveOutputHandlerConfig<States, Events, StateId>
@@ -5634,14 +5904,13 @@ export declare namespace Machine {
     InputEvents extends ReadonlyArray<TaggedSchema> = Events,
     ParentEvents extends ReadonlyArray<TaggedSchema> = readonly []
   > {
-    readonly choice: {
-      /** Statically inspectable upper bound of every possible target. */
-      readonly targets: readonly [StateNodeIdentifier<States>, ...ReadonlyArray<StateNodeIdentifier<States>>]
-      readonly transition: (
-        context: ChoiceContext<States, Events, Emits, ChoiceId, InputEvents, ParentEvents>,
-        enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-      ) => ChoiceResult<States, any, any>
-    }
+    readonly choice: TransitionConfig<
+      States,
+      Events,
+      Emits,
+      ChoiceId,
+      ChoiceContext<States, Events, Emits, ChoiceId, InputEvents, ParentEvents>
+    >
     readonly entry?: never
     readonly exit?: never
     readonly invoke?: never
@@ -5979,12 +6248,6 @@ export declare namespace Machine {
     }
     : unknown
 
-  type TransitionResultTargetPath<Result> = IsAny<Result> extends true ? never
-    : Result extends Effect.Effect<infer Success, any, any> ? TransitionResultTargetPath<Success>
-    : Result extends StateConstruction<infer Constructed> ? TransitionResultTargetPath<Constructed>
-    : Result extends { readonly path: infer Path extends string } ? Path
-    : never
-
   type TransitionResultInitialTargetPath<Result> = IsAny<Result> extends true ? never
     : Result extends Effect.Effect<infer Success, any, any> ? TransitionResultInitialTargetPath<Success>
     : Result extends StateConstruction<infer Constructed> ? TransitionResultInitialTargetPath<Constructed>
@@ -6052,58 +6315,6 @@ export declare namespace Machine {
       Config,
       RequiredInitializersForTargetPath<AllStates, TargetPath>
     >
-    : unknown
-
-  type DeclaredTransitionTarget<Transition> = Transition extends {
-    readonly targets: infer Targets extends ReadonlyArray<string>
-  } ? Targets[number]
-    : never
-
-  type ExcludeDeclaredTransitionTarget<Returned, Declared extends string> = Returned extends string ?
-    Returned extends Declared | `${Declared}.${string}` ? never : Returned
-    : never
-
-  type UndeclaredTransitionTarget<Transition> = "targets" extends keyof Transition ? ExcludeDeclaredTransitionTarget<
-      TransitionResultTargetPath<EventTransitionReturn<Transition>>,
-      DeclaredTransitionTarget<Transition>
-    >
-    : never
-
-  type HandlerOnTargetValidationErrors<StateId extends string, On> = {
-    readonly [
-      EventTag in keyof On as [UndeclaredTransitionTarget<On[EventTag]>] extends [never] ? never
-        : EventTag
-    ]: HandlerValidationError<
-      "Transition returns a target not listed in targets",
-      StateId,
-      readonly [event: EventTag, target: UndeclaredTransitionTarget<On[EventTag]>]
-    >
-  }
-
-  type HandlerOnTargetValidation<StateId extends string, Config> = "on" extends keyof Config ?
-    Config extends { readonly on?: infer On } ? HandlerOnTargetValidationErrors<
-        StateId,
-        NonNullable<On>
-      > extends infer Errors ? keyof Errors extends never ? unknown
-        : { readonly on: Errors }
-      : never
-    : unknown
-    : unknown
-
-  type HandlerDirectTargetValidation<
-    StateId extends string,
-    Config,
-    Trigger extends "always" | "onDone",
-    Transition = Config extends { readonly [Key in Trigger]?: infer Value } ? NonNullable<Value> : never,
-    Undeclared extends string = UndeclaredTransitionTarget<Transition>
-  > = Trigger extends keyof Config ? [Undeclared] extends [never] ? unknown
-    : {
-      readonly [Key in Trigger]: HandlerValidationError<
-        "Transition returns a target not listed in targets",
-        StateId,
-        readonly [trigger: Trigger, target: Undeclared]
-      >
-    }
     : unknown
 
   type HandlerChildrenValidation<
@@ -6185,14 +6396,10 @@ export declare namespace Machine {
     AvailableOutputStates extends StateIdentifier<AllStates>
   > = StateId extends ChoiceIdentifier<AllStates> ?
       & HandlerChoiceUnknownConfigKeyValidation<StateId, Config>
-      & HandlerChoiceTargetValidation<StateId, Config>
       & HandlerRuntimeValidation<Events, Emits, StateId, Config>
     : StateId extends StateIdentifier<AllStates> ?
         & HandlerUnknownConfigKeyValidation<StateId, Config>
         & HandlerOnKeyValidation<Events, StateId, Config>
-        & HandlerOnTargetValidation<StateId, Config>
-        & HandlerDirectTargetValidation<StateId, Config, "always">
-        & HandlerDirectTargetValidation<StateId, Config, "onDone">
         & HandlerInvokeParentEventsValidation<InputEvents, StateId, Config>
         & HandlerChildrenValidation<Node, StateId, Config>
         & HandlerOutputRequirementValidation<AllStates, StateId, AvailableOutputStates, Config>
@@ -6211,17 +6418,6 @@ export declare namespace Machine {
       Key
     >
   }
-
-  type HandlerChoiceTargetValidation<StateId extends string, Config> = Config extends {
-    readonly choice: infer Choice
-  } ? [UndeclaredTransitionTarget<Choice>] extends [never] ? unknown : {
-      readonly choice: HandlerValidationError<
-        "Choice resolver returns a target not listed in targets",
-        StateId,
-        UndeclaredTransitionTarget<Choice>
-      >
-    }
-    : unknown
 
   type HandlerInvokeParentEventsValidation<
     Events extends ReadonlyArray<TaggedSchema>,
@@ -6523,19 +6719,14 @@ export declare namespace Machine {
   > = Readonly<
     Record<
       PropertyKey,
-      | ((
-        context: HandlerContext<States, Events, Emits, StateId, EventTag, E, R>,
-        enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-      ) => HandlerResult<States, E, R>)
-      | {
-        readonly reenter?: boolean
-        /** Statically declared upper bound of possible target paths. */
-        readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
-        readonly transition: (
-          context: HandlerContext<States, Events, Emits, StateId, EventTag, E, R>,
-          enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-        ) => HandlerResult<States, E, R>
-      }
+      TransitionConfig<
+        States,
+        Events,
+        Emits,
+        StateId,
+        HandlerContext<States, Events, Emits, StateId, EventTag, E, R>,
+        true
+      >
     >
   >
 
@@ -6563,30 +6754,20 @@ export declare namespace Machine {
       enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
     ) => StateActionResult<E, R>
     readonly invoke?: InvokeDefinition<States, Events, Emits, StateId>
-    readonly always?:
-      | ((
-        context: AlwaysContext<States, Events, Emits, StateId>,
-        enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-      ) => HandlerResult<States, E, R>)
-      | {
-        readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
-        readonly transition: (
-          context: AlwaysContext<States, Events, Emits, StateId>,
-          enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-        ) => HandlerResult<States, E, R>
-      }
-    readonly onDone?:
-      | ((
-        context: DoneContext<States, Events, Emits, StateId>,
-        enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-      ) => HandlerResult<States, E, R>)
-      | {
-        readonly targets?: ReadonlyArray<StateNodeIdentifier<States>>
-        readonly transition: (
-          context: DoneContext<States, Events, Emits, StateId>,
-          enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-        ) => HandlerResult<States, E, R>
-      }
+    readonly always?: TransitionConfig<
+      States,
+      Events,
+      Emits,
+      StateId,
+      AlwaysContext<States, Events, Emits, StateId>
+    >
+    readonly onDone?: TransitionConfig<
+      States,
+      Events,
+      Emits,
+      StateId,
+      DoneContext<States, Events, Emits, StateId>
+    >
     readonly output?:
       | ((context: FinalOutputContext<States, Events, StateId>) => unknown)
       | ((context: ParallelOutputContext<States, Events, StateId>) => unknown)
@@ -6671,15 +6852,15 @@ export const isFinal: <
  * **When to use**
  *
  * Use when you want to pass a state tree to `make` and also get typed
- * snapshot builders for initial states and tests.
+ * snapshot matching and access helpers.
  *
  * **Details**
  *
  * The returned `states` property is the same object passed to `defineStates`.
- * The returned `initial` builder creates snapshots without user-authored path
- * strings and enforces compound and parallel initial-state rules. Active nodes
- * may omit `schema` when they own no value; those builders expose `.from(...)`
- * and still participate fully in targeting, matching, and snapshots.
+ * `Machine.make` derives its initial target selector from that tree and
+ * enforces compound and parallel initial-state rules. Active nodes may omit
+ * `schema` when they own no value and still participate fully in targeting,
+ * matching, and snapshots.
  *
  * **Example** (Atomic initial snapshot)
  *
@@ -6694,7 +6875,10 @@ export const isFinal: <
  * Machine.make({
  *   states: States.states,
  *   events: Machine.events(),
- *   initial: () => States.initial.idle.from()
+ *   initial: {
+ *     target: (to) => to.idle(),
+ *     resolve: ({ target }) => target.from()
+ *   }
  * })
  * ```
  *
@@ -6702,6 +6886,20 @@ export const isFinal: <
  * @since 0.4.0
  */
 export const defineStates: DefineStates = internal.defineStates
+
+type InitialDirectInput<
+  States extends Machine.StateSchemas,
+  Input,
+  Selection extends Machine.TargetSelection<any, any, any>
+> = {
+  readonly target: (to: Machine.InitialSelector<States>) => Selection
+  readonly resolve?: (context: {
+    readonly input: Input
+    readonly target: Machine.SelectionBuilder<Selection>
+  }) => Machine.SelectedTargetResult<Selection>
+  readonly cases?: never
+  readonly otherwise?: never
+}
 
 type MakeConfig<
   States extends Machine.StateSchemas,
@@ -6727,7 +6925,7 @@ type MakeConfig<
   readonly emittedEvents?: Machine.EventProtocol<"emitted", Emits>
   readonly parentEvents?: Machine.EventProtocol<"public", ParentEvents>
   readonly input?: Input
-  readonly initial: (...args: [...Machine.InputArgs<Input>]) => Machine.InitialResult<States, InitialE, InitialR>
+  readonly initial: unknown
 }
 
 type MakeResult<
@@ -6765,9 +6963,15 @@ interface Make {
     InitialE = never,
     InitialR = never,
     const InternalEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
-    const ParentEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly []
+    const ParentEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+    const InitialSelection extends Machine.TargetSelection<any, any, any> = Machine.TargetSelection<any, any, any>
   >(
-    config: MakeConfig<States, InputEvents, Emits, Input, InitialE, InitialR, InternalEvents, ParentEvents>,
+    config:
+      & Omit<
+        MakeConfig<States, InputEvents, Emits, Input, InitialE, InitialR, InternalEvents, ParentEvents>,
+        "initial"
+      >
+      & { readonly initial: InitialDirectInput<States, Input["Type"], InitialSelection> },
     ..._validation: ValidateDefinedStates<NoInfer<States>>
   ): MakeResult<States, InputEvents, Emits, Input, InitialE, InitialR, InternalEvents, ParentEvents>
   <
@@ -6825,18 +7029,24 @@ interface Make {
  * const counter = Machine.make({
  *   states: States.states,
  *   events: Events,
- *   initial: () => States.initial.Count(new Count({ value: 0 }))
+ *   initial: {
+ *     target: (to) => to.Count(),
+ *     resolve: ({ target }) => target(new Count({ value: 0 }))
+ *   }
  * }).handle({
  *   Count: {
  *     on: {
- *       Increment: ({ event, state }) =>
- *         States.initial.Count(new Count({ value: state.value + event.by }))
+ *       Increment: Machine.transition({
+ *         target: (to) => to.full.Count(),
+ *         resolve: ({ event, state, target }) =>
+ *           target(new Count({ value: state.value + event.by }))
+ *       })
  *     }
  *   }
  * })
  * ```
  *
- * @see {@link defineStates} for typed initial snapshot builders.
+ * @see {@link defineStates} for typed state-tree helpers.
  * @category constructors
  * @since 0.4.0
  */
@@ -6963,7 +7173,10 @@ export const emittedEvents: {
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(),
- *   initial: () => States.initial.Idle.from()
+ *   initial: {
+ *     target: (to) => to.Idle(),
+ *     resolve: ({ target }) => target.from()
+ *   }
  * }).handle({ Idle: {} })
  *
  * const encoded = Effect.gen(function*() {
@@ -7045,7 +7258,10 @@ export const encodeSnapshot: <
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(),
- *   initial: () => States.initial.Idle.from()
+ *   initial: {
+ *     target: (to) => to.Idle(),
+ *     resolve: ({ target }) => target.from()
+ *   }
  * }).handle({ Idle: {} })
  *
  * const roundTrip = Effect.gen(function*() {
@@ -7126,6 +7342,7 @@ type EffectDoneHandler<
   States,
   Events,
   Emits,
+  StateId,
   Machine.InvokeDoneContext<
     States,
     Events,
@@ -7147,6 +7364,7 @@ type EffectFailureHandler<
   States,
   Events,
   Emits,
+  StateId,
   Machine.InvokeFailureContext<
     States,
     Events,
@@ -7207,6 +7425,7 @@ type BoundEffectDoneHandler<
   States,
   Events,
   Emits,
+  StateId,
   Machine.InvokeDoneContext<
     States,
     Events,
@@ -7230,6 +7449,7 @@ type BoundEffectFailureHandler<
   States,
   Events,
   Emits,
+  StateId,
   Machine.InvokeFailureContext<
     States,
     Events,
@@ -7257,6 +7477,215 @@ type BoundEffectInvokeResult<
     Effect.Services<ReturnType<Source>>,
     never
   >
+
+/**
+ * Captures one exact transition topology while preserving handler inference.
+ *
+ * @category constructors
+ * @since 0.14.0
+ */
+type ConditionalTransitionResult<
+  States extends Machine.StateSchemas,
+  Events extends ReadonlyArray<Machine.TaggedSchema>,
+  Emits extends ReadonlyArray<Machine.TaggedSchema>,
+  StateId extends Machine.StateNodeIdentifier<States>,
+  Context,
+  Reenter extends boolean,
+  Cases extends readonly [object, ...ReadonlyArray<object>],
+  OtherwiseSelection extends Machine.TargetSelection<any, any, any>
+> =
+  & Machine.TransitionConditionalInput<
+    States,
+    Events,
+    Emits,
+    StateId,
+    Context,
+    Reenter,
+    Cases,
+    OtherwiseSelection
+  >
+  & Machine.TransitionTyped<States, Events, Emits, StateId, Context, Reenter>
+
+type OptionValue<Value> = Value extends Option.Option<infer Match> ? Match : never
+
+type TransitionCaseFromWhen<
+  States extends Machine.StateSchemas,
+  Events extends ReadonlyArray<Machine.TaggedSchema>,
+  Emits extends ReadonlyArray<Machine.TaggedSchema>,
+  StateId extends Machine.StateNodeIdentifier<States>,
+  Context,
+  Selection extends Machine.TargetSelection<any, any, any>,
+  When extends (context: Omit<Context, "target">) => any
+> =
+  & Omit<
+    Machine.TransitionCaseInput<States, Events, Emits, StateId, Context, Selection, OptionValue<ReturnType<When>>>,
+    "when"
+  >
+  & { readonly when: When }
+
+/**
+ * Contextually types direct and conditional transition definitions.
+ *
+ * @category constructors
+ * @since 0.14.0
+ */
+export interface TransitionConstructor {
+  <
+    const States extends Machine.StateSchemas,
+    const Events extends ReadonlyArray<Machine.TaggedSchema>,
+    const Emits extends ReadonlyArray<Machine.TaggedSchema>,
+    StateId extends Machine.StateNodeIdentifier<States>,
+    Context,
+    const Selection extends Machine.TargetSelection<any, any, any>,
+    Reenter extends boolean = never
+  >(
+    config: Machine.TransitionDirectInput<States, Events, Emits, StateId, Context, Reenter, Selection>
+  ):
+    & Machine.TransitionDirectInput<States, Events, Emits, StateId, Context, Reenter, Selection>
+    & (Machine.SelectionKind<Selection> extends "none" ? Machine.TargetlessTransitionTyped
+      : Machine.TransitionTyped<States, Events, Emits, StateId, Context, Reenter>)
+  <
+    const States extends Machine.StateSchemas,
+    const Events extends ReadonlyArray<Machine.TaggedSchema>,
+    const Emits extends ReadonlyArray<Machine.TaggedSchema>,
+    StateId extends Machine.StateNodeIdentifier<States>,
+    Context,
+    const Selection1 extends Machine.TargetSelection<any, any, any>,
+    const When1 extends (context: Omit<Context, "target">) => any,
+    const OtherwiseSelection extends Machine.TargetSelection<any, any, any>,
+    Reenter extends boolean = never
+  >(
+    config: Machine.TransitionConditionalInput<
+      States,
+      Events,
+      Emits,
+      StateId,
+      Context,
+      Reenter,
+      readonly [TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection1, When1>],
+      OtherwiseSelection
+    >,
+    ..._validation: ReturnType<When1> extends Option.Option<unknown> ? [] : ["when must return Option"]
+  ): ConditionalTransitionResult<
+    States,
+    Events,
+    Emits,
+    StateId,
+    Context,
+    Reenter,
+    readonly [TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection1, When1>],
+    OtherwiseSelection
+  >
+  <
+    const States extends Machine.StateSchemas,
+    const Events extends ReadonlyArray<Machine.TaggedSchema>,
+    const Emits extends ReadonlyArray<Machine.TaggedSchema>,
+    StateId extends Machine.StateNodeIdentifier<States>,
+    Context,
+    const Selection1 extends Machine.TargetSelection<any, any, any>,
+    const When1 extends (context: Omit<Context, "target">) => any,
+    const Selection2 extends Machine.TargetSelection<any, any, any>,
+    const When2 extends (context: Omit<Context, "target">) => any,
+    const OtherwiseSelection extends Machine.TargetSelection<any, any, any>,
+    Reenter extends boolean = never
+  >(
+    config: Machine.TransitionConditionalInput<
+      States,
+      Events,
+      Emits,
+      StateId,
+      Context,
+      Reenter,
+      readonly [
+        TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection1, When1>,
+        TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection2, When2>
+      ],
+      OtherwiseSelection
+    >,
+    ..._validation: ReturnType<When1> extends Option.Option<unknown> ?
+      ReturnType<When2> extends Option.Option<unknown> ? [] : ["when must return Option"]
+      : ["when must return Option"]
+  ): ConditionalTransitionResult<
+    States,
+    Events,
+    Emits,
+    StateId,
+    Context,
+    Reenter,
+    readonly [
+      TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection1, When1>,
+      TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection2, When2>
+    ],
+    OtherwiseSelection
+  >
+  <
+    const States extends Machine.StateSchemas,
+    const Events extends ReadonlyArray<Machine.TaggedSchema>,
+    const Emits extends ReadonlyArray<Machine.TaggedSchema>,
+    StateId extends Machine.StateNodeIdentifier<States>,
+    Context,
+    const Selection1 extends Machine.TargetSelection<any, any, any>,
+    const When1 extends (context: Omit<Context, "target">) => any,
+    const Selection2 extends Machine.TargetSelection<any, any, any>,
+    const When2 extends (context: Omit<Context, "target">) => any,
+    const Selection3 extends Machine.TargetSelection<any, any, any>,
+    const When3 extends (context: Omit<Context, "target">) => any,
+    const OtherwiseSelection extends Machine.TargetSelection<any, any, any>,
+    Reenter extends boolean = never
+  >(
+    config: Machine.TransitionConditionalInput<
+      States,
+      Events,
+      Emits,
+      StateId,
+      Context,
+      Reenter,
+      readonly [
+        TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection1, When1>,
+        TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection2, When2>,
+        TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection3, When3>
+      ],
+      OtherwiseSelection
+    >,
+    ..._validation: ReturnType<When1> extends Option.Option<unknown> ?
+      ReturnType<When2> extends Option.Option<unknown> ?
+        ReturnType<When3> extends Option.Option<unknown> ? [] : ["when must return Option"]
+      : ["when must return Option"]
+      : ["when must return Option"]
+  ): ConditionalTransitionResult<
+    States,
+    Events,
+    Emits,
+    StateId,
+    Context,
+    Reenter,
+    readonly [
+      TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection1, When1>,
+      TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection2, When2>,
+      TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection3, When3>
+    ],
+    OtherwiseSelection
+  >
+}
+
+/**
+ * Defines a statically inspectable transition.
+ *
+ * This constructor is an identity at runtime. It is required for every event,
+ * lifecycle, choice, and invocation transition so the destination selected by
+ * `target` can contextually type the corresponding resolver.
+ *
+ * ```ts
+ * Machine.transition({
+ *   target: (to) => to.full.Ready(),
+ *   resolve: ({ target }) => target.from()
+ * })
+ * ```
+ *
+ * @category constructors
+ * @since 0.14.0
+ */
+export const transition: TransitionConstructor = ((config: unknown) => config) as TransitionConstructor
 
 /**
  * Machine-bound invocation constructor that preserves the owning machine's
@@ -7376,73 +7805,74 @@ export interface Invoker<
   ): Config & Machine.InvokeOwned<States, Events, Emits, StateId> & Machine.InvokeTyped<void, never, never, never>
   <
     StateId extends Machine.StateIdentifier<States>,
-    ChildState,
-    ChildEvent,
-    ChildError,
-    ChildRequirements,
-    ChildOutput,
-    ChildInitialError,
+    const Source extends (
+      context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    ) => unknown,
     Address extends ChildAddress<never>
   >(
-    config: Machine.LogicInvokeArgs<
-      States,
-      Events,
-      Emits,
-      StateId,
-      ChildState,
-      ChildEvent,
-      ChildError,
-      ChildRequirements,
-      ChildOutput,
-      ChildInitialError,
-      Address,
-      (context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>) => Logic<
-        ChildState,
-        ChildEvent,
-        ChildError,
-        ChildRequirements,
-        ChildOutput,
-        ChildInitialError
-      >,
-      InputEvents,
-      ParentEvents
-    >
-  ):
-    & Machine.InvokeConfig<States, Events, Emits, StateId, InputEvents, ParentEvents>
-    & Machine.InvokeTyped<ChildOutput, ChildError, ChildRequirements, ChildInitialError>
-  <
-    StateId extends Machine.StateIdentifier<States>,
-    ChildState,
-    ChildEvent,
-    ChildError,
-    ChildRequirements,
-    ChildOutput,
-    ChildInitialError,
-    Address extends ChildAddress<never>,
-    const Config extends object
-  >(
     config:
-      & Config
+      & { readonly logic: Source }
       & Machine.LogicInvokeArgs<
         States,
         Events,
         Emits,
         StateId,
-        ChildState,
-        ChildEvent,
-        ChildError,
-        ChildRequirements,
-        ChildOutput,
-        ChildInitialError,
+        Machine.LogicStateOf<ReturnType<Source>>,
+        Machine.LogicEventOf<ReturnType<Source>>,
+        Machine.LogicErrorOf<ReturnType<Source>>,
+        Machine.LogicServicesOf<ReturnType<Source>>,
+        Machine.LogicOutputOf<ReturnType<Source>>,
+        Machine.LogicInitialErrorOf<ReturnType<Source>>,
         Address,
-        Logic<ChildState, ChildEvent, ChildError, ChildRequirements, ChildOutput, ChildInitialError>,
+        Source,
         InputEvents,
         ParentEvents
-      >
+      >,
+    ..._validation: ReturnType<Source> extends { readonly initial: unknown; readonly run: unknown } ? [] : [
+      "logic factory must return Machine.Logic"
+    ]
   ):
-    & Config
-    & Machine.InvokeOwned<States, Events, Emits, StateId>
-    & Machine.InvokeTyped<ChildOutput, ChildError, ChildRequirements, ChildInitialError>
+    & Machine.InvokeConfig<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    & Machine.InvokeTyped<
+      Machine.LogicOutputOf<ReturnType<Source>>,
+      Machine.LogicErrorOf<ReturnType<Source>>,
+      Machine.LogicServicesOf<ReturnType<Source>>,
+      Machine.LogicInitialErrorOf<ReturnType<Source>>
+    >
+  <
+    StateId extends Machine.StateIdentifier<States>,
+    const Source,
+    Address extends ChildAddress<never>
+  >(
+    config:
+      & { readonly logic: Source }
+      & Machine.LogicInvokeArgs<
+        States,
+        Events,
+        Emits,
+        StateId,
+        Machine.LogicStateOf<Source>,
+        Machine.LogicEventOf<Source>,
+        Machine.LogicErrorOf<Source>,
+        Machine.LogicServicesOf<Source>,
+        Machine.LogicOutputOf<Source>,
+        Machine.LogicInitialErrorOf<Source>,
+        Address,
+        Source,
+        InputEvents,
+        ParentEvents
+      >,
+    ..._validation: Source extends { readonly initial: unknown; readonly run: unknown } ? [] : [
+      "logic must implement Machine.Logic"
+    ]
+  ):
+    & Machine.InvokeConfig<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    & Machine.InvokeTyped<
+      Machine.LogicOutputOf<Source>,
+      Machine.LogicErrorOf<Source>,
+      Machine.LogicServicesOf<Source>,
+      Machine.LogicInitialErrorOf<Source>
+    >
   <
     StateId extends Machine.StateIdentifier<States>,
     const Child extends ChildMachine.Any,
@@ -7504,8 +7934,14 @@ export interface Invoker<
  *       try: () => fetch("/api/data").then((response) => response.json()),
  *       catch: (cause) => new LoadError({ cause })
  *     }),
- *   onDone: ({ output, target }) => target.full.Ready({ data: output }),
- *   onFailure: ({ error, target }) => target.full.Failed({ error })
+ *   onDone: Machine.transition({
+ *     target: (to) => to.full.Ready(),
+ *     resolve: ({ output, target }) => target.from({ data: output })
+ *   }),
+ *   onFailure: Machine.transition({
+ *     target: (to) => to.full.Failed(),
+ *     resolve: ({ error, target }) => target.from({ error })
+ *   })
  * })
  * ```
  *
@@ -7738,7 +8174,10 @@ export const invoke: {
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(),
- *   initial: () => States.initial.Idle.from()
+ *   initial: {
+ *     target: (to) => to.Idle(),
+ *     resolve: ({ target }) => target.from()
+ *   }
  * }).handle({ Idle: {} })
  *
  * const initialState = Effect.map(Machine.planInitial(machine), (plan) => plan.state)
@@ -7852,9 +8291,9 @@ export const stateNodes: <M extends Machine.Any>(machine: M) => ReadonlyArray<
  *
  * Event handlers retain their handler-key order within each source state and
  * are followed by eventless and completion handlers. This function does not
- * execute handlers. Object-form event, eventless, and completion handlers with
- * a `targets` declaration expose those possible paths; handlers without one
- * remain dynamic.
+ * execute predicates or resolvers. Every direct, conditional, fallback, and
+ * targetless branch exposes the destination selected by its required static
+ * `target` declaration.
  *
  * @category getters
  * @since 0.4.0
@@ -7977,8 +8416,21 @@ export const enabled: <
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(Toggle),
- *   initial: () => States.initial.Off.from()
- * }).handle({ Off: { on: { Toggle: () => States.initial.On.from() } }, On: {} })
+ *   initial: {
+ *     target: (to) => to.Off(),
+ *     resolve: ({ target }) => target.from()
+ *   }
+ * }).handle({
+ *   Off: {
+ *     on: {
+ *       Toggle: Machine.transition({
+ *         target: (to) => to.full.On(),
+ *         resolve: ({ target }) => target.from()
+ *       })
+ *     }
+ *   },
+ *   On: {}
+ * })
  *
  * const nextState = Effect.gen(function*() {
  *   const initial = yield* Machine.planInitial(machine)
@@ -8110,41 +8562,6 @@ export const logic: <
     context: Logic.Context<State, Event>
   ) => Effect.Effect<Output, Error, Requirements>
 }) => Logic<State, Event, Error, Requirements | InitialRequirements, Output, InitialError> = internal.logic
-
-/**
- * Creates child process logic from an initial state and a transition function.
- *
- * **When to use**
- *
- * Use when a child process only needs sequential event-driven state updates and
- * does not need direct control over intermediate snapshots or child ownership.
- *
- * **Details**
- *
- * Each received event runs the transition Effect against the latest state. The
- * resulting state is published before the next queued event is processed.
- *
- * **Example**
- *
- * ```ts
- * import { Effect } from "effect"
- * import { Machine } from "@typeonce/effect-machine"
- *
- * const counter = Machine.transition(
- *   0,
- *   (count, event: { readonly by: number }) => Effect.succeed(count + event.by)
- * )
- * ```
- *
- * Use an inline `invoke` with an `effect` source for one-shot work.
- * @see {@link logic} for direct process lifecycle control.
- * @category constructors
- * @since 0.4.0
- */
-export const transition: <State, Event, Error = never, Requirements = never>(
-  initial: State,
-  transition: (state: State, event: Event) => Effect.Effect<State, Error, Requirements>
-) => Logic<State, Event, Error, Requirements, never> = internal.transition
 
 /**
  * Creates a typed descriptor for a complete child machine.
@@ -8382,7 +8799,10 @@ export const prepare: <
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(),
- *   initial: () => States.initial.Idle.from()
+ *   initial: {
+ *     target: (to) => to.Idle(),
+ *     resolve: ({ target }) => target.from()
+ *   }
  * }).handle({ Idle: {} })
  *
  * const state = Effect.gen(function*() {
@@ -8492,7 +8912,10 @@ export const start: <
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(),
- *   initial: () => States.initial.Idle.from()
+ *   initial: {
+ *     target: (to) => to.Idle(),
+ *     resolve: ({ target }) => target.from()
+ *   }
  * }).handle({ Idle: {} })
  *
  * const resumed = Effect.gen(function*() {

--- a/src/internal/machine/executionPlan.ts
+++ b/src/internal/machine/executionPlan.ts
@@ -150,7 +150,7 @@ const compileIndexedExecutionDescriptor = (
     }
     const byEvent = new Map<PropertyKey, MicrostepTransition<any, any, any, any>>()
     for (const tag of Reflect.ownKeys(config.on)) {
-      const transition = normalizeTransition(config.on[tag])
+      const transition = normalizeTransition(config.on[tag] as Parameters<typeof normalizeTransition>[0])
       if (transition !== undefined) {
         byEvent.set(tag, transition)
       }

--- a/src/internal/machine/machine.ts
+++ b/src/internal/machine/machine.ts
@@ -49,6 +49,7 @@ export { ChildMachineLogicTypeId, InitialEventTypeId, SnapshotBuilderStateTypeId
 
 const TypeId = "~effect/Machine"
 export const InvokeTypeId: unique symbol = Symbol.for("effect/Machine/Invoke")
+export const TransitionTypeId: unique symbol = Symbol.for("effect/Machine/Transition")
 const ChildMachineTypeId = "~effect/Machine/ChildMachine"
 type IsAny<A> = 0 extends 1 & A ? true : false
 type MachineRuntimeRequirement = internalRuntime.MachineRuntime
@@ -127,47 +128,291 @@ const cloneWithHandlers = (
   return machine
 }
 
-const validateTransitionTargets = (
+type DefinitionBranch = {
+  readonly title?: string
+  readonly when?: (context: any) => Option.Option<unknown>
+  readonly target: (selector: unknown) => unknown
+  readonly resolve?: (context: any, enqueue: unknown) => unknown
+}
+
+type CapturedBranch = DefinitionBranch & {
+  readonly selection: Topology.TargetSelection
+}
+
+const makeSelectionMethod = (
+  kind: Topology.TargetSelectionKind,
+  path: string | undefined,
+  scope: Topology.TargetSelectionScope
+): () => Topology.TargetSelection =>
+() => Topology.makeTargetSelection(kind, path, scope)
+
+const addSelectionChildren = (
+  builder: Record<string, unknown>,
+  stateNodes: Machine.StateNodes,
+  parent: string,
+  scope: "local" | "branch"
+): void => {
+  for (const node of stateNodes.byPath.values()) {
+    if (node.parent !== parent || node.type === "history") continue
+    builder[node.key] = makeSelectionNode(stateNodes, node.path, scope)
+  }
+}
+
+const makeSelectionNode = (
   stateNodes: Machine.StateNodes,
   path: string,
-  trigger: PropertyKey,
-  transition: unknown
-): void => {
-  if (typeof transition !== "object" || transition === null || !hasProperty(transition, "targets")) {
-    return
-  }
-  if (!Array.isArray(transition.targets)) {
-    throw new Error(
-      `Machine expected transition targets for state "${path}" on "${String(trigger)}" to be an array`
-    )
-  }
-  for (const target of transition.targets) {
-    if (typeof target !== "string" || !stateNodes.byPath.has(target)) {
-      throw new Error(
-        `Machine transition for state "${path}" on "${String(trigger)}" declares unknown target "${String(target)}"`
-      )
+  scope: Topology.TargetSelectionScope
+): unknown => {
+  const node = getTargetBuilderNode(stateNodes, path)
+  const kind: Topology.TargetSelectionKind = node.type === "choice" ? "choice" : "state"
+  const method = makeSelectionMethod(kind, path, scope) as unknown as Record<string, unknown>
+  if (node.type !== "atomic" && node.type !== "final" && node.type !== "choice" && node.type !== "history") {
+    Object.defineProperty(method, "initial", {
+      value: makeSelectionMethod("initial", path, scope),
+      enumerable: true
+    })
+    if (scope === "local" || scope === "branch") {
+      addSelectionChildren(method, stateNodes, path, scope)
     }
   }
+  return method
 }
 
-const captureTransition = (transition: unknown): unknown => {
+const makeHistorySelectionTree = (
+  stateNodes: Machine.StateNodes,
+  parent: string | undefined
+): Record<string, unknown> => {
+  const builder: Record<string, unknown> = {}
+  for (const node of stateNodes.byPath.values()) {
+    if (node.parent !== parent) continue
+    if (node.type === "history") {
+      builder[node.key] = makeSelectionMethod("history", node.path, "full")
+    } else if (node.type !== "choice") {
+      const children = makeHistorySelectionTree(stateNodes, node.path)
+      if (Object.keys(children).length > 0) builder[node.key] = children
+    }
+  }
+  return builder
+}
+
+const makeTargetSelector = (
+  stateNodes: Machine.StateNodes,
+  source: string
+): unknown => {
+  const full: Record<string, unknown> = {}
+  for (const node of stateNodes.byPath.values()) {
+    if (node.parent === undefined && node.type !== "history" && node.type !== "choice") {
+      full[node.key] = makeSelectionNode(stateNodes, node.path, "full")
+    }
+  }
+  const branch: Record<string, unknown> = {}
+  const root = getTargetBuilderNode(stateNodes, source.split(".")[0]!)
+  branch[root.key] = makeSelectionNode(stateNodes, root.path, "branch")
+  const local: Record<string, unknown> = {}
+  const localScope = getLocalTargetScope(stateNodes, source)
+  if (localScope !== undefined) addSelectionChildren(local, stateNodes, localScope, "local")
+  return {
+    none: makeSelectionMethod("none", undefined, "local"),
+    local,
+    branch,
+    full,
+    history: makeHistorySelectionTree(stateNodes, undefined)
+  }
+}
+
+const captureDefinitionBranch = (
+  branch: unknown,
+  selector: unknown,
+  path: string,
+  trigger: PropertyKey
+): CapturedBranch => {
+  if (
+    typeof branch !== "object" || branch === null || !hasProperty(branch, "target") ||
+    typeof branch.target !== "function"
+  ) {
+    throw new Error(`Machine transition for state "${path}" on "${String(trigger)}" requires a target selector`)
+  }
+  const selection = branch.target(selector)
+  if (!Topology.isTargetSelection(selection)) {
+    throw new Error(`Machine transition for state "${path}" on "${String(trigger)}" must select exactly one target`)
+  }
+  return { ...(branch as DefinitionBranch), selection }
+}
+
+const getSelectionBuilder = (
+  target: Record<string, any>,
+  selection: Topology.TargetSelection,
+  stateNodes: Machine.StateNodes,
+  source: string
+): unknown => {
+  if (selection.kind === "none") return target.none
+  let builder: any
+  let parts = selection.path!.split(".")
+  if (selection.kind === "history") {
+    builder = target.history
+  } else if (selection.scope === "local") {
+    builder = target.local
+    const scope = getLocalTargetScope(stateNodes, source)
+    if (scope !== undefined) parts = selection.path!.slice(scope.length + 1).split(".")
+  } else if (selection.scope === "branch") {
+    builder = target.branch
+  } else {
+    builder = target.full
+  }
+  for (const part of parts) builder = builder[part]
+  if (selection.kind === "initial") builder = builder.initial
+  if (
+    typeof builder !== "function" &&
+    (typeof builder !== "object" || builder === null || typeof builder.from !== "function")
+  ) {
+    throw new Error(`Machine could not construct selected transition target "${selection.path}"`)
+  }
+  return builder
+}
+
+const constructSelectedTarget = (builder: any): unknown => typeof builder === "function" ? builder() : builder.from()
+
+const validateResolvedSelection = (
+  result: unknown,
+  selection: Topology.TargetSelection,
+  stateNodes: Machine.StateNodes
+): void => {
+  if (selection.kind === "none") {
+    if (result !== undefined) {
+      throw new Error("Machine targetless transition resolver must return undefined")
+    }
+    return
+  }
+  if (result === undefined) return
+  const resultPath = typeof result === "object" && result !== null && hasProperty(result, "path") &&
+      typeof result.path === "string"
+    ? result.path
+    : undefined
+  const selectedNode = selection.path === undefined ? undefined : stateNodes.byPath.get(selection.path)
+  const acceptsDescendant = (selection.scope === "local" || selection.scope === "branch") &&
+    (selectedNode?.type === "compound" || selectedNode?.type === "parallel")
+  if (
+    resultPath === undefined ||
+    (resultPath !== selection.path && !(acceptsDescendant && resultPath.startsWith(`${selection.path}.`)))
+  ) {
+    throw new Error(
+      `Machine transition resolver selected "${selection.path}" but constructed "${resultPath ?? "<invalid>"}"`
+    )
+  }
+}
+
+const runCapturedBranch = (
+  branch: CapturedBranch,
+  context: Record<string, any>,
+  enqueue: unknown,
+  stateNodes: Machine.StateNodes,
+  source: string,
+  match?: { readonly value: unknown }
+): unknown => {
+  const selectedTarget = getSelectionBuilder(context.target, branch.selection, stateNodes, source)
+  if (branch.resolve === undefined) return constructSelectedTarget(selectedTarget)
+  const resolverContext = { ...context }
+  if (branch.selection.kind === "none") delete resolverContext.target
+  else resolverContext.target = selectedTarget
+  if (match !== undefined) resolverContext.match = match.value
+  const resolved = branch.resolve(resolverContext, enqueue)
+  validateResolvedSelection(resolved, branch.selection, stateNodes)
+  return resolved === undefined ? constructSelectedTarget(selectedTarget) : resolved
+}
+
+const captureTransition = (
+  transition: unknown,
+  stateNodes: Machine.StateNodes,
+  path: string,
+  trigger: PropertyKey
+): unknown => {
   if (typeof transition !== "object" || transition === null) {
-    return transition
+    throw new Error(`Machine transition for state "${path}" on "${String(trigger)}" must be an object`)
   }
-  const captured = { ...(transition as Record<PropertyKey, unknown>) }
-  if (Array.isArray(captured.targets)) {
-    captured.targets = captured.targets.slice()
+  const definition = transition as Record<PropertyKey, unknown>
+  const selector = makeTargetSelector(stateNodes, path)
+  const reenter = definition.reenter === true
+  if (Array.isArray(definition.cases)) {
+    const rawCases = definition.cases as ReadonlyArray<unknown>
+    if (definition.cases.length === 0 || !hasProperty(definition, "otherwise")) {
+      throw new Error(
+        `Machine conditional transition for state "${path}" on "${String(trigger)}" requires cases and otherwise`
+      )
+    }
+    const cases = rawCases.map((branch) => {
+      const captured = captureDefinitionBranch(branch, selector, path, trigger)
+      if (typeof captured.title !== "string" || captured.title.length === 0 || typeof captured.when !== "function") {
+        throw new Error(
+          `Machine conditional transition case for state "${path}" on "${String(trigger)}" requires title and when`
+        )
+      }
+      return captured
+    })
+    const otherwise = captureDefinitionBranch(definition.otherwise, selector, path, trigger)
+    return {
+      reenter,
+      targets: [
+        ...new Set(
+          [...cases, otherwise].flatMap((branch) => branch.selection.path === undefined ? [] : [branch.selection.path])
+        )
+      ],
+      branches: [
+        ...cases.map((branch) => ({ type: "case" as const, title: branch.title!, target: branch.selection.path })),
+        { type: "otherwise" as const, target: otherwise.selection.path }
+      ],
+      transition: (context: Record<string, any>, enqueue: unknown) => {
+        const predicateContext = { ...context }
+        delete predicateContext.target
+        for (const branch of cases) {
+          const result = branch.when!(predicateContext)
+          if (!Option.isOption(result)) {
+            throw new Error(`Machine conditional transition case "${branch.title}" must return Option`)
+          }
+          if (Option.isSome(result)) {
+            return runCapturedBranch(branch, context, enqueue, stateNodes, path, { value: result.value })
+          }
+        }
+        return runCapturedBranch(otherwise, context, enqueue, stateNodes, path)
+      }
+    }
   }
-  return captured
+  const branch = captureDefinitionBranch(transition, selector, path, trigger)
+  return {
+    reenter,
+    targets: branch.selection.path === undefined ? [] : [branch.selection.path],
+    branches: [{ type: "direct" as const, target: branch.selection.path }],
+    transition: (context: Record<string, any>, enqueue: unknown) =>
+      runCapturedBranch(branch, context, enqueue, stateNodes, path)
+  }
 }
 
-const captureEventHandlers = (on: object): Record<PropertyKey, unknown> => {
+const captureEventHandlers = (
+  on: object,
+  stateNodes: Machine.StateNodes,
+  path: string
+): Record<PropertyKey, unknown> => {
   // The machine owns its dispatch table. Compiled plans may snapshot these
   // definitions, so retaining caller-owned containers would let strategies
   // observe different handlers after an unsafe external mutation.
   const captured: Record<PropertyKey, unknown> = Object.create(null)
   for (const event of Reflect.ownKeys(on)) {
-    captured[event] = captureTransition((on as Record<PropertyKey, unknown>)[event])
+    captured[event] = captureTransition((on as Record<PropertyKey, unknown>)[event], stateNodes, path, event)
+  }
+  return captured
+}
+
+const captureInvokeDefinition = (
+  invoke: unknown,
+  stateNodes: Machine.StateNodes,
+  path: string
+): unknown => {
+  if (Array.isArray(invoke)) return invoke.map((item) => captureInvokeDefinition(item, stateNodes, path))
+  if (typeof invoke !== "object" || invoke === null) return invoke
+  const captured = { ...(invoke as Record<PropertyKey, unknown>) }
+  for (const key of ["onDone", "onFailure", "onSnapshot"] as const) {
+    if (captured[key] !== undefined) {
+      captured[key] = captureTransition(captured[key], stateNodes, path, key)
+    }
   }
   return captured
 }
@@ -191,15 +436,21 @@ const flattenHandlers = (
     const { states: childConfig, ...stateConfig } = nodeConfig as Record<string, unknown>
     const on = stateConfig.on
     if (typeof on === "object" && on !== null) {
-      const capturedOn = captureEventHandlers(on)
+      const capturedOn = captureEventHandlers(on, stateNodes, path)
       stateConfig.on = capturedOn
-      for (const event of Reflect.ownKeys(capturedOn)) {
-        validateTransitionTargets(stateNodes, path, event, capturedOn[event])
-      }
     }
-    validateTransitionTargets(stateNodes, path, "always", stateConfig.always)
-    validateTransitionTargets(stateNodes, path, "done", stateConfig.onDone)
-    validateTransitionTargets(stateNodes, path, "choice", stateConfig.choice)
+    if (stateConfig.always !== undefined) {
+      stateConfig.always = captureTransition(stateConfig.always, stateNodes, path, "always")
+    }
+    if (stateConfig.onDone !== undefined) {
+      stateConfig.onDone = captureTransition(stateConfig.onDone, stateNodes, path, "done")
+    }
+    if (stateConfig.choice !== undefined) {
+      stateConfig.choice = captureTransition(stateConfig.choice, stateNodes, path, "choice")
+    }
+    if (stateConfig.invoke !== undefined) {
+      stateConfig.invoke = captureInvokeDefinition(stateConfig.invoke, stateNodes, path)
+    }
     const node = stateNodes.byPath.get(path)
     if (node?.type === "choice") {
       if (
@@ -208,7 +459,7 @@ const flattenHandlers = (
         !hasProperty(stateConfig.choice, "targets") || !Array.isArray(stateConfig.choice.targets) ||
         stateConfig.choice.targets.length === 0
       ) {
-        throw new Error(`Machine choice state "${path}" requires a transition and at least one declared target`)
+        throw new Error(`Machine choice state "${path}" requires a transition`)
       }
     }
     handlers[path] = stateConfig as Machine.AnyStateConfig
@@ -764,13 +1015,80 @@ const makeTargetBuilder = <const States extends Machine.StateSchemas>(
     }) as Machine.TargetBuilder<States, Source>
 }
 
+const makeInitialSelector = (stateNodes: Machine.StateNodes): unknown => {
+  const selector: Record<string, unknown> = {}
+  for (const node of stateNodes.byPath.values()) {
+    if (node.parent === undefined && node.type !== "history" && node.type !== "choice") {
+      selector[node.key] = makeSelectionNode(stateNodes, node.path, "initial")
+    }
+  }
+  return selector
+}
+
+const getInitialSelectionBuilder = (
+  initialBuilder: Record<string, any>,
+  selection: Topology.TargetSelection
+): (...args: ReadonlyArray<any>) => unknown => {
+  const path = selection.path
+  if (path === undefined || path.includes(".")) {
+    throw new Error("Machine initial target must select one top-level state")
+  }
+  const builder = initialBuilder[path]
+  if (typeof builder !== "function") {
+    throw new Error(`Machine could not construct selected initial state "${path}"`)
+  }
+  return builder
+}
+
+const captureInitialBranch = (
+  branch: unknown,
+  selector: unknown,
+  initialBuilder: Record<string, any>
+): CapturedBranch & { readonly builder: (...args: ReadonlyArray<any>) => unknown } => {
+  const captured = captureDefinitionBranch(branch, selector, "<machine>", "initial")
+  if (captured.selection.kind !== "state" && captured.selection.kind !== "initial") {
+    throw new Error("Machine initial target must select a top-level state or its declared initial entry")
+  }
+  return { ...captured, builder: getInitialSelectionBuilder(initialBuilder, captured.selection) }
+}
+
+const validateInitialSelection = (result: unknown, selection: Topology.TargetSelection): void => {
+  if (
+    typeof result !== "object" || result === null || !hasProperty(result, "path") || result.path !== selection.path
+  ) {
+    const resultPath = typeof result === "object" && result !== null && hasProperty(result, "path")
+      ? String(result.path)
+      : "<invalid>"
+    throw new Error(`Machine initial resolver selected "${selection.path}" but constructed "${resultPath}"`)
+  }
+}
+
+const compileInitial = (
+  definition: unknown,
+  states: Machine.StateTree,
+  stateNodes: Machine.StateNodes
+): (input?: unknown) => unknown => {
+  if (typeof definition !== "object" || definition === null) {
+    throw new Error("Machine initial definition must be an object")
+  }
+  const selector = makeInitialSelector(stateNodes)
+  const initialBuilder = makeSnapshotBuilder(states, { mode: "initial", prefix: "" }) as Record<string, any>
+  const branch = captureInitialBranch(definition, selector, initialBuilder)
+  return (input?: unknown) => {
+    const result = branch.resolve === undefined
+      ? branch.builder()
+      : branch.resolve({ input, target: branch.builder }, undefined)
+    validateInitialSelection(result, branch.selection)
+    return result
+  }
+}
+
 export const defineStates: DefineStates = (<const States extends Machine.StateSchemas>(
   states: States
 ): Machine.DefinedStates<States> => {
   StateDefinition.validateStateDefinitions(states, "Machine.defineStates")
   return {
     states,
-    initial: makeSnapshotBuilder(states, { mode: "initial", prefix: "" }) as Machine.InitialBuilder<States>,
     get:
       ((snapshot: Machine.AtomicSnapshot<string, unknown>, path: string) =>
         Topology.getSnapshotByPath(snapshot, path).pipe(
@@ -813,7 +1131,7 @@ type MakeConfig<
   readonly emittedEvents?: Machine.EventProtocol<"emitted", Emits>
   readonly parentEvents?: Machine.EventProtocol<"public", ParentEvents>
   readonly input?: Input
-  readonly initial: (...args: [...Machine.InputArgs<Input>]) => Machine.InitialResult<States, InitialE, InitialR>
+  readonly initial: unknown
 }
 
 type MakeResult<
@@ -890,7 +1208,7 @@ export const make: Make = (<
     readonly emittedEvents?: Machine.EventProtocol<"emitted", Emits>
     readonly parentEvents?: Machine.EventProtocol<"public", ParentEvents>
     readonly input?: Input
-    readonly initial: (...args: [...Machine.InputArgs<Input>]) => Machine.InitialResult<States, InitialE, InitialR>
+    readonly initial: unknown
   }
 ): MakeResult<States, InputEvents, Emits, Input, InitialE, InitialR, InternalEvents, ParentEvents> => {
   StateDefinition.validateStateDefinitions(config.states, "Machine.make")
@@ -902,8 +1220,8 @@ export const make: Make = (<
   self.parentEvents = config.parentEvents ?? Protocol.makeEventProtocol("public", [] as const)
   self.input = config.input
   self.id = config.id
-  self.initial = config.initial
   self.stateNodes = Topology.compileStateNodes(config.states)
+  self.initial = compileInitial(config.initial, config.states, self.stateNodes)
   self.makeTargetBuilder = makeTargetBuilder(config.states, self.stateNodes)
   self.handlers = Object.create(null)
   self.handle = makeHandle(self)

--- a/src/internal/machine/topology.ts
+++ b/src/internal/machine/topology.ts
@@ -25,6 +25,8 @@ export const ChoiceTargetTypeId: unique symbol = Symbol("effect/Machine/ChoiceTa
 
 export const NoTargetTypeId: unique symbol = Symbol("effect/Machine/NoTarget")
 
+export const TargetSelectionTypeId: unique symbol = Symbol("effect/Machine/TargetSelection")
+
 interface StateInput {
   readonly [StateInputTypeId]: typeof StateInputTypeId
   readonly input: unknown
@@ -61,6 +63,32 @@ export interface ChoiceTarget {
 export interface NoTarget {
   readonly [NoTargetTypeId]: typeof NoTargetTypeId
 }
+
+export type TargetSelectionKind = "state" | "initial" | "history" | "choice" | "none"
+
+export type TargetSelectionScope = "local" | "branch" | "full" | "initial"
+
+/** Immutable destination selected while a machine definition is captured. */
+export interface TargetSelection {
+  readonly [TargetSelectionTypeId]: typeof TargetSelectionTypeId
+  readonly kind: TargetSelectionKind
+  readonly scope: TargetSelectionScope | undefined
+  readonly path: string | undefined
+}
+
+export const makeTargetSelection = (
+  kind: TargetSelectionKind,
+  path?: string,
+  scope?: TargetSelectionScope
+): TargetSelection =>
+  Object.freeze({
+    [TargetSelectionTypeId]: TargetSelectionTypeId as typeof TargetSelectionTypeId,
+    kind,
+    scope,
+    path
+  })
+
+export const isTargetSelection = (u: unknown): u is TargetSelection => hasProperty(u, TargetSelectionTypeId)
 
 const noTarget = Object.freeze({
   [NoTargetTypeId]: NoTargetTypeId
@@ -381,12 +409,10 @@ export const compileStateNodes = (states: Machine.StateSchemas): Machine.StateNo
   } as Machine.StateNodes
 }
 
-const dynamicTransitionTargets = { type: "dynamic" } as const
-
-const transitionTargets = (handler: unknown): Machine.TransitionTargets =>
-  typeof handler === "object" && handler !== null && "targets" in handler && handler.targets !== undefined
-    ? { type: "declared", paths: Array.from(handler.targets as ReadonlyArray<string>) }
-    : dynamicTransitionTargets
+const transitionBranches = (handler: unknown): ReadonlyArray<Machine.TransitionBranch> =>
+  typeof handler === "object" && handler !== null && "branches" in handler && Array.isArray(handler.branches)
+    ? Array.from(handler.branches as ReadonlyArray<Machine.TransitionBranch>)
+    : []
 
 export const transitionDefinitions = (
   machine: Machine.Any
@@ -404,7 +430,7 @@ export const transitionDefinitions = (
           source: node.path,
           trigger: { type: "choice" },
           reenter: false,
-          targets: transitionTargets(choice)
+          branches: transitionBranches(choice)
         })
       }
       continue
@@ -414,8 +440,8 @@ export const transitionDefinitions = (
       definitions.push({
         source: node.path,
         trigger: { type: "event", event },
-        reenter: typeof handler === "object" && handler !== null && handler.reenter === true,
-        targets: transitionTargets(handler)
+        reenter: hasProperty(handler, "reenter") && handler.reenter === true,
+        branches: transitionBranches(handler)
       })
     }
     if (config.always !== undefined) {
@@ -423,7 +449,7 @@ export const transitionDefinitions = (
         source: node.path,
         trigger: { type: "always" },
         reenter: false,
-        targets: transitionTargets(config.always)
+        branches: transitionBranches(config.always)
       })
     }
     if (config.onDone !== undefined) {
@@ -431,7 +457,7 @@ export const transitionDefinitions = (
         source: node.path,
         trigger: { type: "done" },
         reenter: false,
-        targets: transitionTargets(config.onDone)
+        branches: transitionBranches(config.onDone)
       })
     }
     const invokes = config.invoke === undefined
@@ -452,7 +478,7 @@ export const transitionDefinitions = (
             source: node.path,
             trigger: { type: "invoke", id, outcome },
             reenter: typeof handler === "object" && handler !== null && handler.reenter === true,
-            targets: transitionTargets(handler)
+            branches: transitionBranches(handler)
           })
         }
       }

--- a/src/internal/testing/machine/finiteModel.ts
+++ b/src/internal/testing/machine/finiteModel.ts
@@ -1177,44 +1177,6 @@ const stateValue = (
   return { _tag: stateTag(state.path), value: value ?? state.node.value }
 }
 
-const runtimeTargetPath = (
-  byPath: ReadonlyMap<string, FlatFiniteState>,
-  sourcePath: string,
-  requestedPath: string
-): string => {
-  const source = byPath.get(sourcePath)!
-  const requested = byPath.get(requestedPath)!
-  if (requested.node._tag === "History") return requested.parent!
-  if (requested.node._tag === "Choice") return runtimeTargetPath(byPath, sourcePath, requested.node.selected)
-  if (source.root !== requested.root) return requested.path
-
-  const initial = (path: string): string => {
-    const current = byPath.get(path)!
-    if (current.node._tag === "Parallel") {
-      if (sourcePath !== current.path && !sourcePath.startsWith(`${current.path}.`)) {
-        return current.path
-      }
-      const child = sourcePath === current.path
-        ? current.node.states[0]!.key
-        : sourcePath.slice(current.path.length + 1).split(".")[0]!
-      return initial(`${current.path}.${child}`)
-    }
-    return current.node._tag === "Compound" ? initial(`${current.path}.${current.node.initial}`) : current.path
-  }
-  const inspect = (path: string): string => {
-    const current = byPath.get(path)!
-    if (
-      current.node._tag === "Parallel" && sourcePath !== current.path && !sourcePath.startsWith(`${current.path}.`)
-    ) {
-      return current.path
-    }
-    if (current.path === requestedPath) return initial(current.path)
-    const next = requestedPath.slice(current.path.length + 1).split(".")[0]!
-    return inspect(`${current.path}.${next}`)
-  }
-  return inspect(source.root)
-}
-
 const makeStateTree = (
   states: ReadonlyArray<FiniteState>,
   parent: string | undefined
@@ -1357,10 +1319,88 @@ const selectHistoryTarget = (builder: Record<string, any>, path: string): unknow
   return current[parts[parts.length - 1]!]()
 }
 
-type TargetBuilder = {
-  readonly branch: Record<string, any>
-  readonly full: Record<string, any>
-  readonly history: Record<string, any>
+const selectableDefinitionTarget = (
+  source: string,
+  target: string,
+  byPath: ReadonlyMap<string, FlatFiniteState>
+): string => {
+  const parts = target.split(".")
+  for (let index = 0; index < parts.length; index++) {
+    const path = parts.slice(0, index + 1).join(".")
+    const node = byPath.get(path)?.node
+    if (
+      (node?._tag === "Compound" || node?._tag === "Parallel") &&
+      source !== path && !source.startsWith(`${path}.`)
+    ) return path
+  }
+  return target
+}
+
+const selectDefinitionTarget = (
+  selector: Record<string, any>,
+  source: string,
+  target: string,
+  byPath: ReadonlyMap<string, FlatFiniteState>
+): unknown => {
+  const selected = byPath.get(target)!
+  if (selected.node._tag === "History") {
+    return selectHistoryTarget(selector.history, target)
+  }
+  const sourceRoot = byPath.get(source)!.root
+  if (selected.root !== sourceRoot) {
+    const root = target.split(".")[0]!
+    return selector.full[root]()
+  }
+  const selectable = selectableDefinitionTarget(source, target, byPath)
+  let current = selector.branch
+  const parts = selectable.split(".")
+  for (const part of parts) current = current[part]
+  if (typeof current === "function") return current()
+  return current.initial()
+}
+
+const resolveDefinitionTarget = (
+  builder: any,
+  source: string,
+  target: string,
+  byPath: ReadonlyMap<string, FlatFiniteState>,
+  value?: number
+): unknown => {
+  const selected = byPath.get(target)!
+  if (selected.node._tag === "History") return builder()
+  if (selected.root !== byPath.get(source)!.root) {
+    const parts = target.split(".")
+    return selectSnapshot({ [parts[0]!]: builder }, parts[0]!, byPath, parts, 0, source, value)
+  }
+  const selectable = selectableDefinitionTarget(source, target, byPath)
+  if (selectable !== target) {
+    const bound = byPath.get(selectable)!
+    const parts = target.split(".")
+    return selectSnapshot(
+      { [bound.node.key]: builder },
+      selectable,
+      byPath,
+      parts,
+      selectable.split(".").length - 1,
+      source,
+      value
+    )
+  }
+  if (selected.node._tag === "Choice") return builder()
+  const input = { value: value ?? selected.node.value }
+  if (selected.node._tag === "Compound" || selected.node._tag === "Parallel") {
+    const parts = target.split(".")
+    return selectSnapshot(
+      { [selected.node.key]: builder },
+      target,
+      byPath,
+      parts,
+      parts.length - 1,
+      source,
+      value
+    )
+  }
+  return builder.from(input)
 }
 
 const makeHandlers = (
@@ -1375,15 +1415,11 @@ const makeHandlers = (
     if (node._tag === "History") continue
     if (node._tag === "Choice") {
       handlers[node.key] = {
-        choice: {
-          targets: node.targets,
-          transition: ({ target }: { readonly target: TargetBuilder }) => {
-            const selected = byPath.get(node.selected)!
-            const parts = selected.path.split(".")
-            const builder = selected.root === byPath.get(path)!.root ? target.branch : target.full
-            return selectSnapshot(builder, parts[0]!, byPath, parts, 0, path)
-          }
-        }
+        choice: (Machine.transition as any)({
+          target: (to: Record<string, any>) => selectDefinitionTarget(to, path, node.selected, byPath) as any,
+          resolve: ({ target }: { readonly target: any }) =>
+            resolveDefinitionTarget(target, path, node.selected, byPath)
+        } as any)
       }
       continue
     }
@@ -1396,27 +1432,17 @@ const makeHandlers = (
     let onDone: unknown
     for (const transition of transitions.values()) {
       if (transition.source !== path) continue
-      const config = {
+      const config = (Machine.transition as any)({
         ...("reenter" in transition ? { reenter: transition.reenter } : {}),
-        ...(transition.target === undefined
-          ? {}
-          : {
-            targets: [
-              byPath.get(transition.target)!.node._tag === "History" ||
-                byPath.get(transition.target)!.node._tag === "Choice"
-                ? transition.target
-                : runtimeTargetPath(byPath, path, transition.target)
-            ]
-          }),
-        transition: ({ target }: { readonly target: TargetBuilder }) => {
-          if (transition.target === undefined) return undefined
-          const targetState = byPath.get(transition.target)!
-          if (targetState.node._tag === "History") return selectHistoryTarget(target.history, targetState.path)
-          const parts = transition.target.split(".")
-          const builder = targetState.root === byPath.get(path)!.root ? target.branch : target.full
-          return selectSnapshot(builder, parts[0]!, byPath, parts, 0, path, transition.targetValue)
-        }
-      }
+        target: (to: Record<string, any>) =>
+          transition.target === undefined
+            ? to.none()
+            : selectDefinitionTarget(to, path, transition.target, byPath),
+        resolve: transition.target === undefined
+          ? () => undefined
+          : ({ target }: { readonly target: any }) =>
+            resolveDefinitionTarget(target, path, transition.target!, byPath, transition.targetValue)
+      } as any)
       if (transition.trigger.type === "event") on[transition.trigger.event] = config
       else if (transition.trigger.type === "always") always = config
       else onDone = config
@@ -1489,8 +1515,15 @@ export const compileModel = (model: FiniteModel): Machine.Machine.Any => {
   const machine = Machine.make({
     states: defined.states as any,
     events: Machine.events(...eventSchemas) as any,
-    initial: () => selectSnapshot(defined.initial as any, initial.path, byPath, [initial.path], 0) as any
-  })
+    initial: {
+      target: (to: Record<string, any>) => {
+        const selected = to[initial.path]
+        return typeof selected === "function" ? selected() : selected.initial()
+      },
+      resolve: ({ target }: { readonly target: any }) =>
+        selectSnapshot({ [initial.path]: target }, initial.path, byPath, [initial.path], 0) as any
+    }
+  } as any)
   const transitions = new Map(model.transitions.map((transition) => [
     `${transition.source}\u0000${triggerKey(transition.trigger)}`,
     transition

--- a/src/internal/testing/machine/verification.ts
+++ b/src/internal/testing/machine/verification.ts
@@ -475,12 +475,15 @@ const sameCoverageTrigger = (
 ): boolean =>
   left.type === right.type && (left.type !== "event" || right.type === "event" && left.event === right.event)
 
-const targetWithinDeclaredBounds = (
+const targetWithinDeclaredBranches = (
   target: string | undefined,
-  bounds: Machine.Machine.TransitionTargets
+  branches: ReadonlyArray<Machine.Machine.TransitionBranch>
 ): boolean =>
-  target === undefined || bounds.type === "dynamic" ||
-  bounds.paths.some((path) => target === path || target.startsWith(`${path}.`))
+  branches.some((branch) =>
+    branch.target === undefined ?
+      target === undefined
+      : target !== undefined && (target === branch.target || target.startsWith(`${branch.target}.`))
+  )
 
 const finiteTagValues = (ast: SchemaAST.AST): ReadonlyArray<PropertyKey> | undefined => {
   if (SchemaAST.isLiteral(ast)) {
@@ -574,7 +577,7 @@ export const coverage = <M extends AnyMachine>(
       source: definition.source,
       trigger: definition.trigger,
       reenter: definition.reenter,
-      targets: definition.targets
+      branches: definition.branches
     })
   )
   const transitionHits = new Set<number>()
@@ -656,7 +659,7 @@ export const coverage = <M extends AnyMachine>(
         definition.source === retained.source &&
         definition.reenter === retained.reenter &&
         sameCoverageTrigger(definition.trigger, retained.trigger) &&
-        targetWithinDeclaredBounds(retained.target, definition.targets)
+        targetWithinDeclaredBranches(retained.target, definition.branches)
       )
       if (definitionIndex !== -1) transitionHits.add(definitionIndex)
     }
@@ -1511,13 +1514,14 @@ export const verify = <M extends AnyMachine>(
       )
       return
     }
-    if (transition.target === undefined || definition.targets.type === "dynamic") return
-    if (!definition.targets.paths.some((bound) => isDescendantOrSelf(String(transition.target), String(bound)))) {
+    if (targetWithinDeclaredBranches(transition.target, definition.branches)) return
+    const targets = definition.branches.flatMap((branch) => branch.target === undefined ? [] : [branch.target])
+    if (!targets.some((bound) => isDescendantOrSelf(String(transition.target), String(bound)))) {
       add(
         "targetBounds.target",
         location,
         `transition target "${String(transition.target)}" is outside declared bounds ` +
-          `[${definition.targets.paths.join(", ")}]`,
+          `[${targets.join(", ")}]`,
         String(transition.target)
       )
     }

--- a/src/testing/MachineTest.ts
+++ b/src/testing/MachineTest.ts
@@ -231,8 +231,20 @@ export interface Scenarios<M extends AnyMachine> {
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(Reset),
- *   initial: () => States.initial.Idle.from()
- * }).handle({ Idle: { on: { Reset: () => States.initial.Idle.from() } } })
+ *   initial: {
+ *     target: (to) => to.Idle(),
+ *     resolve: ({ target }) => target.from()
+ *   }
+ * }).handle({
+ *   Idle: {
+ *     on: {
+ *       Reset: Machine.transition({
+ *         target: (to) => to.full.Idle(),
+ *         resolve: ({ target }) => target.from()
+ *       })
+ *     }
+ *   }
+ * })
  *
  * const generated = MachineTest.scenarios(machine, { maxEvents: 5 })
  * ```
@@ -480,7 +492,10 @@ export { ProbeUnavailableError } from "../internal/testing/machine/verification.
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(),
- *   initial: () => States.initial.Idle.from()
+ *   initial: {
+ *     target: (to) => to.Idle(),
+ *     resolve: ({ target }) => target.from()
+ *   }
  * }).handle({ Idle: {} })
  *
  * const program = Effect.gen(function*() {
@@ -1090,7 +1105,10 @@ export const Invariant: {
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(),
- *   initial: () => States.initial.Count(new Count({ value: 0 }))
+ *   initial: {
+ *     target: (to) => to.Count(),
+ *     resolve: ({ target }) => target(new Count({ value: 0 }))
+ *   }
  * }).handle({ Count: {} })
  *
  * const nonNegative = MachineTest.invariants(machine).state(
@@ -1408,10 +1426,19 @@ export type ExploreOptions<M extends AnyMachine, Key extends ExplorationKey = Ex
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(Increment),
- *   initial: () => States.initial.Count(new Count({ value: 0 }))
+ *   initial: {
+ *     target: (to) => to.Count(),
+ *     resolve: ({ target }) => target(new Count({ value: 0 }))
+ *   }
  * }).handle({
- *   Count: { on: { Increment: ({ state }) =>
- *     States.initial.Count(new Count({ value: state.value + 1 })) } }
+ *   Count: {
+ *     on: {
+ *       Increment: Machine.transition({
+ *         target: (to) => to.full.Count(),
+ *         resolve: ({ state, target }) => target(new Count({ value: state.value + 1 }))
+ *       })
+ *     }
+ *   }
  * })
  *
  * const explored = MachineTest.explore(machine, {
@@ -1592,7 +1619,10 @@ export type RunServices<M extends AnyMachine> = IsAny<
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(),
- *   initial: () => States.initial.Idle.from()
+ *   initial: {
+ *     target: (to) => to.Idle(),
+ *     resolve: ({ target }) => target.from()
+ *   }
  * }).handle({ Idle: {} })
  *
  * const trace = MachineTest.run(machine, { events: [] })
@@ -1659,7 +1689,7 @@ export interface TransitionCoverageItem<
   readonly source: SourcePath
   readonly trigger: Machine.Machine.TransitionTrigger<EventTag>
   readonly reenter: boolean
-  readonly targets: Machine.Machine.TransitionTargets<TargetPath>
+  readonly branches: ReadonlyArray<Machine.Machine.TransitionBranch<TargetPath>>
 }
 
 /**
@@ -1819,7 +1849,10 @@ export interface Coverage<M extends AnyMachine> {
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(),
- *   initial: () => States.initial.Idle.from()
+ *   initial: {
+ *     target: (to) => to.Idle(),
+ *     resolve: ({ target }) => target.from()
+ *   }
  * }).handle({ Idle: {} })
  *
  * const report = Effect.map(
@@ -2035,7 +2068,10 @@ export interface VerifyOptions {
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(),
- *   initial: () => States.initial.Idle.from()
+ *   initial: {
+ *     target: (to) => to.Idle(),
+ *     resolve: ({ target }) => target.from()
+ *   }
  * }).handle({ Idle: {} })
  *
  * const checked = Effect.gen(function*() {

--- a/src/unstable/cluster/ClusterMachine.ts
+++ b/src/unstable/cluster/ClusterMachine.ts
@@ -316,7 +316,10 @@ export const layerMemory: Layer.Layer<Storage> = internal.layerMemory
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(),
- *   initial: () => States.initial.Idle.from()
+ *   initial: {
+ *     target: (to) => to.Idle(),
+ *     resolve: ({ target }) => target.from()
+ *   }
  * }).handle({ Idle: {} })
  *
  * const adapter = ClusterMachine.make("IdleMachine", machine, { version: "1" })

--- a/src/unstable/reactivity/AtomMachine.ts
+++ b/src/unstable/reactivity/AtomMachine.ts
@@ -370,7 +370,10 @@ type ChildState<Child extends Machine.ChildMachine.Any> = RefState<Machine.Child
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(),
- *   initial: () => States.initial.Count(new Count({ value: 0 }))
+ *   initial: {
+ *     target: (to) => to.Count(),
+ *     resolve: ({ target }) => target(new Count({ value: 0 }))
+ *   }
  * }).handle({ Count: {} })
  * const machineAtom = AtomMachine.make(machine)
  *
@@ -481,7 +484,10 @@ export const selectSnapshotChild: <
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(),
- *   initial: () => States.initial.Idle.from()
+ *   initial: {
+ *     target: (to) => to.Idle(),
+ *     resolve: ({ target }) => target.from()
+ *   }
  * }).handle({ Idle: {} })
  * const machineAtom = AtomMachine.make(machine)
  *
@@ -651,7 +657,10 @@ export interface Bound<Services, RuntimeError = never> {
  * const machine = Machine.make({
  *   states: States.states,
  *   events: Machine.events(),
- *   initial: () => States.initial.Idle.from()
+ *   initial: {
+ *     target: (to) => to.Idle(),
+ *     resolve: ({ target }) => target.from()
+ *   }
  * }).handle({ Idle: {} })
  *
  * const machineAtom = AtomMachine.make(machine)

--- a/test/internal/machine/activities.test.ts
+++ b/test/internal/machine/activities.test.ts
@@ -17,7 +17,10 @@ const childMachine = Machine.make({
   id: "document-worker",
   states: childStates.states,
   events: Machine.events(),
-  initial: () => childStates.initial.ChildIdle(new ChildIdle({}))
+  initial: {
+    target: (to) => to.ChildIdle(),
+    resolve: ({ target }) => target(new ChildIdle({}))
+  }
 })
 const child = Machine.child("child", childMachine)
 
@@ -28,7 +31,10 @@ const activityMachine = Machine.make({
   id: "activity-inspection",
   states: activityStates.states,
   events: Machine.events(WorkSucceeded, WorkFailed, LoadTimedOut),
-  initial: () => activityStates.initial.Loading(new Loading({}))
+  initial: {
+    target: (to) => to.Loading(),
+    resolve: ({ target }) => target(new Loading({}))
+  }
 }).handle({
   Loading: {
     invoke: [
@@ -40,10 +46,23 @@ const activityMachine = Machine.make({
       Machine.invoke({
         id: "load-document",
         effect: () => Effect.fail("unavailable").pipe(Effect.as(1)),
-        onDone: ({ target }) => target.none(),
-        onFailure: ({ target }) => target.none()
+        onDone: Machine.transition({
+          target: (to) => to.none(),
+          resolve: () => undefined
+        }),
+        onFailure: Machine.transition({
+          target: (to) => to.none(),
+          resolve: () => undefined
+        })
       }),
-      Machine.invoke({ id: "load-timeout", after: timerDuration, onDone: ({ target }) => target.none() }),
+      Machine.invoke({
+        id: "load-timeout",
+        after: timerDuration,
+        onDone: Machine.transition({
+          target: (to) => to.none(),
+          resolve: () => undefined
+        })
+      }),
       Machine.invoke({ child })
     ]
   },
@@ -67,11 +86,11 @@ const renderActivityMachine = makeTextRenderer<
 const machine = {
   stateNodes: {
     byPath: new Map([
-      ["Idle", { path: "Idle" }],
-      ["Loading", { path: "Loading" }],
-      ["Parent", { path: "Parent" }],
-      ["Parent.Active", { path: "Parent.Active" }],
-      ["Dynamic", { path: "Dynamic" }]
+      ["Idle", { path: "Idle" as const }],
+      ["Loading", { path: "Loading" as const }],
+      ["Parent", { path: "Parent" as const }],
+      ["Parent.Active", { path: "Parent.Active" as const }],
+      ["Dynamic", { path: "Dynamic" as const }]
     ])
   },
   handlers: {
@@ -156,10 +175,20 @@ describe("machine activity metadata", () => {
         const generated = Machine.make({
           states: activityStates.states,
           events: Machine.events(LoadTimedOut),
-          initial: () => activityStates.initial.Loading(new Loading({}))
+          initial: {
+            target: (to) => to.Loading(),
+            resolve: ({ target }) => target(new Loading({}))
+          }
         }).handle({
           Loading: {
-            invoke: Machine.invoke({ id, after: durationMillis, onDone: ({ target }) => target.none() })
+            invoke: Machine.invoke({
+              id,
+              after: durationMillis,
+              onDone: Machine.transition({
+                target: (to) => to.none(),
+                resolve: () => undefined
+              })
+            })
           }
         })
         const definition = Machine.activityDefinitions(generated)[0]
@@ -202,7 +231,7 @@ describe("machine activity metadata", () => {
   it("does not evaluate source factories while inspecting", () => {
     let evaluations = 0
     const dynamic = {
-      stateNodes: { byPath: new Map([["Active", { path: "Active" }]]) },
+      stateNodes: { byPath: new Map([["Active", { path: "Active" as const }]]) },
       handlers: {
         Active: {
           invoke: {
@@ -242,7 +271,7 @@ describe("machine activity metadata", () => {
     }
 
     const definitions = activityDefinitions(withUnknownHandler)
-    const paths = new Set(Array.from(withUnknownHandler.stateNodes.byPath.values(), ({ path }) => path))
+    const paths = new Set<string>(Array.from(withUnknownHandler.stateNodes.byPath.values(), ({ path }) => path))
 
     assert(definitions.every(({ source }) => paths.has(source)))
     assert.notInclude(definitions.map((definition) => "id" in definition ? definition.id : undefined), "orphan")
@@ -250,15 +279,15 @@ describe("machine activity metadata", () => {
 
   it("renders activities beneath their owning state", () => {
     assert.strictEqual(
-      renderActivityMachine(activityMachine, activityStates.initial.Loading(new Loading({}))),
+      renderActivityMachine(activityMachine, { path: "Loading" as const, value: new Loading({}) }),
       [
         "activity-inspection",
-        "● active  ○ inactive  ◇ transition (→ declared, ∅ none, omitted dynamic)  ◆ activity",
+        "● active  ○ inactive  ◇ transition (→ target, ∅ none)  ◆ activity",
         "",
         "├─ ● Loading",
-        "│  ├─ ◇ invoke load-document done",
-        "│  ├─ ◇ invoke load-document failure",
-        "│  ├─ ◇ invoke load-timeout done",
+        "│  ├─ ◇ invoke load-document done → ∅",
+        "│  ├─ ◇ invoke load-document failure → ∅",
+        "│  ├─ ◇ invoke load-timeout done → ∅",
         "│  ├─ ◆ process: poll-server",
         "│  ├─ ◆ effect: load-document [success: dynamic, failure: dynamic]",
         "│  ├─ ◆ timer: load-timeout [10s]",

--- a/test/internal/machine/protocol.test.ts
+++ b/test/internal/machine/protocol.test.ts
@@ -11,7 +11,10 @@ const InternalEvent = Schema.TaggedStruct("InternalEvent", { value: Schema.Strin
 describe("machine protocols", () => {
   it("rejects forged, misclassified, and overlapping event descriptors", () => {
     const states = Machine.defineStates({ ProtocolIdle })
-    const initial = () => states.initial.ProtocolIdle(new ProtocolIdle({}))
+    const initial = {
+      target: (to: Machine.Machine.InitialSelector<typeof states.states>) => to.ProtocolIdle(),
+      resolve: () => ({ path: "ProtocolIdle" as const, value: new ProtocolIdle({}) })
+    }
 
     assert.throws(
       () => Machine.make({ states: states.states, events: [PublicEvent] as any, initial }),
@@ -40,7 +43,10 @@ describe("machine protocols", () => {
         states: states.states,
         events: Machine.events(PublicEvent),
         internalEvents: Machine.internalEvents(InternalEvent),
-        initial: () => states.initial.ProtocolIdle(new ProtocolIdle({}))
+        initial: {
+          target: (to) => to.ProtocolIdle(),
+          resolve: ({ target }) => target(new ProtocolIdle({}))
+        }
       }).handle({})
 
       assert.strictEqual(Object.hasOwn(machine, "eventSchemas"), false)

--- a/test/internal/machine/strategyDifferential.test.ts
+++ b/test/internal/machine/strategyDifferential.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Deferred, Effect, Fiber, Schema, Stream } from "effect"
+import { Deferred, Effect, Fiber, Option, Schema, Stream } from "effect"
 import { FastCheck } from "effect/testing"
 import { Machine } from "../../../src/index.js"
 import * as Configuration from "../../../src/internal/machine/configuration.js"
@@ -32,21 +32,23 @@ const makeFlatMachine = () => {
   return Machine.make({
     states: states.states,
     events: Machine.events(Noop, Increment, Reenter, Finish),
-    initial: () => states.initial.Count(new Count({ value: 0 }))
+    initial: {
+      target: (to) => to.Count(),
+      resolve: ({ target }) => target(new Count({ value: 0 }))
+    }
   }).handle({
     Count: {
       on: {
-        Noop: {
-          targets: ["Done"],
-          transition: ({ target }) => target.none()
-        },
-        Increment: ({ state, target }) => target.full.Count(new Count({ value: state.value + 1 })),
-        Reenter: {
-          reenter: true,
-          targets: ["Done"],
-          transition: ({ target }) => target.none()
-        },
-        Finish: ({ state, target }) => target.full.Done(new Done({ value: state.value }))
+        Noop: Machine.transition({ target: (to) => to.none(), resolve: () => undefined }),
+        Increment: Machine.transition({
+          target: (to) => to.full.Count(),
+          resolve: ({ state, target }) => target(new Count({ value: state.value + 1 }))
+        }),
+        Reenter: Machine.transition({ target: (to) => to.none(), resolve: () => undefined, reenter: true }),
+        Finish: Machine.transition({
+          target: (to) => to.full.Done(),
+          resolve: ({ state, target }) => target(new Done({ value: state.value }))
+        })
       }
     },
     Done: { output: ({ state }) => state.value }
@@ -108,22 +110,31 @@ describe("machine planner and runtime strategies", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Advance),
-        initial: () =>
-          states.initial.Root(
-            new Root({}),
-            (root) => root.Left(new Left({ value: 0 })).Right(new Right({ value: 0 }))
-          )
+        initial: {
+          target: (to) => to.Root.initial(),
+          resolve: ({ target }) =>
+            target(
+              new Root({}),
+              (root) => root.Left(new Left({ value: 0 })).Right(new Right({ value: 0 }))
+            )
+        }
       }).handle({
         Root: {
           states: {
             Left: {
               on: {
-                Advance: ({ state, target }) => target.branch.Root.Left(new Left({ value: state.value + 1 }))
+                Advance: Machine.transition({
+                  target: (to) => to.branch.Root.Left(),
+                  resolve: ({ state, target }) => target(new Left({ value: state.value + 1 }))
+                })
               }
             },
             Right: {
               on: {
-                Advance: ({ state, target }) => target.branch.Root.Right(new Right({ value: state.value + 10 }))
+                Advance: Machine.transition({
+                  target: (to) => to.branch.Root.Right(),
+                  resolve: ({ state, target }) => target(new Right({ value: state.value + 10 }))
+                })
               }
             }
           }
@@ -155,11 +166,17 @@ describe("machine planner and runtime strategies", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Enter),
-        initial: () => states.initial.Outside(new Outside({}))
+        initial: {
+          target: (to) => to.Outside(),
+          resolve: ({ target }) => target(new Outside({}))
+        }
       }).handle({
         Outside: {
           on: {
-            Enter: ({ target }) => target.full.Opened.initial(new Opened({}))
+            Enter: Machine.transition({
+              target: (to) => to.full.Opened.initial(),
+              resolve: ({ target }) => target(new Opened({}))
+            })
           }
         },
         Opened: {
@@ -235,9 +252,17 @@ describe("machine planner and runtime strategies", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: () => states.initial.Idle(new Idle({}))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({}))
+        }
       }).handle({
-        Idle: { always: ({ target }) => target.full.Ready(new Ready({})) },
+        Idle: {
+          always: Machine.transition({
+            target: (to) => to.full.Ready(),
+            resolve: ({ target }) => target(new Ready({}))
+          })
+        },
         Ready: {}
       })
 
@@ -256,7 +281,10 @@ describe("machine planner and runtime strategies", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: () => states.initial.Idle.from()
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target.from()
+        }
       }).handle({ Idle: {} })
 
       assert.strictEqual(ExecutionPlan.selectExecutionPlanForTesting(machine, "auto").strategy, "generic")
@@ -289,7 +317,10 @@ describe("machine planner and runtime strategies", () => {
         states: states.states,
         events: Machine.events(),
         input: Input,
-        initial: (input) => states.initial.Complete(new Complete({ value: input.value }))
+        initial: {
+          target: (to) => to.Complete(),
+          resolve: ({ input: input, target }) => target(new Complete({ value: input.value }))
+        }
       }).handle({
         Complete: { output: ({ state }) => state.value }
       })
@@ -340,13 +371,19 @@ describe("machine planner and runtime strategies", () => {
       const definition = Machine.make({
         states: states.states,
         events: Machine.events(Event),
-        initial: () => states.initial.Count(new Count({ value: 0 }))
+        initial: {
+          target: (to) => to.Count(),
+          resolve: ({ target }) => target(new Count({ value: 0 }))
+        }
       })
       const events = definition.events
       const machine = definition.handle({
         Count: {
           on: {
-            Set: ({ event, target }) => target.full.Count(new Count({ value: event.value.length }))
+            Set: Machine.transition({
+              target: (to) => to.full.Count(),
+              resolve: ({ event, target }) => target(new Count({ value: event.value.length }))
+            })
           }
         }
       })
@@ -390,16 +427,22 @@ describe("machine planner and runtime strategies", () => {
         states: states.states,
         events: Events,
         emittedEvents: Emissions,
-        initial: () => states.initial.Idle(new Idle({}))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({}))
+        }
       }).handle({
         Idle: {
           on: {
-            Publish: ({ parent, self, target }, enqueue) => {
-              assert.strictEqual(parent, undefined)
-              assert.ok(self.sessionId.startsWith("machine:"))
-              enqueue.emit(Emissions.Published({ value } as never))
-              return target.none()
-            }
+            Publish: Machine.transition({
+              target: (to) => to.none(),
+              resolve: ({ parent, self }, enqueue) => {
+                assert.strictEqual(parent, undefined)
+                assert.ok(self.sessionId.startsWith("machine:"))
+                enqueue.emit(Emissions.Published({ value } as never))
+                return undefined
+              }
+            })
           }
         }
       })
@@ -436,7 +479,10 @@ describe("machine planner and runtime strategies", () => {
         states: states.states,
         events: Machine.events(),
         emittedEvents: Emissions,
-        initial: () => states.initial.Idle(new Idle({}))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({}))
+        }
       }).handle({
         Idle: {
           entry: (_, enqueue) => {
@@ -562,16 +608,27 @@ describe("machine planner and runtime strategies", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Load, Loaded),
-        initial: () => states.initial.Idle(new Idle({}))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({}))
+        }
       }).handle({
         Idle: {
-          on: { Load: () => states.initial.Loading(new Loading({})) }
+          on: {
+            Load: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({}))
+            })
+          }
         },
         Loading: {
           invoke: Machine.invoke({
             id: "load",
             effect: () => Effect.succeed(new Loaded({ value: "complete" })),
-            onDone: ({ output }) => states.initial.Success(new Success({ value: output.value }))
+            onDone: Machine.transition({
+              target: (to) => to.full.Success(),
+              resolve: ({ output, target }) => target(new Success({ value: output.value }))
+            })
           })
         },
         Success: { output: ({ state }) => state.value }
@@ -607,13 +664,19 @@ describe("machine planner and runtime strategies", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: () => states.initial.Loading(new Loading({}))
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target(new Loading({}))
+        }
       }).handle({
         Loading: {
           invoke: Machine.invoke({
             id: "load",
             effect: () => Effect.fail("unavailable"),
-            onFailure: ({ error, target }) => target.full.Failed(new Failed({ error }))
+            onFailure: Machine.transition({
+              target: (to) => to.full.Failed(),
+              resolve: ({ error, target }) => target(new Failed({ error }))
+            })
           })
         },
         Failed: { output: ({ state }) => state.error }
@@ -645,13 +708,42 @@ describe("machine planner and runtime strategies", () => {
         const firstStarted = yield* Deferred.make<void>()
         let generation = 0
         const states = Machine.defineStates({ Loading, Failed })
-        const machine = Machine.make({
+        const definition = Machine.make({
           states: states.states,
           events: Machine.events(Reenter, Stale),
-          initial: () => states.initial.Loading(new Loading({ epoch: 0 }))
-        }).handle({
+          initial: {
+            target: (to) => to.Loading(),
+            resolve: ({ target }) => target(new Loading({ epoch: 0 }))
+          }
+        })
+        const onSnapshot: Machine.Machine.InvokeTransition<
+          Machine.Machine.States<typeof definition>,
+          Machine.Machine.Events<typeof definition>,
+          Machine.Machine.Emits<typeof definition>,
+          "Loading",
+          Machine.Machine.InvokeSnapshotContext<
+            Machine.Machine.States<typeof definition>,
+            Machine.Machine.Events<typeof definition>,
+            Machine.Machine.Emits<typeof definition>,
+            "Loading",
+            string,
+            Machine.StoppedError,
+            never,
+            Machine.Machine.InputEvents<typeof definition>,
+            Machine.Machine.ParentEvents<typeof definition>
+          >
+        > = Machine.transition({
+          cases: [{
+            title: "worker is stale",
+            when: ({ snapshot }) => snapshot.state === "stale" ? Option.some(snapshot) : Option.none(),
+            target: (to) => to.full.Failed(),
+            resolve: ({ target }) => target(new Failed({}))
+          }],
+          otherwise: { target: (to) => to.none(), resolve: () => undefined }
+        })
+        const machine = definition.handle({
           Loading: {
-            invoke: Machine.invoke({
+            invoke: {
               id: "worker",
               address: Machine.childAddress("worker"),
               logic: () => {
@@ -672,16 +764,22 @@ describe("machine planner and runtime strategies", () => {
                       )
                 })
               },
-              onFailure: ({ target }) => target.none(),
-              onSnapshot: ({ snapshot, target }) =>
-                snapshot.state === "stale" ? target.full.Failed(new Failed({})) : target.none()
-            }),
+              onFailure: Machine.transition({
+                target: (to) => to.none(),
+                resolve: () => undefined
+              }),
+              onSnapshot
+            },
             on: {
-              Reenter: {
-                reenter: true,
-                transition: ({ state, target }) => target.full.Loading(new Loading({ epoch: state.epoch + 1 }))
-              },
-              Stale: () => states.initial.Failed(new Failed({}))
+              Reenter: Machine.transition({
+                target: (to) => to.full.Loading(),
+                resolve: ({ state, target }) => target(new Loading({ epoch: state.epoch + 1 })),
+                reenter: true
+              }),
+              Stale: Machine.transition({
+                target: (to) => to.full.Failed(),
+                resolve: ({ target }) => target(new Failed({}))
+              })
             }
           },
           Failed: {}

--- a/test/machine/ActivityLifecycleModel.test.ts
+++ b/test/machine/ActivityLifecycleModel.test.ts
@@ -73,11 +73,17 @@ describe("machine activity lifecycle model", () => {
             const machine = Machine.make({
               states: states.states,
               events: Machine.events(Enter, Leave, Restart),
-              initial: () => states.initial.Idle(new Idle({}))
+              initial: {
+                target: (to) => to.Idle(),
+                resolve: ({ target }) => target(new Idle({}))
+              }
             }).handle({
               Idle: {
                 on: {
-                  Enter: ({ target }) => target.full.Active(new Active({}))
+                  Enter: Machine.transition({
+                    target: (to) => to.full.Active(),
+                    resolve: ({ target }) => target(new Active({}))
+                  })
                 }
               },
               Active: {
@@ -85,15 +91,25 @@ describe("machine activity lifecycle model", () => {
                   id: "activity",
                   address: Machine.childAddress("activity"),
                   logic: probe.logic("active", { _tag: "Blocked" }),
-                  onDone: ({ target }) => target.none(),
-                  onFailure: ({ target }) => target.none()
+                  onDone: Machine.transition({
+                    target: (to) => to.none(),
+                    resolve: () => undefined
+                  }),
+                  onFailure: Machine.transition({
+                    target: (to) => to.none(),
+                    resolve: () => undefined
+                  })
                 }),
                 on: {
-                  Leave: ({ target }) => target.full.Idle(new Idle({})),
-                  Restart: {
-                    reenter: true,
-                    transition: ({ target }) => target.full.Active(new Active({}))
-                  }
+                  Leave: Machine.transition({
+                    target: (to) => to.full.Idle(),
+                    resolve: ({ target }) => target(new Idle({}))
+                  }),
+                  Restart: Machine.transition({
+                    target: (to) => to.full.Active(),
+                    resolve: ({ target }) => target(new Active({})),
+                    reenter: true
+                  })
                 }
               }
             })
@@ -148,15 +164,24 @@ describe("machine activity lifecycle model", () => {
         states: states.states,
         events: Machine.events(),
         internalEvents: Machine.internalEvents(Completed),
-        initial: () => states.initial.Active(new Active({}))
+        initial: {
+          target: (to) => to.Active(),
+          resolve: ({ target }) => target(new Active({}))
+        }
       }).handle({
         Active: {
           invoke: Machine.invoke({
             id: "immediate",
             address: Machine.childAddress("immediate"),
             logic: probe.immediate("immediate", (epoch) => new Completed({ epoch })),
-            onDone: ({ output, target }) => target.full.Done(new Done({ epoch: output.epoch })),
-            onFailure: ({ target }) => target.none()
+            onDone: Machine.transition({
+              target: (to) => to.full.Done(),
+              resolve: ({ output, target }) => target(new Done({ epoch: output.epoch }))
+            }),
+            onFailure: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            })
           })
         },
         Done: {
@@ -184,7 +209,10 @@ describe("machine activity lifecycle model", () => {
         states: states.states,
         events: Machine.events(Restart, QueueBarrier),
         internalEvents: Machine.internalEvents(Completed),
-        initial: () => states.initial.Active(new EpochActive({ acknowledged: 0 }))
+        initial: {
+          target: (to) => to.Active(),
+          resolve: ({ target }) => target(new EpochActive({ acknowledged: 0 }))
+        }
       }).handle({
         Active: {
           invoke: Machine.invoke({
@@ -194,18 +222,29 @@ describe("machine activity lifecycle model", () => {
               _tag: "StaleOnCancel",
               event: (epoch) => new Completed({ epoch })
             }),
-            onDone: ({ target }) => target.none(),
-            onFailure: ({ target }) => target.none()
+            onDone: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            }),
+            onFailure: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            })
           }),
           on: {
-            Restart: {
-              reenter: true,
-              transition: ({ state, target }) =>
-                target.full.Active(new EpochActive({ acknowledged: state.acknowledged }))
-            },
-            QueueBarrier: ({ state, target }) =>
-              target.full.Active(new EpochActive({ acknowledged: state.acknowledged + 1 })),
-            Completed: ({ event, target }) => target.full.Done(new Done({ epoch: event.epoch }))
+            Restart: Machine.transition({
+              target: (to) => to.full.Active(),
+              resolve: ({ state, target }) => target(new EpochActive({ acknowledged: state.acknowledged })),
+              reenter: true
+            }),
+            QueueBarrier: Machine.transition({
+              target: (to) => to.full.Active(),
+              resolve: ({ state, target }) => target(new EpochActive({ acknowledged: state.acknowledged + 1 }))
+            }),
+            Completed: Machine.transition({
+              target: (to) => to.full.Done(),
+              resolve: ({ event, target }) => target(new Done({ epoch: event.epoch }))
+            })
           }
         },
         Done: {}
@@ -281,22 +320,25 @@ describe("machine activity lifecycle model", () => {
           }
         },
         events: Machine.events(LeaveLeft),
-        initial: () => ({
-          path: "Root" as const,
-          value: new Root({}),
-          states: {
-            left: {
-              path: "Root.left" as const,
-              value: new Left({}),
-              state: { path: "Root.left.active" as const, value: new LeftActive({}) }
-            },
-            right: {
-              path: "Root.right" as const,
-              value: new Right({}),
-              state: { path: "Root.right.active" as const, value: new RightActive({}) }
+        initial: {
+          target: (to) => to.Root.initial(),
+          resolve: () => ({
+            path: "Root" as const,
+            value: new Root({}),
+            states: {
+              left: {
+                path: "Root.left" as const,
+                value: new Left({}),
+                state: { path: "Root.left.active" as const, value: new LeftActive({}) }
+              },
+              right: {
+                path: "Root.right" as const,
+                value: new Right({}),
+                state: { path: "Root.right.active" as const, value: new RightActive({}) }
+              }
             }
-          }
-        })
+          })
+        }
       }).handle({
         Root: {
           states: {
@@ -307,11 +349,20 @@ describe("machine activity lifecycle model", () => {
                     id: "left-activity",
                     address: Machine.childAddress("left-activity"),
                     logic: probe.logic("left", { _tag: "Blocked" }),
-                    onDone: ({ target }) => target.none(),
-                    onFailure: ({ target }) => target.none()
+                    onDone: Machine.transition({
+                      target: (to) => to.none(),
+                      resolve: () => undefined
+                    }),
+                    onFailure: Machine.transition({
+                      target: (to) => to.none(),
+                      resolve: () => undefined
+                    })
                   }),
                   on: {
-                    LeaveLeft: ({ target }) => target.local.idle(new LeftIdle({}))
+                    LeaveLeft: Machine.transition({
+                      target: (to) => to.local.idle(),
+                      resolve: ({ target }) => target(new LeftIdle({}))
+                    })
                   }
                 }
               }
@@ -323,8 +374,14 @@ describe("machine activity lifecycle model", () => {
                     id: "right-activity",
                     address: Machine.childAddress("right-activity"),
                     logic: probe.logic("right", { _tag: "Blocked" }),
-                    onDone: ({ target }) => target.none(),
-                    onFailure: ({ target }) => target.none()
+                    onDone: Machine.transition({
+                      target: (to) => to.none(),
+                      resolve: () => undefined
+                    }),
+                    onFailure: Machine.transition({
+                      target: (to) => to.none(),
+                      resolve: () => undefined
+                    })
                   })
                 }
               }
@@ -364,7 +421,10 @@ describe("machine activity lifecycle model", () => {
         states: states.states,
         events: Machine.events(Leave),
         internalEvents: Machine.internalEvents(TimerFired),
-        initial: () => states.initial.Active(new Active({}))
+        initial: {
+          target: (to) => to.Active(),
+          resolve: ({ target }) => target(new Active({}))
+        }
       }).handle({
         Idle: {},
         Active: {
@@ -373,17 +433,29 @@ describe("machine activity lifecycle model", () => {
               id: "timed-activity",
               address: Machine.childAddress("timed-activity"),
               logic: probe.logic("timed", { _tag: "Blocked" }),
-              onDone: ({ target }) => target.none(),
-              onFailure: ({ target }) => target.none()
+              onDone: Machine.transition({
+                target: (to) => to.none(),
+                resolve: () => undefined
+              }),
+              onFailure: Machine.transition({
+                target: (to) => to.none(),
+                resolve: () => undefined
+              })
             }),
             Machine.invoke({
               id: "deadline",
               after: "1 hour",
-              onDone: ({ target }) => target.full.Done(new Done({ epoch: -1 }))
+              onDone: Machine.transition({
+                target: (to) => to.full.Done(),
+                resolve: ({ target }) => target(new Done({ epoch: -1 }))
+              })
             })
           ],
           on: {
-            Leave: ({ target }) => target.full.Idle(new Idle({}))
+            Leave: Machine.transition({
+              target: (to) => to.full.Idle(),
+              resolve: ({ target }) => target(new Idle({}))
+            })
           }
         },
         Done: {}
@@ -410,7 +482,10 @@ describe("machine activity lifecycle model", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: () => states.initial.Active(new Active({}))
+        initial: {
+          target: (to) => to.Active(),
+          resolve: ({ target }) => target(new Active({}))
+        }
       }).handle({
         Active: {
           invoke: [
@@ -418,17 +493,29 @@ describe("machine activity lifecycle model", () => {
               id: "failing",
               address: Machine.childAddress("failing"),
               logic: probe.logic("failing", { _tag: "Failure" }),
-              onDone: ({ target }) => target.none(),
-              onFailure: ({ error }) => {
-                throw error
-              }
+              onDone: Machine.transition({
+                target: (to) => to.none(),
+                resolve: () => undefined
+              }),
+              onFailure: Machine.transition({
+                target: (to) => to.none(),
+                resolve: ({ error }) => {
+                  throw error
+                }
+              })
             }),
             Machine.invoke({
               id: "sibling",
               address: Machine.childAddress("sibling"),
               logic: probe.logic("sibling", { _tag: "Blocked" }),
-              onDone: ({ target }) => target.none(),
-              onFailure: ({ target }) => target.none()
+              onDone: Machine.transition({
+                target: (to) => to.none(),
+                resolve: () => undefined
+              }),
+              onFailure: Machine.transition({
+                target: (to) => to.none(),
+                resolve: () => undefined
+              })
             })
           ]
         }
@@ -458,7 +545,10 @@ describe("machine activity lifecycle model", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: () => states.initial.Active(new Active({}))
+        initial: {
+          target: (to) => to.Active(),
+          resolve: ({ target }) => target(new Active({}))
+        }
       }).handle({
         Active: {
           invoke: [
@@ -466,15 +556,27 @@ describe("machine activity lifecycle model", () => {
               id: "first",
               address: Machine.childAddress("first"),
               logic: probe.logic("first", { _tag: "Blocked" }),
-              onDone: ({ target }) => target.none(),
-              onFailure: ({ target }) => target.none()
+              onDone: Machine.transition({
+                target: (to) => to.none(),
+                resolve: () => undefined
+              }),
+              onFailure: Machine.transition({
+                target: (to) => to.none(),
+                resolve: () => undefined
+              })
             }),
             Machine.invoke({
               id: "second",
               address: Machine.childAddress("second"),
               logic: probe.logic("second", { _tag: "Blocked" }),
-              onDone: ({ target }) => target.none(),
-              onFailure: ({ target }) => target.none()
+              onDone: Machine.transition({
+                target: (to) => to.none(),
+                resolve: () => undefined
+              }),
+              onFailure: Machine.transition({
+                target: (to) => to.none(),
+                resolve: () => undefined
+              })
             })
           ]
         }

--- a/test/machine/Annotations.test.ts
+++ b/test/machine/Annotations.test.ts
@@ -47,7 +47,10 @@ const States = Machine.defineStates({
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(),
-  initial: () => States.initial.Workflow(new Workflow({}), (workflow) => workflow.Idle(new Idle({})))
+  initial: {
+    target: (to) => to.Workflow.initial(),
+    resolve: ({ target }) => target(new Workflow({}), (workflow) => workflow.Idle(new Idle({})))
+  }
 })
 
 describe("Machine state annotations", () => {

--- a/test/machine/AnnotationsVisualization.test.ts
+++ b/test/machine/AnnotationsVisualization.test.ts
@@ -33,7 +33,10 @@ const States = Machine.defineStates({
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(),
-  initial: () => States.initial.Workflow(new Workflow({}), (workflow) => workflow.Idle(new Idle({})))
+  initial: {
+    target: (to) => to.Workflow.initial(),
+    resolve: ({ target }) => target(new Workflow({}), (workflow) => workflow.Idle(new Idle({})))
+  }
 })
 
 const renderMachine = makeTextRenderer<
@@ -47,7 +50,7 @@ describe("Machine annotation visualization", () => {
       renderMachine(machine),
       [
         "Machine",
-        "● active  ○ inactive  ◇ transition (→ declared, ∅ none, omitted dynamic)",
+        "● active  ○ inactive  ◇ transition (→ target, ∅ none)",
         "",
         "└─ ○ Document workflow (Workflow) [compound, initial: Idle]",
         "   ├─ ○ Waiting for edits (Idle)",

--- a/test/machine/Choice.test.ts
+++ b/test/machine/Choice.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Schema } from "effect"
+import { Effect, Option, Schema } from "effect"
 import { Machine } from "../../src/index.js"
 import { MachineTest } from "../../src/testing/index.js"
 
@@ -23,23 +23,35 @@ const States = Machine.defineStates({
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(Recheck),
-  initial: () => States.initial.Flow(new Flow({ score: 80 }), (flow) => flow.Routing())
+  initial: {
+    target: (to) => to.Flow.initial(),
+    resolve: ({ target }) => target(new Flow({ score: 80 }), (flow) => flow.Routing())
+  }
 }).handle({
   Flow: {
     states: {
       Routing: {
-        choice: {
-          targets: ["Flow.Approved", "Flow.Rejected"],
-          transition: ({ containingState, target }) => {
-            return containingState.score >= 70
-              ? target.local.Approved(new Approved({}))
-              : target.local.Rejected(new Rejected({}))
+        choice: Machine.transition({
+          cases: [
+            {
+              title: "score is at least 70",
+              when: ({ containingState }) => containingState.score >= 70 ? Option.some(containingState) : Option.none(),
+              target: (to) => to.local.Approved(),
+              resolve: ({ target }) => target(new Approved({}))
+            }
+          ],
+          otherwise: {
+            target: (to) => to.local.Rejected(),
+            resolve: ({ target }) => target(new Rejected({}))
           }
-        }
+        })
       },
       Approved: {
         on: {
-          Recheck: ({ event, target }) => target.local.with(new Flow({ score: event.score }), (flow) => flow.Routing())
+          Recheck: Machine.transition({
+            target: (to) => to.branch.Flow.initial(),
+            resolve: ({ event, target }) => target(new Flow({ score: event.score }))
+          })
         }
       }
     }
@@ -59,10 +71,10 @@ describe("Machine choice pseudo-states", () => {
       assert.strictEqual(plan.microsteps[0]?.transitions[0]?.source, "Flow.Routing")
       assert.strictEqual(Machine.isInitialEvent(plan.microsteps[0]!.event), true)
       assert.deepStrictEqual(Machine.stateNodes(machine).map(({ path, type }) => ({ path, type })), [
-        { path: "Flow", type: "compound" },
-        { path: "Flow.Routing", type: "choice" },
-        { path: "Flow.Approved", type: "atomic" },
-        { path: "Flow.Rejected", type: "atomic" }
+        { path: "Flow" as const, type: "compound" },
+        { path: "Flow.Routing" as const, type: "choice" },
+        { path: "Flow.Approved" as const, type: "atomic" },
+        { path: "Flow.Rejected" as const, type: "atomic" }
       ])
     }))
 
@@ -94,21 +106,21 @@ describe("Machine choice pseudo-states", () => {
       const chained = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: () => states.initial.Flow(new Flow({ score: 80 }), (flow) => flow.First())
+        initial: {
+          target: (to) => to.Flow.initial(),
+          resolve: ({ target }) => target(new Flow({ score: 80 }), (flow) => flow.First())
+        }
       }).handle({
         Flow: {
           states: {
             First: {
-              choice: {
-                targets: ["Flow.Second"],
-                transition: ({ target }) => target.local.Second()
-              }
+              choice: Machine.transition({ target: (to) => to.local.Second(), resolve: ({ target }) => target() })
             },
             Second: {
-              choice: {
-                targets: ["Flow.Approved"],
-                transition: ({ target }) => target.local.Approved(new Approved({}))
-              }
+              choice: Machine.transition({
+                target: (to) => to.local.Approved(),
+                resolve: ({ target }) => target(new Approved({}))
+              })
             }
           }
         }
@@ -147,15 +159,18 @@ describe("Machine choice pseudo-states", () => {
         id: "ChoiceLoopMachine",
         states: states.states,
         events: Machine.events(),
-        initial: () => states.initial.Flow(new Flow({ score: 80 }), (flow) => flow.First())
+        initial: {
+          target: (to) => to.Flow.initial(),
+          resolve: ({ target }) => target(new Flow({ score: 80 }), (flow) => flow.First())
+        }
       }).handle({
         Flow: {
           states: {
             First: {
-              choice: { targets: ["Flow.Second"], transition: ({ target }) => target.local.Second() }
+              choice: Machine.transition({ target: (to) => to.local.Second(), resolve: ({ target }) => target() })
             },
             Second: {
-              choice: { targets: ["Flow.First"], transition: ({ target }) => target.local.First() }
+              choice: Machine.transition({ target: (to) => to.local.First(), resolve: ({ target }) => target() })
             }
           }
         }
@@ -183,22 +198,28 @@ describe("Machine choice pseudo-states", () => {
       const alwaysMachine = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: () =>
-          states.initial.Flow(
-            new Flow({ score: 10 }),
-            (flow) => flow.Approved(new Approved({}))
-          )
+        initial: {
+          target: (to) => to.Flow.initial(),
+          resolve: ({ target }) =>
+            target(
+              new Flow({ score: 10 }),
+              (flow) => flow.Approved(new Approved({}))
+            )
+        }
       }).handle({
         Flow: {
           states: {
             Approved: {
-              always: ({ target }) => target.local.Routing()
+              always: Machine.transition({
+                target: (to) => to.local.Routing(),
+                resolve: ({ target }) => target()
+              })
             },
             Routing: {
-              choice: {
-                targets: ["Flow.Rejected"],
-                transition: ({ target }) => target.local.Rejected(new Rejected({}))
-              }
+              choice: Machine.transition({
+                target: (to) => to.local.Rejected(),
+                resolve: ({ target }) => target(new Rejected({}))
+              })
             }
           }
         }
@@ -241,16 +262,22 @@ describe("Machine choice pseudo-states", () => {
       const completion = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: () => states.initial.Flow(new Flow({ score: 0 }), (flow) => flow.Done(new Done({})))
+        initial: {
+          target: (to) => to.Flow.initial(),
+          resolve: ({ target }) => target(new Flow({ score: 0 }), (flow) => flow.Done(new Done({})))
+        }
       }).handle({
         Flow: {
-          onDone: ({ state, target }) => target.full.Flow(state, (flow) => flow.Routing()),
+          onDone: Machine.transition({
+            target: (to) => to.full.Flow(),
+            resolve: ({ state, target }) => target(state, (flow) => flow.Routing())
+          }),
           states: {
             Routing: {
-              choice: {
-                targets: ["Flow.Rejected"],
-                transition: ({ target }) => target.local.Rejected(new Rejected({}))
-              }
+              choice: Machine.transition({
+                target: (to) => to.local.Rejected(),
+                resolve: ({ target }) => target(new Rejected({}))
+              })
             }
           }
         }
@@ -301,34 +328,37 @@ describe("Machine choice pseudo-states", () => {
       const parallel = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: () =>
-          states.initial.Board(
-            new Board({}),
-            (board) =>
-              board
-                .Left(new Left({}), (left) => left.Routing())
-                .Right(new Right({}), (right) => right.Routing())
-          )
+        initial: {
+          target: (to) => to.Board.initial(),
+          resolve: ({ target }) =>
+            target(
+              new Board({}),
+              (board) =>
+                board
+                  .Left(new Left({}), (left) => left.Routing())
+                  .Right(new Right({}), (right) => right.Routing())
+            )
+        }
       }).handle({
         Board: {
           states: {
             Left: {
               states: {
                 Routing: {
-                  choice: {
-                    targets: ["Board.Left.Ready"],
-                    transition: ({ target }) => target.local.Ready(new Ready({}))
-                  }
+                  choice: Machine.transition({
+                    target: (to) => to.local.Ready(),
+                    resolve: ({ target }) => target(new Ready({}))
+                  })
                 }
               }
             },
             Right: {
               states: {
                 Routing: {
-                  choice: {
-                    targets: ["Board.Right.Ready"],
-                    transition: ({ target }) => target.local.Ready(new RightReady({}))
-                  }
+                  choice: Machine.transition({
+                    target: (to) => to.local.Ready(),
+                    resolve: ({ target }) => target(new RightReady({}))
+                  })
                 }
               }
             }
@@ -367,31 +397,40 @@ describe("Machine choice pseudo-states", () => {
       const history = Machine.make({
         states: states.states,
         events: Machine.events(Leave, Resume),
-        initial: () => states.initial.Flow(new Flow({ score: 1 }), (flow) => flow.Active(new Active({})))
+        initial: {
+          target: (to) => to.Flow.initial(),
+          resolve: ({ target }) => target(new Flow({ score: 1 }), (flow) => flow.Active(new Active({})))
+        }
       }).handle({
         Flow: {
           history: {
             Recent: {
-              default: () => states.initial.Flow(new Flow({ score: 0 }), (flow) => flow.Active(new Active({})))
+              default: ({ target }) => target.Flow(new Flow({ score: 0 }), (flow) => flow.Active(new Active({})))
             }
           },
           states: {
             Active: {
               on: {
-                Leave: ({ target }) => target.full.Outside(new Outside({}))
+                Leave: Machine.transition({
+                  target: (to) => to.full.Outside(),
+                  resolve: ({ target }) => target(new Outside({}))
+                })
               }
             },
             Routing: {
-              choice: {
-                targets: ["Flow.Recent"],
-                transition: ({ target }) => target.history.Flow.Recent()
-              }
+              choice: Machine.transition({
+                target: (to) => to.history.Flow.Recent(),
+                resolve: ({ target }) => target()
+              })
             }
           }
         },
         Outside: {
           on: {
-            Resume: ({ target }) => target.full.Flow(new Flow({ score: 2 }), (flow) => flow.Routing())
+            Resume: Machine.transition({
+              target: (to) => to.full.Flow(),
+              resolve: ({ target }) => target(new Flow({ score: 2 }), (flow) => flow.Routing())
+            })
           }
         }
       })
@@ -421,24 +460,27 @@ describe("Machine choice pseudo-states", () => {
       const initialHistory = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: () => states.initial.Flow(new Flow({ score: 1 }), (flow) => flow.Routing())
+        initial: {
+          target: (to) => to.Flow.initial(),
+          resolve: ({ target }) => target(new Flow({ score: 1 }), (flow) => flow.Routing())
+        }
       }).handle({
         Flow: {
           history: {
             Recent: {
               default: () => ({
-                path: "Flow",
+                path: "Flow" as const,
                 value: new Flow({ score: 0 }),
-                state: { path: "Flow.Active", value: new Active({}) }
+                state: { path: "Flow.Active" as const, value: new Active({}) }
               })
             }
           },
           states: {
             Routing: {
-              choice: {
-                targets: ["Flow.Recent"],
-                transition: ({ target }) => target.history.Flow.Recent()
-              }
+              choice: Machine.transition({
+                target: (to) => to.history.Flow.Recent(),
+                resolve: ({ target }) => target()
+              })
             }
           }
         }
@@ -468,7 +510,10 @@ describe("Machine choice pseudo-states", () => {
       const historyChoice = Machine.make({
         states: states.states,
         events: Machine.events(Resume),
-        initial: () => states.initial.Outside(new Outside({}))
+        initial: {
+          target: (to) => to.Outside(),
+          resolve: ({ target }) => target(new Outside({}))
+        }
       }).handle({
         Flow: {
           history: {
@@ -478,15 +523,20 @@ describe("Machine choice pseudo-states", () => {
           },
           states: {
             Routing: {
-              choice: {
-                targets: ["Flow.Active"],
-                transition: ({ target }) => target.local.Active(new Active({}))
-              }
+              choice: Machine.transition({
+                target: (to) => to.local.Active(),
+                resolve: ({ target }) => target(new Active({}))
+              })
             }
           }
         },
         Outside: {
-          on: { FallbackChoiceResume: ({ target }) => target.history.Flow.Recent() }
+          on: {
+            FallbackChoiceResume: Machine.transition({
+              target: (to) => to.history.Flow.Recent(),
+              resolve: ({ target }) => target()
+            })
+          }
         }
       })
 
@@ -509,7 +559,10 @@ describe("Machine choice pseudo-states", () => {
         source: "Flow.Routing",
         trigger: { type: "choice" },
         reenter: false,
-        targets: { type: "declared", paths: ["Flow.Approved", "Flow.Rejected"] }
+        branches: [
+          { type: "case", title: "score is at least 70", target: "Flow.Approved" },
+          { type: "otherwise", target: "Flow.Rejected" }
+        ]
       }
     ])
   })

--- a/test/machine/DeepHandlers.test.ts
+++ b/test/machine/DeepHandlers.test.ts
@@ -87,30 +87,28 @@ const States = Machine.defineStates({
   }
 })
 
-const initial = States.initial.n0(
-  new NodeState({ level: 0 }),
-  (n0) =>
-    n0.n1(
-      new NodeState({ level: 1 }),
-      (n1) =>
-        n1.n2(new NodeState({ level: 2 }), (n2) =>
-          n2.n3(new NodeState({ level: 3 }), (n3) =>
-            n3.n4(new NodeState({ level: 4 }), (n4) =>
-              n4.n5(new NodeState({ level: 5 }), (n5) =>
-                n5.n6(new NodeState({ level: 6 }), (n6) =>
-                  n6.n7(new NodeState({ level: 7 }), (n7) =>
-                    n7.n8(new NodeState({ level: 8 }), (n8) =>
-                      n8.n9(new NodeState({ level: 9 }), (n9) =>
-                        n9.n10(new NodeState({ level: 10 }), (n10) =>
-                          n10.n11(new NodeState({ level: 11 }), (n11) =>
-                            n11.idle(new DeepIdle({ value: "initial" }))))))))))))
-    )
-)
+const initial = (() => {
+  let state: any = {
+    path: "n0.n1.n2.n3.n4.n5.n6.n7.n8.n9.n10.n11.idle",
+    value: new DeepIdle({ value: "initial" })
+  }
+  for (let level = 11; level >= 0; level--) {
+    state = {
+      path: Array.from({ length: level + 1 }, (_, index) => `n${index}`).join("."),
+      value: new NodeState({ level }),
+      state
+    }
+  }
+  return state as Machine.Machine.Snapshot<typeof States.states>
+})()
 
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(Advance),
-  initial: () => initial
+  initial: {
+    target: (to) => to.n0.initial(),
+    resolve: () => initial
+  }
 }).handle({
   n0: {
     states: {
@@ -138,8 +136,11 @@ const machine = Machine.make({
                                                 states: {
                                                   idle: {
                                                     on: {
-                                                      Advance: ({ event, target }) =>
-                                                        target.local.done(new DeepDone({ value: event.value }))
+                                                      Advance: Machine.transition({
+                                                        target: (to) => to.local.done(),
+                                                        resolve: ({ event, target }) =>
+                                                          target(new DeepDone({ value: event.value }))
+                                                      })
                                                     }
                                                   },
                                                   done: {}

--- a/test/machine/History.test.ts
+++ b/test/machine/History.test.ts
@@ -96,23 +96,23 @@ const checkoutPaymentVerifying = (
   attempt: number,
   challengeId: string
 ): Machine.Machine.Snapshot<typeof CheckoutStates.states> => ({
-  path: "checkout",
+  path: "checkout" as const,
   value: new Checkout({ orderId }),
   state: {
-    path: "checkout.payment",
+    path: "checkout.payment" as const,
     value: new Payment({ attempt }),
     state: {
-      path: "checkout.payment.verifying",
+      path: "checkout.payment.verifying" as const,
       value: new Verifying({ challengeId })
     }
   }
 })
 
-const checkoutShipping = (orderId: string, address: string) =>
-  CheckoutStates.initial.checkout(
-    new Checkout({ orderId }),
-    (checkout) => checkout.shipping(new Shipping({ address }))
-  )
+const checkoutShipping = (orderId: string, address: string) => ({
+  path: "checkout" as const,
+  value: new Checkout({ orderId }),
+  state: { path: "checkout.shipping" as const, value: new Shipping({ address }) }
+})
 
 const makeCheckoutMachine = (
   initial: Machine.Machine.Snapshot<typeof CheckoutStates.states>,
@@ -123,7 +123,18 @@ const makeCheckoutMachine = (
   Machine.make({
     states: CheckoutStates.states,
     events: Machine.events(Leave, ResumeShallow, ResumeDeep, GoShipping, EnterVerifying, ReenterHistory),
-    initial: () => initial
+    initial: (initial.path === "checkout"
+      ? {
+        target: (to: any) => to.checkout.initial(),
+        resolve: ({ target }: any) =>
+          target(new Checkout({ orderId: "initial" }), (checkout: any) =>
+            checkout.shipping(new Shipping({ address: "initial" })))
+      }
+      : {
+        target: (to: any) =>
+          to.support(),
+        resolve: () => initial
+      }) as any
   }).handle({
     checkout: {
       entry: () => {
@@ -147,21 +158,31 @@ const makeCheckoutMachine = (
         }
       },
       on: {
-        Leave: ({ target }) => target.full.support(new Support({ ticket: "ticket-1" })),
-        GoShipping: ({ event, target }) => target.local.shipping(new Shipping({ address: event.address })),
-        ReenterHistory: {
-          reenter: true,
-          transition: ({ target }) => target.history.checkout.exact()
-        }
+        Leave: Machine.transition({
+          target: (to) => to.full.support(),
+          resolve: ({ target }) => target(new Support({ ticket: "ticket-1" }))
+        }),
+        GoShipping: Machine.transition({
+          target: (to) => to.local.shipping(),
+          resolve: ({ event, target }) => target(new Shipping({ address: event.address }))
+        }),
+        ReenterHistory: Machine.transition({
+          target: (to) => to.history.checkout.exact(),
+          resolve: ({ target }) => target(),
+          reenter: true
+        })
       },
       states: {
         shipping: {
           on: {
-            EnterVerifying: ({ target }) =>
-              target.local.payment(
-                new Payment({ attempt: 2 }),
-                (payment) => payment.verifying(new Verifying({ challengeId: "challenge-7" }))
-              )
+            EnterVerifying: Machine.transition({
+              target: (to) => to.local.payment(),
+              resolve: ({ target }) =>
+                target(
+                  new Payment({ attempt: 2 }),
+                  (payment) => payment.verifying(new Verifying({ challengeId: "challenge-7" }))
+                )
+            })
           }
         },
         payment: {
@@ -196,8 +217,14 @@ const makeCheckoutMachine = (
         lifecycle?.push("exit:support")
       },
       on: {
-        ResumeShallow: ({ target }) => target.history.checkout.recent(),
-        ResumeDeep: ({ target }) => target.history.checkout.exact()
+        ResumeShallow: Machine.transition({
+          target: (to) => to.history.checkout.recent(),
+          resolve: ({ target }) => target()
+        }),
+        ResumeDeep: Machine.transition({
+          target: (to) => to.history.checkout.exact(),
+          resolve: ({ target }) => target()
+        })
       }
     }
   })
@@ -266,22 +293,22 @@ const WorkspaceStates = Machine.defineStates({
 })
 
 const activeWorkspace: Machine.Machine.Snapshot<typeof WorkspaceStates.states> = {
-  path: "workspace",
+  path: "workspace" as const,
   value: new Workspace({ id: "workspace-1" }),
   states: {
     editor: {
-      path: "workspace.editor",
+      path: "workspace.editor" as const,
       value: new Editor({ documentId: "document-1" }),
       state: {
-        path: "workspace.editor.preview",
+        path: "workspace.editor.preview" as const,
         value: new Preview({ page: 4 })
       }
     },
     sidebar: {
-      path: "workspace.sidebar",
+      path: "workspace.sidebar" as const,
       value: new Sidebar({ width: 320 }),
       state: {
-        path: "workspace.sidebar.search",
+        path: "workspace.sidebar.search" as const,
         value: new Search({ query: "history" })
       }
     }
@@ -292,13 +319,20 @@ const makeWorkspaceMachine = (initialized: Array<string>) =>
   Machine.make({
     states: WorkspaceStates.states,
     events: Machine.events(LeaveWorkspace, ResumeWorkspaceShallow, ResumeWorkspaceDeep),
-    initial: () => activeWorkspace
+    initial: {
+      target: (to) => to.workspace.initial(),
+      resolve: ({ target }) =>
+        target(new Workspace({ id: "initial" }), (workspace) =>
+          workspace
+            .editor(new Editor({ documentId: "initial" }), (editor) => editor.writing(new Writing({ draft: "" })))
+            .sidebar(new Sidebar({ width: 0 }), (sidebar) => sidebar.files(new Files({ directory: "/" }))))
+    }
   }).handle({
     workspace: {
       history: {
         recent: {
-          default: () =>
-            WorkspaceStates.initial.workspace(
+          default: ({ target }) =>
+            target.workspace(
               new Workspace({ id: "fallback" }),
               (workspace) =>
                 workspace
@@ -313,8 +347,8 @@ const makeWorkspaceMachine = (initialized: Array<string>) =>
             )
         },
         exact: {
-          default: () =>
-            WorkspaceStates.initial.workspace(
+          default: ({ target }) =>
+            target.workspace(
               new Workspace({ id: "fallback" }),
               (workspace) =>
                 workspace
@@ -330,7 +364,10 @@ const makeWorkspaceMachine = (initialized: Array<string>) =>
         }
       },
       on: {
-        LeaveWorkspace: ({ target }) => target.full.away(new Away({}))
+        LeaveWorkspace: Machine.transition({
+          target: (to) => to.full.away(),
+          resolve: ({ target }) => target(new Away({}))
+        })
       },
       states: {
         editor: {
@@ -349,8 +386,14 @@ const makeWorkspaceMachine = (initialized: Array<string>) =>
     },
     away: {
       on: {
-        ResumeWorkspaceShallow: ({ target }) => target.history.workspace.recent(),
-        ResumeWorkspaceDeep: ({ target }) => target.history.workspace.exact()
+        ResumeWorkspaceShallow: Machine.transition({
+          target: (to) => to.history.workspace.recent(),
+          resolve: ({ target }) => target()
+        }),
+        ResumeWorkspaceDeep: Machine.transition({
+          target: (to) => to.history.workspace.exact(),
+          resolve: ({ target }) => target()
+        })
       }
     }
   })
@@ -378,19 +421,19 @@ const NestedHistoryStates = Machine.defineStates({
 })
 
 const nestedParallelSnapshot: Machine.Machine.Snapshot<typeof NestedHistoryStates.states> = {
-  path: "workspace",
+  path: "workspace" as const,
   value: new Workspace({ id: "workspace-1" }),
   states: {
     editor: {
-      path: "workspace.editor",
+      path: "workspace.editor" as const,
       value: new Editor({ documentId: "document-1" }),
       state: {
-        path: "workspace.editor.preview",
+        path: "workspace.editor.preview" as const,
         value: new Preview({ page: 4 })
       }
     },
     sidebar: {
-      path: "workspace.sidebar",
+      path: "workspace.sidebar" as const,
       value: new Search({ query: "untouched" })
     }
   }
@@ -399,25 +442,28 @@ const nestedParallelSnapshot: Machine.Machine.Snapshot<typeof NestedHistoryState
 const nestedHistoryMachine = Machine.make({
   states: NestedHistoryStates.states,
   events: Machine.events(RestoreEditor, DefaultEditor),
-  initial: () =>
-    NestedHistoryStates.initial.workspace(
-      new Workspace({ id: "workspace-1" }),
-      (workspace) =>
-        workspace
-          .editor(
-            new Editor({ documentId: "document-1" }),
-            (editor) => editor.writing(new Writing({ draft: "" }))
-          )
-          .sidebar(new Search({ query: "untouched" }))
-    )
+  initial: {
+    target: (to) => to.workspace.initial(),
+    resolve: ({ target }) =>
+      target(
+        new Workspace({ id: "workspace-1" }),
+        (workspace) =>
+          workspace
+            .editor(
+              new Editor({ documentId: "document-1" }),
+              (editor) => editor.writing(new Writing({ draft: "" }))
+            )
+            .sidebar(new Search({ query: "untouched" }))
+      )
+  }
 }).handle({
   workspace: {
     states: {
       editor: {
         history: {
           exact: {
-            default: () =>
-              NestedHistoryStates.initial.workspace(
+            default: ({ target }) =>
+              target.workspace(
                 new Workspace({ id: "fallback-workspace" }),
                 (workspace) =>
                   workspace
@@ -432,16 +478,23 @@ const nestedHistoryMachine = Machine.make({
         states: {
           preview: {
             on: {
-              RestoreEditor: {
-                reenter: true,
-                transition: ({ target }) => target.history.workspace.editor.exact()
-              },
-              DefaultEditor: ({ target }) => target.history.workspace.editor.exact()
+              RestoreEditor: Machine.transition({
+                target: (to) => to.history.workspace.editor.exact(),
+                resolve: ({ target }) => target(),
+                reenter: true
+              }),
+              DefaultEditor: Machine.transition({
+                target: (to) => to.history.workspace.editor.exact(),
+                resolve: ({ target }) => target()
+              })
             }
           },
           writing: {
             on: {
-              DefaultEditor: ({ target }) => target.history.workspace.editor.exact()
+              DefaultEditor: Machine.transition({
+                target: (to) => to.history.workspace.editor.exact(),
+                resolve: ({ target }) => target()
+              })
             }
           }
         }
@@ -455,7 +508,7 @@ describe("Machine history states", () => {
     Effect.gen(function*() {
       let initialized = 0
       const machine = makeCheckoutMachine(
-        CheckoutStates.initial.support(new Support({ ticket: "new" })),
+        { path: "support" as const, value: new Support({ ticket: "new" }) },
         () => initialized++
       )
 
@@ -492,7 +545,7 @@ describe("Machine history states", () => {
       const resumedOnce = yield* Machine.plan(machine, secondLeave.next, new ResumeDeep({}))
       assert.strictEqual(resumedOnce.next.path, "checkout")
       assert.deepStrictEqual((resumedOnce.next as any).state, {
-        path: "checkout.shipping",
+        path: "checkout.shipping" as const,
         value: new Shipping({ address: "Second Street" })
       })
 
@@ -516,7 +569,7 @@ describe("Machine history states", () => {
       assert.deepStrictEqual(resumed.next.value, new Checkout({ orderId: "order-1" }))
       assert.deepStrictEqual((resumed.next as any).state.value, new Payment({ attempt: 3 }))
       assert.deepStrictEqual((resumed.next as any).state.state, {
-        path: "checkout.payment.cardEntry",
+        path: "checkout.payment.cardEntry" as const,
         value: new CardEntry({ cardNumber: "fresh-3" })
       })
 
@@ -617,18 +670,18 @@ describe("Machine history states", () => {
       const shallow = yield* Machine.plan(machine, leftAgain.next, new ResumeWorkspaceShallow({}))
       assert.deepStrictEqual(initialized, ["editor", "sidebar"])
       assert.deepStrictEqual((shallow.next as any).states.editor, {
-        path: "workspace.editor",
+        path: "workspace.editor" as const,
         value: new Editor({ documentId: "document-1" }),
         state: {
-          path: "workspace.editor.writing",
+          path: "workspace.editor.writing" as const,
           value: new Writing({ draft: "fresh:document-1" })
         }
       })
       assert.deepStrictEqual((shallow.next as any).states.sidebar, {
-        path: "workspace.sidebar",
+        path: "workspace.sidebar" as const,
         value: new Sidebar({ width: 320 }),
         state: {
-          path: "workspace.sidebar.files",
+          path: "workspace.sidebar.files" as const,
           value: new Files({ directory: "/fresh/320" })
         }
       })
@@ -644,7 +697,7 @@ describe("Machine history states", () => {
 
       assert.deepStrictEqual((restored.next as any).states.editor, (nestedParallelSnapshot as any).states.editor)
       assert.deepStrictEqual((restored.next as any).states.sidebar, {
-        path: "workspace.sidebar",
+        path: "workspace.sidebar" as const,
         value: new Search({ query: "untouched" })
       })
       assert.deepStrictEqual(restored.next.history?.["workspace.editor.exact"]?.active, [
@@ -663,15 +716,15 @@ describe("Machine history states", () => {
       )
 
       assert.deepStrictEqual((restored.next as any).states.editor, {
-        path: "workspace.editor",
+        path: "workspace.editor" as const,
         value: new Editor({ documentId: "fallback" }),
         state: {
-          path: "workspace.editor.writing",
+          path: "workspace.editor.writing" as const,
           value: new Writing({ draft: "" })
         }
       })
       assert.deepStrictEqual((restored.next as any).states.sidebar, {
-        path: "workspace.sidebar",
+        path: "workspace.sidebar" as const,
         value: new Search({ query: "untouched" })
       })
       assert.strictEqual(restored.microsteps[0]?.transitions[0]?.target, "workspace.editor.exact")
@@ -714,12 +767,12 @@ describe("Machine history states", () => {
   it.effect("rejects a forged fallback that omits its declared owner with a precise diagnostic", () =>
     Effect.gen(function*() {
       const unsafe = makeCheckoutMachine(
-        CheckoutStates.initial.support(new Support({ ticket: "new" }))
+        { path: "support" as const, value: new Support({ ticket: "new" }) }
       ).handle({
         checkout: {
           history: {
             exact: {
-              default: (() => CheckoutStates.initial.support(new Support({ ticket: "forged" }))) as any
+              default: (() => ({ path: "support" as const, value: new Support({ ticket: "forged" }) })) as any
             }
           }
         }

--- a/test/machine/InitialEntry.test.ts
+++ b/test/machine/InitialEntry.test.ts
@@ -41,12 +41,21 @@ const makeMachine = () =>
   Machine.make({
     states: States.states,
     events: Machine.events(Open, OpenInvalid),
-    initial: () => States.initial.closed(new Closed({}))
+    initial: {
+      target: (to) => to.closed(),
+      resolve: ({ target }) => target(new Closed({}))
+    }
   }).handle({
     closed: {
       on: {
-        Open: ({ target }) => target.full.opened.initial.from({ id: "team-1" }),
-        OpenInvalid: ({ target }) => target.full.opened.initial.from({ id: "" })
+        Open: Machine.transition({
+          target: (to) => to.full.opened.initial(),
+          resolve: ({ target }) => target.from({ id: "team-1" })
+        }),
+        OpenInvalid: Machine.transition({
+          target: (to) => to.full.opened.initial(),
+          resolve: ({ target }) => target.from({ id: "" })
+        })
       }
     },
     opened: {
@@ -74,11 +83,17 @@ const makeParallelMachine = () =>
   Machine.make({
     states: ParallelStates.states,
     events: Machine.events(EnterDashboard),
-    initial: () => ParallelStates.initial.outside(new Outside({}))
+    initial: {
+      target: (to) => to.outside(),
+      resolve: ({ target }) => target(new Outside({}))
+    }
   }).handle({
     outside: {
       on: {
-        EnterDashboard: ({ target }) => target.full.dashboard.initial(new Dashboard({}))
+        EnterDashboard: Machine.transition({
+          target: (to) => to.full.dashboard.initial(),
+          resolve: ({ target }) => target(new Dashboard({}))
+        })
       }
     },
     dashboard: {
@@ -107,20 +122,26 @@ const makeChoiceMachine = () =>
   Machine.make({
     states: ChoiceStates.states,
     events: Machine.events(EnterFlow),
-    initial: () => ChoiceStates.initial.outside(new Outside({}))
+    initial: {
+      target: (to) => to.outside(),
+      resolve: ({ target }) => target(new Outside({}))
+    }
   }).handle({
     outside: {
       on: {
-        EnterFlow: ({ target }) => target.full.flow.initial(new Flow({}))
+        EnterFlow: Machine.transition({
+          target: (to) => to.full.flow.initial(),
+          resolve: ({ target }) => target(new Flow({}))
+        })
       }
     },
     flow: {
       states: {
         routing: {
-          choice: {
-            targets: ["flow.approved"],
-            transition: ({ target }) => target.local.approved(new Approved({}))
-          }
+          choice: Machine.transition({
+            target: (to) => to.local.approved(),
+            resolve: ({ target }) => target(new Approved({}))
+          })
         }
       }
     }
@@ -138,11 +159,17 @@ const makeStructuralMachine = () =>
   Machine.make({
     states: StructuralStates.states,
     events: Machine.events(EnterFlow),
-    initial: () => StructuralStates.initial.outside(new Outside({}))
+    initial: {
+      target: (to) => to.outside(),
+      resolve: ({ target }) => target(new Outside({}))
+    }
   }).handle({
     outside: {
       on: {
-        EnterFlow: ({ target }) => target.full.group.initial.from()
+        EnterFlow: Machine.transition({
+          target: (to) => to.full.group.initial(),
+          resolve: ({ target }) => target.from()
+        })
       }
     }
   })
@@ -165,14 +192,23 @@ const makeNestedMachine = () =>
   Machine.make({
     states: NestedStates.states,
     events: Machine.events(OpenLocal, OpenBranch),
-    initial: () => NestedStates.initial.root.from((root) => root.closed(new Closed({})))
+    initial: {
+      target: (to) => to.root.initial(),
+      resolve: ({ target }) => target.from((root) => root.closed(new Closed({})))
+    }
   }).handle({
     root: {
       states: {
         closed: {
           on: {
-            OpenLocal: ({ target }) => target.local.opened.initial.from({ id: "local" }),
-            OpenBranch: ({ target }) => target.branch.root.opened.initial.from({ id: "branch" })
+            OpenLocal: Machine.transition({
+              target: (to) => to.local.opened.initial(),
+              resolve: ({ target }) => target.from({ id: "local" })
+            }),
+            OpenBranch: Machine.transition({
+              target: (to) => to.branch.root.opened.initial(),
+              resolve: ({ target }) => target.from({ id: "branch" })
+            })
           }
         },
         opened: {
@@ -191,10 +227,11 @@ describe("declared initial entry", () => {
 
       assert.deepStrictEqual(
         planned.next,
-        States.initial.opened(
-          new Opened({ id: "team-1" }),
-          (opened) => opened.idle(new Idle({ count: 1 }))
-        )
+        {
+          path: "opened" as const,
+          value: new Opened({ id: "team-1" }),
+          state: { path: "opened.idle" as const, value: new Idle({ count: 1 }) }
+        }
       )
     }))
 
@@ -217,16 +254,18 @@ describe("declared initial entry", () => {
 
       assert.deepStrictEqual(
         planned.next,
-        ParallelStates.initial.dashboard(
-          new Dashboard({}),
-          (dashboard) =>
-            dashboard
-              .filters(
-                new Filters({ id: "all" }),
-                (filters) => filters.ready(new Ready({ enabled: true }))
-              )
-              .results(new Results({ count: 2 }))
-        )
+        {
+          path: "dashboard" as const,
+          value: new Dashboard({}),
+          states: {
+            filters: {
+              path: "dashboard.filters" as const,
+              value: new Filters({ id: "all" }),
+              state: { path: "dashboard.filters.ready" as const, value: new Ready({ enabled: true }) }
+            },
+            results: { path: "dashboard.results" as const, value: new Results({ count: 2 }) }
+          }
+        }
       )
     }))
 
@@ -239,9 +278,9 @@ describe("declared initial entry", () => {
       assert.deepStrictEqual(
         planned.next,
         {
-          path: "flow",
+          path: "flow" as const,
           value: new Flow({}),
-          state: { path: "flow.approved", value: new Approved({}) }
+          state: { path: "flow.approved" as const, value: new Approved({}) }
         }
       )
       assert.deepStrictEqual(planned.microsteps[0]?.transitions, [{
@@ -266,9 +305,9 @@ describe("declared initial entry", () => {
       const planned = yield* Machine.plan(machine, initial.state, new EnterFlow({}))
 
       assert.deepStrictEqual(planned.next, {
-        path: "group",
+        path: "group" as const,
         value: undefined,
-        state: { path: "group.idle", value: undefined }
+        state: { path: "group.idle" as const, value: undefined }
       })
     }))
 
@@ -281,12 +320,12 @@ describe("declared initial entry", () => {
 
       for (const [planned, id] of [[local, "local"], [branch, "branch"]] as const) {
         assert.deepStrictEqual(planned.next, {
-          path: "root",
+          path: "root" as const,
           value: undefined,
           state: {
-            path: "root.opened",
+            path: "root.opened" as const,
             value: new Opened({ id }),
-            state: { path: "root.opened.idle", value: new Idle({ count: 3 }) }
+            state: { path: "root.opened.idle" as const, value: new Idle({ count: 3 }) }
           }
         })
       }

--- a/test/machine/Inspection.test.ts
+++ b/test/machine/Inspection.test.ts
@@ -37,11 +37,14 @@ const States = Machine.defineStates({
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(),
-  initial: () =>
-    States.initial.root(new Root({}), (root) =>
-      root
-        .flow(new Flow({}), (flow) => flow.idle(new Idle({})))
-        .side(new Side({})))
+  initial: {
+    target: (to) => to.root.initial(),
+    resolve: ({ target }) =>
+      target(new Root({}), (root) =>
+        root
+          .flow(new Flow({}), (flow) => flow.idle(new Idle({})))
+          .side(new Side({})))
+  }
 })
 
 const ChoiceStates = Machine.defineStates({
@@ -58,15 +61,15 @@ const ChoiceStates = Machine.defineStates({
 const choiceMachine = Machine.make({
   states: ChoiceStates.states,
   events: Machine.events(),
-  initial: () => ChoiceStates.initial.Flow(new ChoiceFlow({}), (flow) => flow.Routing())
+  initial: {
+    target: (to) => to.Flow.initial(),
+    resolve: ({ target }) => target(new ChoiceFlow({}), (flow) => flow.Routing())
+  }
 }).handle({
   Flow: {
     states: {
       Routing: {
-        choice: {
-          targets: ["Flow.Ready"],
-          transition: ({ target }) => target.local.Ready(new Ready({}))
-        }
+        choice: Machine.transition({ target: (to) => to.local.Ready(), resolve: ({ target }) => target(new Ready({})) })
       }
     }
   }
@@ -140,8 +143,8 @@ describe("Machine compiled state-node inspection", () => {
       assert.deepStrictEqual(
         Machine.configuration(choiceMachine, plan.state).map(({ path, type }) => ({ path, type })),
         [
-          { path: "Flow", type: "compound" },
-          { path: "Flow.Ready", type: "atomic" }
+          { path: "Flow" as const, type: "compound" },
+          { path: "Flow.Ready" as const, type: "atomic" }
         ]
       )
     }))

--- a/test/machine/Invoke.test.ts
+++ b/test/machine/Invoke.test.ts
@@ -20,13 +20,19 @@ describe("inline invoke", () => {
       const machine = Machine.make({
         states: States.states,
         events: Machine.events(),
-        initial: () => States.initial.Loading.from()
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target.from()
+        }
       }).handle({
         Loading: {
           invoke: Machine.invoke({
             id: "load",
             effect: () => Effect.succeed("ready"),
-            onDone: ({ output, target }) => target.full.Complete(new Complete({ value: output }))
+            onDone: Machine.transition({
+              target: (to) => to.full.Complete(),
+              resolve: ({ output, target }) => target(new Complete({ value: output }))
+            })
           })
         },
         Complete: {},
@@ -37,12 +43,12 @@ describe("inline invoke", () => {
         source: "Loading",
         trigger: { type: "invoke", id: "load", outcome: "done" },
         reenter: false,
-        targets: { type: "dynamic" }
+        branches: [{ type: "direct", target: "Complete" }]
       }])
 
       const ref = yield* Machine.start(machine)
       for (let index = 0; index < 5; index += 1) yield* Effect.yieldNow
-      assert.deepStrictEqual(yield* ref.state, States.initial.Complete(new Complete({ value: "ready" })))
+      assert.deepStrictEqual(yield* ref.state, { path: "Complete" as const, value: new Complete({ value: "ready" }) })
     }))
 
   it.effect("plans a typed Effect failure directly", () =>
@@ -50,13 +56,19 @@ describe("inline invoke", () => {
       const machine = Machine.make({
         states: States.states,
         events: Machine.events(),
-        initial: () => States.initial.Loading.from()
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target.from()
+        }
       }).handle({
         Loading: {
           invoke: Machine.invoke({
             id: "load",
             effect: () => Effect.fail("offline"),
-            onFailure: ({ error, target }) => target.full.Failed(new Failed({ message: error }))
+            onFailure: Machine.transition({
+              target: (to) => to.full.Failed(),
+              resolve: ({ error, target }) => target(new Failed({ message: error }))
+            })
           })
         },
         Complete: {},
@@ -65,7 +77,7 @@ describe("inline invoke", () => {
 
       const ref = yield* Machine.start(machine)
       for (let index = 0; index < 5; index += 1) yield* Effect.yieldNow
-      assert.deepStrictEqual(yield* ref.state, States.initial.Failed(new Failed({ message: "offline" })))
+      assert.deepStrictEqual(yield* ref.state, { path: "Failed" as const, value: new Failed({ message: "offline" }) })
     }))
 
   it.effect("fails the owning machine when an Effect source factory defects", () =>
@@ -74,10 +86,18 @@ describe("inline invoke", () => {
       const machine = Machine.make({
         states: States.states,
         events: Machine.events(Start),
-        initial: () => States.initial.Idle.from()
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target.from()
+        }
       }).handle({
         Idle: {
-          on: { Start: ({ target }) => target.full.Loading.from() }
+          on: {
+            Start: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target.from()
+            })
+          }
         },
         Loading: {
           invoke: Machine.invoke({
@@ -85,7 +105,10 @@ describe("inline invoke", () => {
             effect: (): Effect.Effect<string> => {
               throw defect
             },
-            onDone: ({ target }) => target.none()
+            onDone: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            })
           })
         },
         Complete: {},
@@ -112,10 +135,18 @@ describe("inline invoke", () => {
       const machine = Machine.make({
         states: States.states,
         events: Machine.events(Start),
-        initial: () => States.initial.Idle.from()
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target.from()
+        }
       }).handle({
         Idle: {
-          on: { Start: ({ target }) => target.full.Loading.from() }
+          on: {
+            Start: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target.from()
+            })
+          }
         },
         Loading: {
           invoke: Machine.invoke({

--- a/test/machine/LiveInspection.test.ts
+++ b/test/machine/LiveInspection.test.ts
@@ -19,14 +19,20 @@ const machine = Machine.make({
   states: states.states,
   events: Events,
   emittedEvents: Emissions,
-  initial: () => states.initial.Idle(new Idle({}))
+  initial: {
+    target: (to) => to.Idle(),
+    resolve: ({ target }) => target(new Idle({}))
+  }
 }).handle({
   Idle: {
     on: {
-      Increment: ({ event, target }, enqueue) => {
-        enqueue.emit(Emissions.Notice({ value: event.by }))
-        return target.full.Idle(new Idle({}))
-      }
+      Increment: Machine.transition({
+        target: (to) => to.full.Idle(),
+        resolve: ({ event, target }, enqueue) => {
+          enqueue.emit(Emissions.Notice({ value: event.by }))
+          return target(new Idle({}))
+        }
+      })
     }
   }
 })
@@ -99,8 +105,11 @@ describe("Machine live inspection", () => {
       const invalid = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: () => {
-          throw new Error("boom")
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: () => {
+            throw new Error("boom")
+          }
         }
       }).handle({ Idle: {} })
       const prepared = yield* Machine.prepare(invalid)
@@ -124,7 +133,10 @@ describe("Machine live inspection", () => {
         id: "activity-root",
         states: states.states,
         events: Machine.events(),
-        initial: () => states.initial.Idle(new Idle({}))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({}))
+        }
       }).handle({
         Idle: {
           invoke: Machine.invoke({ id: "worker", effect: () => Effect.never })
@@ -183,14 +195,20 @@ describe("Machine live inspection", () => {
         states: childStates.states,
         events: ChildEvents,
         parentEvents: ParentEvents,
-        initial: () => childStates.initial.ChildIdle(new ChildIdle({}))
+        initial: {
+          target: (to) => to.ChildIdle(),
+          resolve: ({ target }) => target(new ChildIdle({}))
+        }
       }).handle({
         ChildIdle: {
           on: {
-            Trigger: ({ parent, target }, enqueue) => {
-              if (parent !== undefined) enqueue.sendTo(parent, ParentEvents.ChildReady())
-              return target.none()
-            }
+            Trigger: Machine.transition({
+              target: (to) => to.none(),
+              resolve: ({ parent }, enqueue) => {
+                if (parent !== undefined) enqueue.sendTo(parent, ParentEvents.ChildReady())
+                return undefined
+              }
+            })
           }
         }
       })
@@ -203,12 +221,18 @@ describe("Machine live inspection", () => {
         id: "parent-machine",
         states: parentStates.states,
         events: Machine.events(ParentEvents),
-        initial: () => parentStates.initial.ParentIdle(new ParentIdle({}))
+        initial: {
+          target: (to) => to.ParentIdle(),
+          resolve: ({ target }) => target(new ParentIdle({}))
+        }
       }).handle({
         ParentIdle: {
           invoke: Machine.invoke({ child: Child }),
           on: {
-            ChildReady: ({ target }) => target.full.ParentDone(new ParentDone({}))
+            ChildReady: Machine.transition({
+              target: (to) => to.full.ParentDone(),
+              resolve: ({ target }) => target(new ParentDone({}))
+            })
           }
         },
         ParentDone: {}

--- a/test/machine/Machine.test.ts
+++ b/test/machine/Machine.test.ts
@@ -106,35 +106,32 @@ describe("Machine", () => {
       class Stable extends Schema.TaggedClass<Stable>("Stable")("Stable", {}) {}
       class Ping extends Schema.TaggedClass<Ping>("Ping")("Ping", {}) {}
       const states = Machine.defineStates({ Stable })
-      const transition = {
-        reenter: false,
-        targets: [] as Array<"Stable">,
-        transition: ({ target }: Machine.Machine.HandlerContext<
-          typeof states.states,
-          readonly [typeof Ping],
-          readonly [],
-          "Stable",
-          "Ping",
-          never,
-          never
-        >) => target.none()
-      }
-      const on: { Ping?: typeof transition } = { Ping: transition }
+      const transition = Machine.transition({
+        target: (to) => to.none(),
+        resolve: () => undefined,
+        reenter: false
+      })
+      const on: any = { Ping: transition }
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Ping),
-        initial: () => states.initial.Stable(new Stable({}))
+        initial: {
+          target: (to) => to.Stable(),
+          resolve: ({ target }) => target(new Stable({}))
+        }
       }).handle({ Stable: { on } })
 
       delete on.Ping
-      transition.reenter = true
-      transition.targets.push("Stable")
+      ;(transition as any).reenter = true
+      ;(transition as any).target = () => {
+        throw new Error("captured transition unexpectedly re-evaluated its target selector")
+      }
 
       assert.deepStrictEqual(Machine.transitionDefinitions(machine), [{
         source: "Stable",
         trigger: { type: "event", event: "Ping" },
         reenter: false,
-        targets: { type: "declared", paths: [] }
+        branches: [{ type: "direct", target: undefined }]
       }])
 
       const initial = yield* Machine.planInitial(machine)
@@ -278,7 +275,12 @@ describe("Machine", () => {
   class ReserveInventory extends Schema.TaggedClass<ReserveInventory>("ReserveInventory")("ReserveInventory", {
     reservationId: Schema.String
   }) {}
-  const FlatInitial = Machine.defineStates({ Idle, Loading, Success, Failed }).initial
+  const FlatInitial = {
+    Idle: (value: Idle) => ({ path: "Idle" as const, value }),
+    Loading: (value: Loading) => ({ path: "Loading" as const, value }),
+    Success: (value: Success) => ({ path: "Success" as const, value }),
+    Failed: (value: Failed) => ({ path: "Failed" as const, value })
+  }
   const SuccessOutput = {
     schema: Success,
     type: "final",
@@ -289,8 +291,11 @@ describe("Machine", () => {
     type: "final",
     output: Schema.String
   } as const
-  const LowercaseInitial = Machine.defineStates({ idle: Idle, loading: Loading, success: Success }).initial
-  const DuplicateInitial = Machine.defineStates({ a: Duplicate, b: Duplicate }).initial
+  const LowercaseInitial = {
+    idle: (value: Idle) => ({ path: "idle" as const, value }),
+    loading: (value: Loading) => ({ path: "loading" as const, value }),
+    success: (value: Success) => ({ path: "success" as const, value })
+  }
 
   it.effect("make constructs the initial state from input", () =>
     Effect.gen(function*() {
@@ -299,7 +304,10 @@ describe("Machine", () => {
         states: states.states,
         events: Machine.events(Submit),
         input: Input,
-        initial: (input) => states.initial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       })
 
       const planned = yield* Machine.planInitial(machine, { userId: "user-1" })
@@ -313,7 +321,10 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: states.states,
       events: Machine.events(),
-      initial: () => states.initial.Idle(new Idle({ userId: "user-1" }))
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ target }) => target(new Idle({ userId: "user-1" }))
+      }
     })
 
     assert.strictEqual(Machine.isMachine(machine), true)
@@ -324,24 +335,31 @@ describe("Machine", () => {
     Effect.gen(function*() {
       class Convert extends Schema.TaggedClass<Convert>("Convert")("Convert", {}) {}
       const states = Machine.defineStates({ Submit, RequestSucceeded })
-      const machine = Machine.make({
+      const definition = Machine.make({
         states: states.states,
         events: Machine.events(Convert),
-        initial: () => states.initial.Submit(new Submit({ value: "loaded" }))
-      }).handle({
+        initial: {
+          target: (to) => to.Submit(),
+          resolve: ({ target }) => target(new Submit({ value: "loaded" }))
+        }
+      })
+      const machine = definition.handle({
         Submit: {
           on: {
-            Convert: ({ state, target }) => {
-              const { _tag: _, ...fields } = state
-              return target.full.RequestSucceeded.from(fields)
-            }
+            Convert: Machine.transition({
+              target: (to) => to.full.RequestSucceeded(),
+              resolve: ({ state, target }) => {
+                const { _tag: _, ...fields } = state
+                return target.from(fields)
+              }
+            })
           }
         }
       })
 
       const plan = yield* Machine.plan(
         machine,
-        states.initial.Submit(new Submit({ value: "loaded" })),
+        { path: "Submit" as const, value: new Submit({ value: "loaded" }) },
         new Convert({})
       )
       assert.instanceOf(plan.next.value, RequestSucceeded)
@@ -355,13 +373,19 @@ describe("Machine", () => {
       states: states.states,
       events: Machine.events(Submit),
       input: Input,
-      initial: (input) => states.initial.Idle(new Idle({ userId: input.userId }))
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+      }
     }).handle({
       Idle: {
         on: {
-          Submit: ({ target }) => {
-            return target.full.Loading(new Loading({ requestId: "request-1" }))
-          }
+          Submit: Machine.transition({
+            target: (to) => to.full.Loading(),
+            resolve: ({ target }) => {
+              return target(new Loading({ requestId: "request-1" }))
+            }
+          })
         }
       }
     })
@@ -381,7 +405,10 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: defined.states,
         events: Machine.events(Submit),
-        initial: () => defined.initial.idle(new Idle({ userId: "user-1" }))
+        initial: {
+          target: (to) => to.idle(),
+          resolve: ({ target }) => target(new Idle({ userId: "user-1" }))
+        }
       })
 
       const planned = yield* Machine.planInitial(machine)
@@ -421,13 +448,22 @@ describe("Machine", () => {
     const checking = new CheckingInventory({ sku: "sku-1" })
     const shipping = new Shipping({ address: "Main Street" })
     const quoting = new QuotingShipping({ postalCode: "12345" })
-    const snapshot = states.initial.fulfillment(
-      fulfillment,
-      (fulfillment) =>
-        fulfillment
-          .inventory(inventory, (inventory) => inventory.checking(checking))
-          .shipping(shipping, (shipping) => shipping.quoting(quoting))
-    )
+    const snapshot = {
+      path: "fulfillment" as const,
+      value: fulfillment,
+      states: {
+        inventory: {
+          path: "fulfillment.inventory" as const,
+          value: inventory,
+          state: { path: "fulfillment.inventory.checking" as const, value: checking }
+        },
+        shipping: {
+          path: "fulfillment.shipping" as const,
+          value: shipping,
+          state: { path: "fulfillment.shipping.quoting" as const, value: quoting }
+        }
+      }
+    }
 
     assert.deepStrictEqual(states.get(snapshot, "fulfillment"), Option.some(fulfillment))
     assert.deepStrictEqual(states.get(snapshot, "fulfillment.inventory"), Option.some(inventory))
@@ -451,7 +487,7 @@ describe("Machine", () => {
     assert.deepStrictEqual(states.getWithParents(snapshot, "fulfillment.inventory.reserved"), Option.none())
     assert.deepStrictEqual(
       states.getSnapshot(snapshot, "fulfillment.inventory.checking"),
-      Option.some({ path: "fulfillment.inventory.checking", value: checking })
+      Option.some({ path: "fulfillment.inventory.checking" as const, value: checking })
     )
     assert.strictEqual(states.matches(snapshot, "fulfillment.shipping"), true)
     assert.strictEqual(states.matches(snapshot, "fulfillment.shipping.quoted"), false)
@@ -492,17 +528,20 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Authorize),
-        initial: () =>
-          states.initial.payment(
-            payment,
-            (payment) => payment.entering(entering)
-          )
+        initial: {
+          target: (to) => to.payment.initial(),
+          resolve: ({ target }) =>
+            target(
+              payment,
+              (payment) => payment.entering(entering)
+            )
+        }
       })
 
       const planned = yield* Machine.planInitial(machine)
 
       assertCompoundStateSnapshot(planned.state, "payment", payment, {
-        path: "payment.entering",
+        path: "payment.entering" as const,
         value: entering
       })
     }))
@@ -541,38 +580,41 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(ReserveInventory),
-        initial: () =>
-          states.initial.fulfillment(
-            fulfillment,
-            (fulfillment) =>
-              fulfillment
-                .inventory(
-                  inventory,
-                  (inventory) => inventory.checking(checking)
-                )
-                .shipping(
-                  shipping,
-                  (shipping) => shipping.quoting(quoting)
-                )
-          )
+        initial: {
+          target: (to) => to.fulfillment.initial(),
+          resolve: ({ target }) =>
+            target(
+              fulfillment,
+              (fulfillment) =>
+                fulfillment
+                  .inventory(
+                    inventory,
+                    (inventory) => inventory.checking(checking)
+                  )
+                  .shipping(
+                    shipping,
+                    (shipping) => shipping.quoting(quoting)
+                  )
+            )
+        }
       })
 
       const planned = yield* Machine.planInitial(machine)
 
       assertParallelStateSnapshot(planned.state, "fulfillment", fulfillment, {
         inventory: {
-          path: "fulfillment.inventory",
+          path: "fulfillment.inventory" as const,
           value: inventory,
           state: {
-            path: "fulfillment.inventory.checking",
+            path: "fulfillment.inventory.checking" as const,
             value: checking
           }
         },
         shipping: {
-          path: "fulfillment.shipping",
+          path: "fulfillment.shipping" as const,
           value: shipping,
           state: {
-            path: "fulfillment.shipping.quoting",
+            path: "fulfillment.shipping.quoting" as const,
             value: quoting
           }
         }
@@ -609,21 +651,45 @@ describe("Machine", () => {
           states: states.states,
           events,
           internalEvents,
-          initial: () => states.initial.Active.from({ value: "initial" })
+          initial: {
+            target: (to) => to.Active(),
+            resolve: ({ target }) => target.from({ value: "initial" })
+          }
         })
         const machine = definition.handle({
           Active: {
             on: {
-              SetValue: ({ event, target }) => target.full.Active.from({ value: event.value }),
-              Reset: (_, enqueue) => {
-                enqueue.raise(internalEvents.Loaded({ value: "loaded" }))
-                return _.target.none()
-              },
-              Defaulted: ({ event, target }) => target.full.Active.from({ value: event.label ?? "default-label" }),
-              Loaded: ({ event, target }) => target.full.Active.from({ value: event.value }),
-              TimedOut: ({ target }) => target.full.Active.from({ value: "timed-out" }),
-              Alpha: ({ event, target }) => target.full.Active.from({ value: event.value }),
-              Beta: ({ event, target }) => target.full.Active.from({ value: event.value })
+              SetValue: Machine.transition({
+                target: (to) => to.full.Active(),
+                resolve: ({ event, target }) => target.from({ value: event.value })
+              }),
+              Reset: Machine.transition({
+                target: (to) => to.none(),
+                resolve: (_, enqueue) => {
+                  enqueue.raise(internalEvents.Loaded({ value: "loaded" }))
+                  return undefined
+                }
+              }),
+              Defaulted: Machine.transition({
+                target: (to) => to.full.Active(),
+                resolve: ({ event, target }) => target.from({ value: event.label ?? "default-label" })
+              }),
+              Loaded: Machine.transition({
+                target: (to) => to.full.Active(),
+                resolve: ({ event, target }) => target.from({ value: event.value })
+              }),
+              TimedOut: Machine.transition({
+                target: (to) => to.full.Active(),
+                resolve: ({ target }) => target.from({ value: "timed-out" })
+              }),
+              Alpha: Machine.transition({
+                target: (to) => to.full.Active(),
+                resolve: ({ event, target }) => target.from({ value: event.value })
+              }),
+              Beta: Machine.transition({
+                target: (to) => to.full.Active(),
+                resolve: ({ event, target }) => target.from({ value: event.value })
+              })
             }
           }
         })
@@ -646,25 +712,25 @@ describe("Machine", () => {
         fields.value = "mutated"
         const set = yield* Machine.plan(machine, initial.state, setValue)
         assert.deepStrictEqual(set.next, {
-          path: "Active",
+          path: "Active" as const,
           value: { _tag: "DeferredEventState", value: "next" }
         })
 
         const defaulted = yield* Machine.plan(machine, set.next, events.Defaulted({ id: "event-1" }))
         assert.deepStrictEqual(defaulted.next, {
-          path: "Active",
+          path: "Active" as const,
           value: { _tag: "DeferredEventState", value: "default-label" }
         })
 
         const loaded = yield* Machine.plan(machine, defaulted.next, events.Reset())
         assert.deepStrictEqual(loaded.next, {
-          path: "Active",
+          path: "Active" as const,
           value: { _tag: "DeferredEventState", value: "loaded" }
         })
 
         const alpha = yield* Machine.plan(machine, loaded.next, events.Alpha({ value: "alpha" }))
         assert.deepStrictEqual(alpha.next, {
-          path: "Active",
+          path: "Active" as const,
           value: { _tag: "DeferredEventState", value: "alpha" }
         })
       }))
@@ -679,10 +745,22 @@ describe("Machine", () => {
           id: "deferred-event-failure",
           states: states.states,
           events: Machine.events(Event),
-          initial: () => states.initial.Idle.from()
+          initial: {
+            target: (to) => to.Idle(),
+            resolve: ({ target }) => target.from()
+          }
         })
         const events = definition.events
-        const machine = definition.handle({ Idle: { on: { Submit: ({ target }) => target.none() } } })
+        const machine = definition.handle({
+          Idle: {
+            on: {
+              Submit: Machine.transition({
+                target: (to) => to.none(),
+                resolve: () => undefined
+              })
+            }
+          }
+        })
 
         let construction: ReturnType<typeof events.Submit> | undefined
         assert.doesNotThrow(() => {
@@ -724,21 +802,30 @@ describe("Machine", () => {
           states: states.states,
           events: Machine.events(),
           internalEvents: Machine.internalEvents(InternalEvent),
-          initial: () => states.initial.Loading.from()
+          initial: {
+            target: (to) => to.Loading(),
+            resolve: ({ target }) => target.from()
+          }
         })
         const machine = definition.handle({
           Loading: {
             invoke: Machine.invoke({
               id: "load",
               effect: () => Deferred.await(release),
-              onDone: ({ target }) => target.full.Waiting.from()
+              onDone: Machine.transition({
+                target: (to) => to.full.Waiting(),
+                resolve: ({ target }) => target.from()
+              })
             })
           },
           Waiting: {
             invoke: Machine.invoke({
               id: "timeout",
               after: "1 second",
-              onDone: ({ target }) => target.full.Done.from()
+              onDone: Machine.transition({
+                target: (to) => to.full.Done(),
+                resolve: ({ target }) => target.from()
+              })
             })
           },
           Done: {}
@@ -769,13 +856,28 @@ describe("Machine", () => {
         const first = Machine.make({
           states: states.states,
           events: Machine.events(FirstEvent),
-          initial: () => states.initial.Idle.from()
+          initial: {
+            target: (to) => to.Idle(),
+            resolve: ({ target }) => target.from()
+          }
         })
         const second = Machine.make({
           states: states.states,
           events: Machine.events(SecondEvent),
-          initial: () => states.initial.Idle.from()
-        }).handle({ Idle: { on: { Submit: ({ target }) => target.none() } } })
+          initial: {
+            target: (to) => to.Idle(),
+            resolve: ({ target }) => target.from()
+          }
+        }).handle({
+          Idle: {
+            on: {
+              Submit: Machine.transition({
+                target: (to) => to.none(),
+                resolve: () => undefined
+              })
+            }
+          }
+        })
         const construction = first.events.Submit({ value: "value" })
         const initial = yield* Machine.planInitial(second)
         const error = yield* Machine.plan(second, initial.state, construction).pipe(Effect.flip)
@@ -795,7 +897,10 @@ describe("Machine", () => {
           id: "from-default",
           states: states.states,
           events: Machine.events(),
-          initial: () => states.initial.idle.from({ id: "idle-1" })
+          initial: {
+            target: (to) => to.idle(),
+            resolve: ({ target }) => target.from({ id: "idle-1" })
+          }
         })
 
         const planned = yield* Machine.planInitial(machine)
@@ -823,11 +928,17 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(Event),
-          initial: () => states.initial.Idle.from()
+          initial: {
+            target: (to) => to.Idle(),
+            resolve: ({ target }) => target.from()
+          }
         }).handle({
           Idle: {
             on: {
-              Submit: ({ event, target }) => target.full.Done.from({ requestId: event.requestId })
+              Submit: Machine.transition({
+                target: (to) => to.full.Done(),
+                resolve: ({ event, target }) => target.from({ requestId: event.requestId })
+              })
             }
           },
           Done: {}
@@ -858,7 +969,10 @@ describe("Machine", () => {
           id: "from-default-only",
           states: states.states,
           events: Machine.events(),
-          initial: () => states.initial.DefaultOnly.from()
+          initial: {
+            target: (to) => to.DefaultOnly(),
+            resolve: ({ target }) => target.from()
+          }
         })
 
         const planned = yield* Machine.planInitial(machine)
@@ -915,18 +1029,36 @@ describe("Machine", () => {
             Event.cases.Full,
             Event.cases.Finish
           ),
-          initial: () => states.initial.Flow.from((flow) => flow.Idle.from())
+          initial: {
+            target: (to) => to.Flow.initial(),
+            resolve: ({ target }) => target.from((flow) => flow.Idle.from())
+          }
         }).handle({
           Flow: {
             states: {
               Idle: {
                 on: {
-                  Local: ({ target }) => target.local.Running.from(),
-                  LocalWith: ({ target }) => target.local.with.from((flow) => flow.Running.from()),
-                  Branch: ({ target }) => target.branch.Flow.Nested.from((nested) => nested.NestedIdle.from()),
-                  Full: ({ target }) =>
-                    target.full.Flow.from((flow) => flow.Nested.from((nested) => nested.NestedIdle.from())),
-                  Finish: ({ target }) => target.local.Done.from()
+                  Local: Machine.transition({
+                    target: (to) => to.local.Running(),
+                    resolve: ({ target }) => target.from()
+                  }),
+                  LocalWith: Machine.transition({
+                    target: (to) => to.local.Running(),
+                    resolve: ({ target }) => target.from()
+                  }),
+                  Branch: Machine.transition({
+                    target: (to) => to.branch.Flow.Nested(),
+                    resolve: ({ target }) => target.from((nested) => nested.NestedIdle.from())
+                  }),
+                  Full: Machine.transition({
+                    target: (to) => to.full.Flow(),
+                    resolve: ({ target }) =>
+                      target.from((flow) => flow.Nested.from((nested) => nested.NestedIdle.from()))
+                  }),
+                  Finish: Machine.transition({
+                    target: (to) => to.local.Done(),
+                    resolve: ({ target }) => target.from()
+                  })
                 }
               },
               Running: {},
@@ -993,12 +1125,15 @@ describe("Machine", () => {
           id: "from-empty-parallel",
           states: states.states,
           events: Machine.events(),
-          initial: () =>
-            states.initial.Parallel.from((parallel) =>
-              parallel
-                .left.from((left) => left.LeftIdle.from())
-                .right.from((right) => right.RightIdle.from())
-            )
+          initial: {
+            target: (to) => to.Parallel.initial(),
+            resolve: ({ target }) =>
+              target.from((parallel) =>
+                parallel
+                  .left.from((left) => left.LeftIdle.from())
+                  .right.from((right) => right.RightIdle.from())
+              )
+          }
         })
 
         const planned = yield* Machine.planInitial(machine)
@@ -1017,12 +1152,14 @@ describe("Machine", () => {
           Schema.makeFilter(() => "blocked state cannot be entered")
         )
         const states = Machine.defineStates({ Blocked })
-        const invalid = states.initial.Blocked.from()
         const machine = Machine.make({
           id: "from-empty-refinement",
           states: states.states,
           events: Machine.events(),
-          initial: () => invalid
+          initial: {
+            target: (to) => to.Blocked(),
+            resolve: ({ target }) => target.from()
+          }
         })
 
         const error = yield* Effect.flip(Machine.planInitial(machine))
@@ -1034,12 +1171,14 @@ describe("Machine", () => {
     it.effect("fails invalid refinement input through MachineSchemaDecodeError without throwing in the builder", () =>
       Effect.gen(function*() {
         const states = Machine.defineStates({ NonEmptyIdle })
-        const invalid = states.initial.NonEmptyIdle.from({ userId: "" })
         const machine = Machine.make({
           id: "from-refinement",
           states: states.states,
           events: Machine.events(),
-          initial: () => invalid
+          initial: {
+            target: (to) => to.NonEmptyIdle(),
+            resolve: ({ target }) => target.from({ userId: "" })
+          }
         })
 
         const error = yield* Effect.flip(Machine.planInitial(machine))
@@ -1055,11 +1194,17 @@ describe("Machine", () => {
           id: "from-transition-refinement",
           states: states.states,
           events: Machine.events(NonEmptySubmit),
-          initial: () => states.initial.NonEmptyIdle.from({ userId: "user-1" })
+          initial: {
+            target: (to) => to.NonEmptyIdle(),
+            resolve: ({ target }) => target.from({ userId: "user-1" })
+          }
         }).handle({
           NonEmptyIdle: {
             on: {
-              NonEmptySubmit: ({ target }) => target.full.NonEmptyLoading.from({ requestId: "" })
+              NonEmptySubmit: Machine.transition({
+                target: (to) => to.full.NonEmptyLoading(),
+                resolve: ({ target }) => target.from({ requestId: "" })
+              })
             }
           }
         })
@@ -1107,24 +1252,30 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(Submit),
-          initial: () => states.initial.idle.from({ userId: "user-1" })
+          initial: {
+            target: (to) => to.idle(),
+            resolve: ({ target }) => target.from({ userId: "user-1" })
+          }
         }).handle({
           idle: {
             on: {
-              Submit: ({ event, target }) =>
-                target.full.fulfillment.from(
-                  { id: event.value },
-                  (fulfillment) =>
-                    fulfillment
-                      .inventory.from(
-                        { warehouse: "warehouse-1" },
-                        (inventory) => inventory.reserved.from({ reservationId: event.value })
-                      )
-                      .shipping.from(
-                        { address: "Main Street" },
-                        (shipping) => shipping.quoted.from({ quoteId: event.value })
-                      )
-                )
+              Submit: Machine.transition({
+                target: (to) => to.full.fulfillment(),
+                resolve: ({ event, target }) =>
+                  target.from(
+                    { id: event.value },
+                    (fulfillment) =>
+                      fulfillment
+                        .inventory.from(
+                          { warehouse: "warehouse-1" },
+                          (inventory) => inventory.reserved.from({ reservationId: event.value })
+                        )
+                        .shipping.from(
+                          { address: "Main Street" },
+                          (shipping) => shipping.quoted.from({ quoteId: event.value })
+                        )
+                  )
+              })
             }
           }
         })
@@ -1134,18 +1285,18 @@ describe("Machine", () => {
 
         assertParallelStateSnapshot(planned.next as any, "fulfillment", new Fulfillment({ id: "order-1" }), {
           inventory: {
-            path: "fulfillment.inventory",
+            path: "fulfillment.inventory" as const,
             value: new Inventory({ warehouse: "warehouse-1" }),
             state: {
-              path: "fulfillment.inventory.reserved",
+              path: "fulfillment.inventory.reserved" as const,
               value: new InventoryReserved({ reservationId: "order-1" })
             }
           },
           shipping: {
-            path: "fulfillment.shipping",
+            path: "fulfillment.shipping" as const,
             value: new Shipping({ address: "Main Street" }),
             state: {
-              path: "fulfillment.shipping.quoted",
+              path: "fulfillment.shipping.quoted" as const,
               value: new ShippingQuoted({ quoteId: "order-1" })
             }
           }
@@ -1167,21 +1318,27 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(Submit),
-          initial: () =>
-            states.initial.payment.from(
-              { id: "payment-1" },
-              (payment) => payment.entering.from({ amount: 1 })
-            )
+          initial: {
+            target: (to) => to.payment.initial(),
+            resolve: ({ target }) =>
+              target.from(
+                { id: "payment-1" },
+                (payment) => payment.entering.from({ amount: 1 })
+              )
+          }
         }).handle({
           payment: {
             states: {
               entering: {
                 on: {
-                  Submit: ({ event, target }) =>
-                    target.local.with.from(
-                      { id: "payment-2" },
-                      (payment) => payment.authorized.from({ code: event.value })
-                    )
+                  Submit: Machine.transition({
+                    target: (to) => to.branch.payment(),
+                    resolve: ({ event, target }) =>
+                      target.from(
+                        { id: "payment-2" },
+                        (payment) => payment.authorized.from({ code: event.value })
+                      )
+                  })
                 }
               }
             }
@@ -1192,7 +1349,7 @@ describe("Machine", () => {
         const planned = yield* Machine.plan(machine, initial.state, new Submit({ value: "auth-1" }))
 
         assertCompoundStateSnapshot(planned.next as any, "payment", new Payment({ id: "payment-2" }), {
-          path: "payment.authorized",
+          path: "payment.authorized" as const,
           value: new AuthorizedPayment({ code: "auth-1" })
         })
       }))
@@ -1218,25 +1375,31 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(Submit),
-          initial: () =>
-            states.initial.workflow.from(
-              { id: "workflow-1" },
-              (workflow) => workflow.idle.from({ userId: "user-1" })
-            )
+          initial: {
+            target: (to) => to.workflow.initial(),
+            resolve: ({ target }) =>
+              target.from(
+                { id: "workflow-1" },
+                (workflow) => workflow.idle.from({ userId: "user-1" })
+              )
+          }
         }).handle({
           workflow: {
             states: {
               idle: {
                 on: {
-                  Submit: ({ event, target }) =>
-                    target.branch.workflow.from(
-                      { id: "workflow-2" },
-                      (workflow) =>
-                        workflow.checkout.from(
-                          { id: "checkout-1" },
-                          (checkout) => checkout.quoted.from({ quoteId: event.value })
-                        )
-                    )
+                  Submit: Machine.transition({
+                    target: (to) => to.branch.workflow(),
+                    resolve: ({ event, target }) =>
+                      target.from(
+                        { id: "workflow-2" },
+                        (workflow) =>
+                          workflow.checkout.from(
+                            { id: "checkout-1" },
+                            (checkout) => checkout.quoted.from({ quoteId: event.value })
+                          )
+                      )
+                  })
                 }
               }
             }
@@ -1247,10 +1410,10 @@ describe("Machine", () => {
         const planned = yield* Machine.plan(machine, initial.state, new Submit({ value: "quote-1" }))
 
         assertCompoundStateSnapshot(planned.next as any, "workflow", new Payment({ id: "workflow-2" }), {
-          path: "workflow.checkout",
+          path: "workflow.checkout" as const,
           value: new Fulfillment({ id: "checkout-1" }),
           state: {
-            path: "workflow.checkout.quoted",
+            path: "workflow.checkout.quoted" as const,
             value: new ShippingQuoted({ quoteId: "quote-1" })
           }
         })
@@ -1265,7 +1428,10 @@ describe("Machine", () => {
           states: states.states,
           events: Machine.events(NonEmptySubmit),
           input: NonEmptyInput,
-          initial: (input) => states.initial.NonEmptyIdle(new NonEmptyIdle({ userId: input.userId }))
+          initial: {
+            target: (to) => to.NonEmptyIdle(),
+            resolve: ({ input: input, target }) => target(new NonEmptyIdle({ userId: input.userId }))
+          }
         })
 
         const error = yield* Effect.flip(Machine.planInitial(machine, { userId: "" as any }))
@@ -1279,7 +1445,10 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(NonEmptySubmit),
-          initial: () => states.initial.NonEmptyIdle(unsafeTagged({ _tag: "NonEmptyIdle", userId: "" }))
+          initial: {
+            target: (to) => to.NonEmptyIdle(),
+            resolve: ({ target }) => target(unsafeTagged({ _tag: "NonEmptyIdle", userId: "" }))
+          }
         })
 
         const error = yield* Effect.flip(Machine.planInitial(machine))
@@ -1293,11 +1462,17 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(NonEmptySubmit),
-          initial: () => states.initial.NonEmptyIdle(new NonEmptyIdle({ userId: "user-1" }))
+          initial: {
+            target: (to) => to.NonEmptyIdle(),
+            resolve: ({ target }) => target(new NonEmptyIdle({ userId: "user-1" }))
+          }
         }).handle({
           NonEmptyIdle: {
             on: {
-              NonEmptySubmit: ({ state, target }) => target.full.NonEmptyIdle(state)
+              NonEmptySubmit: Machine.transition({
+                target: (to) => to.full.NonEmptyIdle(),
+                resolve: ({ state, target }) => target(state)
+              })
             }
           }
         })
@@ -1305,7 +1480,7 @@ describe("Machine", () => {
         const error = yield* Effect.flip(
           Machine.plan(
             machine,
-            states.initial.NonEmptyIdle(new NonEmptyIdle({ userId: "user-1" })),
+            { path: "NonEmptyIdle" as const, value: new NonEmptyIdle({ userId: "user-1" }) },
             unsafeTagged({ _tag: "NonEmptySubmit", value: "" })
           )
         )
@@ -1319,11 +1494,17 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(NonEmptySubmit),
-          initial: () => states.initial.NonEmptyIdle(new NonEmptyIdle({ userId: "user-1" }))
+          initial: {
+            target: (to) => to.NonEmptyIdle(),
+            resolve: ({ target }) => target(new NonEmptyIdle({ userId: "user-1" }))
+          }
         }).handle({
           NonEmptyIdle: {
             on: {
-              NonEmptySubmit: ({ state, target }) => target.full.NonEmptyIdle(state)
+              NonEmptySubmit: Machine.transition({
+                target: (to) => to.full.NonEmptyIdle(),
+                resolve: ({ state, target }) => target(state)
+              })
             }
           }
         })
@@ -1354,12 +1535,17 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(NonEmptySubmit),
-          initial: () => states.initial.NonEmptyIdle(new NonEmptyIdle({ userId: "user-1" }))
+          initial: {
+            target: (to) => to.NonEmptyIdle(),
+            resolve: ({ target }) => target(new NonEmptyIdle({ userId: "user-1" }))
+          }
         }).handle({
           NonEmptyIdle: {
             on: {
-              NonEmptySubmit: ({ target }) =>
-                target.full.NonEmptyLoading(unsafeTagged({ _tag: "NonEmptyLoading", requestId: "" }))
+              NonEmptySubmit: Machine.transition({
+                target: (to) => to.full.NonEmptyLoading(),
+                resolve: ({ target }) => target(unsafeTagged({ _tag: "NonEmptyLoading", requestId: "" }))
+              })
             }
           }
         })
@@ -1367,7 +1553,7 @@ describe("Machine", () => {
         const error = yield* Effect.flip(
           Machine.plan(
             machine,
-            states.initial.NonEmptyIdle(new NonEmptyIdle({ userId: "user-1" })),
+            { path: "NonEmptyIdle" as const, value: new NonEmptyIdle({ userId: "user-1" }) },
             new NonEmptySubmit({ value: "request-1" })
           )
         )
@@ -1381,12 +1567,17 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(NonEmptySubmit),
-          initial: () => states.initial.NonEmptyIdle(new NonEmptyIdle({ userId: "user-1" }))
+          initial: {
+            target: (to) => to.NonEmptyIdle(),
+            resolve: ({ target }) => target(new NonEmptyIdle({ userId: "user-1" }))
+          }
         }).handle({
           NonEmptyIdle: {
             on: {
-              NonEmptySubmit: ({ target }) =>
-                target.full.NonEmptyIdle(unsafeTagged({ _tag: "NonEmptyIdle", userId: "" }))
+              NonEmptySubmit: Machine.transition({
+                target: (to) => to.full.NonEmptyIdle(),
+                resolve: ({ target }) => target(unsafeTagged({ _tag: "NonEmptyIdle", userId: "" }))
+              })
             }
           }
         })
@@ -1416,11 +1607,17 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(NonEmptySubmit),
-          initial: () => states.initial.NonEmptyIdle(new NonEmptyIdle({ userId: "user-1" }))
+          initial: {
+            target: (to) => to.NonEmptyIdle(),
+            resolve: ({ target }) => target(new NonEmptyIdle({ userId: "user-1" }))
+          }
         }).handle({
           NonEmptyIdle: {
             on: {
-              NonEmptySubmit: ({ event, target }) => target.full.done(new NonEmptyDone({ requestId: event.value }))
+              NonEmptySubmit: Machine.transition({
+                target: (to) => to.full.done(),
+                resolve: ({ event, target }) => target(new NonEmptyDone({ requestId: event.value }))
+              })
             }
           },
           done: {
@@ -1431,7 +1628,7 @@ describe("Machine", () => {
         const error = yield* Effect.flip(
           Machine.plan(
             machine,
-            states.initial.NonEmptyIdle(new NonEmptyIdle({ userId: "user-1" })),
+            { path: "NonEmptyIdle" as const, value: new NonEmptyIdle({ userId: "user-1" }) },
             new NonEmptySubmit({ value: "request-1" })
           )
         )
@@ -1461,14 +1658,17 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(),
-          initial: () =>
-            states.initial.all(
-              new ParallelRoot({ id: "all" }),
-              (all) =>
-                all
-                  .left(new ParallelLeftDone({ id: "left" }))
-                  .right(new ParallelRightDone({ id: "right" }))
-            )
+          initial: {
+            target: (to) => to.all.initial(),
+            resolve: ({ target }) =>
+              target(
+                new ParallelRoot({ id: "all" }),
+                (all) =>
+                  all
+                    .left(new ParallelLeftDone({ id: "left" }))
+                    .right(new ParallelRightDone({ id: "right" }))
+              )
+          }
         }).handle({
           all: {
             output: () => ({ summary: "" as any })
@@ -1486,13 +1686,16 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(NonEmptySubmit),
-          initial: () => states.initial.NonEmptyIdle(new NonEmptyIdle({ userId: "user-1" }))
+          initial: {
+            target: (to) => to.NonEmptyIdle(),
+            resolve: ({ target }) => target(new NonEmptyIdle({ userId: "user-1" }))
+          }
         })
 
         const error = yield* Effect.flip(
           Machine.plan(
             machine,
-            { path: "missing", value: new NonEmptyIdle({ userId: "user-1" }) } as any,
+            { path: "missing" as const, value: new NonEmptyIdle({ userId: "user-1" }) } as any,
             new NonEmptySubmit({ value: "request-1" })
           )
         )
@@ -1510,7 +1713,10 @@ describe("Machine", () => {
           id: "Counter",
           states: states.states,
           events: Machine.events(),
-          initial: () => states.initial.count(new EncodedCount({ count: 1 }))
+          initial: {
+            target: (to) => to.count(),
+            resolve: ({ target }) => target(new EncodedCount({ count: 1 }))
+          }
         })
         const planned = yield* Machine.planInitial(machine)
 
@@ -1520,7 +1726,7 @@ describe("Machine", () => {
         assert.deepStrictEqual(encoded, {
           _tag: "MachineSnapshot",
           active: [{
-            path: "count",
+            path: "count" as const,
             value: { _tag: "EncodedCount", count: "1" }
           }]
         })
@@ -1557,20 +1763,23 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(),
-          initial: () =>
-            states.initial.fulfillment(
-              new Fulfillment({ id: "fulfillment-1" }),
-              (fulfillment) =>
-                fulfillment
-                  .inventory(
-                    new Inventory({ warehouse: "warehouse-1" }),
-                    (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
-                  )
-                  .shipping(
-                    new Shipping({ address: "Main Street" }),
-                    (shipping) => shipping.quoting(new QuotingShipping({ postalCode: "12345" }))
-                  )
-            )
+          initial: {
+            target: (to) => to.fulfillment.initial(),
+            resolve: ({ target }) =>
+              target(
+                new Fulfillment({ id: "fulfillment-1" }),
+                (fulfillment) =>
+                  fulfillment
+                    .inventory(
+                      new Inventory({ warehouse: "warehouse-1" }),
+                      (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
+                    )
+                    .shipping(
+                      new Shipping({ address: "Main Street" }),
+                      (shipping) => shipping.quoting(new QuotingShipping({ postalCode: "12345" }))
+                    )
+              )
+          }
         })
         const planned = yield* Machine.planInitial(machine)
 
@@ -1606,14 +1815,17 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(),
-          initial: () =>
-            states.initial.all(
-              new ParallelRoot({ id: "all" }),
-              (all) =>
-                all
-                  .left(new ParallelLeftDone({ id: "left" }))
-                  .right(new ParallelRightDone({ id: "right" }))
-            )
+          initial: {
+            target: (to) => to.all.initial(),
+            resolve: ({ target }) =>
+              target(
+                new ParallelRoot({ id: "all" }),
+                (all) =>
+                  all
+                    .left(new ParallelLeftDone({ id: "left" }))
+                    .right(new ParallelRightDone({ id: "right" }))
+              )
+          }
         }).handle({
           all: {
             states: {
@@ -1628,8 +1840,8 @@ describe("Machine", () => {
         const encoded = yield* Machine.encodeSnapshot(machine, planned.state)
         const decoded = yield* Machine.decodeSnapshot(machine, encoded)
 
-        assert.deepStrictEqual(encoded.completed, [{ path: "all.left", output: "1" }])
-        assert.deepStrictEqual(decoded.completed, [{ path: "all.left", output: 1 }])
+        assert.deepStrictEqual(encoded.completed, [{ path: "all.left" as const, output: "1" }])
+        assert.deepStrictEqual(decoded.completed, [{ path: "all.left" as const, output: 1 }])
       }))
 
     it.effect("round-trips void completion outputs through JSON", () =>
@@ -1650,14 +1862,17 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(),
-          initial: () =>
-            states.initial.all(
-              new ParallelRoot({ id: "all" }),
-              (all) =>
-                all
-                  .left(new ParallelLeftDone({ id: "left" }))
-                  .right(new ParallelRightDone({ id: "right" }))
-            )
+          initial: {
+            target: (to) => to.all.initial(),
+            resolve: ({ target }) =>
+              target(
+                new ParallelRoot({ id: "all" }),
+                (all) =>
+                  all
+                    .left(new ParallelLeftDone({ id: "left" }))
+                    .right(new ParallelRightDone({ id: "right" }))
+              )
+          }
         }).handle({
           all: {
             states: {
@@ -1670,8 +1885,8 @@ describe("Machine", () => {
         const encoded = yield* Machine.encodeSnapshot(machine, planned.state)
         const decoded = yield* Machine.decodeSnapshot(machine, JSON.parse(JSON.stringify(encoded)))
 
-        assert.deepStrictEqual(encoded.completed, [{ path: "all.left" }])
-        assert.deepStrictEqual(decoded.completed, [{ path: "all.left", output: undefined }])
+        assert.deepStrictEqual(encoded.completed, [{ path: "all.left" as const }])
+        assert.deepStrictEqual(decoded.completed, [{ path: "all.left" as const, output: undefined }])
       }))
 
     it.effect("rejects state values that cannot be encoded", () =>
@@ -1680,11 +1895,14 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(),
-          initial: () => states.initial.NonEmptyIdle(new NonEmptyIdle({ userId: "user-1" }))
+          initial: {
+            target: (to) => to.NonEmptyIdle(),
+            resolve: ({ target }) => target(new NonEmptyIdle({ userId: "user-1" }))
+          }
         })
 
         const error = yield* Machine.encodeSnapshot(machine, {
-          path: "NonEmptyIdle",
+          path: "NonEmptyIdle" as const,
           value: unsafeTagged({ _tag: "NonEmptyIdle", userId: "" })
         }).pipe(Effect.flip)
 
@@ -1697,12 +1915,15 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(),
-          initial: () => states.initial.NonEmptyIdle(new NonEmptyIdle({ userId: "user-1" }))
+          initial: {
+            target: (to) => to.NonEmptyIdle(),
+            resolve: ({ target }) => target(new NonEmptyIdle({ userId: "user-1" }))
+          }
         })
 
         const error = yield* Machine.encodeSnapshot(machine, {
-          ...states.initial.NonEmptyIdle(new NonEmptyIdle({ userId: "user-1" })),
-          completed: [{ path: "missing", output: undefined }]
+          ...{ path: "NonEmptyIdle" as const, value: new NonEmptyIdle({ userId: "user-1" }) },
+          completed: [{ path: "missing" as const, output: undefined }]
         }).pipe(Effect.flip)
 
         assert.instanceOf(error, Machine.MachineSchemaEncodeError)
@@ -1715,13 +1936,16 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(),
-          initial: () => states.initial.NonEmptyIdle(new NonEmptyIdle({ userId: "user-1" }))
+          initial: {
+            target: (to) => to.NonEmptyIdle(),
+            resolve: ({ target }) => target(new NonEmptyIdle({ userId: "user-1" }))
+          }
         })
 
         const error = yield* Machine.decodeSnapshot(machine, {
           _tag: "MachineSnapshot",
           active: [{
-            path: "NonEmptyIdle",
+            path: "NonEmptyIdle" as const,
             value: { _tag: "NonEmptyIdle", userId: "" }
           }]
         }).pipe(Effect.flip)
@@ -1744,17 +1968,20 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(),
-          initial: () =>
-            states.initial.payment(
-              new Payment({ id: "payment-1" }),
-              (payment) => payment.entering(new EnteringPayment({ amount: 1 }))
-            )
+          initial: {
+            target: (to) => to.payment.initial(),
+            resolve: ({ target }) =>
+              target(
+                new Payment({ id: "payment-1" }),
+                (payment) => payment.entering(new EnteringPayment({ amount: 1 }))
+              )
+          }
         })
 
         const error = yield* Machine.decodeSnapshot(machine, {
           _tag: "MachineSnapshot",
           active: [{
-            path: "payment.entering",
+            path: "payment.entering" as const,
             value: { _tag: "EnteringPayment", amount: 1 }
           }]
         }).pipe(Effect.flip)
@@ -1773,12 +2000,18 @@ describe("Machine", () => {
         },
         events: Machine.events(Submit),
         input: Input,
-        initial: (input) => LowercaseInitial.idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         idle: {
           on: {
-            Submit: ({ event, state, target }) =>
-              target.full.loading(new Loading({ requestId: `${state.userId}:${event.value}` }))
+            Submit: Machine.transition({
+              target: (to) => to.full.loading(),
+              resolve: ({ event, state, target }) =>
+                target(new Loading({ requestId: `${state.userId}:${event.value}` }))
+            })
           }
         }
       })
@@ -1804,16 +2037,25 @@ describe("Machine", () => {
           b: Duplicate
         },
         events: Machine.events(Submit, Reset),
-        initial: () => DuplicateInitial.a(new Duplicate({ value: "a" }))
+        initial: {
+          target: (to) => to.a(),
+          resolve: ({ target }) => target(new Duplicate({ value: "a" }))
+        }
       }).handle({
         a: {
           on: {
-            Submit: ({ event, target }) => target.full.b(new Duplicate({ value: event.value }))
+            Submit: Machine.transition({
+              target: (to) => to.full.b(),
+              resolve: ({ event, target }) => target(new Duplicate({ value: event.value }))
+            })
           }
         },
         b: {
           on: {
-            Reset: ({ target }) => target.full.a(new Duplicate({ value: "reset" }))
+            Reset: Machine.transition({
+              target: (to) => to.full.a(),
+              resolve: ({ target }) => target(new Duplicate({ value: "reset" }))
+            })
           }
         }
       })
@@ -1823,7 +2065,7 @@ describe("Machine", () => {
       assert.deepStrictEqual(Machine.enabled(machine, initial.state), ["Submit"])
       assert.deepStrictEqual(
         Machine.enabled(machine, {
-          path: "b",
+          path: "b" as const,
           value: new Duplicate({ value: "b" })
         }),
         ["Reset"]
@@ -1844,11 +2086,17 @@ describe("Machine", () => {
           b: Duplicate
         },
         events: Machine.events(Submit),
-        initial: () => DuplicateInitial.a(new Duplicate({ value: "a" }))
+        initial: {
+          target: (to) => to.a(),
+          resolve: ({ target }) => target(new Duplicate({ value: "a" }))
+        }
       }).handle({
         a: {
           on: {
-            Submit: ({ event, target }) => target.full.b(new Duplicate({ value: event.value }))
+            Submit: Machine.transition({
+              target: (to) => to.full.b(),
+              resolve: ({ event, target }) => target(new Duplicate({ value: event.value }))
+            })
           }
         }
       })
@@ -1876,11 +2124,17 @@ describe("Machine", () => {
           }
         },
         events: Machine.events(Submit),
-        initial: () => LowercaseInitial.idle(new Idle({ userId: "user-1" }))
+        initial: {
+          target: (to) => to.idle(),
+          resolve: ({ target }) => target(new Idle({ userId: "user-1" }))
+        }
       }).handle({
         idle: {
           on: {
-            Submit: ({ event, target }) => target.full.success(new Success({ requestId: event.value }))
+            Submit: Machine.transition({
+              target: (to) => to.full.success(),
+              resolve: ({ event, target }) => target(new Success({ requestId: event.value }))
+            })
           }
         }
       })
@@ -1914,27 +2168,36 @@ describe("Machine", () => {
           failed: Failed
         },
         events: Machine.events(Authorize),
-        initial: () => ({
-          path: "payment",
-          value: payment,
-          state: {
-            path: "payment.entering" as const,
-            value: entering
-          }
-        })
+        initial: {
+          target: (to) => to.payment.initial(),
+          resolve: () => ({
+            path: "payment" as const,
+            value: payment,
+            state: {
+              path: "payment.entering" as const,
+              value: entering
+            }
+          })
+        }
       }).handle({
         payment: {
           on: {
-            Authorize: ({ target }) => target.full.failed(new Failed({ message: "parent" }))
+            Authorize: Machine.transition({
+              target: (to) => to.full.failed(),
+              resolve: ({ target }) => target(new Failed({ message: "parent" }))
+            })
           },
           states: {
             entering: {
               on: {
-                Authorize: ({ event, containingState, ancestors, target }) => {
-                  assert.deepStrictEqual(containingState, payment)
-                  assert.deepStrictEqual(ancestors, { payment })
-                  return target.local.authorized(new AuthorizedPayment({ code: event.code }))
-                }
+                Authorize: Machine.transition({
+                  target: (to) => to.local.authorized(),
+                  resolve: ({ event, containingState, ancestors, target }) => {
+                    assert.deepStrictEqual(containingState, payment)
+                    assert.deepStrictEqual(ancestors, { payment })
+                    return target(new AuthorizedPayment({ code: event.code }))
+                  }
+                })
               }
             }
           }
@@ -1971,23 +2234,32 @@ describe("Machine", () => {
           failed: Failed
         },
         events: Machine.events(Authorize, Reset),
-        initial: () => ({
-          path: "payment",
-          value: payment,
-          state: {
-            path: "payment.entering" as const,
-            value: entering
-          }
-        })
+        initial: {
+          target: (to) => to.payment.initial(),
+          resolve: () => ({
+            path: "payment" as const,
+            value: payment,
+            state: {
+              path: "payment.entering" as const,
+              value: entering
+            }
+          })
+        }
       }).handle({
         payment: {
           on: {
-            Reset: ({ target }) => target.full.failed(new Failed({ message: "reset" }))
+            Reset: Machine.transition({
+              target: (to) => to.full.failed(),
+              resolve: ({ target }) => target(new Failed({ message: "reset" }))
+            })
           },
           states: {
             entering: {
               on: {
-                Authorize: ({ event, target }) => target.local.authorized(new AuthorizedPayment({ code: event.code }))
+                Authorize: Machine.transition({
+                  target: (to) => to.local.authorized(),
+                  resolve: ({ event, target }) => target(new AuthorizedPayment({ code: event.code }))
+                })
               }
             },
             authorized: {
@@ -2032,18 +2304,24 @@ describe("Machine", () => {
           }
         },
         events: Machine.events(Reset),
-        initial: () => ({
-          path: "payment",
-          value: payment,
-          state: {
-            path: "payment.entering" as const,
-            value: entering
-          }
-        })
+        initial: {
+          target: (to) => to.payment.initial(),
+          resolve: () => ({
+            path: "payment" as const,
+            value: payment,
+            state: {
+              path: "payment.entering" as const,
+              value: entering
+            }
+          })
+        }
       }).handle({
         payment: {
           on: {
-            Reset: ({ target }) => target.full.idle(new Idle({ userId: "user-1" }))
+            Reset: Machine.transition({
+              target: (to) => to.full.idle(),
+              resolve: ({ target }) => target(new Idle({ userId: "user-1" }))
+            })
           }
         }
       })
@@ -2092,48 +2370,54 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Submit),
-        initial: () => states.initial.idle(new Idle({ userId: "user-1" }))
+        initial: {
+          target: (to) => to.idle(),
+          resolve: ({ target }) => target(new Idle({ userId: "user-1" }))
+        }
       }).handle({
         idle: {
           on: {
-            Submit: ({ event, target }) =>
-              target.full.fulfillment(
-                new Fulfillment({ id: event.value }),
-                (fulfillment) =>
-                  fulfillment
-                    .inventory(
-                      new Inventory({ warehouse: "warehouse-1" }),
-                      (inventory) => inventory.reserved(new InventoryReserved({ reservationId: event.value }))
-                    )
-                    .shipping(
-                      new Shipping({ address: "Main Street" }),
-                      (shipping) => shipping.quoted(new ShippingQuoted({ quoteId: event.value }))
-                    )
-              )
+            Submit: Machine.transition({
+              target: (to) => to.full.fulfillment(),
+              resolve: ({ event, target }) =>
+                target(
+                  new Fulfillment({ id: event.value }),
+                  (fulfillment) =>
+                    fulfillment
+                      .inventory(
+                        new Inventory({ warehouse: "warehouse-1" }),
+                        (inventory) => inventory.reserved(new InventoryReserved({ reservationId: event.value }))
+                      )
+                      .shipping(
+                        new Shipping({ address: "Main Street" }),
+                        (shipping) => shipping.quoted(new ShippingQuoted({ quoteId: event.value }))
+                      )
+                )
+            })
           }
         }
       })
 
       const planned = yield* Machine.plan(
         machine,
-        states.initial.idle(new Idle({ userId: "user-1" })),
+        { path: "idle" as const, value: new Idle({ userId: "user-1" }) },
         new Submit({ value: "order-1" })
       )
 
       assertParallelStateSnapshot(planned.next as any, "fulfillment", new Fulfillment({ id: "order-1" }), {
         inventory: {
-          path: "fulfillment.inventory",
+          path: "fulfillment.inventory" as const,
           value: new Inventory({ warehouse: "warehouse-1" }),
           state: {
-            path: "fulfillment.inventory.reserved",
+            path: "fulfillment.inventory.reserved" as const,
             value: new InventoryReserved({ reservationId: "order-1" })
           }
         },
         shipping: {
-          path: "fulfillment.shipping",
+          path: "fulfillment.shipping" as const,
           value: new Shipping({ address: "Main Street" }),
           state: {
-            path: "fulfillment.shipping.quoted",
+            path: "fulfillment.shipping.quoted" as const,
             value: new ShippingQuoted({ quoteId: "order-1" })
           }
         }
@@ -2184,30 +2468,36 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Submit),
-        initial: () =>
-          states.initial.workflow(
-            workflow,
-            (workflow) => workflow.idle(new Idle({ userId: "user-1" }))
-          )
+        initial: {
+          target: (to) => to.workflow.initial(),
+          resolve: ({ target }) =>
+            target(
+              workflow,
+              (workflow) => workflow.idle(new Idle({ userId: "user-1" }))
+            )
+        }
       }).handle({
         workflow: {
           states: {
             idle: {
               on: {
-                Submit: ({ event, target }) =>
-                  target.local.fulfillment(
-                    new Fulfillment({ id: event.value }),
-                    (fulfillment) =>
-                      fulfillment
-                        .inventory(
-                          new Inventory({ warehouse: "warehouse-1" }),
-                          (inventory) => inventory.reserved(new InventoryReserved({ reservationId: event.value }))
-                        )
-                        .shipping(
-                          new Shipping({ address: "Main Street" }),
-                          (shipping) => shipping.quoted(new ShippingQuoted({ quoteId: event.value }))
-                        )
-                  )
+                Submit: Machine.transition({
+                  target: (to) => to.local.fulfillment(),
+                  resolve: ({ event, target }) =>
+                    target(
+                      new Fulfillment({ id: event.value }),
+                      (fulfillment) =>
+                        fulfillment
+                          .inventory(
+                            new Inventory({ warehouse: "warehouse-1" }),
+                            (inventory) => inventory.reserved(new InventoryReserved({ reservationId: event.value }))
+                          )
+                          .shipping(
+                            new Shipping({ address: "Main Street" }),
+                            (shipping) => shipping.quoted(new ShippingQuoted({ quoteId: event.value }))
+                          )
+                    )
+                })
               }
             }
           }
@@ -2216,30 +2506,31 @@ describe("Machine", () => {
 
       const planned = yield* Machine.plan(
         machine,
-        states.initial.workflow(
-          workflow,
-          (workflow) => workflow.idle(new Idle({ userId: "user-1" }))
-        ),
+        {
+          path: "workflow" as const,
+          value: workflow,
+          state: { path: "workflow.idle" as const, value: new Idle({ userId: "user-1" }) }
+        },
         new Submit({ value: "order-1" })
       )
 
       assertCompoundStateSnapshot(planned.next as any, "workflow", workflow, {
-        path: "workflow.fulfillment",
+        path: "workflow.fulfillment" as const,
         value: new Fulfillment({ id: "order-1" }),
         states: {
           inventory: {
-            path: "workflow.fulfillment.inventory",
+            path: "workflow.fulfillment.inventory" as const,
             value: new Inventory({ warehouse: "warehouse-1" }),
             state: {
-              path: "workflow.fulfillment.inventory.reserved",
+              path: "workflow.fulfillment.inventory.reserved" as const,
               value: new InventoryReserved({ reservationId: "order-1" })
             }
           },
           shipping: {
-            path: "workflow.fulfillment.shipping",
+            path: "workflow.fulfillment.shipping" as const,
             value: new Shipping({ address: "Main Street" }),
             state: {
-              path: "workflow.fulfillment.shipping.quoted",
+              path: "workflow.fulfillment.shipping.quoted" as const,
               value: new ShippingQuoted({ quoteId: "order-1" })
             }
           }
@@ -2283,20 +2574,25 @@ describe("Machine", () => {
           }
         }
       })
-      const initial = states.initial.app(
-        app,
-        (app) =>
-          app
-            .flow(
-              flow,
-              (flow) => flow.idle(new Idle({ userId: "user-1" }))
-            )
-            .monitor(monitor)
-      )
+      const initial = {
+        path: "app" as const,
+        value: app,
+        states: {
+          flow: {
+            path: "app.flow" as const,
+            value: flow,
+            state: { path: "app.flow.idle" as const, value: new Idle({ userId: "user-1" }) }
+          },
+          monitor: { path: "app.monitor" as const, value: monitor }
+        }
+      }
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Submit),
-        initial: () => initial
+        initial: {
+          target: (to) => to.app.initial(),
+          resolve: () => initial
+        }
       }).handle({
         app: {
           states: {
@@ -2304,14 +2600,17 @@ describe("Machine", () => {
               states: {
                 idle: {
                   on: {
-                    Submit: ({ event, target }) =>
-                      target.branch.app.flow.fulfillment(
-                        new Fulfillment({ id: event.value }),
-                        (fulfillment) =>
-                          fulfillment
-                            .inventory(new Inventory({ warehouse: "warehouse-1" }))
-                            .shipping(new Shipping({ address: "Main Street" }))
-                      )
+                    Submit: Machine.transition({
+                      target: (to) => to.branch.app.flow.fulfillment(),
+                      resolve: ({ event, target }) =>
+                        target(
+                          new Fulfillment({ id: event.value }),
+                          (fulfillment) =>
+                            fulfillment
+                              .inventory(new Inventory({ warehouse: "warehouse-1" }))
+                              .shipping(new Shipping({ address: "Main Street" }))
+                        )
+                    })
                   }
                 }
               }
@@ -2324,25 +2623,25 @@ describe("Machine", () => {
 
       assertParallelStateSnapshot(planned.next as any, "app", app, {
         flow: {
-          path: "app.flow",
+          path: "app.flow" as const,
           value: flow,
           state: {
-            path: "app.flow.fulfillment",
+            path: "app.flow.fulfillment" as const,
             value: new Fulfillment({ id: "order-1" }),
             states: {
               inventory: {
-                path: "app.flow.fulfillment.inventory",
+                path: "app.flow.fulfillment.inventory" as const,
                 value: new Inventory({ warehouse: "warehouse-1" })
               },
               shipping: {
-                path: "app.flow.fulfillment.shipping",
+                path: "app.flow.fulfillment.shipping" as const,
                 value: new Shipping({ address: "Main Street" })
               }
             }
           }
         },
         monitor: {
-          path: "app.monitor",
+          path: "app.monitor" as const,
           value: monitor
         }
       })
@@ -2381,20 +2680,23 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(ReserveInventory),
-        initial: () =>
-          states.initial.fulfillment(
-            fulfillment,
-            (fulfillment) =>
-              fulfillment
-                .inventory(
-                  inventory,
-                  (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
-                )
-                .shipping(
-                  shipping,
-                  (shipping) => shipping.quoting(quoting)
-                )
-          )
+        initial: {
+          target: (to) => to.fulfillment.initial(),
+          resolve: ({ target }) =>
+            target(
+              fulfillment,
+              (fulfillment) =>
+                fulfillment
+                  .inventory(
+                    inventory,
+                    (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
+                  )
+                  .shipping(
+                    shipping,
+                    (shipping) => shipping.quoting(quoting)
+                  )
+            )
+        }
       }).handle({
         fulfillment: {
           states: {
@@ -2402,8 +2704,11 @@ describe("Machine", () => {
               states: {
                 checking: {
                   on: {
-                    ReserveInventory: ({ event, target }) =>
-                      target.local.reserved(new InventoryReserved({ reservationId: event.reservationId }))
+                    ReserveInventory: Machine.transition({
+                      target: (to) => to.local.reserved(),
+                      resolve: ({ event, target }) =>
+                        target(new InventoryReserved({ reservationId: event.reservationId }))
+                    })
                   }
                 }
               }
@@ -2417,18 +2722,18 @@ describe("Machine", () => {
 
       assertParallelStateSnapshot(planned.next as any, "fulfillment", fulfillment, {
         inventory: {
-          path: "fulfillment.inventory",
+          path: "fulfillment.inventory" as const,
           value: inventory,
           state: {
-            path: "fulfillment.inventory.reserved",
+            path: "fulfillment.inventory.reserved" as const,
             value: new InventoryReserved({ reservationId: "res-1" })
           }
         },
         shipping: {
-          path: "fulfillment.shipping",
+          path: "fulfillment.shipping" as const,
           value: shipping,
           state: {
-            path: "fulfillment.shipping.quoting",
+            path: "fulfillment.shipping.quoting" as const,
             value: quoting
           }
         }
@@ -2468,20 +2773,23 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(ReserveInventory),
-        initial: () =>
-          states.initial.fulfillment(
-            fulfillment,
-            (fulfillment) =>
-              fulfillment
-                .inventory(
-                  new Inventory({ warehouse: "warehouse-1" }),
-                  (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
-                )
-                .shipping(
-                  shipping,
-                  (shipping) => shipping.quoting(quoting)
-                )
-          )
+        initial: {
+          target: (to) => to.fulfillment.initial(),
+          resolve: ({ target }) =>
+            target(
+              fulfillment,
+              (fulfillment) =>
+                fulfillment
+                  .inventory(
+                    new Inventory({ warehouse: "warehouse-1" }),
+                    (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
+                  )
+                  .shipping(
+                    shipping,
+                    (shipping) => shipping.quoting(quoting)
+                  )
+            )
+        }
       }).handle({
         fulfillment: {
           states: {
@@ -2489,11 +2797,15 @@ describe("Machine", () => {
               states: {
                 checking: {
                   on: {
-                    ReserveInventory: ({ event, target }) =>
-                      target.local.with(
-                        nextInventory,
-                        (inventory) => inventory.reserved(new InventoryReserved({ reservationId: event.reservationId }))
-                      )
+                    ReserveInventory: Machine.transition({
+                      target: (to) => to.branch.fulfillment.inventory(),
+                      resolve: ({ event, target }) =>
+                        target(
+                          nextInventory,
+                          (inventory) =>
+                            inventory.reserved(new InventoryReserved({ reservationId: event.reservationId }))
+                        )
+                    })
                   }
                 }
               }
@@ -2507,18 +2819,18 @@ describe("Machine", () => {
 
       assertParallelStateSnapshot(planned.next as any, "fulfillment", fulfillment, {
         inventory: {
-          path: "fulfillment.inventory",
+          path: "fulfillment.inventory" as const,
           value: nextInventory,
           state: {
-            path: "fulfillment.inventory.reserved",
+            path: "fulfillment.inventory.reserved" as const,
             value: new InventoryReserved({ reservationId: "res-1" })
           }
         },
         shipping: {
-          path: "fulfillment.shipping",
+          path: "fulfillment.shipping" as const,
           value: shipping,
           state: {
-            path: "fulfillment.shipping.quoting",
+            path: "fulfillment.shipping.quoting" as const,
             value: quoting
           }
         }
@@ -2559,20 +2871,23 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(ReserveInventory),
-        initial: () =>
-          states.initial.fulfillment(
-            fulfillment,
-            (fulfillment) =>
-              fulfillment
-                .inventory(
-                  inventory,
-                  (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
-                )
-                .shipping(
-                  shipping,
-                  (shipping) => shipping.quoting(quoting)
-                )
-          )
+        initial: {
+          target: (to) => to.fulfillment.initial(),
+          resolve: ({ target }) =>
+            target(
+              fulfillment,
+              (fulfillment) =>
+                fulfillment
+                  .inventory(
+                    inventory,
+                    (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
+                  )
+                  .shipping(
+                    shipping,
+                    (shipping) => shipping.quoting(quoting)
+                  )
+            )
+        }
       }).handle({
         fulfillment: {
           states: {
@@ -2580,11 +2895,15 @@ describe("Machine", () => {
               states: {
                 checking: {
                   on: {
-                    ReserveInventory: ({ event, target }) =>
-                      target.branch.fulfillment.inventory(
-                        nextInventory,
-                        (inventory) => inventory.reserved(new InventoryReserved({ reservationId: event.reservationId }))
-                      )
+                    ReserveInventory: Machine.transition({
+                      target: (to) => to.branch.fulfillment.inventory(),
+                      resolve: ({ event, target }) =>
+                        target(
+                          nextInventory,
+                          (inventory) =>
+                            inventory.reserved(new InventoryReserved({ reservationId: event.reservationId }))
+                        )
+                    })
                   }
                 }
               }
@@ -2598,18 +2917,18 @@ describe("Machine", () => {
 
       assertParallelStateSnapshot(planned.next as any, "fulfillment", fulfillment, {
         inventory: {
-          path: "fulfillment.inventory",
+          path: "fulfillment.inventory" as const,
           value: nextInventory,
           state: {
-            path: "fulfillment.inventory.reserved",
+            path: "fulfillment.inventory.reserved" as const,
             value: new InventoryReserved({ reservationId: "res-1" })
           }
         },
         shipping: {
-          path: "fulfillment.shipping",
+          path: "fulfillment.shipping" as const,
           value: shipping,
           state: {
-            path: "fulfillment.shipping.quoting",
+            path: "fulfillment.shipping.quoting" as const,
             value: quoting
           }
         }
@@ -2651,20 +2970,23 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(ReserveInventory),
-        initial: () =>
-          states.initial.fulfillment(
-            fulfillment,
-            (fulfillment) =>
-              fulfillment
-                .inventory(
-                  inventory,
-                  (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
-                )
-                .shipping(
-                  shipping,
-                  (shipping) => shipping.quoting(quoting)
-                )
-          )
+        initial: {
+          target: (to) => to.fulfillment.initial(),
+          resolve: ({ target }) =>
+            target(
+              fulfillment,
+              (fulfillment) =>
+                fulfillment
+                  .inventory(
+                    inventory,
+                    (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
+                  )
+                  .shipping(
+                    shipping,
+                    (shipping) => shipping.quoting(quoting)
+                  )
+            )
+        }
       }).handle({
         fulfillment: {
           states: {
@@ -2672,16 +2994,19 @@ describe("Machine", () => {
               states: {
                 checking: {
                   on: {
-                    ReserveInventory: ({ event, target }) =>
-                      target.branch.fulfillment(
-                        nextFulfillment,
-                        (fulfillment) =>
-                          fulfillment.inventory(
-                            nextInventory,
-                            (inventory) =>
-                              inventory.reserved(new InventoryReserved({ reservationId: event.reservationId }))
-                          )
-                      )
+                    ReserveInventory: Machine.transition({
+                      target: (to) => to.branch.fulfillment(),
+                      resolve: ({ event, target }) =>
+                        target(
+                          nextFulfillment,
+                          (fulfillment) =>
+                            fulfillment.inventory(
+                              nextInventory,
+                              (inventory) =>
+                                inventory.reserved(new InventoryReserved({ reservationId: event.reservationId }))
+                            )
+                        )
+                    })
                   }
                 }
               }
@@ -2695,18 +3020,18 @@ describe("Machine", () => {
 
       assertParallelStateSnapshot(planned.next as any, "fulfillment", nextFulfillment, {
         inventory: {
-          path: "fulfillment.inventory",
+          path: "fulfillment.inventory" as const,
           value: nextInventory,
           state: {
-            path: "fulfillment.inventory.reserved",
+            path: "fulfillment.inventory.reserved" as const,
             value: new InventoryReserved({ reservationId: "res-1" })
           }
         },
         shipping: {
-          path: "fulfillment.shipping",
+          path: "fulfillment.shipping" as const,
           value: shipping,
           state: {
-            path: "fulfillment.shipping.quoting",
+            path: "fulfillment.shipping.quoting" as const,
             value: quoting
           }
         }
@@ -2745,15 +3070,18 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(ReserveInventory),
-        initial: () =>
-          states.initial.payment(
-            payment,
-            (payment) =>
-              payment.inventory(
-                inventory,
-                (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
-              )
-          )
+        initial: {
+          target: (to) => to.payment.initial(),
+          resolve: ({ target }) =>
+            target(
+              payment,
+              (payment) =>
+                payment.inventory(
+                  inventory,
+                  (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
+                )
+            )
+        }
       }).handle({
         payment: {
           states: {
@@ -2761,11 +3089,14 @@ describe("Machine", () => {
               states: {
                 checking: {
                   on: {
-                    ReserveInventory: ({ event, target }) =>
-                      target.branch.payment.shipping(
-                        shipping,
-                        (shipping) => shipping.quoted(new ShippingQuoted({ quoteId: event.reservationId }))
-                      )
+                    ReserveInventory: Machine.transition({
+                      target: (to) => to.branch.payment.shipping(),
+                      resolve: ({ event, target }) =>
+                        target(
+                          shipping,
+                          (shipping) => shipping.quoted(new ShippingQuoted({ quoteId: event.reservationId }))
+                        )
+                    })
                   }
                 }
               }
@@ -2782,10 +3113,10 @@ describe("Machine", () => {
       )
 
       assertCompoundStateSnapshot(planned.next as any, "payment", payment, {
-        path: "payment.shipping",
+        path: "payment.shipping" as const,
         value: shipping,
         state: {
-          path: "payment.shipping.quoted",
+          path: "payment.shipping.quoted" as const,
           value: new ShippingQuoted({ quoteId: "quote-1" })
         }
       })
@@ -2810,23 +3141,32 @@ describe("Machine", () => {
           }
         },
         events: Machine.events(Authorize, Reset),
-        initial: () => ({
-          path: "payment",
-          value: payment,
-          state: {
-            path: "payment.entering" as const,
-            value: new EnteringPayment({ amount: 100 })
-          }
-        })
+        initial: {
+          target: (to) => to.payment.initial(),
+          resolve: () => ({
+            path: "payment" as const,
+            value: payment,
+            state: {
+              path: "payment.entering" as const,
+              value: new EnteringPayment({ amount: 100 })
+            }
+          })
+        }
       }).handle({
         payment: {
           on: {
-            Reset: ({ target }) => target.local.entering(new EnteringPayment({ amount: 0 }))
+            Reset: Machine.transition({
+              target: (to) => to.local.entering(),
+              resolve: ({ target }) => target(new EnteringPayment({ amount: 0 }))
+            })
           },
           states: {
             entering: {
               on: {
-                Authorize: ({ event, target }) => target.local.authorized(new AuthorizedPayment({ code: event.code }))
+                Authorize: Machine.transition({
+                  target: (to) => to.local.authorized(),
+                  resolve: ({ event, target }) => target(new AuthorizedPayment({ code: event.code }))
+                })
               }
             },
             authorized: {
@@ -2867,14 +3207,17 @@ describe("Machine", () => {
           }
         },
         events: Machine.events(Reset),
-        initial: () => ({
-          path: "payment",
-          value: payment,
-          state: {
-            path: "payment.authorized" as const,
-            value: authorized
-          }
-        })
+        initial: {
+          target: (to) => to.payment.initial(),
+          resolve: () => ({
+            path: "payment" as const,
+            value: payment,
+            state: {
+              path: "payment.authorized" as const,
+              value: authorized
+            }
+          })
+        }
       }).handle({
         payment: {
           states: {
@@ -2916,23 +3259,32 @@ describe("Machine", () => {
           }
         },
         events: Machine.events(Authorize, Reset),
-        initial: () => ({
-          path: "payment",
-          value: payment,
-          state: {
-            path: "payment.entering" as const,
-            value: new EnteringPayment({ amount: 100 })
-          }
-        })
+        initial: {
+          target: (to) => to.payment.initial(),
+          resolve: () => ({
+            path: "payment" as const,
+            value: payment,
+            state: {
+              path: "payment.entering" as const,
+              value: new EnteringPayment({ amount: 100 })
+            }
+          })
+        }
       }).handle({
         payment: {
           on: {
-            Reset: ({ target }) => target.full.idle(new Idle({ userId: "user-1" }))
+            Reset: Machine.transition({
+              target: (to) => to.full.idle(),
+              resolve: ({ target }) => target(new Idle({ userId: "user-1" }))
+            })
           },
           states: {
             entering: {
               on: {
-                Authorize: ({ event, target }) => target.local.authorized(new AuthorizedPayment({ code: event.code }))
+                Authorize: Machine.transition({
+                  target: (to) => to.local.authorized(),
+                  resolve: ({ event, target }) => target(new AuthorizedPayment({ code: event.code }))
+                })
               }
             },
             authorized: {
@@ -2951,15 +3303,15 @@ describe("Machine", () => {
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "done",
         state: {
-          path: "payment",
+          path: "payment" as const,
           value: payment,
           state: {
-            path: "payment.authorized",
+            path: "payment.authorized" as const,
             value: new AuthorizedPayment({ code: "auth-1" })
           },
           completed: [
-            { path: "payment.authorized", output: "auth-1" },
-            { path: "payment", output: "auth-1" }
+            { path: "payment.authorized" as const, output: "auth-1" },
+            { path: "payment" as const, output: "auth-1" }
           ]
         },
         output: "auth-1"
@@ -2994,32 +3346,43 @@ describe("Machine", () => {
           failed: Failed
         },
         events: Machine.events(ReserveInventory, Reset),
-        initial: () => ({
-          path: "checkout",
-          value: checkout,
-          state: {
-            path: "checkout.inventory" as const,
-            value: inventory,
+        initial: {
+          target: (to) => to.checkout.initial(),
+          resolve: () => ({
+            path: "checkout" as const,
+            value: checkout,
             state: {
-              path: "checkout.inventory.checking" as const,
-              value: new CheckingInventory({ sku: "sku-1" })
+              path: "checkout.inventory" as const,
+              value: inventory,
+              state: {
+                path: "checkout.inventory.checking" as const,
+                value: new CheckingInventory({ sku: "sku-1" })
+              }
             }
-          }
-        })
+          })
+        }
       }).handle({
         checkout: {
           on: {
-            Reset: ({ target }) => target.full.failed(new Failed({ message: "reset" }))
+            Reset: Machine.transition({
+              target: (to) => to.full.failed(),
+              resolve: ({ target }) => target(new Failed({ message: "reset" }))
+            })
           },
           states: {
             inventory: {
-              onDone: ({ output, target }) =>
-                target.branch.checkout.shipped(new ShippingQuoted({ quoteId: String(output) })),
+              onDone: Machine.transition({
+                target: (to) => to.branch.checkout.shipped(),
+                resolve: ({ output, target }) => target(new ShippingQuoted({ quoteId: String(output) }))
+              }),
               states: {
                 checking: {
                   on: {
-                    ReserveInventory: ({ event, target }) =>
-                      target.local.reserved(new InventoryReserved({ reservationId: event.reservationId }))
+                    ReserveInventory: Machine.transition({
+                      target: (to) => to.local.reserved(),
+                      resolve: ({ event, target }) =>
+                        target(new InventoryReserved({ reservationId: event.reservationId }))
+                    })
                   }
                 },
                 reserved: {
@@ -3035,7 +3398,7 @@ describe("Machine", () => {
       const planned = yield* Machine.plan(machine, initial.state, new ReserveInventory({ reservationId: "res-1" }))
 
       assertCompoundStateSnapshot(planned.next as any, "checkout", checkout, {
-        path: "checkout.shipped",
+        path: "checkout.shipped" as const,
         value: new ShippingQuoted({ quoteId: "res-1" })
       })
       assert.strictEqual(Machine.isFinal(machine, planned.next), false)
@@ -3082,28 +3445,31 @@ describe("Machine", () => {
           }
         },
         events: Machine.events(ReserveInventory),
-        initial: () => ({
-          path: "fulfillment",
-          value: fulfillment,
-          states: {
-            inventory: {
-              path: "fulfillment.inventory" as const,
-              value: inventory,
-              state: {
-                path: "fulfillment.inventory.checking" as const,
-                value: new CheckingInventory({ sku: "sku-1" })
-              }
-            },
-            shipping: {
-              path: "fulfillment.shipping" as const,
-              value: shipping,
-              state: {
-                path: "fulfillment.shipping.quoting" as const,
-                value: quoting
+        initial: {
+          target: (to) => to.fulfillment.initial(),
+          resolve: () => ({
+            path: "fulfillment" as const,
+            value: fulfillment,
+            states: {
+              inventory: {
+                path: "fulfillment.inventory" as const,
+                value: inventory,
+                state: {
+                  path: "fulfillment.inventory.checking" as const,
+                  value: new CheckingInventory({ sku: "sku-1" })
+                }
+              },
+              shipping: {
+                path: "fulfillment.shipping" as const,
+                value: shipping,
+                state: {
+                  path: "fulfillment.shipping.quoting" as const,
+                  value: quoting
+                }
               }
             }
-          }
-        })
+          })
+        }
       }).handle({
         fulfillment: {
           states: {
@@ -3111,8 +3477,11 @@ describe("Machine", () => {
               states: {
                 checking: {
                   on: {
-                    ReserveInventory: ({ event, target }) =>
-                      target.local.reserved(new InventoryReserved({ reservationId: event.reservationId }))
+                    ReserveInventory: Machine.transition({
+                      target: (to) => to.local.reserved(),
+                      resolve: ({ event, target }) =>
+                        target(new InventoryReserved({ reservationId: event.reservationId }))
+                    })
                   }
                 }
               }
@@ -3133,18 +3502,18 @@ describe("Machine", () => {
 
       assertParallelStateSnapshot(planned.next as any, "fulfillment", fulfillment, {
         inventory: {
-          path: "fulfillment.inventory",
+          path: "fulfillment.inventory" as const,
           value: inventory,
           state: {
-            path: "fulfillment.inventory.reserved",
+            path: "fulfillment.inventory.reserved" as const,
             value: new InventoryReserved({ reservationId: "res-1" })
           }
         },
         shipping: {
-          path: "fulfillment.shipping",
+          path: "fulfillment.shipping" as const,
           value: shipping,
           state: {
-            path: "fulfillment.shipping.quoting",
+            path: "fulfillment.shipping.quoting" as const,
             value: quoting
           }
         }
@@ -3197,28 +3566,31 @@ describe("Machine", () => {
           }
         },
         events: Machine.events(ReserveInventory),
-        initial: () => ({
-          path: "fulfillment",
-          value: fulfillment,
-          states: {
-            inventory: {
-              path: "fulfillment.inventory" as const,
-              value: inventory,
-              state: {
-                path: "fulfillment.inventory.checking" as const,
-                value: checking
-              }
-            },
-            shipping: {
-              path: "fulfillment.shipping" as const,
-              value: shipping,
-              state: {
-                path: "fulfillment.shipping.quoting" as const,
-                value: quoting
+        initial: {
+          target: (to) => to.fulfillment.initial(),
+          resolve: () => ({
+            path: "fulfillment" as const,
+            value: fulfillment,
+            states: {
+              inventory: {
+                path: "fulfillment.inventory" as const,
+                value: inventory,
+                state: {
+                  path: "fulfillment.inventory.checking" as const,
+                  value: checking
+                }
+              },
+              shipping: {
+                path: "fulfillment.shipping" as const,
+                value: shipping,
+                state: {
+                  path: "fulfillment.shipping.quoting" as const,
+                  value: quoting
+                }
               }
             }
-          }
-        })
+          })
+        }
       }).handle({
         fulfillment: {
           output: ({ outputs }) => ({
@@ -3230,8 +3602,11 @@ describe("Machine", () => {
               states: {
                 checking: {
                   on: {
-                    ReserveInventory: ({ event, target }) =>
-                      target.local.reserved(new InventoryReserved({ reservationId: event.reservationId }))
+                    ReserveInventory: Machine.transition({
+                      target: (to) => to.local.reserved(),
+                      resolve: ({ event, target }) =>
+                        target(new InventoryReserved({ reservationId: event.reservationId }))
+                    })
                   }
                 },
                 reserved: {
@@ -3243,8 +3618,10 @@ describe("Machine", () => {
               states: {
                 quoting: {
                   on: {
-                    ReserveInventory: ({ event, target }) =>
-                      target.local.quoted(new ShippingQuoted({ quoteId: event.reservationId }))
+                    ReserveInventory: Machine.transition({
+                      target: (to) => to.local.quoted(),
+                      resolve: ({ event, target }) => target(new ShippingQuoted({ quoteId: event.reservationId }))
+                    })
                   }
                 },
                 quoted: {
@@ -3261,18 +3638,18 @@ describe("Machine", () => {
 
       assertParallelStateSnapshot(planned.next as any, "fulfillment", fulfillment, {
         inventory: {
-          path: "fulfillment.inventory",
+          path: "fulfillment.inventory" as const,
           value: inventory,
           state: {
-            path: "fulfillment.inventory.reserved",
+            path: "fulfillment.inventory.reserved" as const,
             value: new InventoryReserved({ reservationId: "res-1" })
           }
         },
         shipping: {
-          path: "fulfillment.shipping",
+          path: "fulfillment.shipping" as const,
           value: shipping,
           state: {
-            path: "fulfillment.shipping.quoted",
+            path: "fulfillment.shipping.quoted" as const,
             value: new ShippingQuoted({ quoteId: "res-1" })
           }
         }
@@ -3337,28 +3714,31 @@ describe("Machine", () => {
           }
         },
         events: Machine.events(ReserveInventory, Resolve),
-        initial: () => ({
-          path: "fulfillment",
-          value: fulfillment,
-          states: {
-            inventory: {
-              path: "fulfillment.inventory" as const,
-              value: inventory,
-              state: {
-                path: "fulfillment.inventory.checking" as const,
-                value: new CheckingInventory({ sku: "sku-1" })
-              }
-            },
-            shipping: {
-              path: "fulfillment.shipping" as const,
-              value: shipping,
-              state: {
-                path: "fulfillment.shipping.quoting" as const,
-                value: quoting
+        initial: {
+          target: (to) => to.fulfillment.initial(),
+          resolve: () => ({
+            path: "fulfillment" as const,
+            value: fulfillment,
+            states: {
+              inventory: {
+                path: "fulfillment.inventory" as const,
+                value: inventory,
+                state: {
+                  path: "fulfillment.inventory.checking" as const,
+                  value: new CheckingInventory({ sku: "sku-1" })
+                }
+              },
+              shipping: {
+                path: "fulfillment.shipping" as const,
+                value: shipping,
+                state: {
+                  path: "fulfillment.shipping.quoting" as const,
+                  value: quoting
+                }
               }
             }
-          }
-        })
+          })
+        }
       }).handle({
         fulfillment: {
           output: ({ outputs }) => outputs,
@@ -3367,8 +3747,11 @@ describe("Machine", () => {
               states: {
                 checking: {
                   on: {
-                    ReserveInventory: ({ event, target }) =>
-                      target.local.reserved(new InventoryReserved({ reservationId: event.reservationId }))
+                    ReserveInventory: Machine.transition({
+                      target: (to) => to.local.reserved(),
+                      resolve: ({ event, target }) =>
+                        target(new InventoryReserved({ reservationId: event.reservationId }))
+                    })
                   }
                 },
                 reserved: {
@@ -3380,7 +3763,10 @@ describe("Machine", () => {
               states: {
                 quoting: {
                   on: {
-                    Resolve: ({ target }) => target.local.quoted(new ShippingQuoted({ quoteId: "quote-1" }))
+                    Resolve: Machine.transition({
+                      target: (to) => to.local.quoted(),
+                      resolve: ({ target }) => target(new ShippingQuoted({ quoteId: "quote-1" }))
+                    })
                   }
                 },
                 quoted: {
@@ -3460,28 +3846,31 @@ describe("Machine", () => {
           }
         },
         events: Machine.events(ReserveInventory),
-        initial: () => ({
-          path: "fulfillment",
-          value: fulfillment,
-          states: {
-            inventory: {
-              path: "fulfillment.inventory" as const,
-              value: inventory,
-              state: {
-                path: "fulfillment.inventory.checking" as const,
-                value: checking
-              }
-            },
-            shipping: {
-              path: "fulfillment.shipping" as const,
-              value: shipping,
-              state: {
-                path: "fulfillment.shipping.quoting" as const,
-                value: quoting
+        initial: {
+          target: (to) => to.fulfillment.initial(),
+          resolve: () => ({
+            path: "fulfillment" as const,
+            value: fulfillment,
+            states: {
+              inventory: {
+                path: "fulfillment.inventory" as const,
+                value: inventory,
+                state: {
+                  path: "fulfillment.inventory.checking" as const,
+                  value: checking
+                }
+              },
+              shipping: {
+                path: "fulfillment.shipping" as const,
+                value: shipping,
+                state: {
+                  path: "fulfillment.shipping.quoting" as const,
+                  value: quoting
+                }
               }
             }
-          }
-        })
+          })
+        }
       }).handle({
         fulfillment: {
           states: {
@@ -3489,8 +3878,11 @@ describe("Machine", () => {
               states: {
                 checking: {
                   on: {
-                    ReserveInventory: ({ event, target }) =>
-                      target.local.reserved(new InventoryReserved({ reservationId: event.reservationId }))
+                    ReserveInventory: Machine.transition({
+                      target: (to) => to.local.reserved(),
+                      resolve: ({ event, target }) =>
+                        target(new InventoryReserved({ reservationId: event.reservationId }))
+                    })
                   }
                 }
               }
@@ -3499,8 +3891,10 @@ describe("Machine", () => {
               states: {
                 quoting: {
                   on: {
-                    ReserveInventory: ({ event, target }) =>
-                      target.local.quoted(new ShippingQuoted({ quoteId: event.reservationId }))
+                    ReserveInventory: Machine.transition({
+                      target: (to) => to.local.quoted(),
+                      resolve: ({ event, target }) => target(new ShippingQuoted({ quoteId: event.reservationId }))
+                    })
                   }
                 }
               }
@@ -3514,18 +3908,18 @@ describe("Machine", () => {
 
       assertParallelStateSnapshot(planned.next as any, "fulfillment", fulfillment, {
         inventory: {
-          path: "fulfillment.inventory",
+          path: "fulfillment.inventory" as const,
           value: inventory,
           state: {
-            path: "fulfillment.inventory.reserved",
+            path: "fulfillment.inventory.reserved" as const,
             value: new InventoryReserved({ reservationId: "res-1" })
           }
         },
         shipping: {
-          path: "fulfillment.shipping",
+          path: "fulfillment.shipping" as const,
           value: shipping,
           state: {
-            path: "fulfillment.shipping.quoted",
+            path: "fulfillment.shipping.quoted" as const,
             value: new ShippingQuoted({ quoteId: "res-1" })
           }
         }
@@ -3565,28 +3959,31 @@ describe("Machine", () => {
           }
         },
         events: Machine.events(ReserveInventory, Resolve),
-        initial: () => ({
-          path: "fulfillment",
-          value: fulfillment,
-          states: {
-            inventory: {
-              path: "fulfillment.inventory" as const,
-              value: inventory,
-              state: {
-                path: "fulfillment.inventory.checking" as const,
-                value: checking
-              }
-            },
-            shipping: {
-              path: "fulfillment.shipping" as const,
-              value: shipping,
-              state: {
-                path: "fulfillment.shipping.quoting" as const,
-                value: quoting
+        initial: {
+          target: (to) => to.fulfillment.initial(),
+          resolve: () => ({
+            path: "fulfillment" as const,
+            value: fulfillment,
+            states: {
+              inventory: {
+                path: "fulfillment.inventory" as const,
+                value: inventory,
+                state: {
+                  path: "fulfillment.inventory.checking" as const,
+                  value: checking
+                }
+              },
+              shipping: {
+                path: "fulfillment.shipping" as const,
+                value: shipping,
+                state: {
+                  path: "fulfillment.shipping.quoting" as const,
+                  value: quoting
+                }
               }
             }
-          }
-        })
+          })
+        }
       }).handle({
         fulfillment: {
           states: {
@@ -3594,14 +3991,17 @@ describe("Machine", () => {
               states: {
                 checking: {
                   on: {
-                    ReserveInventory: ({ event, target }, enqueue) => {
-                      enqueue.raise(new Resolve({}))
-                      return target.local.reserved(
-                        new InventoryReserved({
-                          reservationId: event.reservationId
-                        })
-                      )
-                    }
+                    ReserveInventory: Machine.transition({
+                      target: (to) => to.local.reserved(),
+                      resolve: ({ event, target }, enqueue) => {
+                        enqueue.raise(new Resolve({}))
+                        return target(
+                          new InventoryReserved({
+                            reservationId: event.reservationId
+                          })
+                        )
+                      }
+                    })
                   }
                 }
               }
@@ -3610,7 +4010,10 @@ describe("Machine", () => {
               states: {
                 quoting: {
                   on: {
-                    Resolve: ({ target }) => target.local.quoted(new ShippingQuoted({ quoteId: "raised" }))
+                    Resolve: Machine.transition({
+                      target: (to) => to.local.quoted(),
+                      resolve: ({ target }) => target(new ShippingQuoted({ quoteId: "raised" }))
+                    })
                   }
                 }
               }
@@ -3624,18 +4027,18 @@ describe("Machine", () => {
 
       assertParallelStateSnapshot(planned.next as any, "fulfillment", fulfillment, {
         inventory: {
-          path: "fulfillment.inventory",
+          path: "fulfillment.inventory" as const,
           value: inventory,
           state: {
-            path: "fulfillment.inventory.reserved",
+            path: "fulfillment.inventory.reserved" as const,
             value: new InventoryReserved({ reservationId: "res-1" })
           }
         },
         shipping: {
-          path: "fulfillment.shipping",
+          path: "fulfillment.shipping" as const,
           value: shipping,
           state: {
-            path: "fulfillment.shipping.quoted",
+            path: "fulfillment.shipping.quoted" as const,
             value: new ShippingQuoted({ quoteId: "raised" })
           }
         }
@@ -3648,7 +4051,10 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: { Idle },
         events: Machine.events(Submit),
-        initial: () => FlatInitial.Idle(new Idle({ userId: "user-1" }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({ userId: "user-1" }))
+        }
       })
 
       const actor = yield* Machine.start(machine)
@@ -3662,11 +4068,17 @@ describe("Machine", () => {
         states: { Idle, Loading },
         events: Machine.events(Submit),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+            })
           }
         }
       })
@@ -3681,7 +4093,7 @@ describe("Machine", () => {
 
       assert.deepStrictEqual(snapshot, {
         status: "active",
-        state: { path: "Loading", value: new Loading({ requestId: "request-1" }) }
+        state: { path: "Loading" as const, value: new Loading({ requestId: "request-1" }) }
       })
     }))
 
@@ -3690,16 +4102,25 @@ describe("Machine", () => {
       states: { Idle, Loading },
       events: Machine.events(Submit, Reset),
       input: Input,
-      initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+      }
     }).handle({
       Idle: {
         on: {
-          Submit: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+          Submit: Machine.transition({
+            target: (to) => to.full.Loading(),
+            resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+          })
         }
       },
       Loading: {
         on: {
-          Reset: () => FlatInitial.Idle(new Idle({ userId: "user-1" }))
+          Reset: Machine.transition({
+            target: (to) => to.full.Idle(),
+            resolve: ({ target }) => target(new Idle({ userId: "user-1" }))
+          })
         }
       }
     })
@@ -3719,11 +4140,17 @@ describe("Machine", () => {
       },
       events: Machine.events(Submit),
       input: Input,
-      initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+      }
     }).handle({
       Idle: {
         on: {
-          Submit: () => FlatInitial.Success(new Success({ requestId: "request-1" }))
+          Submit: Machine.transition({
+            target: (to) => to.full.Success(),
+            resolve: ({ target }) => target(new Success({ requestId: "request-1" }))
+          })
         }
       },
       Success: {}
@@ -3741,11 +4168,17 @@ describe("Machine", () => {
         states: { Idle, Success: SuccessOutput },
         events: Machine.events(Submit),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Success(new Success({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Success(),
+              resolve: ({ target }) => target(new Success({ requestId: "request-1" }))
+            })
           }
         },
         Success: {
@@ -3757,7 +4190,7 @@ describe("Machine", () => {
 
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "active",
-        state: { path: "Idle", value: new Idle({ userId: "user-1" }) }
+        state: { path: "Idle" as const, value: new Idle({ userId: "user-1" }) }
       })
 
       yield* actor.send(new Submit({ value: "hello" }))
@@ -3771,11 +4204,17 @@ describe("Machine", () => {
         states: { Idle, Success: SuccessOutput },
         events: Machine.events(Submit),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Success(new Success({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Success(),
+              resolve: ({ target }) => target(new Success({ requestId: "request-1" }))
+            })
           }
         },
         Success: {
@@ -3798,7 +4237,10 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: { Success: SuccessOutput },
         events: Machine.events(Submit),
-        initial: () => FlatInitial.Success(new Success({ requestId: "request-1" }))
+        initial: {
+          target: (to) => to.Success(),
+          resolve: ({ target }) => target(new Success({ requestId: "request-1" }))
+        }
       }).handle({
         Success: {
           output: ({ state }) => {
@@ -3818,9 +4260,9 @@ describe("Machine", () => {
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "done",
         state: {
-          path: "Success",
+          path: "Success" as const,
           value: new Success({ requestId: "request-1" }),
-          completed: [{ path: "Success", output: "request-1" }]
+          completed: [{ path: "Success" as const, output: "request-1" }]
         },
         output: "request-1"
       })
@@ -3832,7 +4274,10 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: { Success: SuccessOutput },
         events: Machine.events(Submit),
-        initial: () => FlatInitial.Success(new Success({ requestId: "request-1" }))
+        initial: {
+          target: (to) => to.Success(),
+          resolve: ({ target }) => target(new Success({ requestId: "request-1" }))
+        }
       }).handle({
         Success: {
           output: ({ state }) => {
@@ -3847,7 +4292,7 @@ describe("Machine", () => {
       const planned = yield* Machine.plan(machine, cloned, new Submit({ value: "ignored" }))
 
       assert.strictEqual(initial.done, true)
-      assert.deepStrictEqual(cloned.completed, [{ path: "Success", output: "request-1" }])
+      assert.deepStrictEqual(cloned.completed, [{ path: "Success" as const, output: "request-1" }])
       assert.strictEqual(planned.done, true)
       assert.strictEqual(planned.output, "request-1")
       assert.strictEqual(outputCalls, 1)
@@ -3862,11 +4307,17 @@ describe("Machine", () => {
         },
         events: Machine.events(Submit),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Success(new Success({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Success(),
+              resolve: ({ target }) => target(new Success({ requestId: "request-1" }))
+            })
           }
         },
         Success: {}
@@ -3879,9 +4330,9 @@ describe("Machine", () => {
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "done",
         state: {
-          path: "Success",
+          path: "Success" as const,
           value: new Success({ requestId: "request-1" }),
-          completed: [{ path: "Success", output: undefined }]
+          completed: [{ path: "Success" as const, output: undefined }]
         },
         output: undefined
       })
@@ -3896,12 +4347,21 @@ describe("Machine", () => {
         },
         events: Machine.events(Submit, Reset),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Success(new Success({ requestId: "request-1" })),
-            Reset: () => FlatInitial.Idle(new Idle({ userId: "user-2" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Success(),
+              resolve: ({ target }) => target(new Success({ requestId: "request-1" }))
+            }),
+            Reset: Machine.transition({
+              target: (to) => to.full.Idle(),
+              resolve: ({ target }) => target(new Idle({ userId: "user-2" }))
+            })
           }
         },
         Success: {}
@@ -3915,9 +4375,9 @@ describe("Machine", () => {
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "done",
         state: {
-          path: "Success",
+          path: "Success" as const,
           value: new Success({ requestId: "request-1" }),
-          completed: [{ path: "Success", output: undefined }]
+          completed: [{ path: "Success" as const, output: undefined }]
         },
         output: undefined
       })
@@ -3928,11 +4388,17 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: { Idle, Loading },
         events: Machine.events(Submit),
-        initial: () => FlatInitial.Idle(new Idle({ userId: "user-1" }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({ userId: "user-1" }))
+        }
       }).handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+            })
           }
         }
       })
@@ -3956,11 +4422,17 @@ describe("Machine", () => {
         states: { Idle, Loading },
         events: Machine.events(Submit),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+            })
           }
         }
       })
@@ -3974,7 +4446,7 @@ describe("Machine", () => {
 
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "stopped",
-        state: { path: "Idle", value: new Idle({ userId: "user-1" }) }
+        state: { path: "Idle" as const, value: new Idle({ userId: "user-1" }) }
       })
     }))
 
@@ -3987,7 +4459,10 @@ describe("Machine", () => {
         },
         events: Machine.events(Submit),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Success: {}
       })
@@ -4006,11 +4481,17 @@ describe("Machine", () => {
         states: { Idle, Loading },
         events: Machine.events(Submit),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Idle: {
           on: {
-            Submit: ({ target }) => target.none()
+            Submit: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            })
           }
         }
       })
@@ -4029,11 +4510,17 @@ describe("Machine", () => {
         states: { Idle, Loading },
         events: Machine.events(Submit),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+            })
           }
         }
       })
@@ -4048,7 +4535,7 @@ describe("Machine", () => {
 
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "active",
-        state: { path: "Idle", value: new Idle({ userId: "user-1" }) }
+        state: { path: "Idle" as const, value: new Idle({ userId: "user-1" }) }
       })
 
       yield* actor.send(new Submit({ value: "hello" }))
@@ -4056,14 +4543,14 @@ describe("Machine", () => {
       const snapshots = Array.from(yield* Fiber.join(observer))
       assert.deepStrictEqual(snapshots, [{
         status: "active",
-        state: { path: "Loading", value: new Loading({ requestId: "request-1" }) }
+        state: { path: "Loading" as const, value: new Loading({ requestId: "request-1" }) }
       }])
       assert.deepStrictEqual((yield* actor.state).value, new Loading({ requestId: "request-1" }))
 
       yield* actor.stop
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "stopped",
-        state: { path: "Loading", value: new Loading({ requestId: "request-1" }) }
+        state: { path: "Loading" as const, value: new Loading({ requestId: "request-1" }) }
       })
     }))
 
@@ -4073,11 +4560,17 @@ describe("Machine", () => {
         states: { Idle, Success: SuccessOutput },
         events: Machine.events(Submit),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Success(new Success({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Success(),
+              resolve: ({ target }) => target(new Success({ requestId: "request-1" }))
+            })
           }
         },
         Success: {
@@ -4093,9 +4586,9 @@ describe("Machine", () => {
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "done",
         state: {
-          path: "Success",
+          path: "Success" as const,
           value: new Success({ requestId: "request-1" }),
-          completed: [{ path: "Success", output: "request-1" }]
+          completed: [{ path: "Success" as const, output: "request-1" }]
         },
         output: "request-1"
       })
@@ -4108,11 +4601,17 @@ describe("Machine", () => {
         states: { Idle, Loading },
         events: Machine.events(Submit, Reset),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+            })
           }
         }
       })
@@ -4128,22 +4627,32 @@ describe("Machine", () => {
 
   it.effect("start runs invoke configs", () =>
     Effect.gen(function*() {
-      const machine = Machine.make({
+      const definition = Machine.make({
         states: { Idle, Loading, Success: SuccessOutput },
         events: Machine.events(Submit, RequestSucceeded),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
-      }).handle({
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
+      })
+      const machine = definition.handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+            })
           }
         },
         Loading: {
-          invoke: Machine.invoke({
+          invoke: definition.invoke({
             id: "request",
             effect: () => Effect.succeed("done:request-1"),
-            onDone: ({ output, target }) => target.full.Success(new Success({ requestId: output }))
+            onDone: Machine.transition({
+              target: (to) => to.full.Success(),
+              resolve: ({ output, target }) => target(new Success({ requestId: output }))
+            })
           })
         },
         Success: {
@@ -4159,9 +4668,9 @@ describe("Machine", () => {
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "done",
         state: {
-          path: "Success",
+          path: "Success" as const,
           value: new Success({ requestId: "done:request-1" }),
-          completed: [{ path: "Success", output: "done:request-1" }]
+          completed: [{ path: "Success" as const, output: "done:request-1" }]
         },
         output: "done:request-1"
       })
@@ -4169,22 +4678,32 @@ describe("Machine", () => {
 
   it.effect("start invokes a child process and handles its output event", () =>
     Effect.gen(function*() {
-      const machine = Machine.make({
+      const definition = Machine.make({
         states: { Idle, Loading, Success: SuccessOutput },
         events: Machine.events(Submit, RequestSucceeded),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
-      }).handle({
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
+      })
+      const machine = definition.handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+            })
           }
         },
         Loading: {
-          invoke: Machine.invoke({
+          invoke: definition.invoke({
             id: "request",
             effect: () => Effect.succeed("done:request-1"),
-            onDone: ({ output, target }) => target.full.Success(new Success({ requestId: output }))
+            onDone: Machine.transition({
+              target: (to) => to.full.Success(),
+              resolve: ({ output, target }) => target(new Success({ requestId: output }))
+            })
           })
         },
         Success: {
@@ -4200,9 +4719,9 @@ describe("Machine", () => {
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "done",
         state: {
-          path: "Success",
+          path: "Success" as const,
           value: new Success({ requestId: "done:request-1" }),
-          completed: [{ path: "Success", output: "done:request-1" }]
+          completed: [{ path: "Success" as const, output: "done:request-1" }]
         },
         output: "done:request-1"
       })
@@ -4214,14 +4733,20 @@ describe("Machine", () => {
       const childMachine = Machine.make({
         states: childStates.states,
         events: Machine.events(),
-        initial: () => childStates.initial.Idle(new Idle({ userId: "child" }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({ userId: "child" }))
+        }
       })
       const Child = Machine.child("shared-child", childMachine)
       const parentStates = Machine.defineStates({ Loading })
       const parentMachine = Machine.make({
         states: parentStates.states,
         events: Machine.events(),
-        initial: () => parentStates.initial.Loading(new Loading({ requestId: "parent" }))
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target(new Loading({ requestId: "parent" }))
+        }
       }).handle({
         Loading: {
           invoke: Machine.invoke({ child: Child })
@@ -4250,11 +4775,11 @@ describe("Machine", () => {
       yield* first.stop
       assert.deepStrictEqual(yield* second.snapshot, {
         status: "active",
-        state: { path: "Loading", value: new Loading({ requestId: "parent" }) }
+        state: { path: "Loading" as const, value: new Loading({ requestId: "parent" }) }
       })
       assert.deepStrictEqual(yield* secondChild.value.snapshot, {
         status: "active",
-        state: { path: "Idle", value: new Idle({ userId: "child" }) }
+        state: { path: "Idle" as const, value: new Idle({ userId: "child" }) }
       })
       yield* second.stop
     }))
@@ -4265,14 +4790,20 @@ describe("Machine", () => {
       const childMachine = Machine.make({
         states: childStates.states,
         events: Machine.events(),
-        initial: () => childStates.initial.Idle(new Idle({ userId: "child" }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({ userId: "child" }))
+        }
       }).handle({ Idle: {} })
       const Child = Machine.child("owned-child", childMachine)
       const parentStates = Machine.defineStates({ Loading })
       const parentMachine = Machine.make({
         states: parentStates.states,
         events: Machine.events(),
-        initial: () => parentStates.initial.Loading(new Loading({ requestId: "parent" }))
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target(new Loading({ requestId: "parent" }))
+        }
       }).handle({
         Loading: { invoke: Machine.invoke({ child: Child }) }
       })
@@ -4285,7 +4816,7 @@ describe("Machine", () => {
 
       assert.deepStrictEqual(yield* child.value.snapshot, {
         status: "stopped",
-        state: { path: "Idle", value: new Idle({ userId: "child" }) }
+        state: { path: "Idle" as const, value: new Idle({ userId: "child" }) }
       })
       assert.instanceOf(yield* Effect.flip(child.value.join), Machine.StoppedError)
       assert(Option.isNone(yield* parent.child(Child)))
@@ -4299,9 +4830,12 @@ describe("Machine", () => {
         states: childStates.states,
         events: Machine.events(),
         input: Input,
-        initial: (input) => {
-          starts += 1
-          return childStates.initial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input, target }) => {
+            starts += 1
+            return target(new Idle({ userId: input.userId }))
+          }
         }
       }).handle({ Idle: {} })
       const Child = Machine.child("input-child", childMachine)
@@ -4309,7 +4843,10 @@ describe("Machine", () => {
       const parentMachine = Machine.make({
         states: parentStates.states,
         events: Machine.events(),
-        initial: () => parentStates.initial.Loading(new Loading({ requestId: "parent" }))
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target(new Loading({ requestId: "parent" }))
+        }
       }).handle({
         Loading: {
           invoke: Machine.invoke({ child: Child, input: { userId: "configured" } })
@@ -4327,7 +4864,7 @@ describe("Machine", () => {
       assert(Option.isSome(secondChild))
       assert.notStrictEqual(firstChild.value, secondChild.value)
       assert.deepStrictEqual(yield* firstChild.value.state, {
-        path: "Idle",
+        path: "Idle" as const,
         value: new Idle({ userId: "configured" })
       })
       yield* Effect.all([first.stop, second.stop], { concurrency: "unbounded" })
@@ -4344,7 +4881,10 @@ describe("Machine", () => {
       const childMachine = Machine.make({
         states: childStates.states,
         events: Machine.events(),
-        initial: () => childStates.initial.Success(new Success({ requestId: "child-output" }))
+        initial: {
+          target: (to) => to.Success(),
+          resolve: ({ target }) => target(new Success({ requestId: "child-output" }))
+        }
       }).handle({
         Success: { output: ({ state }) => state.requestId }
       })
@@ -4356,12 +4896,18 @@ describe("Machine", () => {
       const parentMachine = Machine.make({
         states: parentStates.states,
         events: Machine.events(ChildFinished),
-        initial: () => parentStates.initial.Loading(new Loading({ requestId: "parent" }))
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target(new Loading({ requestId: "parent" }))
+        }
       }).handle({
         Loading: {
           invoke: Machine.invoke({
             child: Child,
-            onDone: ({ output, target }) => target.full.Success(new Success({ requestId: output }))
+            onDone: Machine.transition({
+              target: (to) => to.full.Success(),
+              resolve: ({ output, target }) => target(new Success({ requestId: output }))
+            })
           })
         },
         Success: { output: ({ state }) => state.requestId }
@@ -4379,7 +4925,10 @@ describe("Machine", () => {
         states: states.states,
         events: Machine.events(),
         input: Input,
-        initial: (input) => states.initial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Idle: {}
       })
@@ -4392,11 +4941,11 @@ describe("Machine", () => {
       )
 
       assert.deepStrictEqual(yield* first.state, {
-        path: "Idle",
+        path: "Idle" as const,
         value: new Idle({ userId: "first" })
       })
       assert.deepStrictEqual(yield* second.state, {
-        path: "Idle",
+        path: "Idle" as const,
         value: new Idle({ userId: "second" })
       })
       yield* Effect.all([first.stop, second.stop], { concurrency: "unbounded" })
@@ -4408,14 +4957,20 @@ describe("Machine", () => {
       const child = Machine.make({
         states: childStates.states,
         events: Machine.events(),
-        initial: () => childStates.initial.Idle(new Idle({ userId: "child" }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({ userId: "child" }))
+        }
       })
       const Child = Machine.child("child-machine", child)
       const parentStates = Machine.defineStates({ Loading })
       const parent = Machine.make({
         states: parentStates.states,
         events: Machine.events(),
-        initial: () => parentStates.initial.Loading(new Loading({ requestId: "request-1" }))
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+        }
       }).handle({
         Loading: {
           invoke: [
@@ -4444,7 +4999,10 @@ describe("Machine", () => {
       const parent = Machine.make({
         states: parentStates.states,
         events: Machine.events(),
-        initial: () => parentStates.initial.Loading(new Loading({ requestId: "request-1" }))
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+        }
       }).handle({
         Loading: {
           invoke: [
@@ -4477,18 +5035,27 @@ describe("Machine", () => {
         states: { Idle, Loading, Failed: FailedOutput },
         events: Machine.events(Submit, RequestFailed),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+            })
           }
         },
         Loading: {
           invoke: Machine.invoke({
             id: "request",
             effect: () => Effect.fail(error),
-            onFailure: ({ error, target }) => target.full.Failed(new Failed({ message: error.message }))
+            onFailure: Machine.transition({
+              target: (to) => to.full.Failed(),
+              resolve: ({ error, target }) => target(new Failed({ message: error.message }))
+            })
           })
         },
         Failed: {
@@ -4504,9 +5071,9 @@ describe("Machine", () => {
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "done",
         state: {
-          path: "Failed",
+          path: "Failed" as const,
           value: new Failed({ message: "boom" }),
-          completed: [{ path: "Failed", output: "boom" }]
+          completed: [{ path: "Failed" as const, output: "boom" }]
         },
         output: "boom"
       })
@@ -4518,18 +5085,27 @@ describe("Machine", () => {
         states: { Idle, Loading, Success: SuccessOutput },
         events: Machine.events(Submit),
         internalEvents: Machine.internalEvents(RequestSucceeded),
-        initial: () => FlatInitial.Idle(new Idle({ userId: "user-1" }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({ userId: "user-1" }))
+        }
       }).handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+            })
           }
         },
         Loading: {
           invoke: Machine.invoke({
             id: "request",
             effect: () => Effect.succeed("loaded"),
-            onDone: ({ output, target }) => target.full.Success(new Success({ requestId: output }))
+            onDone: Machine.transition({
+              target: (to) => to.full.Success(),
+              resolve: ({ output, target }) => target(new Success({ requestId: output }))
+            })
           })
         },
         Success: {
@@ -4549,7 +5125,10 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: { Loading, Success: SuccessOutput },
         events: Machine.events(RequestSucceeded),
-        initial: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+        }
       }).handle({
         Loading: {
           invoke: Machine.invoke({
@@ -4565,10 +5144,16 @@ describe("Machine", () => {
                     Effect.andThen(Effect.never)
                   )
             }),
-            onFailure: ({ target }) => target.none()
+            onFailure: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            })
           }),
           on: {
-            RequestSucceeded: ({ event }) => FlatInitial.Success(new Success({ requestId: event.value }))
+            RequestSucceeded: Machine.transition({
+              target: (to) => to.full.Success(),
+              resolve: ({ event, target }) => target(new Success({ requestId: event.value }))
+            })
           }
         },
         Success: {
@@ -4588,11 +5173,17 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: { Idle, Loading, Success: SuccessOutput },
         events: Machine.events(Resolve, RequestSucceeded),
-        initial: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+        }
       }).handle({
         Idle: {
           on: {
-            RequestSucceeded: ({ event }) => FlatInitial.Success(new Success({ requestId: event.value }))
+            RequestSucceeded: Machine.transition({
+              target: (to) => to.full.Success(),
+              resolve: ({ event, target }) => target(new Success({ requestId: event.value }))
+            })
           }
         },
         Loading: {
@@ -4609,10 +5200,16 @@ describe("Machine", () => {
                     Effect.onInterrupt(() => sendTo(parent, new RequestSucceeded({ value: "stale" })))
                   )
             }),
-            onFailure: ({ target }) => target.none()
+            onFailure: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            })
           }),
           on: {
-            Resolve: () => FlatInitial.Idle(new Idle({ userId: "resolved" }))
+            Resolve: Machine.transition({
+              target: (to) => to.full.Idle(),
+              resolve: ({ target }) => target(new Idle({ userId: "resolved" }))
+            })
           }
         },
         Success: {
@@ -4631,7 +5228,7 @@ describe("Machine", () => {
 
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "active",
-        state: { path: "Idle", value: new Idle({ userId: "resolved" }) }
+        state: { path: "Idle" as const, value: new Idle({ userId: "resolved" }) }
       })
       yield* actor.stop
     }))
@@ -4643,13 +5240,19 @@ describe("Machine", () => {
         states: { Loading, Failed: FailedOutput },
         events: Machine.events(),
         internalEvents: Machine.internalEvents(RequestSucceeded, RequestFailed),
-        initial: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+        }
       }).handle({
         Loading: {
           invoke: Machine.invoke({
             id: "request",
             effect: () => Effect.fail(failure),
-            onFailure: ({ error, target }) => target.full.Failed(new Failed({ message: error.message }))
+            onFailure: Machine.transition({
+              target: (to) => to.full.Failed(),
+              resolve: ({ error, target }) => target(new Failed({ message: error.message }))
+            })
           })
         },
         Failed: {
@@ -4671,13 +5274,19 @@ describe("Machine", () => {
         states: { Loading, Success: SuccessOutput },
         events: Machine.events(),
         internalEvents: Machine.internalEvents(RequestSucceeded),
-        initial: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+        }
       }).handle({
         Loading: {
           invoke: Machine.invoke({
             id: "request",
             effect: () => requiredMessage,
-            onDone: ({ output, target }) => target.full.Success(new Success({ requestId: output }))
+            onDone: Machine.transition({
+              target: (to) => to.full.Success(),
+              resolve: ({ output, target }) => target(new Success({ requestId: output }))
+            })
           })
         },
         Success: {
@@ -4701,13 +5310,19 @@ describe("Machine", () => {
         states: { Loading, Success: SuccessOutput },
         events: Machine.events(),
         internalEvents: Machine.internalEvents(RequestSucceeded),
-        initial: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+        }
       }).handle({
         Loading: {
           invoke: Machine.invoke({
             id: "timeout",
             after: "1 hour",
-            onDone: ({ target }) => target.full.Success(new Success({ requestId: "timeout" }))
+            onDone: Machine.transition({
+              target: (to) => to.full.Success(),
+              resolve: ({ target }) => target(new Success({ requestId: "timeout" }))
+            })
           })
         },
         Success: {
@@ -4724,25 +5339,51 @@ describe("Machine", () => {
 
   it.effect("start maps invoked child active snapshots to machine events", () =>
     Effect.gen(function*() {
-      const machine = Machine.make({
+      const definition = Machine.make({
         states: { Idle, Loading, Success: SuccessOutput },
         events: Machine.events(Submit, RequestProgress),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
-      }).handle({
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
+      })
+      const onSnapshot: Machine.Machine.InvokeTransition<
+        Machine.Machine.States<typeof definition>,
+        Machine.Machine.Events<typeof definition>,
+        Machine.Machine.Emits<typeof definition>,
+        "Loading",
+        Machine.Machine.InvokeSnapshotContext<
+          Machine.Machine.States<typeof definition>,
+          Machine.Machine.Events<typeof definition>,
+          Machine.Machine.Emits<typeof definition>,
+          "Loading",
+          string,
+          never,
+          never,
+          Machine.Machine.InputEvents<typeof definition>,
+          Machine.Machine.ParentEvents<typeof definition>
+        >
+      > = Machine.transition({
+        target: (to) => to.full.Success(),
+        resolve: ({ id, snapshot, target }) => target(new Success({ requestId: `${id}:${snapshot.state}` }))
+      })
+      const machine = definition.handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+            })
           }
         },
         Loading: {
-          invoke: Machine.invoke({
+          invoke: {
             id: "request",
             address: Machine.childAddress("progress-request"),
             logic: Machine.logic({ initial: "pending", run: () => Effect.never }),
-            onSnapshot: ({ id, snapshot, target }) =>
-              target.full.Success(new Success({ requestId: `${id}:${snapshot.state}` }))
-          })
+            onSnapshot
+          }
         },
         Success: {
           output: ({ state }) => state.requestId
@@ -4757,9 +5398,9 @@ describe("Machine", () => {
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "done",
         state: {
-          path: "Success",
+          path: "Success" as const,
           value: new Success({ requestId: "request:pending" }),
-          completed: [{ path: "Success", output: "request:pending" }]
+          completed: [{ path: "Success" as const, output: "request:pending" }]
         },
         output: "request:pending"
       })
@@ -4772,11 +5413,17 @@ describe("Machine", () => {
         states: { Idle, Loading },
         events: Machine.events(Submit),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+            })
           }
         },
         Loading: {
@@ -4797,7 +5444,7 @@ describe("Machine", () => {
       if (snapshot.status !== "error") return assert.fail("expected an error snapshot")
       assert.strictEqual(Cause.squash(snapshot.cause), error)
       assert.deepStrictEqual(snapshot.state, {
-        path: "Loading",
+        path: "Loading" as const,
         value: new Loading({ requestId: "request-1" })
       })
     }))
@@ -4806,19 +5453,51 @@ describe("Machine", () => {
     Effect.gen(function*() {
       const started = yield* Deferred.make<void>()
       const release = yield* Deferred.make<void>()
-      const machine = Machine.make({
+      const definition = Machine.make({
         states: { Idle, Loading, Success: SuccessOutput },
         events: Machine.events(Submit, RequestProgress),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
-      }).handle({
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
+      })
+      const onSnapshot: Machine.Machine.InvokeTransition<
+        Machine.Machine.States<typeof definition>,
+        Machine.Machine.Events<typeof definition>,
+        Machine.Machine.Emits<typeof definition>,
+        "Loading",
+        Machine.Machine.InvokeSnapshotContext<
+          Machine.Machine.States<typeof definition>,
+          Machine.Machine.Events<typeof definition>,
+          Machine.Machine.Emits<typeof definition>,
+          "Loading",
+          string,
+          never,
+          never,
+          Machine.Machine.InputEvents<typeof definition>,
+          Machine.Machine.ParentEvents<typeof definition>
+        >
+      > = Machine.transition({
+        cases: [{
+          title: "request is ready",
+          when: ({ snapshot }) => snapshot.state === "ready" ? Option.some(snapshot) : Option.none(),
+          target: (to) => to.full.Success(),
+          resolve: ({ snapshot, target }) => target(new Success({ requestId: snapshot.state }))
+        }],
+        otherwise: { target: (to) => to.none(), resolve: () => undefined }
+      })
+      const machine = definition.handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+            })
           }
         },
         Loading: {
-          invoke: Machine.invoke({
+          invoke: {
             id: "request",
             address: Machine.childAddress("filtered-progress"),
             logic: Machine.logic({
@@ -4830,11 +5509,8 @@ describe("Machine", () => {
                   Effect.andThen(Effect.never)
                 )
             }),
-            onSnapshot: ({ snapshot, target }) =>
-              snapshot.state === "ready"
-                ? target.full.Success(new Success({ requestId: snapshot.state }))
-                : target.none()
-          })
+            onSnapshot
+          }
         },
         Success: {
           output: ({ state }) => state.requestId
@@ -4849,7 +5525,7 @@ describe("Machine", () => {
 
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "active",
-        state: { path: "Loading", value: new Loading({ requestId: "request-1" }) }
+        state: { path: "Loading" as const, value: new Loading({ requestId: "request-1" }) }
       })
 
       yield* Deferred.succeed(release, void 0)
@@ -4858,9 +5534,9 @@ describe("Machine", () => {
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "done",
         state: {
-          path: "Success",
+          path: "Success" as const,
           value: new Success({ requestId: "ready" }),
-          completed: [{ path: "Success", output: "ready" }]
+          completed: [{ path: "Success" as const, output: "ready" }]
         },
         output: "ready"
       })
@@ -4872,11 +5548,17 @@ describe("Machine", () => {
         states: { Idle, Loading },
         events: Machine.events(Submit),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+            })
           }
         },
         Loading: {
@@ -4887,7 +5569,10 @@ describe("Machine", () => {
               initial: "pending",
               run: () => Effect.void
             }),
-            onDone: ({ target }) => target.none()
+            onDone: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            })
           })
         }
       })
@@ -4899,7 +5584,7 @@ describe("Machine", () => {
 
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "active",
-        state: { path: "Loading", value: new Loading({ requestId: "request-1" }) }
+        state: { path: "Loading" as const, value: new Loading({ requestId: "request-1" }) }
       })
 
       yield* actor.stop
@@ -4927,11 +5612,17 @@ describe("Machine", () => {
         states: { Idle, Loading, Success: SuccessOutput },
         events: Machine.events(Submit, Resolve, RequestSucceeded),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Idle: {
           on: {
-            Submit: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+            })
           }
         },
         Loading: {
@@ -4941,8 +5632,14 @@ describe("Machine", () => {
             logic: childLogic
           }),
           on: {
-            Resolve: () => FlatInitial.Success(new Success({ requestId: "request-1" })),
-            RequestSucceeded: ({ event }) => FlatInitial.Success(new Success({ requestId: event.value }))
+            Resolve: Machine.transition({
+              target: (to) => to.full.Success(),
+              resolve: ({ target }) => target(new Success({ requestId: "request-1" }))
+            }),
+            RequestSucceeded: Machine.transition({
+              target: (to) => to.full.Success(),
+              resolve: ({ event, target }) => target(new Success({ requestId: event.value }))
+            })
           }
         },
         Success: {
@@ -4964,7 +5661,7 @@ describe("Machine", () => {
       assert.strictEqual(yield* Ref.get(joinDone), false)
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "active",
-        state: { path: "Loading", value: new Loading({ requestId: "request-1" }) }
+        state: { path: "Loading" as const, value: new Loading({ requestId: "request-1" }) }
       })
 
       yield* Deferred.succeed(releaseChildStop, void 0)
@@ -4973,9 +5670,9 @@ describe("Machine", () => {
       assert.deepStrictEqual(yield* actor.snapshot, {
         status: "done",
         state: {
-          path: "Success",
+          path: "Success" as const,
           value: new Success({ requestId: "request-1" }),
-          completed: [{ path: "Success", output: "request-1" }]
+          completed: [{ path: "Success" as const, output: "request-1" }]
         },
         output: "request-1"
       })
@@ -5010,14 +5707,17 @@ describe("Machine", () => {
           }
         },
         events: Machine.events(Authorize),
-        initial: () => ({
-          path: "payment",
-          value: payment,
-          state: {
-            path: "payment.entering" as const,
-            value: entering
-          }
-        })
+        initial: {
+          target: (to) => to.payment.initial(),
+          resolve: () => ({
+            path: "payment" as const,
+            value: payment,
+            state: {
+              path: "payment.entering" as const,
+              value: entering
+            }
+          })
+        }
       }).handle({
         payment: {
           invoke: Machine.invoke({
@@ -5037,7 +5737,10 @@ describe("Machine", () => {
                 logic: makeInvokeLogic("entering", enteringStarted)
               }),
               on: {
-                Authorize: ({ event, target }) => target.local.authorized(new AuthorizedPayment({ code: event.code }))
+                Authorize: Machine.transition({
+                  target: (to) => to.local.authorized(),
+                  resolve: ({ event, target }) => target(new AuthorizedPayment({ code: event.code }))
+                })
               }
             },
             authorized: {
@@ -5128,28 +5831,31 @@ describe("Machine", () => {
           }
         },
         events: Machine.events(ReserveInventory),
-        initial: () => ({
-          path: "fulfillment",
-          value: fulfillment,
-          states: {
-            inventory: {
-              path: "fulfillment.inventory" as const,
-              value: inventory,
-              state: {
-                path: "fulfillment.inventory.checking" as const,
-                value: new CheckingInventory({ sku: "sku-1" })
-              }
-            },
-            shipping: {
-              path: "fulfillment.shipping" as const,
-              value: shipping,
-              state: {
-                path: "fulfillment.shipping.quoting" as const,
-                value: new QuotingShipping({ postalCode: "12345" })
+        initial: {
+          target: (to) => to.fulfillment.initial(),
+          resolve: () => ({
+            path: "fulfillment" as const,
+            value: fulfillment,
+            states: {
+              inventory: {
+                path: "fulfillment.inventory" as const,
+                value: inventory,
+                state: {
+                  path: "fulfillment.inventory.checking" as const,
+                  value: new CheckingInventory({ sku: "sku-1" })
+                }
+              },
+              shipping: {
+                path: "fulfillment.shipping" as const,
+                value: shipping,
+                state: {
+                  path: "fulfillment.shipping.quoting" as const,
+                  value: new QuotingShipping({ postalCode: "12345" })
+                }
               }
             }
-          }
-        })
+          })
+        }
       }).handle({
         fulfillment: {
           invoke: Machine.invoke({
@@ -5167,7 +5873,10 @@ describe("Machine", () => {
               states: {
                 checking: {
                   on: {
-                    ReserveInventory: ({ target }) => target.full.success(new Success({ requestId: "done" }))
+                    ReserveInventory: Machine.transition({
+                      target: (to) => to.full.success(),
+                      resolve: ({ target }) => target(new Success({ requestId: "done" }))
+                    })
                   }
                 }
               }
@@ -5216,8 +5925,11 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: { Idle },
         events: Machine.events(),
-        initial: () => {
-          throw defect
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: () => {
+            throw defect
+          }
         }
       })
 
@@ -5243,17 +5955,20 @@ describe("Machine", () => {
         }
       })
       const invalidInitialState = {
-        path: "payment",
+        path: "payment" as const,
         value: new Payment({ id: "payment-1" }),
         state: {
-          path: "payment.authorized",
+          path: "payment.authorized" as const,
           value: new AuthorizedPayment({ code: "authorization-1" })
         }
       }
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: () => invalidInitialState as any
+        initial: {
+          target: (to) => to.payment.initial(),
+          resolve: () => invalidInitialState as any
+        }
       })
 
       const planningError = yield* Effect.flip(Machine.planInitial(machine))
@@ -5272,16 +5987,28 @@ describe("Machine", () => {
         states: { Idle, Loading },
         events: Machine.events(Submit),
         input: Input,
-        initial: (input) => FlatInitial.Idle(new Idle({ userId: input.userId }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ input: input, target }) => target(new Idle({ userId: input.userId }))
+        }
       }).handle({
         Idle: {
-          always: () => FlatInitial.Loading(new Loading({ requestId: "request-1" })),
+          always: Machine.transition({
+            target: (to) => to.full.Loading(),
+            resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+          }),
           on: {
-            Submit: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+            Submit: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+            })
           }
         },
         Loading: {
-          always: () => FlatInitial.Idle(new Idle({ userId: "user-1" }))
+          always: Machine.transition({
+            target: (to) => to.full.Idle(),
+            resolve: ({ target }) => target(new Idle({ userId: "user-1" }))
+          })
         }
       })
 
@@ -5301,13 +6028,22 @@ describe("Machine", () => {
         id: "InitialLoopMachine",
         states: { Idle, Loading },
         events: Machine.events(),
-        initial: () => FlatInitial.Idle(new Idle({ userId: "user-1" }))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({ userId: "user-1" }))
+        }
       }).handle({
         Idle: {
-          always: () => FlatInitial.Loading(new Loading({ requestId: "request-1" }))
+          always: Machine.transition({
+            target: (to) => to.full.Loading(),
+            resolve: ({ target }) => target(new Loading({ requestId: "request-1" }))
+          })
         },
         Loading: {
-          always: () => FlatInitial.Idle(new Idle({ userId: "user-1" }))
+          always: Machine.transition({
+            target: (to) => to.full.Idle(),
+            resolve: ({ target }) => target(new Idle({ userId: "user-1" }))
+          })
         }
       })
 
@@ -5341,30 +6077,39 @@ describe("Machine", () => {
         id: "CompletionLoopMachine",
         states: states.states,
         events: Machine.events(Submit),
-        initial: () => states.initial.idle(new Idle({ userId: "user-1" }))
+        initial: {
+          target: (to) => to.idle(),
+          resolve: ({ target }) => target(new Idle({ userId: "user-1" }))
+        }
       }).handle({
         idle: {
           on: {
-            Submit: () =>
-              states.initial.flow(
-                new Loading({ requestId: "request-1" }),
-                (flow) => flow.done(new Success({ requestId: "request-1" }))
-              )
+            Submit: Machine.transition({
+              target: (to) => to.full.flow(),
+              resolve: ({ target }) =>
+                target(
+                  new Loading({ requestId: "request-1" }),
+                  (flow) => flow.done(new Success({ requestId: "request-1" }))
+                )
+            })
           }
         },
         flow: {
-          onDone: ({ state, target }) =>
-            target.full.flow(
-              state,
-              (flow) => flow.done(new Success({ requestId: state.requestId }))
-            )
+          onDone: Machine.transition({
+            target: (to) => to.full.flow(),
+            resolve: ({ state, target }) =>
+              target(
+                state,
+                (flow) => flow.done(new Success({ requestId: state.requestId }))
+              )
+          })
         }
       })
 
       const error = yield* Effect.flip(
         Machine.plan(
           machine,
-          states.initial.idle(new Idle({ userId: "user-1" })),
+          { path: "idle" as const, value: new Idle({ userId: "user-1" }) },
           new Submit({ value: "request-1" })
         )
       )
@@ -5405,24 +6150,31 @@ describe("Machine", () => {
     Machine.make({
       states: ParallelCounterStates.states,
       events: Machine.events(AdvanceCounters),
-      initial: () =>
-        ParallelCounterStates.initial.running(
-          new CounterRunning({}),
-          (running) => running.left(new LeftCounter({ value: 0 })).right(new RightCounter({ value: 0 }))
-        )
+      initial: {
+        target: (to) => to.running.initial(),
+        resolve: ({ target }) =>
+          target(
+            new CounterRunning({}),
+            (running) => running.left(new LeftCounter({ value: 0 })).right(new RightCounter({ value: 0 }))
+          )
+      }
     }).handle({
       running: {
         states: {
           left: {
             on: {
-              AdvanceCounters: ({ state, target }) =>
-                target.branch.running.left(new LeftCounter({ value: state.value + 1 }))
+              AdvanceCounters: Machine.transition({
+                target: (to) => to.branch.running.left(),
+                resolve: ({ state, target }) => target(new LeftCounter({ value: state.value + 1 }))
+              })
             }
           },
           right: {
             on: {
-              AdvanceCounters: ({ state, target }) =>
-                target.branch.running.right(new RightCounter({ value: state.value + 1 }))
+              AdvanceCounters: Machine.transition({
+                target: (to) => to.branch.running.right(),
+                resolve: ({ state, target }) => target(new RightCounter({ value: state.value + 1 }))
+              })
             }
           }
         }
@@ -5434,11 +6186,17 @@ describe("Machine", () => {
     return Machine.make({
       states: states.states,
       events: Machine.events(ConcurrentPing),
-      initial: () => states.initial.ConcurrentIdle(new ConcurrentIdle({}))
+      initial: {
+        target: (to) => to.ConcurrentIdle(),
+        resolve: ({ target }) => target(new ConcurrentIdle({}))
+      }
     }).handle({
       ConcurrentIdle: {
         on: {
-          ConcurrentPing: ({ target }) => target.none()
+          ConcurrentPing: Machine.transition({
+            target: (to) => to.none(),
+            resolve: () => undefined
+          })
         }
       }
     })
@@ -5492,7 +6250,7 @@ describe("Machine", () => {
 
       assert.deepStrictEqual(yield* ref.snapshot, {
         status: "stopped",
-        state: { path: "ConcurrentIdle", value: new ConcurrentIdle({}) }
+        state: { path: "ConcurrentIdle" as const, value: new ConcurrentIdle({}) }
       })
     }))
 

--- a/test/machine/MachineReferences.test.ts
+++ b/test/machine/MachineReferences.test.ts
@@ -19,9 +19,12 @@ describe("machine reference event channels", () => {
         states: states.states,
         events: Machine.events(),
         emittedEvents: Emissions,
-        initial: () => {
-          initializations += 1
-          return states.initial.Idle(new Idle({}))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => {
+            initializations += 1
+            return target(new Idle({}))
+          }
         }
       }).handle({
         Idle: {
@@ -70,7 +73,10 @@ describe("machine reference event channels", () => {
         states: states.states,
         events: Machine.events(),
         emittedEvents: Emissions,
-        initial: () => states.initial.Idle(new Idle({}))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({}))
+        }
       }).handle({
         Idle: {
           entry: (_, enqueue) => {
@@ -109,14 +115,20 @@ describe("machine reference event channels", () => {
         states: states.states,
         events: Events,
         emittedEvents: Emissions,
-        initial: () => states.initial.Idle(new Idle({}))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({}))
+        }
       }).handle({
         Idle: {
           on: {
-            Publish: ({ event, target }, enqueue) => {
-              enqueue.emit(Emissions.Published({ value: event.value }))
-              return target.none()
-            }
+            Publish: Machine.transition({
+              target: (to) => to.none(),
+              resolve: ({ event }, enqueue) => {
+                enqueue.emit(Emissions.Published({ value: event.value }))
+                return undefined
+              }
+            })
           }
         }
       })
@@ -159,14 +171,20 @@ describe("machine reference event channels", () => {
         states: states.states,
         events: Events,
         emittedEvents: Emissions,
-        initial: () => states.initial.Idle(new Idle({}))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({}))
+        }
       }).handle({
         Idle: {
           on: {
-            Publish: ({ target }, enqueue) => {
-              enqueue.emit(Emissions.Published({ value: "invalid" } as never))
-              return target.none()
-            }
+            Publish: Machine.transition({
+              target: (to) => to.none(),
+              resolve: (_, enqueue) => {
+                enqueue.emit(Emissions.Published({ value: "invalid" } as never))
+                return undefined
+              }
+            })
           }
         }
       })
@@ -212,18 +230,24 @@ describe("machine reference event channels", () => {
         events: ChildEvents,
         parentEvents: ParentEvents,
         emittedEvents: ChildEmissions,
-        initial: () => childStates.initial.Waiting(new Waiting({}))
+        initial: {
+          target: (to) => to.Waiting(),
+          resolve: ({ target }) => target(new Waiting({}))
+        }
       }).handle({
         Waiting: {
           on: {
-            Trigger: ({ parent, target }, enqueue) => {
-              rootHadParent = parent !== undefined
-              enqueue.emit(ChildEmissions.Notice({ value: 1 }))
-              if (parent !== undefined) {
-                enqueue.sendTo(parent, ParentEvents.ChildReported({ value: 1 }))
+            Trigger: Machine.transition({
+              target: (to) => to.full.Reported(),
+              resolve: ({ parent, target }, enqueue) => {
+                rootHadParent = parent !== undefined
+                enqueue.emit(ChildEmissions.Notice({ value: 1 }))
+                if (parent !== undefined) {
+                  enqueue.sendTo(parent, ParentEvents.ChildReported({ value: 1 }))
+                }
+                return target(new Reported({}))
               }
-              return target.full.Reported(new Reported({}))
-            }
+            })
           }
         },
         Reported: {}
@@ -249,13 +273,22 @@ describe("machine reference event channels", () => {
       const parentMachine = Machine.make({
         states: parentStates.states,
         events: Machine.events(ParentEvents, Notice),
-        initial: () => parentStates.initial.Awaiting(new Awaiting({}))
+        initial: {
+          target: (to) => to.Awaiting(),
+          resolve: ({ target }) => target(new Awaiting({}))
+        }
       }).handle({
         Awaiting: {
           invoke: Machine.invoke({ child: Child }),
           on: {
-            ChildReported: ({ target }) => target.full.Finished(new Finished({ source: "parent event" })),
-            Notice: ({ target }) => target.full.Finished(new Finished({ source: "emission" }))
+            ChildReported: Machine.transition({
+              target: (to) => to.full.Finished(),
+              resolve: ({ target }) => target(new Finished({ source: "parent event" }))
+            }),
+            Notice: Machine.transition({
+              target: (to) => to.full.Finished(),
+              resolve: ({ target }) => target(new Finished({ source: "emission" }))
+            })
           }
         },
         Finished: { output: ({ state }) => state.source }
@@ -287,15 +320,24 @@ describe("machine reference event channels", () => {
         states: childStates.states,
         events: Machine.events(),
         parentEvents: ParentEvents,
-        initial: () => childStates.initial.ChildIdle(new ChildIdle({}))
+        initial: {
+          target: (to) => to.ChildIdle(),
+          resolve: ({ target }) => target(new ChildIdle({}))
+        }
       })
       const childMachine = childDefinition.handle({
         ChildIdle: {
           invoke: childDefinition.invoke({
             id: "notify-ready",
             effect: ({ parent }) => parent === undefined ? Effect.void : parent.send(ParentEvents.ChildReady()),
-            onDone: ({ target }) => target.none(),
-            onFailure: ({ target }) => target.none()
+            onDone: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            }),
+            onFailure: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            })
           })
         }
       })
@@ -307,12 +349,24 @@ describe("machine reference event channels", () => {
       const parentMachine = Machine.make({
         states: parentStates.states,
         events: ParentEvents,
-        initial: () => parentStates.initial.ParentWaiting(new ParentWaiting({}))
+        initial: {
+          target: (to) => to.ParentWaiting(),
+          resolve: ({ target }) => target(new ParentWaiting({}))
+        }
       }).handle({
         ParentWaiting: {
-          invoke: Machine.invoke({ child: Child, onFailure: ({ target }) => target.none() }),
+          invoke: Machine.invoke({
+            child: Child,
+            onFailure: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            })
+          }),
           on: {
-            ChildReady: ({ target }) => target.full.ParentDone(new ParentDone({}))
+            ChildReady: Machine.transition({
+              target: (to) => to.full.ParentDone(),
+              resolve: ({ target }) => target(new ParentDone({}))
+            })
           }
         },
         ParentDone: { output: () => undefined }

--- a/test/machine/PublicPrototype.test.ts
+++ b/test/machine/PublicPrototype.test.ts
@@ -10,7 +10,10 @@ it("uses the public pipeable and inspectable prototypes", () => {
   const machine = Machine.make({
     states: states.states,
     events: Machine.events(Start),
-    initial: () => states.initial.Idle(new Idle())
+    initial: {
+      target: (to) => to.Idle(),
+      resolve: ({ target }) => target(new Idle())
+    }
   })
 
   assert.strictEqual(machine.pipe((value) => value), machine)

--- a/test/machine/Resume.test.ts
+++ b/test/machine/Resume.test.ts
@@ -70,7 +70,10 @@ describe("Machine.resume", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: () => states.initial.Inactive(new Inactive({}))
+        initial: {
+          target: (to) => to.Inactive(),
+          resolve: ({ target }) => target(new Inactive({}))
+        }
       }).handle({
         Root: {
           invoke: Machine.invoke({
@@ -121,10 +124,22 @@ describe("Machine.resume", () => {
           })
         }
       })
-      const snapshot = states.initial.Root(new Root({}), (root) =>
-        root
-          .left(new Left({}), (left) => left.On(new LeftOn({})))
-          .right(new Right({}), (right) => right.On(new RightOn({}))))
+      const snapshot = {
+        path: "Root" as const,
+        value: new Root({}),
+        states: {
+          left: {
+            path: "Root.left" as const,
+            value: new Left({}),
+            state: { path: "Root.left.On" as const, value: new LeftOn({}) }
+          },
+          right: {
+            path: "Root.right" as const,
+            value: new Right({}),
+            state: { path: "Root.right.On" as const, value: new RightOn({}) }
+          }
+        }
+      }
 
       const ref = yield* Machine.resume(machine, snapshot)
       yield* Effect.forEach(Array.from({ length: 20 }), () => Effect.yieldNow, { discard: true })
@@ -153,19 +168,53 @@ describe("Machine.resume", () => {
           }
         }
       })
-      const initial = states.initial.Root(new Root({}), (root) =>
-        root
-          .left(new Left({}), (left) => left.A(new LeftA({})))
-          .right(new Right({}), (right) => right.A(new RightA({}))))
-      const machine = Machine.make({ states: states.states, events: Machine.events(Advance), initial: () => initial })
+      const initial = {
+        path: "Root" as const,
+        value: new Root({}),
+        states: {
+          left: {
+            path: "Root.left" as const,
+            value: new Left({}),
+            state: { path: "Root.left.A" as const, value: new LeftA({}) }
+          },
+          right: {
+            path: "Root.right" as const,
+            value: new Right({}),
+            state: { path: "Root.right.A" as const, value: new RightA({}) }
+          }
+        }
+      }
+      const machine = Machine.make({
+        states: states.states,
+        events: Machine.events(Advance),
+        initial: { target: (to) => to.Root.initial(), resolve: () => initial }
+      })
         .handle({
           Root: {
             states: {
               left: {
-                states: { A: { on: { Advance: ({ target }) => target.local.B(new LeftB({})) } } }
+                states: {
+                  A: {
+                    on: {
+                      Advance: Machine.transition({
+                        target: (to) => to.local.B(),
+                        resolve: ({ target }) => target(new LeftB({}))
+                      })
+                    }
+                  }
+                }
               },
               right: {
-                states: { A: { on: { Advance: ({ target }) => target.local.B(new RightB({})) } } }
+                states: {
+                  A: {
+                    on: {
+                      Advance: Machine.transition({
+                        target: (to) => to.local.B(),
+                        resolve: ({ target }) => target(new RightB({}))
+                      })
+                    }
+                  }
+                }
               }
             }
           }
@@ -180,18 +229,18 @@ describe("Machine.resume", () => {
           snapshot.state.states.right.state.path === "Root.right.B"
       )
       assert.deepStrictEqual(yield* ref.state, {
-        path: "Root",
+        path: "Root" as const,
         value: new Root({}),
         states: {
           left: {
-            path: "Root.left",
+            path: "Root.left" as const,
             value: new Left({}),
-            state: { path: "Root.left.B", value: new LeftB({}) }
+            state: { path: "Root.left.B" as const, value: new LeftB({}) }
           },
           right: {
-            path: "Root.right",
+            path: "Root.right" as const,
             value: new Right({}),
-            state: { path: "Root.right.B", value: new RightB({}) }
+            state: { path: "Root.right.B" as const, value: new RightB({}) }
           }
         }
       })
@@ -207,12 +256,22 @@ describe("Machine.resume", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Finish),
-        initial: () => states.initial.Count(new Count({ value: 0 }))
+        initial: {
+          target: (to) => to.Count(),
+          resolve: ({ target }) => target(new Count({ value: 0 }))
+        }
       }).handle({
-        Count: { on: { Finish: ({ target }) => target.full.Done(new Done({ value: 9 })) } },
+        Count: {
+          on: {
+            Finish: Machine.transition({
+              target: (to) => to.full.Done(),
+              resolve: ({ target }) => target(new Done({ value: 9 }))
+            })
+          }
+        },
         Done: { output: ({ state }) => state.value }
       })
-      const logical = states.initial.Done(new Done({ value: 9 }))
+      const logical = { path: "Done" as const, value: new Done({ value: 9 }) }
       const decoded = yield* Machine.decodeSnapshot(machine, yield* Machine.encodeSnapshot(machine, logical))
       const ref = yield* Machine.resume(machine, decoded)
 
@@ -235,17 +294,26 @@ describe("Machine.resume", () => {
         Next
       })
       const logical: Machine.Machine.Snapshot<typeof states.states> = {
-        path: "Flow",
+        path: "Flow" as const,
         value: new Flow({}),
-        state: { path: "Flow.Finished", value: new Finished({}) },
+        state: { path: "Flow.Finished" as const, value: new Finished({}) },
         completed: [
-          { path: "Flow.Finished", output: undefined },
-          { path: "Flow", output: undefined }
+          { path: "Flow.Finished" as const, output: undefined },
+          { path: "Flow" as const, output: undefined }
         ]
       }
-      const machine = Machine.make({ states: states.states, events: Machine.events(Ping), initial: () => logical })
+      const machine = Machine.make({
+        states: states.states,
+        events: Machine.events(Ping),
+        initial: { target: (to) => to.Flow.initial(), resolve: () => logical }
+      })
         .handle({
-          Flow: { onDone: ({ target }) => target.full.Next(new Next({})) },
+          Flow: {
+            onDone: Machine.transition({
+              target: (to) => to.full.Next(),
+              resolve: ({ target }) => target(new Next({}))
+            })
+          },
           Next: {}
         })
       const decoded = yield* Machine.decodeSnapshot(machine, yield* Machine.encodeSnapshot(machine, logical))
@@ -266,13 +334,21 @@ describe("Machine.resume", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Ping),
-        initial: () => states.initial.A(new A({}))
+        initial: {
+          target: (to) => to.A(),
+          resolve: ({ target }) => target(new A({}))
+        }
       }).handle({
-        A: { always: ({ target }) => target.full.B(new B({})) },
+        A: {
+          always: Machine.transition({
+            target: (to) => to.full.B(),
+            resolve: ({ target }) => target(new B({}))
+          })
+        },
         B: {}
       })
 
-      const ref = yield* Machine.resume(machine, states.initial.A(new A({})))
+      const ref = yield* Machine.resume(machine, { path: "A" as const, value: new A({}) })
       assert.strictEqual((yield* ref.state).path, "A")
       yield* ref.send(new Ping({}))
       yield* Effect.yieldNow
@@ -290,30 +366,39 @@ describe("Machine.resume", () => {
         states: states.states,
         events: Machine.events(Cancel),
         internalEvents: Machine.internalEvents(Timeout),
-        initial: () => states.initial.Cancelled(new Cancelled({}))
+        initial: {
+          target: (to) => to.Cancelled(),
+          resolve: ({ target }) => target(new Cancelled({}))
+        }
       }).handle({
         Waiting: {
           invoke: Machine.invoke({
             id: "timeout",
             after: "1 second",
-            onDone: ({ target }) => target.full.TimedOut(new TimedOut({}))
+            onDone: Machine.transition({
+              target: (to) => to.full.TimedOut(),
+              resolve: ({ target }) => target(new TimedOut({}))
+            })
           }),
           on: {
-            Cancel: ({ target }) => target.full.Cancelled(new Cancelled({}))
+            Cancel: Machine.transition({
+              target: (to) => to.full.Cancelled(),
+              resolve: ({ target }) => target(new Cancelled({}))
+            })
           }
         },
         Cancelled: {},
         TimedOut: {}
       })
 
-      const first = yield* Machine.resume(machine, states.initial.Waiting(new Waiting({})))
+      const first = yield* Machine.resume(machine, { path: "Waiting" as const, value: new Waiting({}) })
       yield* TestClock.adjust("999 millis")
       assert.strictEqual((yield* first.state).path, "Waiting")
       yield* TestClock.adjust("1 millis")
       yield* waitFor(first, (snapshot) => snapshot.state.path === "TimedOut")
       yield* first.stop
 
-      const second = yield* Machine.resume(machine, states.initial.Waiting(new Waiting({})))
+      const second = yield* Machine.resume(machine, { path: "Waiting" as const, value: new Waiting({}) })
       yield* sendAndWait(second, new Cancel({}), (snapshot) => snapshot.state.path === "Cancelled")
       yield* TestClock.adjust("1 second")
       assert.strictEqual((yield* second.state).path, "Cancelled")
@@ -333,22 +418,28 @@ describe("Machine.resume", () => {
         states: states.states,
         events: Machine.events(),
         internalEvents: Machine.internalEvents(LoadedEvent),
-        initial: () => states.initial.Loaded(new Loaded({ value: "initial" }))
+        initial: {
+          target: (to) => to.Loaded(),
+          resolve: ({ target }) => target(new Loaded({ value: "initial" }))
+        }
       }).handle({
         Loading: {
           invoke: Machine.invoke({
             id: "load",
             effect: () => Ref.updateAndGet(runs, (n) => n + 1).pipe(Effect.as("fresh")),
-            onDone: ({ output, target }) => target.full.Loaded(new Loaded({ value: output }))
+            onDone: Machine.transition({
+              target: (to) => to.full.Loaded(),
+              resolve: ({ output, target }) => target(new Loaded({ value: output }))
+            })
           })
         },
         Loaded: {}
       })
 
-      const ref = yield* Machine.resume(machine, states.initial.Loading(new Loading({})))
+      const ref = yield* Machine.resume(machine, { path: "Loading" as const, value: new Loading({}) })
       yield* waitFor(ref, (snapshot) => snapshot.state.path === "Loaded")
       assert.strictEqual(yield* Ref.get(runs), 1)
-      assert.deepStrictEqual(yield* ref.state, states.initial.Loaded(new Loaded({ value: "fresh" })))
+      assert.deepStrictEqual(yield* ref.state, { path: "Loaded" as const, value: new Loaded({ value: "fresh" }) })
       yield* ref.stop
     }))
 
@@ -368,7 +459,10 @@ describe("Machine.resume", () => {
         states: states.states,
         events: Machine.events(),
         internalEvents: Machine.internalEvents(FailedEvent),
-        initial: () => states.initial.Failed(new Failed({ message: "initial" }))
+        initial: {
+          target: (to) => to.Failed(),
+          resolve: ({ target }) => target(new Failed({ message: "initial" }))
+        }
       }).handle({
         Loading: {
           invoke: Machine.invoke({
@@ -377,16 +471,19 @@ describe("Machine.resume", () => {
               Ref.update(runs, (n) => n + 1).pipe(
                 Effect.andThen(Effect.fail(new LoadFailure({ message: "offline" })))
               ),
-            onFailure: ({ error, target }) => target.full.Failed(new Failed({ message: error.message }))
+            onFailure: Machine.transition({
+              target: (to) => to.full.Failed(),
+              resolve: ({ error, target }) => target(new Failed({ message: error.message }))
+            })
           })
         },
         Failed: {}
       })
 
-      const ref = yield* Machine.resume(machine, states.initial.Loading(new Loading({})))
+      const ref = yield* Machine.resume(machine, { path: "Loading" as const, value: new Loading({}) })
       yield* waitFor(ref, (snapshot) => snapshot.state.path === "Failed")
       assert.strictEqual(yield* Ref.get(runs), 1)
-      assert.deepStrictEqual(yield* ref.state, states.initial.Failed(new Failed({ message: "offline" })))
+      assert.deepStrictEqual(yield* ref.state, { path: "Failed" as const, value: new Failed({ message: "offline" }) })
       yield* ref.stop
     }))
 
@@ -406,10 +503,18 @@ describe("Machine.resume", () => {
       const child = Machine.make({
         states: childStates.states,
         events: Machine.events(ChildFinish),
-        initial: () => childStates.initial.ChildIdle(new ChildIdle({ value: 1 }))
+        initial: {
+          target: (to) => to.ChildIdle(),
+          resolve: ({ target }) => target(new ChildIdle({ value: 1 }))
+        }
       }).handle({
         ChildIdle: {
-          on: { ChildFinish: ({ state, target }) => target.full.ChildDone(new ChildDone({ value: state.value + 1 })) }
+          on: {
+            ChildFinish: Machine.transition({
+              target: (to) => to.full.ChildDone(),
+              resolve: ({ state, target }) => target(new ChildDone({ value: state.value + 1 }))
+            })
+          }
         },
         ChildDone: { output: ({ state }) => state.value }
       })
@@ -418,28 +523,34 @@ describe("Machine.resume", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(ChildOutput),
-        initial: () => states.initial.ChildOutput(new ChildOutput({ value: 0 }))
+        initial: {
+          target: (to) => to.ChildOutput(),
+          resolve: ({ target }) => target(new ChildOutput({ value: 0 }))
+        }
       }).handle({
         Parent: {
           invoke: Machine.invoke({
             child: Child,
-            onDone: ({ output, target }) => target.full.ChildOutput(new ChildOutput({ value: output }))
+            onDone: Machine.transition({
+              target: (to) => to.full.ChildOutput(),
+              resolve: ({ output, target }) => target(new ChildOutput({ value: output }))
+            })
           })
         },
         ChildOutput: {}
       })
 
-      const ref = yield* Machine.resume(machine, states.initial.Parent(new Parent({})))
+      const ref = yield* Machine.resume(machine, { path: "Parent" as const, value: new Parent({}) })
       const active = yield* ref.childChanges(Child).pipe(
         Stream.filter(Option.isSome),
         Stream.take(1),
         Stream.runCollect,
         Effect.map((values) => values[0]!.value)
       )
-      assert.deepStrictEqual(yield* active.state, childStates.initial.ChildIdle(new ChildIdle({ value: 1 })))
+      assert.deepStrictEqual(yield* active.state, { path: "ChildIdle" as const, value: new ChildIdle({ value: 1 }) })
       yield* active.send(new ChildFinish({}))
       yield* waitFor(ref, (snapshot) => snapshot.state.path === "ChildOutput")
-      assert.deepStrictEqual(yield* ref.state, states.initial.ChildOutput(new ChildOutput({ value: 2 })))
+      assert.deepStrictEqual(yield* ref.state, { path: "ChildOutput" as const, value: new ChildOutput({ value: 2 }) })
       assert(Option.isNone(yield* ref.child(Child)))
       yield* ref.stop
     }))
@@ -459,19 +570,35 @@ describe("Machine.resume", () => {
           }
         }
       })
-      const valid = states.initial.Root(new Root({}), (root) =>
-        root
-          .left(new Region({}), (left) => left.Leaf(new Leaf({ value: 1 })))
-          .right(new Region({}), (right) => right.Leaf(new Leaf({ value: 2 }))))
-      const machine = Machine.make({ states: states.states, events: Machine.events(), initial: () => valid })
+      const valid = {
+        path: "Root" as const,
+        value: new Root({}),
+        states: {
+          left: {
+            path: "Root.left" as const,
+            value: new Region({}),
+            state: { path: "Root.left.Leaf" as const, value: new Leaf({ value: 1 }) }
+          },
+          right: {
+            path: "Root.right" as const,
+            value: new Region({}),
+            state: { path: "Root.right.Leaf" as const, value: new Leaf({ value: 2 }) }
+          }
+        }
+      }
+      const machine = Machine.make({
+        states: states.states,
+        events: Machine.events(),
+        initial: { target: (to) => to.Root.initial(), resolve: () => valid }
+      })
       const forged: ReadonlyArray<unknown> = [
-        { path: "Missing", value: {} },
-        { path: "Root", value: new Root({}), states: { left: valid.states.left } },
+        { path: "Missing" as const, value: {} },
+        { path: "Root" as const, value: new Root({}), states: { left: valid.states.left } },
         {
           ...valid,
           states: {
             ...valid.states,
-            left: { path: "Root.left", value: new Region({}) }
+            left: { path: "Root.left" as const, value: new Region({}) }
           }
         },
         {
@@ -481,7 +608,7 @@ describe("Machine.resume", () => {
             left: { ...valid.states.left, state: { ...valid.states.left.state, value: { _tag: "Leaf", value: "x" } } }
           }
         },
-        { ...valid, completed: [{ path: "Root.left.Leaf", output: undefined }] },
+        { ...valid, completed: [{ path: "Root.left.Leaf" as const, output: undefined }] },
         { ...valid, completed: {} },
         { ...valid, history: { missing: { mode: "deep", active: [], values: {} } } }
       ]
@@ -501,11 +628,17 @@ describe("Machine.resume", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Add),
-        initial: () => states.initial.Count(new Count({ value: 0 }))
+        initial: {
+          target: (to) => to.Count(),
+          resolve: ({ target }) => target(new Count({ value: 0 }))
+        }
       }).handle({
         Count: {
           on: {
-            Add: ({ event, state, target }) => target.full.Count(new Count({ value: state.value + event.value }))
+            Add: Machine.transition({
+              target: (to) => to.full.Count(),
+              resolve: ({ event, state, target }) => target(new Count({ value: state.value + event.value }))
+            })
           }
         }
       })

--- a/test/machine/RuntimeDifferential.test.ts
+++ b/test/machine/RuntimeDifferential.test.ts
@@ -54,16 +54,28 @@ describe("pure planning and managed runtime differential", () => {
         states: states.states,
         events: Machine.events(Cascade, Ignore, Finish),
         internalEvents: Machine.internalEvents(Increment),
-        initial: () => states.initial.Count(new Count({ value: 0 }))
+        initial: {
+          target: (to) => to.Count(),
+          resolve: ({ target }) => target(new Count({ value: 0 }))
+        }
       }).handle({
         Count: {
           on: {
-            Cascade: (_, enqueue) => {
-              enqueue.raise(new Increment({}))
-              return _.target.none()
-            },
-            Increment: ({ state, target }) => target.full.Count(new Count({ value: state.value + 1 })),
-            Finish: ({ state, target }) => target.full.Done(new Done({ value: state.value }))
+            Cascade: Machine.transition({
+              target: (to) => to.none(),
+              resolve: (_, enqueue) => {
+                enqueue.raise(new Increment({}))
+                return undefined
+              }
+            }),
+            Increment: Machine.transition({
+              target: (to) => to.full.Count(),
+              resolve: ({ state, target }) => target(new Count({ value: state.value + 1 }))
+            }),
+            Finish: Machine.transition({
+              target: (to) => to.full.Done(),
+              resolve: ({ state, target }) => target(new Done({ value: state.value }))
+            })
           }
         },
         Done: { output: ({ state }) => state.value }
@@ -140,69 +152,85 @@ describe("pure planning and managed runtime differential", () => {
         states: states.states,
         events: Machine.events(Advance, Inspect, Finish),
         internalEvents: Machine.internalEvents(Bump),
-        initial: () =>
-          states.initial.Running(
-            new Running({}),
-            (running) => running.Left(new Left({ value: 0 })).Right(new Right({ value: 0 }))
-          )
+        initial: {
+          target: (to) => to.Running.initial(),
+          resolve: ({ target }) =>
+            target(
+              new Running({}),
+              (running) => running.Left(new Left({ value: 0 })).Right(new Right({ value: 0 }))
+            )
+        }
       }).handle({
         Running: {
           on: {
-            Finish: ({ snapshot, target }) => {
-              if (snapshot.path !== "Running") throw new Error("expected Running snapshot")
-              return target.full.Done(
-                new Done({
-                  value: snapshot.states.Left.value.value + snapshot.states.Right.value.value
-                })
-              )
-            }
+            Finish: Machine.transition({
+              target: (to) => to.full.Done(),
+              resolve: ({ snapshot, target }) => {
+                if (snapshot.path !== "Running") throw new Error("expected Running snapshot")
+                return target(
+                  new Done({
+                    value: snapshot.states.Left.value.value + snapshot.states.Right.value.value
+                  })
+                )
+              }
+            })
           },
           states: {
             Left: {
               on: {
-                Advance: ({ state, target }, enqueue) => {
-                  enqueue.raise(new Bump({}))
-                  return target.branch.Running.Left(new Left({ value: state.value + 1 }))
-                }
+                Advance: Machine.transition({
+                  target: (to) => to.branch.Running.Left(),
+                  resolve: ({ state, target }, enqueue) => {
+                    enqueue.raise(new Bump({}))
+                    return target(new Left({ value: state.value + 1 }))
+                  }
+                })
               }
             },
             Right: {
               on: {
-                Advance: ({ state, target }) => target.branch.Running.Right(new Right({ value: state.value + 10 })),
-                Bump: ({ state, target }) => target.branch.Running.Right(new Right({ value: state.value + 100 })),
-                Inspect: (context) => {
-                  const { state, containingState, ancestors, snapshot } = context
-                  if (snapshot.path !== "Running") throw new Error("expected Running snapshot")
-                  const expectedKeys = [
-                    "self",
-                    "parent",
-                    "state",
-                    "containingState",
-                    "ancestors",
-                    "event",
-                    "snapshot",
-                    "target"
-                  ]
-                  const spread = { ...context }
-                  assert.deepStrictEqual(Object.keys(context), expectedKeys)
-                  assert.deepStrictEqual(Object.keys(spread), expectedKeys)
-                  assert.strictEqual(spread.self, context.self)
-                  assert.strictEqual(spread.parent, context.parent)
-                  assert.strictEqual(spread.state, state)
-                  assert.strictEqual(spread.containingState, containingState)
-                  assert.strictEqual(spread.ancestors, ancestors)
-                  assert.strictEqual(spread.event, context.event)
-                  assert.strictEqual(spread.snapshot, snapshot)
-                  assert.strictEqual(spread.target, context.target)
-                  observations.push({
-                    state: state.value,
-                    parent: containingState._tag,
-                    parents: ancestors.Running._tag,
-                    left: snapshot.states.Left.value.value,
-                    right: snapshot.states.Right.value.value
-                  })
-                  return context.target.none()
-                }
+                Advance: Machine.transition({
+                  target: (to) => to.branch.Running.Right(),
+                  resolve: ({ state, target }) => target(new Right({ value: state.value + 10 }))
+                }),
+                Bump: Machine.transition({
+                  target: (to) => to.branch.Running.Right(),
+                  resolve: ({ state, target }) => target(new Right({ value: state.value + 100 }))
+                }),
+                Inspect: Machine.transition({
+                  target: (to) => to.none(),
+                  resolve: (context) => {
+                    const { state, containingState, ancestors, snapshot } = context
+                    if (snapshot.path !== "Running") throw new Error("expected Running snapshot")
+                    const expectedKeys = [
+                      "self",
+                      "parent",
+                      "state",
+                      "containingState",
+                      "ancestors",
+                      "event",
+                      "snapshot"
+                    ]
+                    const spread = { ...context }
+                    assert.deepStrictEqual(Object.keys(context), expectedKeys)
+                    assert.deepStrictEqual(Object.keys(spread), expectedKeys)
+                    assert.strictEqual(spread.self, context.self)
+                    assert.strictEqual(spread.parent, context.parent)
+                    assert.strictEqual(spread.state, state)
+                    assert.strictEqual(spread.containingState, containingState)
+                    assert.strictEqual(spread.ancestors, ancestors)
+                    assert.strictEqual(spread.event, context.event)
+                    assert.strictEqual(spread.snapshot, snapshot)
+                    observations.push({
+                      state: state.value,
+                      parent: containingState._tag,
+                      parents: ancestors.Running._tag,
+                      left: snapshot.states.Left.value.value,
+                      right: snapshot.states.Right.value.value
+                    })
+                    return undefined
+                  }
+                })
               }
             }
           }
@@ -439,7 +467,10 @@ describe("pure planning and managed runtime differential", () => {
         events: Machine.events(Begin),
         internalEvents: Machine.internalEvents(RaisedOne, RaisedTwo),
         emittedEvents: Machine.emittedEvents(Notice),
-        initial: () => states.initial.Idle(new Idle({}))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({}))
+        }
       }).handle({
         Idle: {
           entry: (_, enqueue) => {
@@ -447,12 +478,15 @@ describe("pure planning and managed runtime differential", () => {
             enqueue.emit(new Notice({ label: "initial" }))
           },
           on: {
-            Begin: ({ target }, enqueue) => {
-              record("transition:begin")
-              enqueue.emit(new Notice({ label: "transition" }))
-              enqueue.raise(new RaisedOne({}))
-              return target.full.Working(new Working({}))
-            }
+            Begin: Machine.transition({
+              target: (to) => to.full.Working(),
+              resolve: ({ target }, enqueue) => {
+                record("transition:begin")
+                enqueue.emit(new Notice({ label: "transition" }))
+                enqueue.raise(new RaisedOne({}))
+                return target(new Working({}))
+              }
+            })
           }
         },
         Working: {
@@ -462,16 +496,22 @@ describe("pure planning and managed runtime differential", () => {
             enqueue.raise(new RaisedTwo({}))
           },
           on: {
-            RaisedOne: (_, enqueue) => {
-              record("raised:one")
-              enqueue.emit(new Notice({ label: "raised-one" }))
-              return _.target.none()
-            },
-            RaisedTwo: ({ target }, enqueue) => {
-              record("raised:two")
-              enqueue.emit(new Notice({ label: "raised-two" }))
-              return target.full.Finished(new Finished({}))
-            }
+            RaisedOne: Machine.transition({
+              target: (to) => to.none(),
+              resolve: (_, enqueue) => {
+                record("raised:one")
+                enqueue.emit(new Notice({ label: "raised-one" }))
+                return undefined
+              }
+            }),
+            RaisedTwo: Machine.transition({
+              target: (to) => to.full.Finished(),
+              resolve: ({ target }, enqueue) => {
+                record("raised:two")
+                enqueue.emit(new Notice({ label: "raised-two" }))
+                return target(new Finished({}))
+              }
+            })
           }
         },
         Finished: {
@@ -549,9 +589,19 @@ describe("pure planning and managed runtime differential", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Ignore, Go),
-        initial: () => states.initial.Idle(new Idle({}))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({}))
+        }
       }).handle({
-        Idle: { on: { Go: () => states.initial.Active(new Active({})) } },
+        Idle: {
+          on: {
+            Go: Machine.transition({
+              target: (to) => to.full.Active(),
+              resolve: ({ target }) => target(new Active({}))
+            })
+          }
+        },
         Active: {}
       })
       const initial = yield* Machine.planInitial(machine)

--- a/test/machine/Scheduling.test.ts
+++ b/test/machine/Scheduling.test.ts
@@ -21,19 +21,28 @@ describe("machine scheduling", () => {
         states: states.states,
         events: Machine.events(StartBurst),
         internalEvents: Machine.internalEvents(Burst),
-        initial: () => states.initial.SchedulingActive(new SchedulingActive({ count: 0 }))
+        initial: {
+          target: (to) => to.SchedulingActive(),
+          resolve: ({ target }) => target(new SchedulingActive({ count: 0 }))
+        }
       }).handle({
         SchedulingActive: {
           on: {
-            StartBurst: ({ state, target }, enqueue) => {
-              enqueue.raise(new Burst({}))
-              return target.full.SchedulingActive(state)
-            },
-            Burst: ({ state, target }, enqueue) => {
-              const count = state.count + 1
-              if (count < burstSize) enqueue.raise(new Burst({}))
-              return target.full.SchedulingActive(new SchedulingActive({ count }))
-            }
+            StartBurst: Machine.transition({
+              target: (to) => to.full.SchedulingActive(),
+              resolve: ({ state, target }, enqueue) => {
+                enqueue.raise(new Burst({}))
+                return target(state)
+              }
+            }),
+            Burst: Machine.transition({
+              target: (to) => to.full.SchedulingActive(),
+              resolve: ({ state, target }, enqueue) => {
+                const count = state.count + 1
+                if (count < burstSize) enqueue.raise(new Burst({}))
+                return target(new SchedulingActive({ count }))
+              }
+            })
           }
         }
       })

--- a/test/machine/SnapshotCodecAdversarial.test.ts
+++ b/test/machine/SnapshotCodecAdversarial.test.ts
@@ -54,34 +54,45 @@ const topologyMachine = Machine.make({
   id: "codec-topology",
   states: TopologyStates.states,
   events: Machine.events(),
-  initial: () => topologyActive()
+  initial: { target: (to) => to.Root.initial(), resolve: () => topologyActive() }
 })
 
-const topologyActive = () =>
-  TopologyStates.initial.Root(new Root({ id: "root-1" }), (root) =>
-    root
-      .left(new Left({}), (left) => left.working(new LeftWorking({ task: "left-1" })))
-      .right(new Right({}), (right) => right.working(new RightWorking({ enabled: true }))))
+const topologyActive = () => ({
+  path: "Root" as const,
+  value: new Root({ id: "root-1" }),
+  states: {
+    left: {
+      path: "Root.left" as const,
+      value: new Left({}),
+      state: { path: "Root.left.working" as const, value: new LeftWorking({ task: "left-1" }) }
+    },
+    right: {
+      path: "Root.right" as const,
+      value: new Right({}),
+      state: { path: "Root.right.working" as const, value: new RightWorking({ enabled: true }) }
+    }
+  }
+})
 
 const topologyFinal = () =>
   ({
-    path: "Root",
+    path: "Root" as const,
     value: new Root({ id: "root-1" }),
     states: {
       left: {
-        path: "Root.left",
+        path: "Root.left" as const,
         value: new Left({}),
-        state: { path: "Root.left.done", value: new LeftDone({}) }
+        state: { path: "Root.left.done" as const, value: new LeftDone({}) }
       },
       right: {
-        path: "Root.right",
+        path: "Root.right" as const,
         value: new Right({}),
-        state: { path: "Root.right.done", value: new RightDone({}) }
+        state: { path: "Root.right.done" as const, value: new RightDone({}) }
       }
     },
     completed: [
-      { path: "Root.left.done", output: 7 },
-      { path: "Root.right.done", output: true }
+      { path: "Root.left.done" as const, output: 7 },
+      { path: "Root.right.done" as const, output: true }
     ]
   }) as Machine.Machine.Snapshot<typeof TopologyStates.states>
 
@@ -123,12 +134,15 @@ const historyMachine = Machine.make({
   id: "codec-history",
   states: HistoryStates.states,
   events: Machine.events(),
-  initial: () => HistoryStates.initial.Outside(new Outside({}))
+  initial: {
+    target: (to) => to.Outside(),
+    resolve: ({ target }) => target(new Outside({}))
+  }
 })
 
 const historySnapshot = () =>
   ({
-    ...HistoryStates.initial.Outside(new Outside({})),
+    ...{ path: "Outside" as const, value: new Outside({}) },
     history: {
       "Workspace.recent": {
         mode: "shallow" as const,
@@ -202,8 +216,8 @@ describe("snapshot codec adversarial boundaries", () => {
 
       const encodedFinal = yield* Machine.encodeSnapshot(topologyMachine, topologyFinal())
       assert.deepStrictEqual(encodedFinal.completed, [
-        { path: "Root.left.done", output: "7" },
-        { path: "Root.right.done", output: true }
+        { path: "Root.left.done" as const, output: "7" },
+        { path: "Root.right.done" as const, output: true }
       ])
     }))
 
@@ -228,9 +242,17 @@ describe("snapshot codec adversarial boundaries", () => {
         id: "codec-automatic-original",
         states: states.states,
         events: Machine.events(),
-        initial: () => states.initial.Before(new Before({}))
+        initial: {
+          target: (to) => to.Before(),
+          resolve: ({ target }) => target(new Before({}))
+        }
       }).handle({
-        Before: { always: ({ target }) => target.full.Boundary(new Boundary({})) },
+        Before: {
+          always: Machine.transition({
+            target: (to) => to.full.Boundary(),
+            resolve: ({ target }) => target(new Boundary({}))
+          })
+        },
         Boundary: {},
         After: {}
       })
@@ -238,10 +260,18 @@ describe("snapshot codec adversarial boundaries", () => {
         id: "codec-automatic-changed",
         states: states.states,
         events: Machine.events(),
-        initial: () => states.initial.Before(new Before({}))
+        initial: {
+          target: (to) => to.Before(),
+          resolve: ({ target }) => target(new Before({}))
+        }
       }).handle({
         Before: {},
-        Boundary: { always: ({ target }) => target.full.After(new After({})) },
+        Boundary: {
+          always: Machine.transition({
+            target: (to) => to.full.After(),
+            resolve: ({ target }) => target(new After({}))
+          })
+        },
         After: {}
       })
 
@@ -261,7 +291,7 @@ describe("snapshot codec adversarial boundaries", () => {
     Effect.gen(function*() {
       const valid = topologyActive()
       const malformed: ReadonlyArray<unknown> = [
-        { path: "Missing", value: {} },
+        { path: "Missing" as const, value: {} },
         { ...valid, states: { left: valid.states.left } },
         {
           ...valid,
@@ -303,7 +333,7 @@ describe("snapshot codec adversarial boundaries", () => {
       mutations.push(missingRegion)
 
       const extraCompoundBranch = structuredClone(encoded) as any
-      extraCompoundBranch.active.push({ path: "Root.left.done", value: { _tag: "CodecLeftDone" } })
+      extraCompoundBranch.active.push({ path: "Root.left.done" as const, value: { _tag: "CodecLeftDone" } })
       mutations.push(extraCompoundBranch)
 
       const impossibleAncestry = structuredClone(encoded) as any
@@ -333,11 +363,11 @@ describe("snapshot codec adversarial boundaries", () => {
       mutations.push(wrongOutput)
 
       const activeNotFinal = yield* Machine.encodeSnapshot(topologyMachine, topologyActive())
-      ;(activeNotFinal as any).completed = [{ path: "Root.left.working", output: undefined }]
+      ;(activeNotFinal as any).completed = [{ path: "Root.left.working" as const, output: undefined }]
       mutations.push(activeNotFinal)
 
       const inactiveFinal = yield* Machine.encodeSnapshot(topologyMachine, topologyActive())
-      ;(inactiveFinal as any).completed = [{ path: "Root.left.done", output: "1" }]
+      ;(inactiveFinal as any).completed = [{ path: "Root.left.done" as const, output: "1" }]
       mutations.push(inactiveFinal)
 
       for (const mutation of mutations) {
@@ -351,9 +381,9 @@ describe("snapshot codec adversarial boundaries", () => {
       const active = topologyActive()
       const malformed: ReadonlyArray<unknown> = [
         { ...final, completed: [...(final.completed ?? []), final.completed?.[0]] },
-        { ...final, completed: [{ path: "Root.left.missing", output: 1 }] },
-        { ...active, completed: [{ path: "Root.left.working", output: undefined }] },
-        { ...final, completed: [{ path: "Root.left.done", output: null }] }
+        { ...final, completed: [{ path: "Root.left.missing" as const, output: 1 }] },
+        { ...active, completed: [{ path: "Root.left.working" as const, output: undefined }] },
+        { ...final, completed: [{ path: "Root.left.done" as const, output: null }] }
       ]
 
       for (const snapshot of malformed) {

--- a/test/machine/SnapshotContext.test.ts
+++ b/test/machine/SnapshotContext.test.ts
@@ -31,14 +31,27 @@ const States = Machine.defineStates({
   }
 })
 
-const initial = () =>
-  States.initial.System(
-    new System({}),
-    (system) =>
-      system
-        .Playback(new Playback({}), (playback) => playback.Buffering(new Buffering({})))
-        .Network(new Network({}), (network) => network.Online(new Online({})))
-  )
+const initial = {
+  path: "System" as const,
+  value: new System({}),
+  states: {
+    Playback: {
+      path: "System.Playback" as const,
+      value: new Playback({}),
+      state: { path: "System.Playback.Buffering" as const, value: new Buffering({}) }
+    },
+    Network: {
+      path: "System.Network" as const,
+      value: new Network({}),
+      state: { path: "System.Network.Online" as const, value: new Online({}) }
+    }
+  }
+}
+
+const initialDefinition = {
+  target: (to: Machine.Machine.InitialSelector<typeof States.states>) => to.System.initial(),
+  resolve: () => initial
+}
 
 describe("Machine transition snapshot context", () => {
   it.effect("lets an effectful event handler inspect a sibling region", () =>
@@ -47,7 +60,7 @@ describe("Machine transition snapshot context", () => {
       const machine = Machine.make({
         states: States.states,
         events: Machine.events(BufferReady),
-        initial
+        initial: initialDefinition
       }).handle({
         System: {
           states: {
@@ -55,12 +68,20 @@ describe("Machine transition snapshot context", () => {
               states: {
                 Buffering: {
                   on: {
-                    BufferReady: ({ snapshot, target }) => {
-                      captured = snapshot
-                      return States.matches(snapshot, "System.Network.Online")
-                        ? target.local.Playing(new Playing({}))
-                        : target.none()
-                    }
+                    BufferReady: Machine.transition({
+                      cases: [{
+                        title: "network is online",
+                        when: ({ snapshot }) => {
+                          captured = snapshot
+                          return States.matches(snapshot, "System.Network.Online")
+                            ? Option.some(snapshot)
+                            : Option.none()
+                        },
+                        target: (to) => to.local.Playing(),
+                        resolve: ({ target }) => target(new Playing({}))
+                      }],
+                      otherwise: { target: (to) => to.none(), resolve: () => undefined }
+                    })
                   }
                 }
               }
@@ -69,7 +90,7 @@ describe("Machine transition snapshot context", () => {
         }
       })
 
-      const plan = yield* Machine.plan(machine, initial(), new BufferReady({}))
+      const plan = yield* Machine.plan(machine, initial, new BufferReady({}))
 
       assert.strictEqual(States.matches(plan.next, "System.Playback.Playing"), true)
       assert.strictEqual(States.matches(captured!, "System.Playback.Buffering"), true)
@@ -86,7 +107,7 @@ describe("Machine transition snapshot context", () => {
       const machine = Machine.make({
         states: States.states,
         events: Machine.events(Disconnect),
-        initial
+        initial: initialDefinition
       }).handle({
         System: {
           states: {
@@ -94,10 +115,13 @@ describe("Machine transition snapshot context", () => {
               states: {
                 Buffering: {
                   on: {
-                    Disconnect: ({ snapshot, target }) => {
-                      captured.push(snapshot)
-                      return target.local.Playing(new Playing({}))
-                    }
+                    Disconnect: Machine.transition({
+                      target: (to) => to.local.Playing(),
+                      resolve: ({ snapshot, target }) => {
+                        captured.push(snapshot)
+                        return target(new Playing({}))
+                      }
+                    })
                   }
                 }
               }
@@ -106,10 +130,13 @@ describe("Machine transition snapshot context", () => {
               states: {
                 Online: {
                   on: {
-                    Disconnect: ({ snapshot, target }) => {
-                      captured.push(snapshot)
-                      return target.local.Offline(new Offline({}))
-                    }
+                    Disconnect: Machine.transition({
+                      target: (to) => to.local.Offline(),
+                      resolve: ({ snapshot, target }) => {
+                        captured.push(snapshot)
+                        return target(new Offline({}))
+                      }
+                    })
                   }
                 }
               }
@@ -118,7 +145,7 @@ describe("Machine transition snapshot context", () => {
         }
       })
 
-      const plan = yield* Machine.plan(machine, initial(), new Disconnect({}))
+      const plan = yield* Machine.plan(machine, initial, new Disconnect({}))
 
       assert.lengthOf(plan.microsteps[0]!.transitions, 2)
       assert.lengthOf(captured, 2)
@@ -135,19 +162,25 @@ describe("Machine transition snapshot context", () => {
       const machine = Machine.make({
         states: States.states,
         events: Machine.events(),
-        initial
+        initial: initialDefinition
       }).handle({
         System: {
           states: {
             Playback: {
               states: {
                 Buffering: {
-                  always: ({ snapshot, target }) => {
-                    captured = snapshot
-                    return States.matches(snapshot, "System.Network.Online")
-                      ? target.local.Playing(new Playing({}))
-                      : target.none()
-                  }
+                  always: Machine.transition({
+                    cases: [{
+                      title: "network is online",
+                      when: ({ snapshot }) => {
+                        captured = snapshot
+                        return States.matches(snapshot, "System.Network.Online") ? Option.some(snapshot) : Option.none()
+                      },
+                      target: (to) => to.local.Playing(),
+                      resolve: ({ target }) => target(new Playing({}))
+                    }],
+                    otherwise: { target: (to) => to.none(), resolve: () => undefined }
+                  })
                 }
               }
             }
@@ -194,22 +227,28 @@ describe("Machine transition snapshot context", () => {
       const machine = Machine.make({
         states: completionStates.states,
         events: Machine.events(),
-        initial: () =>
-          completionStates.initial.System(
-            new System({}),
-            (system) =>
-              system
-                .Work(new Work({}), (work) => work.Finished(new Finished({})))
-                .Monitor(new Monitor({}), (monitor) => monitor.Active(new Active({})))
-          )
+        initial: {
+          target: (to) => to.System.initial(),
+          resolve: ({ target }) =>
+            target(
+              new System({}),
+              (system) =>
+                system
+                  .Work(new Work({}), (work) => work.Finished(new Finished({})))
+                  .Monitor(new Monitor({}), (monitor) => monitor.Active(new Active({})))
+            )
+        }
       }).handle({
         System: {
           states: {
             Work: {
-              onDone: ({ snapshot, target }) => {
-                captured = snapshot
-                return target.local.Restarted(new Restarted({}))
-              }
+              onDone: Machine.transition({
+                target: (to) => to.local.Restarted(),
+                resolve: ({ snapshot, target }) => {
+                  captured = snapshot
+                  return target(new Restarted({}))
+                }
+              })
             }
           }
         }
@@ -219,8 +258,8 @@ describe("Machine transition snapshot context", () => {
 
       assert.strictEqual(completionStates.matches(captured!, "System.Work.Finished"), true)
       assert.strictEqual(completionStates.matches(captured!, "System.Monitor.Active"), true)
-      assert.deepStrictEqual(captured!.completed, [{ path: "System.Work.Finished", output: undefined }, {
-        path: "System.Work",
+      assert.deepStrictEqual(captured!.completed, [{ path: "System.Work.Finished" as const, output: undefined }, {
+        path: "System.Work" as const,
         output: undefined
       }])
       assert.strictEqual(completionStates.matches(plan.state, "System.Work.Restarted"), true)

--- a/test/machine/StateDefinition.test.ts
+++ b/test/machine/StateDefinition.test.ts
@@ -37,9 +37,7 @@ const makeFromUnknownStates = (states: unknown): unknown =>
   Machine.make({
     states: states as Machine.Machine.StateSchemas,
     events: Machine.events(),
-    initial: (): never => {
-      throw new Error("unreachable")
-    }
+    initial: {} as any
   })
 
 describe("exact state-definition runtime validation", () => {
@@ -66,7 +64,10 @@ describe("exact state-definition runtime validation", () => {
     const machine = Machine.make({
       states: states.states,
       events: Machine.events(),
-      initial: () => states.initial.Idle.from()
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ target }) => target.from()
+      }
     })
 
     const nodes = Machine.stateNodes(machine)
@@ -89,16 +90,17 @@ describe("exact state-definition runtime validation", () => {
     const machine = Machine.make({
       states: states.states,
       events: Machine.events(),
-      initial: () => states.initial.Idle(new Idle({}))
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ target }) => target(new Idle({}))
+      }
     })
 
     assert.strictEqual(Machine.stateNodes(machine)[0]?.path, "Idle")
 
     const prototypeNamed = Machine.defineStates({ constructor: Idle, toString: Done })
-    assert.deepStrictEqual(prototypeNamed.initial.constructor(new Idle({})), {
-      path: "constructor",
-      value: new Idle({})
-    })
+    assert.strictEqual(prototypeNamed.states.constructor, Idle)
+    assert.strictEqual(prototypeNamed.states.toString, Done)
   })
 
   it("accepts an opaque declaration whose Type satisfies TaggedSchema", () => {
@@ -106,7 +108,10 @@ describe("exact state-definition runtime validation", () => {
     const machine = Machine.make({
       states: states.states,
       events: Machine.events(),
-      initial: () => states.initial.Opaque({ _tag: "OpaqueState", value: 1 })
+      initial: {
+        target: (to) => to.Opaque(),
+        resolve: ({ target }) => target({ _tag: "OpaqueState", value: 1 })
+      }
     })
 
     assert.strictEqual(Machine.stateNodes(machine)[0]?.path, "Opaque")

--- a/test/machine/StructuralStates.test.ts
+++ b/test/machine/StructuralStates.test.ts
@@ -69,17 +69,19 @@ const States = Machine.defineStates({
   }
 })
 
-const initial = States.initial.player.from((player) =>
-  player
-    .transport.from((transport) => transport.Empty.from())
-    .settings.from((settings) => settings.Audible.from({ volume: 1 }))
-)
-
 const makeMachine = () =>
   Machine.make({
     states: States.states,
     events: Machine.events(SourceSelected, Loaded, Play, Mute),
-    initial: () => initial
+    initial: {
+      target: (to) => to.player.initial(),
+      resolve: ({ target }) =>
+        target.from((player) =>
+          player
+            .transport.from((transport) => transport.Empty.from())
+            .settings.from((settings) => settings.Audible.from({ volume: 1 }))
+        )
+    }
   }).handle({
     player: {
       states: {
@@ -87,36 +89,48 @@ const makeMachine = () =>
           states: {
             Empty: {
               on: {
-                SourceSelected: ({ event, state, target }) => {
-                  assert.strictEqual(state, undefined)
-                  return target.local.Loading.from({ url: event.url })
-                }
+                SourceSelected: Machine.transition({
+                  target: (to) => to.local.Loading(),
+                  resolve: ({ event, state, target }) => {
+                    assert.strictEqual(state, undefined)
+                    return target.from({ url: event.url })
+                  }
+                })
               }
             },
             Loading: {
               on: {
-                Loaded: ({ event, state, target }) => {
-                  assert.strictEqual(state._tag, "Loading")
-                  return target.local.Ready.from(
-                    { duration: event.duration },
-                    (ready) => ready.Paused.from()
-                  )
-                }
+                Loaded: Machine.transition({
+                  target: (to) => to.local.Ready(),
+                  resolve: ({ event, state, target }) => {
+                    assert.strictEqual(state._tag, "Loading")
+                    return target.from(
+                      { duration: event.duration },
+                      (ready) => ready.Paused.from()
+                    )
+                  }
+                })
               }
             },
             Ready: {
               states: {
                 Paused: {
                   on: {
-                    Play: ({ containingState, state, target }) => {
-                      assert.strictEqual(state, undefined)
-                      return target.local.Playing.from({ position: Math.min(0, containingState.duration) })
-                    }
+                    Play: Machine.transition({
+                      target: (to) => to.local.Playing(),
+                      resolve: ({ containingState, state, target }) => {
+                        assert.strictEqual(state, undefined)
+                        return target.from({ position: Math.min(0, containingState.duration) })
+                      }
+                    })
                   }
                 },
                 Playing: {
                   on: {
-                    Mute: ({ event, target }) => target.branch.player.settings.Muted.from({ volume: event.volume })
+                    Mute: Machine.transition({
+                      target: (to) => to.branch.player.settings.Muted(),
+                      resolve: ({ event, target }) => target.from({ volume: event.volume })
+                    })
                   }
                 }
               }
@@ -145,13 +159,23 @@ const HistoryStates = Machine.defineStates({
   away: {}
 })
 
-const historyFallback = () =>
-  HistoryStates.initial.flow.from((flow) => flow.section.from((section) => section.Idle.from()))
+const historyFallback = () => ({
+  path: "flow" as const,
+  value: undefined,
+  state: {
+    path: "flow.section" as const,
+    value: undefined,
+    state: { path: "flow.section.Idle" as const, value: undefined }
+  }
+})
 
 const historyMachine = Machine.make({
   states: HistoryStates.states,
   events: Machine.events(Edit, Leave, ResumeShallow, ResumeDeep),
-  initial: historyFallback
+  initial: {
+    target: (to) => to.flow.initial(),
+    resolve: ({ target }) => target.from((flow) => flow.section.from((section) => section.Idle.from()))
+  }
 }).handle({
   flow: {
     history: {
@@ -159,14 +183,20 @@ const historyMachine = Machine.make({
       exact: { default: historyFallback }
     },
     on: {
-      Leave: ({ target }) => target.full.away.from()
+      Leave: Machine.transition({
+        target: (to) => to.full.away(),
+        resolve: ({ target }) => target.from()
+      })
     },
     states: {
       section: {
         states: {
           Idle: {
             on: {
-              Edit: ({ event, target }) => target.local.Editing.from({ draft: event.draft })
+              Edit: Machine.transition({
+                target: (to) => to.local.Editing(),
+                resolve: ({ event, target }) => target.from({ draft: event.draft })
+              })
             }
           }
         }
@@ -175,8 +205,14 @@ const historyMachine = Machine.make({
   },
   away: {
     on: {
-      ResumeShallow: ({ target }) => target.history.flow.recent(),
-      ResumeDeep: ({ target }) => target.history.flow.exact()
+      ResumeShallow: Machine.transition({
+        target: (to) => to.history.flow.recent(),
+        resolve: ({ target }) => target()
+      }),
+      ResumeDeep: Machine.transition({
+        target: (to) => to.history.flow.exact(),
+        resolve: ({ target }) => target()
+      })
     }
   }
 })
@@ -194,22 +230,22 @@ describe("structural active states", () => {
       const planned = yield* Machine.planInitial(makeMachine())
       const snapshot = planned.state
       assert.deepStrictEqual(snapshot, {
-        path: "player",
+        path: "player" as const,
         value: undefined,
         states: {
           transport: {
-            path: "player.transport",
+            path: "player.transport" as const,
             value: undefined,
             state: {
-              path: "player.transport.Empty",
+              path: "player.transport.Empty" as const,
               value: undefined
             }
           },
           settings: {
-            path: "player.settings",
+            path: "player.settings" as const,
             value: undefined,
             state: {
-              path: "player.settings.Audible",
+              path: "player.settings.Audible" as const,
               value: new Audible({ volume: 1 })
             }
           }
@@ -269,11 +305,11 @@ describe("structural active states", () => {
       const encoded = yield* Machine.encodeSnapshot(machine, started.state)
 
       assert.deepStrictEqual(encoded.active, [
-        { path: "player" },
-        { path: "player.transport" },
-        { path: "player.transport.Empty" },
-        { path: "player.settings" },
-        { path: "player.settings.Audible", value: { _tag: "Audible", volume: 1 } }
+        { path: "player" as const },
+        { path: "player.transport" as const },
+        { path: "player.transport.Empty" as const },
+        { path: "player.settings" as const },
+        { path: "player.settings.Audible" as const, value: { _tag: "Audible", volume: 1 } }
       ])
 
       const decoded = yield* Machine.decodeSnapshot(machine, encoded)
@@ -312,7 +348,10 @@ describe("structural active states", () => {
       const machine = Machine.make({
         states: FinalStates.states,
         events: Machine.events(),
-        initial: () => FinalStates.initial.Done.from()
+        initial: {
+          target: (to) => to.Done(),
+          resolve: ({ target }) => target.from()
+        }
       }).handle({
         Done: {
           output: ({ state }) => {
@@ -326,9 +365,9 @@ describe("structural active states", () => {
       assert.isTrue(planned.done)
       assert.strictEqual(planned.output, "complete")
       assert.deepStrictEqual(planned.state, {
-        path: "Done",
+        path: "Done" as const,
         value: undefined,
-        completed: [{ path: "Done", output: "complete" }]
+        completed: [{ path: "Done" as const, output: "complete" }]
       })
     }))
 })

--- a/test/machine/Totality.test.ts
+++ b/test/machine/Totality.test.ts
@@ -257,9 +257,19 @@ describe("machine operation totality", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Finish),
-        initial: () => states.initial.Value({ _tag: "Value", amount: 42 })
+        initial: {
+          target: (to) => to.Value(),
+          resolve: ({ target }) => target({ _tag: "Value", amount: 42 })
+        }
       }).handle({
-        Value: { on: { Finish: ({ target }) => target.full.Done({ _tag: "Done" }) } },
+        Value: {
+          on: {
+            Finish: Machine.transition({
+              target: (to) => to.full.Done(),
+              resolve: ({ target }) => target({ _tag: "Done" })
+            })
+          }
+        },
         Done: { output: () => 42 }
       })
       const plan = yield* Machine.planInitial(machine)

--- a/test/machine/Visualization.test.ts
+++ b/test/machine/Visualization.test.ts
@@ -56,13 +56,22 @@ const States = Machine.defineStates({
   disabled: Disabled
 })
 
-const initial = States.initial.application(
-  new Application({}),
-  (application) =>
-    application
-      .workflow(new Workflow({}), (workflow) => workflow.idle(new Idle({})))
-      .connection(new Connection({}), (connection) => connection.online(new Online({})))
-)
+const initial = {
+  path: "application" as const,
+  value: new Application({}),
+  states: {
+    workflow: {
+      path: "application.workflow" as const,
+      value: new Workflow({}),
+      state: { path: "application.workflow.idle" as const, value: new Idle({}) }
+    },
+    connection: {
+      path: "application.connection" as const,
+      value: new Connection({}),
+      state: { path: "application.connection.online" as const, value: new Online({}) }
+    }
+  }
+}
 
 const initialWorkflow = (): Machine.Machine.CompleteSnapshotContaining<
   typeof States.states,
@@ -73,7 +82,7 @@ const machine = Machine.make({
   id: "inspection-example",
   states: States.states,
   events: Machine.events(Start, Disconnect, Refresh),
-  initial: () => initial
+  initial: { target: (to) => to.application.initial(), resolve: () => initial }
 }).handle({
   application: {
     states: {
@@ -86,15 +95,11 @@ const machine = Machine.make({
         states: {
           idle: {
             on: {
-              Start: {
-                targets: ["application.workflow.running"],
-                transition: ({ target }) =>
-                  target.local.running(new Running({}), (running) => running.editing(new Editing({})))
-              },
-              Refresh: {
-                targets: [],
-                transition: ({ target }) => target.none()
-              }
+              Start: Machine.transition({
+                target: (to) => to.local.running(),
+                resolve: ({ target }) => target(new Running({}), (running) => running.editing(new Editing({})))
+              }),
+              Refresh: Machine.transition({ target: (to) => to.none(), resolve: () => undefined })
             }
           },
           running: {
@@ -106,7 +111,10 @@ const machine = Machine.make({
         states: {
           online: {
             on: {
-              Disconnect: ({ target }) => target.local.offline(new Offline({}))
+              Disconnect: Machine.transition({
+                target: (to) => to.local.offline(),
+                resolve: ({ target }) => target(new Offline({}))
+              })
             }
           }
         }
@@ -136,20 +144,22 @@ const lifecycleMachine = Machine.make({
   id: "lifecycle-inspection",
   states: LifecycleStates.states,
   events: Machine.events(),
-  initial: () => LifecycleStates.initial.idle(new Idle({}))
+  initial: {
+    target: (to) => to.idle(),
+    resolve: ({ target }) => target(new Idle({}))
+  }
 }).handle({
   idle: {
-    always: {
-      targets: ["workflow"],
-      transition: ({ target }) =>
-        target.full.workflow(new Workflow({}), (workflow) => workflow.complete(new Complete({})))
-    }
+    always: Machine.transition({
+      target: (to) => to.full.workflow(),
+      resolve: ({ target }) => target(new Workflow({}), (workflow) => workflow.complete(new Complete({})))
+    })
   },
   workflow: {
-    onDone: {
-      targets: ["disabled"],
-      transition: ({ target }) => target.full.disabled(new Disabled({}))
-    }
+    onDone: Machine.transition({
+      target: (to) => to.full.disabled(),
+      resolve: ({ target }) => target(new Disabled({}))
+    })
   }
 })
 
@@ -161,17 +171,17 @@ const renderLifecycleMachine = makeTextRenderer<
 describe("Machine structural visualization", () => {
   it("exposes every state node in definition order", () => {
     assert.deepStrictEqual(Machine.stateNodes(machine).map(({ path, type }) => ({ path, type })), [
-      { path: "application", type: "parallel" },
-      { path: "application.workflow", type: "compound" },
-      { path: "application.workflow.idle", type: "atomic" },
-      { path: "application.workflow.running", type: "compound" },
-      { path: "application.workflow.running.editing", type: "atomic" },
-      { path: "application.workflow.running.complete", type: "final" },
-      { path: "application.workflow.recent", type: "history" },
-      { path: "application.connection", type: "compound" },
-      { path: "application.connection.online", type: "atomic" },
-      { path: "application.connection.offline", type: "atomic" },
-      { path: "disabled", type: "atomic" }
+      { path: "application" as const, type: "parallel" },
+      { path: "application.workflow" as const, type: "compound" },
+      { path: "application.workflow.idle" as const, type: "atomic" },
+      { path: "application.workflow.running" as const, type: "compound" },
+      { path: "application.workflow.running.editing" as const, type: "atomic" },
+      { path: "application.workflow.running.complete" as const, type: "final" },
+      { path: "application.workflow.recent" as const, type: "history" },
+      { path: "application.connection" as const, type: "compound" },
+      { path: "application.connection.online" as const, type: "atomic" },
+      { path: "application.connection.offline" as const, type: "atomic" },
+      { path: "disabled" as const, type: "atomic" }
     ])
   })
 
@@ -191,19 +201,19 @@ describe("Machine structural visualization", () => {
         source: "application.workflow.idle",
         trigger: { type: "event", event: "Start" },
         reenter: false,
-        targets: { type: "declared", paths: ["application.workflow.running"] }
+        branches: [{ type: "direct", target: "application.workflow.running" }]
       },
       {
         source: "application.workflow.idle",
         trigger: { type: "event", event: "Refresh" },
         reenter: false,
-        targets: { type: "declared", paths: [] }
+        branches: [{ type: "direct", target: undefined }]
       },
       {
         source: "application.connection.online",
         trigger: { type: "event", event: "Disconnect" },
         reenter: false,
-        targets: { type: "dynamic" }
+        branches: [{ type: "direct", target: "application.connection.offline" }]
       }
     ])
   })
@@ -212,23 +222,17 @@ describe("Machine structural visualization", () => {
     const metadataMachine = Machine.make({
       states: { idle: Idle },
       events: Machine.events(Refresh),
-      initial: () => ({ path: "idle", value: new Idle({}) })
+      initial: {
+        target: (to) => to.idle(),
+        resolve: () => ({ path: "idle" as const, value: new Idle({}) })
+      }
     }).handle({
       idle: {
         on: {
-          Refresh: {
-            reenter: true,
-            transition: ({ target }) => target.none()
-          }
+          Refresh: Machine.transition({ target: (to) => to.none(), resolve: () => undefined, reenter: true })
         },
-        always: {
-          targets: ["idle"],
-          transition: ({ target }) => target.none()
-        },
-        onDone: {
-          targets: ["idle"],
-          transition: ({ target }) => target.none()
-        }
+        always: Machine.transition({ target: (to) => to.none(), resolve: () => undefined }),
+        onDone: Machine.transition({ target: (to) => to.none(), resolve: () => undefined })
       }
     })
 
@@ -237,19 +241,19 @@ describe("Machine structural visualization", () => {
         source: "idle",
         trigger: { type: "event", event: "Refresh" },
         reenter: true,
-        targets: { type: "dynamic" }
+        branches: [{ type: "direct", target: undefined }]
       },
       {
         source: "idle",
         trigger: { type: "always" },
         reenter: false,
-        targets: { type: "declared", paths: ["idle"] }
+        branches: [{ type: "direct", target: undefined }]
       },
       {
         source: "idle",
         trigger: { type: "done" },
         reenter: false,
-        targets: { type: "declared", paths: ["idle"] }
+        branches: [{ type: "direct", target: undefined }]
       }
     ])
   })
@@ -266,20 +270,20 @@ describe("Machine structural visualization", () => {
           source: "idle",
           trigger: { type: "always" },
           reenter: false,
-          targets: { type: "declared", paths: ["workflow"] }
+          branches: [{ type: "direct", target: "workflow" }]
         },
         {
           source: "workflow",
           trigger: { type: "done" },
           reenter: false,
-          targets: { type: "declared", paths: ["disabled"] }
+          branches: [{ type: "direct", target: "disabled" }]
         }
       ])
       assert.strictEqual(
         renderLifecycleMachine(lifecycleMachine, planned.state),
         [
           "lifecycle-inspection",
-          "● active  ○ inactive  ◇ transition (→ declared, ∅ none, omitted dynamic)",
+          "● active  ○ inactive  ◇ transition (→ target, ∅ none)",
           "",
           "├─ ○ idle",
           "│  └─ ◇ always → workflow",
@@ -298,7 +302,7 @@ describe("Machine structural visualization", () => {
       renderMachine(machine, initial),
       [
         "inspection-example",
-        "● active  ○ inactive  ◇ transition (→ declared, ∅ none, omitted dynamic)",
+        "● active  ○ inactive  ◇ transition (→ target, ∅ none)",
         "",
         "├─ ● application [parallel]",
         "│  ├─ ● workflow [compound, initial: idle]",
@@ -310,7 +314,7 @@ describe("Machine structural visualization", () => {
         "│  │  └─ ○ recent [history, shallow]",
         "│  └─ ● connection [compound, initial: online]",
         "│     ├─ ● online",
-        "│     │  └─ ◇ on: Disconnect",
+        "│     │  └─ ◇ on: Disconnect → offline",
         "│     └─ ○ offline",
         "└─ ○ disabled",
         "",
@@ -342,14 +346,11 @@ describe("Machine structural visualization", () => {
               states: {
                 idle: {
                   on: {
-                    Start: {
-                      targets: ["application.workflow.idle"],
-                      transition: ({ target }) =>
-                        target.full.disabled(new Disabled({})) as unknown as Machine.Machine.Target<
-                          typeof States.states,
-                          "application.workflow.idle"
-                        >
-                    }
+                    Start: Machine.transition({
+                      target: (to) => to.full.disabled(),
+                      resolve: ({ target }) =>
+                        ({ ...target(new Disabled({})), path: "application.workflow.idle" }) as any
+                    })
                   }
                 }
               }
@@ -362,7 +363,7 @@ describe("Machine structural visualization", () => {
       assert.strictEqual(exit._tag, "Failure")
       if (exit._tag === "Failure") {
         assert(Cause.hasDies(exit.cause))
-        assert.include(Cause.pretty(exit.cause), "returned target \"disabled\" outside declared targets")
+        assert.include(Cause.pretty(exit.cause), "selected \"disabled\" but constructed \"application.workflow.idle\"")
       }
     }))
 
@@ -370,89 +371,36 @@ describe("Machine structural visualization", () => {
     Effect.gen(function*() {
       const unsafeAlways = lifecycleMachine.handle({
         idle: {
-          always: {
-            targets: ["idle"],
-            transition: ({ target }) =>
-              target.full.workflow(
-                new Workflow({}),
-                (workflow) => workflow.complete(new Complete({}))
-              ) as unknown as Machine.Machine.Target<typeof LifecycleStates.states, "idle">
-          }
+          always: Machine.transition({
+            target: (to) => to.full.workflow(),
+            resolve: ({ target }) =>
+              ({
+                ...target(new Workflow({}), (workflow) => workflow.complete(new Complete({}))),
+                path: "idle"
+              }) as any
+          })
         }
       })
       const alwaysExit = yield* Effect.exit(Machine.planInitial(unsafeAlways))
 
       assert.strictEqual(alwaysExit._tag, "Failure")
       if (alwaysExit._tag === "Failure") {
-        assert.include(Cause.pretty(alwaysExit.cause), "on \"always\" returned target \"workflow\"")
+        assert.include(Cause.pretty(alwaysExit.cause), "selected \"workflow\" but constructed \"idle\"")
       }
 
       const unsafeDone = lifecycleMachine.handle({
         workflow: {
-          onDone: {
-            targets: ["workflow"],
-            transition: ({ target }) =>
-              target.full.disabled(new Disabled({})) as unknown as Machine.Machine.Target<
-                typeof LifecycleStates.states,
-                "workflow"
-              >
-          }
+          onDone: Machine.transition({
+            target: (to) => to.full.disabled(),
+            resolve: ({ target }) => ({ ...target(new Disabled({})), path: "workflow" }) as any
+          })
         }
       })
       const doneExit = yield* Effect.exit(Machine.planInitial(unsafeDone))
 
       assert.strictEqual(doneExit._tag, "Failure")
       if (doneExit._tag === "Failure") {
-        assert.include(Cause.pretty(doneExit.cause), "on \"done\" returned target \"disabled\"")
+        assert.include(Cause.pretty(doneExit.cause), "selected \"disabled\" but constructed \"workflow\"")
       }
     }))
-
-  it("rejects a declared path that is not a machine state", () => {
-    assert.throws(
-      () =>
-        machine.handle({
-          application: {
-            states: {
-              workflow: {
-                states: {
-                  idle: {
-                    on: {
-                      Start: {
-                        targets: ["missing"] as any,
-                        transition: ({ target }) => target.none()
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }),
-      /declares unknown target "missing"/
-    )
-    assert.throws(
-      () =>
-        lifecycleMachine.handle({
-          idle: {
-            always: {
-              targets: ["missing"],
-              transition: ({ target }: any) => target.none()
-            }
-          }
-        } as any),
-      /on "always" declares unknown target "missing"/
-    )
-    assert.throws(
-      () =>
-        lifecycleMachine.handle({
-          workflow: {
-            onDone: {
-              targets: ["missing"],
-              transition: ({ target }: any) => target.none()
-            }
-          }
-        } as any),
-      /on "done" declares unknown target "missing"/
-    )
-  })
 })

--- a/test/machine/visualization/text.ts
+++ b/test/machine/visualization/text.ts
@@ -37,14 +37,21 @@ interface TransitionDefinition {
       readonly outcome: "done" | "failure" | "snapshot"
     }
   readonly reenter: boolean
-  readonly targets:
+  readonly branches: ReadonlyArray<
     | {
-      readonly type: "dynamic"
+      readonly type: "direct"
+      readonly target: string | undefined
     }
     | {
-      readonly type: "declared"
-      readonly paths: ReadonlyArray<string>
+      readonly type: "case"
+      readonly title: string
+      readonly target: string | undefined
     }
+    | {
+      readonly type: "otherwise"
+      readonly target: string | undefined
+    }
+  >
 }
 
 type ActivityDefinition =
@@ -101,16 +108,20 @@ const nodeLabel = (node: StateNode, active: ReadonlySet<string>): string => {
 
 const triggerLabels = (definitions: ReadonlyArray<TransitionDefinition>): ReadonlyArray<string> => {
   const labels: Array<string> = []
-  const targets = (definition: TransitionDefinition): string =>
-    definition.targets.type === "dynamic" ?
-      ""
-      : definition.targets.paths.length === 0 ?
-      " → ∅"
-      : ` → ${definition.targets.paths.map((path) => path.slice(path.lastIndexOf(".") + 1)).join(" | ")}`
+  const target = (path: string | undefined): string =>
+    path === undefined ? " → ∅" : ` → ${path.slice(path.lastIndexOf(".") + 1)}`
+  const branches = (definition: TransitionDefinition): string =>
+    definition.branches.map((branch) =>
+      branch.type === "direct" ?
+        target(branch.target)
+        : branch.type === "case" ?
+        ` [${branch.title}]${target(branch.target)}`
+        : ` [otherwise]${target(branch.target)}`
+    ).join(" |")
   const events = definitions.flatMap((definition) =>
     definition.trigger.type === "event" ?
       [
-        `${String(definition.trigger.event)}${definition.reenter ? " [reenter]" : ""}${targets(definition)}`
+        `${String(definition.trigger.event)}${definition.reenter ? " [reenter]" : ""}${branches(definition)}`
       ]
       : []
   )
@@ -120,13 +131,13 @@ const triggerLabels = (definitions: ReadonlyArray<TransitionDefinition>): Readon
   }
   for (const definition of definitions) {
     if (definition.trigger.type === "always") {
-      labels.push(`◇ always${definition.reenter ? " [reenter]" : ""}${targets(definition)}`)
+      labels.push(`◇ always${definition.reenter ? " [reenter]" : ""}${branches(definition)}`)
     } else if (definition.trigger.type === "done") {
-      labels.push(`◇ done${definition.reenter ? " [reenter]" : ""}${targets(definition)}`)
+      labels.push(`◇ done${definition.reenter ? " [reenter]" : ""}${branches(definition)}`)
     } else if (definition.trigger.type === "choice") {
-      labels.push(`◇ choice${targets(definition)}`)
+      labels.push(`◇ choice${branches(definition)}`)
     } else if (definition.trigger.type === "invoke") {
-      labels.push(`◇ invoke ${definition.trigger.id} ${definition.trigger.outcome}${targets(definition)}`)
+      labels.push(`◇ invoke ${definition.trigger.id} ${definition.trigger.outcome}${branches(definition)}`)
     }
   }
   return labels
@@ -187,8 +198,8 @@ export const makeTextRenderer = <Machine extends MachineValue, Snapshot>(
   const lines = [
     machine.id ?? "Machine",
     activities.size === 0
-      ? "● active  ○ inactive  ◇ transition (→ declared, ∅ none, omitted dynamic)"
-      : "● active  ○ inactive  ◇ transition (→ declared, ∅ none, omitted dynamic)  ◆ activity",
+      ? "● active  ○ inactive  ◇ transition (→ target, ∅ none)"
+      : "● active  ○ inactive  ◇ transition (→ target, ∅ none)  ◆ activity",
     ""
   ]
   const visit = (node: StateNode, prefix: string, isLast: boolean): void => {

--- a/test/testing/Coverage.test.ts
+++ b/test/testing/Coverage.test.ts
@@ -20,19 +20,19 @@ const CounterStates = Machine.defineStates({ count: Count, done: Done })
 const counterMachine = Machine.make({
   states: CounterStates.states,
   events: Machine.events(Add, Finish),
-  initial: () => CounterStates.initial.count(new Count({ value: 0 }))
+  initial: {
+    target: (to) => to.count(),
+    resolve: ({ target }) => target(new Count({ value: 0 }))
+  }
 }).handle({
   count: {
     on: {
-      Add: {
-        reenter: true,
-        targets: ["count"],
-        transition: ({ event, state, target }) => target.full.count(new Count({ value: state.value + event.amount }))
-      },
-      Finish: {
-        targets: ["done"],
-        transition: ({ target }) => target.full.done(new Done({}))
-      }
+      Add: Machine.transition({
+        target: (to) => to.full.count(),
+        resolve: ({ event, state, target }) => target(new Count({ value: state.value + event.amount })),
+        reenter: true
+      }),
+      Finish: Machine.transition({ target: (to) => to.full.done(), resolve: ({ target }) => target(new Done({})) })
     }
   },
   done: {}
@@ -47,22 +47,36 @@ const opaqueMachine = Machine.make({
   states: OpaqueStates.states,
   events: Machine.events(),
   input: Schema.Any,
-  initial: (payload) => OpaqueStates.initial.opaque(new Opaque({ payload }))
+  initial: {
+    target: (to) => to.opaque(),
+    resolve: ({ input: payload, target }) => target(new Opaque({ payload }))
+  }
 })
 
 const StartupStates = Machine.defineStates({ count: Count })
 const startupMachine = Machine.make({
   states: StartupStates.states,
   events: Machine.events(Add),
-  initial: () => StartupStates.initial.count(new Count({ value: 0 }))
+  initial: {
+    target: (to) => to.count(),
+    resolve: ({ target }) => target(new Count({ value: 0 }))
+  }
 }).handle({
   count: {
-    always: ({ target, state }) =>
-      state.value === 0
-        ? target.full.count(new Count({ value: 1 }))
-        : target.none(),
+    always: Machine.transition({
+      cases: [{
+        title: "count is zero",
+        when: ({ state }) => state.value === 0 ? Option.some(state) : Option.none(),
+        target: (to) => to.full.count(),
+        resolve: ({ target }) => target(new Count({ value: 1 }))
+      }],
+      otherwise: { target: (to) => to.none(), resolve: () => undefined }
+    }),
     on: {
-      Add: ({ event, state, target }) => target.full.count(new Count({ value: state.value + event.amount }))
+      Add: Machine.transition({
+        target: (to) => to.full.count(),
+        resolve: ({ event, state, target }) => target(new Count({ value: state.value + event.amount }))
+      })
     }
   }
 })
@@ -77,20 +91,35 @@ const EventStates = Machine.defineStates({ count: Count })
 const finiteEventMachine = Machine.make({
   states: EventStates.states,
   events: Machine.events(TickEvent, ChoiceEvent),
-  initial: () => EventStates.initial.count(new Count({ value: 0 }))
+  initial: {
+    target: (to) => to.count(),
+    resolve: ({ target }) => target(new Count({ value: 0 }))
+  }
 }).handle({
   count: {
     on: {
-      [Tick]: ({ target }) => target.none(),
-      Alpha: ({ target }) => target.none(),
-      Beta: ({ target }) => target.none()
+      [Tick]: Machine.transition({
+        target: (to) => to.none(),
+        resolve: () => undefined
+      }),
+      Alpha: Machine.transition({
+        target: (to) => to.none(),
+        resolve: () => undefined
+      }),
+      Beta: Machine.transition({
+        target: (to) => to.none(),
+        resolve: () => undefined
+      })
     }
   }
 })
 const openEventMachine = Machine.make({
   states: EventStates.states,
   events: Machine.events(OpenEvent),
-  initial: () => EventStates.initial.count(new Count({ value: 0 }))
+  initial: {
+    target: (to) => to.count(),
+    resolve: ({ target }) => target(new Count({ value: 0 }))
+  }
 }).handle({ count: {} })
 
 const event = (_tag: string): { readonly _tag: string } => ({ _tag })
@@ -241,7 +270,7 @@ describe("MachineTest trace coverage", () => {
       })
       const historyCoverage = MachineTest.coverage(historyMachine, history)
       assert.ok(historyCoverage.history.recordObservations > 0)
-      assert.deepStrictEqual(historyCoverage.history.recorded, [{ path: "owner.exact", modes: ["deep"] }])
+      assert.deepStrictEqual(historyCoverage.history.recorded, [{ path: "owner.exact" as const, modes: ["deep"] }])
       assert.strictEqual(historyCoverage.history.targets, 1)
       assert.strictEqual(historyCoverage.history.resolvedTargets, 1)
     }))

--- a/test/testing/Exploration.test.ts
+++ b/test/testing/Exploration.test.ts
@@ -17,13 +17,25 @@ const States = Machine.defineStates({ counter: Counter })
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(Increment, Reset, Corrupt),
-  initial: () => States.initial.counter(new Counter({ count: 0 }))
+  initial: {
+    target: (to) => to.counter(),
+    resolve: ({ target }) => target(new Counter({ count: 0 }))
+  }
 }).handle({
   counter: {
     on: {
-      Increment: ({ state, target }) => target.full.counter(new Counter({ count: state.count + 1 })),
-      Reset: ({ target }) => target.full.counter(new Counter({ count: 0 })),
-      Corrupt: ({ target }) => target.full.counter(new Counter({ count: -1 }))
+      Increment: Machine.transition({
+        target: (to) => to.full.counter(),
+        resolve: ({ state, target }) => target(new Counter({ count: state.count + 1 }))
+      }),
+      Reset: Machine.transition({
+        target: (to) => to.full.counter(),
+        resolve: ({ target }) => target(new Counter({ count: 0 }))
+      }),
+      Corrupt: Machine.transition({
+        target: (to) => to.full.counter(),
+        resolve: ({ target }) => target(new Counter({ count: -1 }))
+      })
     }
   }
 })
@@ -208,7 +220,10 @@ describe("MachineTest bounded exploration", () => {
         states: States.states,
         events: Machine.events(Increment),
         input: Seed,
-        initial: ({ count }) => States.initial.counter(new Counter({ count }))
+        initial: {
+          target: (to) => to.counter(),
+          resolve: ({ input, target }) => target(new Counter({ count: input.count }))
+        }
       }).handle({ counter: {} })
       const explored = yield* MachineTest.explore(inputMachine, {
         input: new Seed({ count: 7 }),

--- a/test/testing/FiniteModel.test.ts
+++ b/test/testing/FiniteModel.test.ts
@@ -146,7 +146,7 @@ const canonicalTransition = (transition: Machine.Machine.TransitionDefinition) =
   source: transition.source,
   trigger: transition.trigger,
   reenter: transition.reenter,
-  targets: transition.targets.type === "declared" ? transition.targets.paths : undefined
+  branches: transition.branches
 })
 
 describe("MachineTest finite models", () => {
@@ -314,11 +314,13 @@ describe("MachineTest finite models", () => {
         assert.strictEqual(actual.source, expected.source)
         assert.deepStrictEqual(actual.trigger, expected.trigger)
         assert.strictEqual(actual.reenter, "reenter" in expected ? expected.reenter : false)
+        assert.strictEqual(actual.branches.length, 1)
+        const target = actual.branches[0]!.target
         if (expected.target === undefined) {
-          assert.strictEqual(actual.targets, undefined)
+          assert.strictEqual(target, undefined)
         } else {
-          assert.strictEqual(actual.targets?.length, 1)
-          const bound = actual.targets![0]!
+          assert.notStrictEqual(target, undefined)
+          const bound = target!
           assert.ok(
             expected.target === bound || expected.target.startsWith(`${bound}.`) ||
               bound.startsWith(`${expected.target}.`)

--- a/test/testing/Invariant.test.ts
+++ b/test/testing/Invariant.test.ts
@@ -22,14 +22,21 @@ const makeAccountMachine = (withdraw: (balance: number, amount: number) => numbe
   Machine.make({
     states: States.states,
     events: Machine.events(Withdraw, Deposit),
-    initial: () => States.initial.account(new Account({ balance: 10 }))
+    initial: {
+      target: (to) => to.account(),
+      resolve: ({ target }) => target(new Account({ balance: 10 }))
+    }
   }).handle({
     account: {
       on: {
-        Withdraw: ({ event, state, target }) =>
-          target.full.account(new Account({ balance: withdraw(state.balance, event.amount) })),
-        Deposit: ({ event, state, target }) =>
-          target.full.account(new Account({ balance: state.balance + event.amount }))
+        Withdraw: Machine.transition({
+          target: (to) => to.full.account(),
+          resolve: ({ event, state, target }) => target(new Account({ balance: withdraw(state.balance, event.amount) }))
+        }),
+        Deposit: Machine.transition({
+          target: (to) => to.full.account(),
+          resolve: ({ event, state, target }) => target(new Account({ balance: state.balance + event.amount }))
+        })
       }
     }
   })

--- a/test/testing/MachineTest.test.ts
+++ b/test/testing/MachineTest.test.ts
@@ -29,22 +29,31 @@ const makeTraceMachine = (onAction: () => void) =>
     states: States.states,
     events: Machine.events(Start, Add),
     input: TestInput,
-    initial: ({ userId }) => States.initial.Ready(new Ready({ count: userId.length - userId.length }))
+    initial: {
+      target: (to) => to.Ready(),
+      resolve: ({ input, target }) => target(new Ready({ count: input.userId.length - input.userId.length }))
+    }
   }).handle({
     Idle: {
       on: {
-        Start: ({ target }) => {
-          onAction()
-          return target.full.Ready(new Ready({ count: 0 }))
-        }
+        Start: Machine.transition({
+          target: (to) => to.full.Ready(),
+          resolve: ({ target }) => {
+            onAction()
+            return target(new Ready({ count: 0 }))
+          }
+        })
       }
     },
     Ready: {
       on: {
-        Add: ({ event, state, target }) => {
-          onAction()
-          return target.full.Ready(new Ready({ count: state.count + event.amount }))
-        }
+        Add: Machine.transition({
+          target: (to) => to.full.Ready(),
+          resolve: ({ event, state, target }) => {
+            onAction()
+            return target(new Ready({ count: state.count + event.amount }))
+          }
+        })
       }
     }
   })
@@ -98,7 +107,10 @@ describe("MachineTest", () => {
       states: States.states,
       events: Machine.events(),
       input: PositiveInput,
-      initial: () => States.initial.Idle(new Idle({ userId: "user-1" }))
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ target }) => target(new Idle({ userId: "user-1" }))
+      }
     })
 
     const generated = MachineTest.scenarios(machine)
@@ -116,7 +128,10 @@ describe("MachineTest", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(),
-      initial: () => States.initial.Idle(new Idle({ userId: "user-1" }))
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ target }) => target(new Idle({ userId: "user-1" }))
+      }
     })
 
     assert.throws(
@@ -188,14 +203,17 @@ describe("MachineTest", () => {
       const machine = Machine.make({
         states: ParallelStates.states,
         events: Machine.events(Stop),
-        initial: () =>
-          ParallelStates.initial.app(
-            new App({}),
-            (app) =>
-              app
-                .left(new Left({}), (left) => left.idle(new LeftIdle({})))
-                .right(new Right({}), (right) => right.idle(new RightIdle({})))
-          )
+        initial: {
+          target: (to) => to.app.initial(),
+          resolve: ({ target }) =>
+            target(
+              new App({}),
+              (app) =>
+                app
+                  .left(new Left({}), (left) => left.idle(new LeftIdle({})))
+                  .right(new Right({}), (right) => right.idle(new RightIdle({})))
+            )
+        }
       }).handle({
         app: {
           states: {
@@ -203,7 +221,10 @@ describe("MachineTest", () => {
               states: {
                 idle: {
                   on: {
-                    Stop: ({ target }) => target.full.disabled(new Disabled({}))
+                    Stop: Machine.transition({
+                      target: (to) => to.full.disabled(),
+                      resolve: ({ target }) => target(new Disabled({}))
+                    })
                   }
                 }
               }
@@ -212,7 +233,10 @@ describe("MachineTest", () => {
               states: {
                 idle: {
                   on: {
-                    Stop: ({ target }) => target.full.disabled(new Disabled({}))
+                    Stop: Machine.transition({
+                      target: (to) => to.full.disabled(),
+                      resolve: ({ target }) => target(new Disabled({}))
+                    })
                   }
                 }
               }
@@ -245,14 +269,14 @@ describe("MachineTest", () => {
       const machine = Machine.make({
         states: { Idle },
         events: Machine.events(Start),
-        initial: () => ({ path: "Idle", value: new Idle({ userId: "user-1" }) })
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: () => ({ path: "Idle" as const, value: new Idle({ userId: "user-1" }) })
+        }
       }).handle({
         Idle: {
           on: {
-            Start: {
-              targets: ["Idle"],
-              transition: ({ target }) => target.none()
-            }
+            Start: Machine.transition({ target: (to) => to.none(), resolve: () => undefined })
           }
         }
       })

--- a/test/testing/Probe.test.ts
+++ b/test/testing/Probe.test.ts
@@ -23,21 +23,37 @@ const machine = Machine.make({
   states: states.states,
   events: Machine.events(Increment, Noop, Ignored, Burst, Reenter),
   internalEvents: Machine.internalEvents(RaisedIncrement),
-  initial: () => states.initial.Counter(new Counter({ count: 0 }))
+  initial: {
+    target: (to) => to.Counter(),
+    resolve: ({ target }) => target(new Counter({ count: 0 }))
+  }
 }).handle({
   Counter: {
     on: {
-      Increment: ({ event, state, target }) => target.full.Counter(new Counter({ count: state.count + event.amount })),
-      Noop: ({ target }) => target.none(),
-      Reenter: {
-        reenter: true,
-        transition: ({ state, target }) => target.full.Counter(new Counter({ count: state.count }))
-      },
-      Burst: ({ state, target }, enqueue) => {
-        enqueue.raise(new RaisedIncrement({}))
-        return target.full.Counter(new Counter({ count: state.count + 1 }))
-      },
-      RaisedIncrement: ({ state, target }) => target.full.Counter(new Counter({ count: state.count + 10 }))
+      Increment: Machine.transition({
+        target: (to) => to.full.Counter(),
+        resolve: ({ event, state, target }) => target(new Counter({ count: state.count + event.amount }))
+      }),
+      Noop: Machine.transition({
+        target: (to) => to.none(),
+        resolve: () => undefined
+      }),
+      Reenter: Machine.transition({
+        target: (to) => to.full.Counter(),
+        resolve: ({ state, target }) => target(new Counter({ count: state.count })),
+        reenter: true
+      }),
+      Burst: Machine.transition({
+        target: (to) => to.full.Counter(),
+        resolve: ({ state, target }, enqueue) => {
+          enqueue.raise(new RaisedIncrement({}))
+          return target(new Counter({ count: state.count + 1 }))
+        }
+      }),
+      RaisedIncrement: Machine.transition({
+        target: (to) => to.full.Counter(),
+        resolve: ({ state, target }) => target(new Counter({ count: state.count + 10 }))
+      })
     }
   }
 })
@@ -142,10 +158,18 @@ describe("MachineTest probe", () => {
       const invokeMachine = Machine.make({
         states: invokeStates.states,
         events: Machine.events(Load),
-        initial: () => invokeStates.initial.Idle(new Idle({}))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({}))
+        }
       }).handle({
         Idle: {
-          on: { Load: ({ target }) => target.full.Loading(new Loading({})) }
+          on: {
+            Load: Machine.transition({
+              target: (to) => to.full.Loading(),
+              resolve: ({ target }) => target(new Loading({}))
+            })
+          }
         },
         Loading: {
           invoke: Machine.invoke({

--- a/test/testing/ReferenceModel.test.ts
+++ b/test/testing/ReferenceModel.test.ts
@@ -28,6 +28,51 @@ const snapshotAtPath = (snapshot: unknown, path: string): unknown => {
 }
 
 describe("MachineTest finite-model reference interpreter", () => {
+  it.effect("compiles transitions to an inactive compound's initial choice", () =>
+    Effect.gen(function*() {
+      const model: MachineTest.FiniteModel = {
+        roots: [{
+          _tag: "Compound",
+          key: "root",
+          value: 0,
+          initial: "idle",
+          states: [
+            { _tag: "Atomic", key: "idle", value: 1 },
+            {
+              _tag: "Compound",
+              key: "destination",
+              value: 2,
+              initial: "route",
+              states: [
+                { _tag: "Atomic", key: "ready", value: 3 },
+                {
+                  _tag: "Choice",
+                  key: "route",
+                  targets: ["root.destination.ready"],
+                  selected: "root.destination.ready"
+                }
+              ]
+            }
+          ]
+        }],
+        initial: "root",
+        events: ["Start"],
+        transitions: [{
+          source: "root.idle",
+          trigger: { type: "event", event: "Start" },
+          target: "root.destination.route",
+          reenter: false
+        }]
+      }
+
+      const reference = MachineTest.interpretModel(model, ["Start"])
+      assert.deepStrictEqual(reference.final.activePaths, ["root", "root.destination", "root.destination.ready"])
+
+      const machine = MachineTest.compileModel(model)
+      const trace = yield* MachineTest.run(machine, { events: [event("Start")] })
+      yield* MachineTest.verifyModel(model, trace)
+    }))
+
   it.effect("stabilizes acyclic always and completion transitions in semantic order", () =>
     Effect.gen(function*() {
       const model: MachineTest.FiniteModel = {
@@ -488,8 +533,8 @@ describe("MachineTest finite-model reference interpreter", () => {
       ])
       assert.strictEqual(reference.steps[0]!.done, false)
       assert.deepStrictEqual(afterLeft.completions, [
-        { path: "workflow.left.done", output: "left:done" },
-        { path: "workflow.left", output: "left:done" }
+        { path: "workflow.left.done" as const, output: "left:done" },
+        { path: "workflow.left" as const, output: "left:done" }
       ])
 
       const afterRight = reference.steps[1]!.after
@@ -940,11 +985,14 @@ describe("MachineTest finite-model reference interpreter", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Local, Exit),
-        initial: () =>
-          states.initial.root({ _tag: "Root", version: 0 }, (regions) =>
-            regions
-              .left({ _tag: "Left", version: 0 }, (left) => left.idle({ _tag: "LeftIdle", version: 0 }))
-              .right({ _tag: "Right", version: 0 }, (right) => right.idle({ _tag: "RightIdle", version: 0 })))
+        initial: {
+          target: (to) => to.root.initial(),
+          resolve: ({ target }) =>
+            target({ _tag: "Root", version: 0 }, (regions) =>
+              regions
+                .left({ _tag: "Left", version: 0 }, (left) => left.idle({ _tag: "LeftIdle", version: 0 }))
+                .right({ _tag: "Right", version: 0 }, (right) => right.idle({ _tag: "RightIdle", version: 0 })))
+        }
       }).handle({
         root: {
           states: {
@@ -952,8 +1000,14 @@ describe("MachineTest finite-model reference interpreter", () => {
               states: {
                 idle: {
                   on: {
-                    Local: ({ target }) => target.local.done({ _tag: "LeftDone", version: 1 }),
-                    Exit: ({ target }) => target.full.outside({ _tag: "Outside", version: 1 })
+                    Local: Machine.transition({
+                      target: (to) => to.local.done(),
+                      resolve: ({ target }) => target({ _tag: "LeftDone", version: 1 })
+                    }),
+                    Exit: Machine.transition({
+                      target: (to) => to.full.outside(),
+                      resolve: ({ target }) => target({ _tag: "Outside", version: 1 })
+                    })
                   }
                 }
               }
@@ -962,8 +1016,14 @@ describe("MachineTest finite-model reference interpreter", () => {
               states: {
                 idle: {
                   on: {
-                    Local: ({ target }) => target.local.idle({ _tag: "RightIdle", version: 1 }),
-                    Exit: ({ target }) => target.local.idle({ _tag: "RightIdle", version: 2 })
+                    Local: Machine.transition({
+                      target: (to) => to.local.idle(),
+                      resolve: ({ target }) => target({ _tag: "RightIdle", version: 1 })
+                    }),
+                    Exit: Machine.transition({
+                      target: (to) => to.local.idle(),
+                      resolve: ({ target }) => target({ _tag: "RightIdle", version: 2 })
+                    })
                   }
                 }
               }
@@ -1050,7 +1110,7 @@ describe("MachineTest finite-model reference interpreter", () => {
 
       const reference = MachineTest.interpretModel(model, ["After"])
       assert.deepStrictEqual(reference.initial.startingState.completions, [])
-      assert.deepStrictEqual(reference.initial.state.completions, [{ path: "finished", output: "complete" }])
+      assert.deepStrictEqual(reference.initial.state.completions, [{ path: "finished" as const, output: "complete" }])
       assert.strictEqual(reference.initial.done, true)
       assert.strictEqual(reference.initial.output, "complete")
       assert.strictEqual(reference.steps[0]?.done, true)
@@ -1079,8 +1139,8 @@ describe("MachineTest finite-model reference interpreter", () => {
 
       const reference = MachineTest.interpretModel(model, [])
       assert.deepStrictEqual(reference.initial.state.completions, [
-        { path: "job.done", output: "result" },
-        { path: "job", output: "result" }
+        { path: "job.done" as const, output: "result" },
+        { path: "job" as const, output: "result" }
       ])
       assert.strictEqual(reference.initial.state.status, "done")
       assert.strictEqual(reference.initial.output, "result")
@@ -1124,8 +1184,8 @@ describe("MachineTest finite-model reference interpreter", () => {
         [{ type: "done" }]
       )
       assert.deepStrictEqual(reference.final.completions, [
-        { path: "job.done", output: "job:done" },
-        { path: "job", output: "job:done" }
+        { path: "job.done" as const, output: "job:done" },
+        { path: "job" as const, output: "job:done" }
       ])
       assert.strictEqual(reference.final.status, "done")
 
@@ -1278,10 +1338,10 @@ describe("MachineTest finite-model reference interpreter", () => {
       const machine = MachineTest.compileModel(model)
       const trace = yield* MachineTest.run(machine, { events: [] })
       const right = {
-        path: "root",
+        path: "root" as const,
         value: { _tag: "State_root", value: 0 },
         state: {
-          path: "root.right",
+          path: "root.right" as const,
           value: { _tag: "State_root_right", value: 2 }
         }
       }

--- a/test/testing/Runtime.test.ts
+++ b/test/testing/Runtime.test.ts
@@ -27,13 +27,21 @@ const makeCounterMachine = () =>
     states: CounterStates.states,
     events: Machine.events(Add),
     internalEvents: Machine.internalEvents(InternalAdd),
-    initial: () => CounterStates.initial.Counter(new Counter({ count: 0 }))
+    initial: {
+      target: (to) => to.Counter(),
+      resolve: ({ target }) => target(new Counter({ count: 0 }))
+    }
   }).handle({
     Counter: {
       on: {
-        Add: ({ event, state, target }) => target.full.Counter(new Counter({ count: state.count + event.amount })),
-        InternalAdd: ({ event, state, target }) =>
-          target.full.Counter(new Counter({ count: state.count + event.amount }))
+        Add: Machine.transition({
+          target: (to) => to.full.Counter(),
+          resolve: ({ event, state, target }) => target(new Counter({ count: state.count + event.amount }))
+        }),
+        InternalAdd: Machine.transition({
+          target: (to) => to.full.Counter(),
+          resolve: ({ event, state, target }) => target(new Counter({ count: state.count + event.amount }))
+        })
       }
     }
   })
@@ -42,17 +50,32 @@ const causalMachine = Machine.make({
   states: CounterStates.states,
   events: Machine.events(Add, Noop, Ignored, Burst),
   internalEvents: Machine.internalEvents(InternalAdd),
-  initial: () => CounterStates.initial.Counter(new Counter({ count: 0 }))
+  initial: {
+    target: (to) => to.Counter(),
+    resolve: ({ target }) => target(new Counter({ count: 0 }))
+  }
 }).handle({
   Counter: {
     on: {
-      Add: ({ event, state, target }) => target.full.Counter(new Counter({ count: state.count + event.amount })),
-      Noop: ({ target }) => target.none(),
-      Burst: ({ state, target }, enqueue) => {
-        enqueue.raise(new InternalAdd({ amount: 10 }))
-        return target.full.Counter(new Counter({ count: state.count + 1 }))
-      },
-      InternalAdd: ({ event, state, target }) => target.full.Counter(new Counter({ count: state.count + event.amount }))
+      Add: Machine.transition({
+        target: (to) => to.full.Counter(),
+        resolve: ({ event, state, target }) => target(new Counter({ count: state.count + event.amount }))
+      }),
+      Noop: Machine.transition({
+        target: (to) => to.none(),
+        resolve: () => undefined
+      }),
+      Burst: Machine.transition({
+        target: (to) => to.full.Counter(),
+        resolve: ({ state, target }, enqueue) => {
+          enqueue.raise(new InternalAdd({ amount: 10 }))
+          return target(new Counter({ count: state.count + 1 }))
+        }
+      }),
+      InternalAdd: Machine.transition({
+        target: (to) => to.full.Counter(),
+        resolve: ({ event, state, target }) => target(new Counter({ count: state.count + event.amount }))
+      })
     }
   }
 })
@@ -235,13 +258,19 @@ describe("MachineTest runtime commands", () => {
         states: states.states,
         events: Machine.events(),
         internalEvents: Machine.internalEvents(Timeout),
-        initial: () => states.initial.Waiting(new Waiting({}))
+        initial: {
+          target: (to) => to.Waiting(),
+          resolve: ({ target }) => target(new Waiting({}))
+        }
       }).handle({
         Waiting: {
           invoke: Machine.invoke({
             id: "timeout",
             after: "1 second",
-            onDone: ({ target }) => target.full.TimedOut(new TimedOut({}))
+            onDone: Machine.transition({
+              target: (to) => to.full.TimedOut(),
+              resolve: ({ target }) => target(new TimedOut({}))
+            })
           })
         },
         TimedOut: {}
@@ -716,13 +745,19 @@ describe("MachineTest causal runtime commands", () => {
         states: states.states,
         events: Machine.events(),
         internalEvents: Machine.internalEvents(Timeout),
-        initial: () => states.initial.Waiting(new Waiting({}))
+        initial: {
+          target: (to) => to.Waiting(),
+          resolve: ({ target }) => target(new Waiting({}))
+        }
       }).handle({
         Waiting: {
           invoke: Machine.invoke({
             id: "timeout",
             after: "1 second",
-            onDone: ({ target }) => target.full.TimedOut(new TimedOut({}))
+            onDone: Machine.transition({
+              target: (to) => to.full.TimedOut(),
+              resolve: ({ target }) => target(new TimedOut({}))
+            })
           })
         },
         TimedOut: {}

--- a/test/testing/Verification.test.ts
+++ b/test/testing/Verification.test.ts
@@ -30,14 +30,17 @@ const NavigationStates = Machine.defineStates({
 const navigationMachine = Machine.make({
   states: NavigationStates.states,
   events: Machine.events(Go),
-  initial: () => NavigationStates.initial.off(new Off({}))
+  initial: {
+    target: (to) => to.off(),
+    resolve: ({ target }) => target(new Off({}))
+  }
 }).handle({
   off: {
     on: {
-      Go: {
-        targets: ["app"],
-        transition: ({ target }) => target.full.app(new App({}), (app) => app.two(new Two({})))
-      }
+      Go: Machine.transition({
+        target: (to) => to.full.app(),
+        resolve: ({ target }) => target(new App({}), (app) => app.two(new Two({})))
+      })
     }
   }
 })
@@ -45,12 +48,21 @@ const navigationMachine = Machine.make({
 const raisedNavigationMachine = Machine.make({
   states: NavigationStates.states,
   events: Machine.events(Go),
-  initial: () => NavigationStates.initial.off(new Off({}))
+  initial: {
+    target: (to) => to.off(),
+    resolve: ({ target }) => target(new Off({}))
+  }
 }).handle({
   off: {
-    always: ({ target }) => target.full.app(new App({}), (app) => app.one(new One({}))),
+    always: Machine.transition({
+      target: (to) => to.full.app(),
+      resolve: ({ target }) => target(new App({}), (app) => app.one(new One({})))
+    }),
     on: {
-      Go: ({ target }) => target.full.app(new App({}), (app) => app.one(new One({})))
+      Go: Machine.transition({
+        target: (to) => to.full.app(),
+        resolve: ({ target }) => target(new App({}), (app) => app.one(new One({})))
+      })
     }
   }
 })
@@ -60,12 +72,21 @@ const CounterStates = Machine.defineStates({ counter: Counter })
 const counterMachine = Machine.make({
   states: CounterStates.states,
   events: Machine.events(Increment, Noop),
-  initial: () => CounterStates.initial.counter(new Counter({ count: 0 }))
+  initial: {
+    target: (to) => to.counter(),
+    resolve: ({ target }) => target(new Counter({ count: 0 }))
+  }
 }).handle({
   counter: {
     on: {
-      Increment: ({ state, target }) => target.full.counter(new Counter({ count: state.count + 1 })),
-      Noop: ({ target }) => target.none()
+      Increment: Machine.transition({
+        target: (to) => to.full.counter(),
+        resolve: ({ state, target }) => target(new Counter({ count: state.count + 1 }))
+      }),
+      Noop: Machine.transition({
+        target: (to) => to.none(),
+        resolve: () => undefined
+      })
     }
   }
 })
@@ -73,18 +94,22 @@ const counterMachine = Machine.make({
 const reentryMachine = Machine.make({
   states: NavigationStates.states,
   events: Machine.events(Restart),
-  initial: () =>
-    NavigationStates.initial.app(
-      new App({}),
-      (app) => app.one(new One({}))
-    )
+  initial: {
+    target: (to) => to.app.initial(),
+    resolve: ({ target }) =>
+      target(
+        new App({}),
+        (app) => app.one(new One({}))
+      )
+  }
 }).handle({
   app: {
     on: {
-      Restart: {
-        reenter: true,
-        transition: ({ target }) => target.full.app(new App({}), (app) => app.one(new One({})))
-      }
+      Restart: Machine.transition({
+        target: (to) => to.full.app(),
+        resolve: ({ target }) => target(new App({}), (app) => app.one(new One({}))),
+        reenter: true
+      })
     }
   }
 })
@@ -107,11 +132,14 @@ const ParallelStates = Machine.defineStates({
 const parallelMachine = Machine.make({
   states: ParallelStates.states,
   events: Machine.events(),
-  initial: () =>
-    ParallelStates.initial.dashboard(
-      new Dashboard({}),
-      (dashboard) => dashboard.left(new Left({})).right(new Right({}))
-    )
+  initial: {
+    target: (to) => to.dashboard.initial(),
+    resolve: ({ target }) =>
+      target(
+        new Dashboard({}),
+        (dashboard) => dashboard.left(new Left({})).right(new Right({}))
+      )
+  }
 }).handle({ dashboard: {} })
 
 class Workspace extends Schema.TaggedClass<Workspace>("Workspace")("Workspace", {}) {}
@@ -149,21 +177,24 @@ const HistoryStates = Machine.defineStates({
 const historyMachine = Machine.make({
   states: HistoryStates.states,
   events: Machine.events(Leave),
-  initial: () =>
-    HistoryStates.initial.workspace(
-      new Workspace({}),
-      (workspace) =>
-        workspace.editor(
-          new Editor({}),
-          (editor) => editor.editing(new Editing({ revision: 1 }))
-        )
-    )
+  initial: {
+    target: (to) => to.workspace.initial(),
+    resolve: ({ target }) =>
+      target(
+        new Workspace({}),
+        (workspace) =>
+          workspace.editor(
+            new Editor({}),
+            (editor) => editor.editing(new Editing({ revision: 1 }))
+          )
+      )
+  }
 }).handle({
   workspace: {
     history: {
       recent: {
-        default: () =>
-          HistoryStates.initial.workspace(
+        default: ({ target }) =>
+          target.workspace(
             new Workspace({}),
             (workspace) =>
               workspace.editor(
@@ -173,8 +204,8 @@ const historyMachine = Machine.make({
           )
       },
       exact: {
-        default: () =>
-          HistoryStates.initial.workspace(
+        default: ({ target }) =>
+          target.workspace(
             new Workspace({}),
             (workspace) =>
               workspace.editor(
@@ -185,7 +216,10 @@ const historyMachine = Machine.make({
       }
     },
     on: {
-      Leave: ({ target }) => target.full.away(new Away({}))
+      Leave: Machine.transition({
+        target: (to) => to.full.away(),
+        resolve: ({ target }) => target(new Away({}))
+      })
     },
     states: {
       editor: {
@@ -209,20 +243,33 @@ const StructuralHistoryStates = Machine.defineStates({
   away: {}
 })
 
-const structuralHistoryInitial = () =>
-  StructuralHistoryStates.initial.workspace.from((workspace) => workspace.editor.from((editor) => editor.idle.from()))
+const structuralHistoryInitial = () => ({
+  path: "workspace" as const,
+  value: undefined,
+  state: {
+    path: "workspace.editor" as const,
+    value: undefined,
+    state: { path: "workspace.editor.idle" as const, value: undefined }
+  }
+})
 
 const structuralHistoryMachine = Machine.make({
   states: StructuralHistoryStates.states,
   events: Machine.events(Leave),
-  initial: structuralHistoryInitial
+  initial: {
+    target: (to) => to.workspace.initial(),
+    resolve: ({ target }) => target.from((workspace) => workspace.editor.from((editor) => editor.idle.from()))
+  }
 }).handle({
   workspace: {
     history: {
       exact: { default: structuralHistoryInitial }
     },
     on: {
-      Leave: ({ target }) => target.full.away.from()
+      Leave: Machine.transition({
+        target: (to) => to.full.away(),
+        resolve: ({ target }) => target.from()
+      })
     }
   }
 })
@@ -240,7 +287,10 @@ const CompletionStates = Machine.defineStates({
 const completionMachine = Machine.make({
   states: CompletionStates.states,
   events: Machine.events(),
-  initial: () => CompletionStates.initial.finished(new Finished({}))
+  initial: {
+    target: (to) => to.finished(),
+    resolve: ({ target }) => target(new Finished({}))
+  }
 }).handle({
   finished: {
     output: () => "complete"
@@ -268,14 +318,20 @@ const DoneTransitionStates = Machine.defineStates({
 const doneTransitionMachine = Machine.make({
   states: DoneTransitionStates.states,
   events: Machine.events(),
-  initial: () =>
-    DoneTransitionStates.initial.workflow(
-      new Workflow({}),
-      (workflow) => workflow.finished(new Finished({}))
-    )
+  initial: {
+    target: (to) => to.workflow.initial(),
+    resolve: ({ target }) =>
+      target(
+        new Workflow({}),
+        (workflow) => workflow.finished(new Finished({}))
+      )
+  }
 }).handle({
   workflow: {
-    onDone: ({ target }) => target.full.archived(new Archived({})),
+    onDone: Machine.transition({
+      target: (to) => to.full.archived(),
+      resolve: ({ target }) => target(new Archived({}))
+    }),
     states: {
       finished: {
         output: () => "workflow-output"
@@ -287,11 +343,14 @@ const doneTransitionMachine = Machine.make({
 const nestedCompletionMachine = Machine.make({
   states: DoneTransitionStates.states,
   events: Machine.events(),
-  initial: () =>
-    DoneTransitionStates.initial.workflow(
-      new Workflow({}),
-      (workflow) => workflow.finished(new Finished({}))
-    )
+  initial: {
+    target: (to) => to.workflow.initial(),
+    resolve: ({ target }) =>
+      target(
+        new Workflow({}),
+        (workflow) => workflow.finished(new Finished({}))
+      )
+  }
 }).handle({
   workflow: {
     states: {
@@ -508,7 +567,7 @@ describe("MachineTest.verify", () => {
         ...trace,
         final: {
           ...workspace,
-          state: { path: "workspace.missing", value: new Editing({ revision: 1 }) }
+          state: { path: "workspace.missing" as const, value: new Editing({ revision: 1 }) }
         }
       } as typeof trace
       const unknownError = yield* MachineTest.verify(historyMachine, unknown, {
@@ -520,7 +579,7 @@ describe("MachineTest.verify", () => {
         ...trace,
         final: {
           ...workspace,
-          state: { path: "workspace.recent", value: new Editing({ revision: 1 }) }
+          state: { path: "workspace.recent" as const, value: new Editing({ revision: 1 }) }
         }
       } as typeof trace
       const historyError = yield* MachineTest.verify(historyMachine, activeHistory, {

--- a/test/unstable/cluster/ClusterMachine.test.ts
+++ b/test/unstable/cluster/ClusterMachine.test.ts
@@ -44,7 +44,10 @@ const CounterStates = Machine.defineStates({
 const UnsupportedChildMachine = Machine.make({
   states: { Count },
   events: Machine.events(),
-  initial: () => ({ path: "Count", value: new Count({ value: 0 }) })
+  initial: {
+    target: (to) => to.Count(),
+    resolve: () => ({ path: "Count" as const, value: new Count({ value: 0 }) })
+  }
 })
 const UnsupportedChild = Machine.child("unsupported", UnsupportedChildMachine)
 
@@ -60,35 +63,53 @@ const makeCounter = (state: {
     states: CounterStates.states,
     events: Machine.events(Increment, Fail, Finish, RaiseFromAction, SpawnFromAction),
     emittedEvents: Machine.emittedEvents(Changed),
-    initial: () => CounterStates.initial.Count(new Count({ value: 0 }))
+    initial: {
+      target: (to) => to.Count(),
+      resolve: ({ target }) => target(new Count({ value: 0 }))
+    }
   }).handle({
     Count: {
       entry: () => {
         state.initialEntries += 1
       },
       on: {
-        Increment: ({ event, state: current }, enqueue) => {
-          state.actions += 1
-          state.inFlight += 1
-          state.maxInFlight = Math.max(state.maxInFlight, state.inFlight)
-          state.inFlight -= 1
-          const value = current.value + event.by
-          enqueue.emit(new Changed({ value }))
-          return CounterStates.initial.Count(new Count({ value }))
-        },
-        Fail: ({ state: current }, enqueue) => {
-          enqueue.emit(new Changed({ value: 999 }))
-          return CounterStates.initial.Count(current)
-        },
-        Finish: ({ state: current }) => CounterStates.initial.Done(new Done({ value: current.value })),
-        RaiseFromAction: ({ state: current }, enqueue) => {
-          enqueue.raise(new Increment({ by: 1, block: false }))
-          return CounterStates.initial.Count(current)
-        },
-        SpawnFromAction: ({ state: current }, enqueue) => {
-          enqueue.stop(UnsupportedChild)
-          return CounterStates.initial.Count(current)
-        }
+        Increment: Machine.transition({
+          target: (to) => to.full.Count(),
+          resolve: ({ event, state: current, target }, enqueue) => {
+            state.actions += 1
+            state.inFlight += 1
+            state.maxInFlight = Math.max(state.maxInFlight, state.inFlight)
+            state.inFlight -= 1
+            const value = current.value + event.by
+            enqueue.emit(new Changed({ value }))
+            return target(new Count({ value }))
+          }
+        }),
+        Fail: Machine.transition({
+          target: (to) => to.full.Count(),
+          resolve: ({ state: current, target }, enqueue) => {
+            enqueue.emit(new Changed({ value: 999 }))
+            return target(current)
+          }
+        }),
+        Finish: Machine.transition({
+          target: (to) => to.full.Done(),
+          resolve: ({ state: current, target }) => target(new Done({ value: current.value }))
+        }),
+        RaiseFromAction: Machine.transition({
+          target: (to) => to.full.Count(),
+          resolve: ({ state: current, target }, enqueue) => {
+            enqueue.raise(new Increment({ by: 1, block: false }))
+            return target(current)
+          }
+        }),
+        SpawnFromAction: Machine.transition({
+          target: (to) => to.full.Count(),
+          resolve: ({ state: current, target }, enqueue) => {
+            enqueue.stop(UnsupportedChild)
+            return target(current)
+          }
+        })
       }
     },
     Done: {}
@@ -262,7 +283,7 @@ describe("ClusterMachine", () => {
         assert.deepStrictEqual(emitted, [new Changed({ value: 2 })])
         assert.deepStrictEqual(storage.entries.get(storageKey("CounterEntity", "counter-1"))?.snapshot, {
           _tag: "MachineSnapshot",
-          active: [{ path: "Count", value: { _tag: "Count", value: "2" } }]
+          active: [{ path: "Count" as const, value: { _tag: "Count", value: "2" } }]
         })
 
         yield* TestClock.adjust(5000)
@@ -273,7 +294,7 @@ describe("ClusterMachine", () => {
         assert.strictEqual(state.initialEntries, 1)
         assert.strictEqual(state.actions, 2)
         assert.deepStrictEqual(storage.entries.get(storageKey("CounterEntity", "counter-1"))?.snapshot.active, [{
-          path: "Count",
+          path: "Count" as const,
           value: { _tag: "Count", value: "5" }
         }])
         assert.isTrue(storage.transactionFlags.every(Boolean))
@@ -306,7 +327,7 @@ describe("ClusterMachine", () => {
         assert.strictEqual(state.maxInFlight, 1)
         assert.strictEqual(state.actions, 2)
         assert.deepStrictEqual(storage.entries.get(storageKey("SerializedCounter", "counter-1"))?.snapshot.active, [{
-          path: "Count",
+          path: "Count" as const,
           value: { _tag: "Count", value: "2" }
         }])
       }).pipe(Effect.provide(makeLayer(bridge, storage.service, () => Effect.void)))
@@ -373,7 +394,7 @@ describe("ClusterMachine", () => {
         assert.strictEqual(state.actions, 1)
         assert.strictEqual(storage.commits, 1)
         assert.deepStrictEqual(storage.entries.get(key)?.snapshot.active, [{
-          path: "Count",
+          path: "Count" as const,
           value: { _tag: "Count", value: "1" }
         }])
         const reply = driver.requests.get(String(requestId))!.replies[0]!
@@ -438,12 +459,18 @@ describe("ClusterMachine", () => {
         machineId: "Counter",
         version: "1",
         requestId: firstId,
-        snapshot: { _tag: "MachineSnapshot", active: [{ path: "Count", value: { _tag: "Count", value: "1" } }] }
+        snapshot: {
+          _tag: "MachineSnapshot",
+          active: [{ path: "Count" as const, value: { _tag: "Count", value: "1" } }]
+        }
       }
       const second: ClusterMachine.Checkpoint = {
         ...first,
         requestId: secondId,
-        snapshot: { _tag: "MachineSnapshot", active: [{ path: "Count", value: { _tag: "Count", value: "2" } }] }
+        snapshot: {
+          _tag: "MachineSnapshot",
+          active: [{ path: "Count" as const, value: { _tag: "Count", value: "2" } }]
+        }
       }
 
       assert.deepStrictEqual(yield* storage.commit(address, first), ClusterMachine.CommitResult.Committed())
@@ -467,21 +494,27 @@ describe("ClusterMachine", () => {
           entityType: "WrongMachineCounter",
           machineId: "Other",
           version: "1",
-          snapshot: { _tag: "MachineSnapshot", active: [{ path: "Count", value: { _tag: "Count", value: "0" } }] },
+          snapshot: {
+            _tag: "MachineSnapshot",
+            active: [{ path: "Count" as const, value: { _tag: "Count", value: "0" } }]
+          },
           reason: "MachineIdMismatch"
         },
         {
           entityType: "WrongVersionCounter",
           machineId: "Counter",
           version: "0",
-          snapshot: { _tag: "MachineSnapshot", active: [{ path: "Count", value: { _tag: "Count", value: "0" } }] },
+          snapshot: {
+            _tag: "MachineSnapshot",
+            active: [{ path: "Count" as const, value: { _tag: "Count", value: "0" } }]
+          },
           reason: "VersionMismatch"
         },
         {
           entityType: "InvalidSnapshotCounter",
           machineId: "Counter",
           version: "1",
-          snapshot: { _tag: "MachineSnapshot", active: [{ path: "Missing", value: {} }] },
+          snapshot: { _tag: "MachineSnapshot", active: [{ path: "Missing" as const, value: {} }] },
           reason: "InvalidCheckpoint"
         }
       ]
@@ -526,7 +559,7 @@ describe("ClusterMachine", () => {
         const client = makeClient("counter-1")
         assertAccepted(yield* client.send(new Finish({})))
         assert.deepStrictEqual(storage.entries.get(storageKey("FinalCounter", "counter-1"))?.snapshot.active, [{
-          path: "Done",
+          path: "Done" as const,
           value: { _tag: "Done", value: "0" }
         }])
 
@@ -534,7 +567,7 @@ describe("ClusterMachine", () => {
         assert.strictEqual(state.actions, 0)
         assert.strictEqual(storage.commits, 2)
         assert.deepStrictEqual(storage.entries.get(storageKey("FinalCounter", "counter-1"))?.snapshot.active, [{
-          path: "Done",
+          path: "Done" as const,
           value: { _tag: "Done", value: "0" }
         }])
       }).pipe(Effect.provide(makeLayer(bridge, storage.service, () => Effect.void)))
@@ -562,13 +595,19 @@ describe("ClusterMachine", () => {
         id: "Invoked",
         states: states.states,
         events: Machine.events(Increment),
-        initial: () => states.initial.Count(new Count({ value: 0 }))
+        initial: {
+          target: (to) => to.Count(),
+          resolve: ({ target }) => target(new Count({ value: 0 }))
+        }
       }).handle({
         Count: {
           invoke: Machine.invoke({
             id: "child",
             effect: () => Effect.void,
-            onDone: ({ target }) => target.none()
+            onDone: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            })
           })
         }
       })

--- a/test/unstable/reactivity/AtomMachine.test.ts
+++ b/test/unstable/reactivity/AtomMachine.test.ts
@@ -36,11 +36,6 @@ class Online extends Schema.TaggedClass<Online>("Online")("Online", {}) {}
 
 class Offline extends Schema.TaggedClass<Offline>("Offline")("Offline", {}) {}
 
-const MachineInitial = Machine.defineStates({
-  Count,
-  Done: { schema: Done, type: "final" },
-  ValueRead: { schema: ValueRead, type: "final" }
-}).initial
 const CounterStates = Machine.defineStates({
   Count,
   Done: { schema: Done, type: "final" }
@@ -73,11 +68,17 @@ const makeCounterMachine = () =>
   Machine.make({
     states: CounterStates.states,
     events: Machine.events(Finish),
-    initial: () => CounterStates.initial.Count(new Count({ value: 0 }))
+    initial: {
+      target: (to) => to.Count(),
+      resolve: ({ target }) => target(new Count({ value: 0 }))
+    }
   }).handle({
     Count: {
       on: {
-        Finish: ({ state, event }) => MachineInitial.Count(new Count({ value: state.value + event.by }))
+        Finish: Machine.transition({
+          target: (to) => to.full.Count(),
+          resolve: ({ state, event, target }) => target(new Count({ value: state.value + event.by }))
+        })
       }
     },
     Done: {}
@@ -110,7 +111,10 @@ describe("AtomMachine", () => {
         states: states.states,
         events: Machine.events(),
         emittedEvents: Emissions,
-        initial: () => states.initial.Idle(new Idle({}))
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({}))
+        }
       }).handle({
         Idle: {
           entry: (_, enqueue) => {
@@ -140,9 +144,12 @@ describe("AtomMachine", () => {
       const machine = Machine.make({
         states: CounterStates.states,
         events: Machine.events(Finish),
-        initial: () => {
-          initialCalls += 1
-          return CounterStates.initial.Count(new Count({ value: 0 }))
+        initial: {
+          target: (to) => to.Count(),
+          resolve: ({ target }) => {
+            initialCalls += 1
+            return target(new Count({ value: 0 }))
+          }
         }
       }).handle({
         Count: {
@@ -155,12 +162,15 @@ describe("AtomMachine", () => {
             })
           }),
           on: {
-            Finish: ({ event, state, target }) => target.full.Count(new Count({ value: state.value + event.by }))
+            Finish: Machine.transition({
+              target: (to) => to.full.Count(),
+              resolve: ({ event, state, target }) => target(new Count({ value: state.value + event.by }))
+            })
           }
         },
         Done: {}
       })
-      const bridge = AtomMachine.resume(machine, CounterStates.initial.Count(new Count({ value: 5 })))
+      const bridge = AtomMachine.resume(machine, { path: "Count" as const, value: new Count({ value: 5 }) })
       const firstRegistry = AtomRegistry.make()
       const secondRegistry = AtomRegistry.make()
 
@@ -171,7 +181,7 @@ describe("AtomMachine", () => {
       assert.strictEqual(first, firstAgain)
       assert.notStrictEqual(first, second)
       assert.deepStrictEqual(yield* AtomRegistry.getResult(firstRegistry, bridge.state), {
-        path: "Count",
+        path: "Count" as const,
         value: new Count({ value: 5 })
       })
       assert.strictEqual(initialCalls, 0)
@@ -198,17 +208,32 @@ describe("AtomMachine", () => {
       const parent = Machine.make({
         states: { Count, ValueRead },
         events: Machine.events(Finish, ReadValue),
-        initial: () => MachineInitial.Count(new Count({ value: 0 }))
+        initial: {
+          target: (to) => to.Count(),
+          resolve: ({ target }) => target(new Count({ value: 0 }))
+        }
       }).handle({
         Count: {
           on: {
-            Finish: () => MachineInitial.ValueRead(new ValueRead({ value: "active" }))
+            Finish: Machine.transition({
+              target: (to) => to.full.ValueRead(),
+              resolve: ({ target }) => target(new ValueRead({ value: "active" }))
+            })
           }
         },
         ValueRead: {
-          invoke: Machine.invoke({ child: Child, onDone: ({ target }) => target.none() }),
+          invoke: Machine.invoke({
+            child: Child,
+            onDone: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            })
+          }),
           on: {
-            ReadValue: () => MachineInitial.Count(new Count({ value: 0 }))
+            ReadValue: Machine.transition({
+              target: (to) => to.full.Count(),
+              resolve: ({ target }) => target(new Count({ value: 0 }))
+            })
           }
         }
       })
@@ -257,7 +282,7 @@ describe("AtomMachine", () => {
       const selectedInitialSnapshot = yield* waitForResult(registry, selectedCountSnapshot, Option.isSome)
       assert(Option.isSome(selectedInitialSnapshot))
       assert.deepStrictEqual(selectedInitialSnapshot.value, {
-        path: "Count",
+        path: "Count" as const,
         value: new Count({ value: 0 })
       })
       assert.strictEqual(yield* AtomRegistry.getResult(registry, countMatches), true)
@@ -302,7 +327,7 @@ describe("AtomMachine", () => {
       assert.deepStrictEqual(initial, {
         status: "active",
         state: {
-          path: "Count",
+          path: "Count" as const,
           value: new Count({ value: 0 })
         }
       })
@@ -311,7 +336,7 @@ describe("AtomMachine", () => {
 
       const state = yield* waitForResult(registry, bridge.state, (state) => state.value.value === 2)
       assert.deepStrictEqual(state, {
-        path: "Count",
+        path: "Count" as const,
         value: new Count({ value: 2 })
       })
     })))
@@ -380,11 +405,14 @@ describe("AtomMachine", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: () =>
-          states.initial.Ready(new Ready({}), (ready) =>
-            ready
-              .editor(new Editor({}), (editor) => editor.Editing(new Editing({})))
-              .network(new Network({}), (network) => network.Online(new Online({}))))
+        initial: {
+          target: (to) => to.Ready.initial(),
+          resolve: ({ target }) =>
+            target(new Ready({}), (ready) =>
+              ready
+                .editor(new Editor({}), (editor) => editor.Editing(new Editing({})))
+                .network(new Network({}), (network) => network.Online(new Online({}))))
+        }
       }).handle({
         Ready: {
           states: {
@@ -466,7 +494,7 @@ describe("AtomMachine", () => {
       assert.deepStrictEqual(snapshot, {
         status: "stopped",
         state: {
-          path: "Count",
+          path: "Count" as const,
           value: new Count({ value: 0 })
         }
       })
@@ -513,11 +541,17 @@ describe("AtomMachine", () => {
           }
         },
         events: Machine.events(Finish),
-        initial: () => MachineInitial.Count(new Count({ value: 1 }))
+        initial: {
+          target: (to) => to.Count(),
+          resolve: ({ target }) => target(new Count({ value: 1 }))
+        }
       }).handle({
         Count: {
           on: {
-            Finish: ({ state, event }) => MachineInitial.Done(new Done({ value: state.value + event.by }))
+            Finish: Machine.transition({
+              target: (to) => to.full.Done(),
+              resolve: ({ state, event, target }) => target(new Done({ value: state.value + event.by }))
+            })
           }
         },
         Done: {
@@ -533,9 +567,9 @@ describe("AtomMachine", () => {
       assert.deepStrictEqual(snapshot, {
         status: "done",
         state: {
-          path: "Done",
+          path: "Done" as const,
           value: new Done({ value: 4 }),
-          completed: [{ path: "Done", output: 4 }]
+          completed: [{ path: "Done" as const, output: 4 }]
         },
         output: 4
       })

--- a/typetest/machine/Activities.tst.ts
+++ b/typetest/machine/Activities.tst.ts
@@ -10,13 +10,30 @@ const States = Machine.defineStates({ Loading, Dynamic })
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(TimedOut),
-  initial: () => States.initial.Loading(new Loading({}))
+  initial: {
+    target: (to) => to.Loading(),
+    resolve: ({ target }) => (target(new Loading({})))
+  }
 }).handle({
   Loading: {
-    invoke: Machine.invoke({ id: "timeout", after: "1 second", onDone: ({ target }) => target.none() })
+    invoke: Machine.invoke({
+      id: "timeout",
+      after: "1 second",
+      onDone: Machine.transition({
+        target: (to) => to.none(),
+        resolve: () => undefined
+      })
+    })
   },
   Dynamic: {
-    invoke: Machine.invoke({ id: "dynamic", after: () => "2 seconds" as const, onDone: ({ target }) => target.none() })
+    invoke: Machine.invoke({
+      id: "dynamic",
+      after: () => "2 seconds" as const,
+      onDone: Machine.transition({
+        target: (to) => to.none(),
+        resolve: () => undefined
+      })
+    })
   }
 })
 

--- a/typetest/machine/Annotations.tst.ts
+++ b/typetest/machine/Annotations.tst.ts
@@ -39,7 +39,10 @@ const States = Machine.defineStates({
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(),
-  initial: () => States.initial.Workflow(new Workflow({}), (workflow) => workflow.Idle(new Idle({})))
+  initial: {
+    target: (to) => to.Workflow.initial(),
+    resolve: ({ target }) => (target(new Workflow({}), (workflow) => workflow.Idle(new Idle({}))))
+  }
 })
 
 describe("Machine state annotations", () => {

--- a/typetest/machine/Choice.tst.ts
+++ b/typetest/machine/Choice.tst.ts
@@ -34,23 +34,26 @@ describe("Machine choice pseudo-states", () => {
     const incomplete = Machine.make({
       states: States.states,
       events: Machine.events(),
-      initial: () => States.initial.Flow(new Flow({ score: 80 }), (flow) => flow.Routing())
+      initial: {
+        target: (to) => to.Flow.initial(),
+        resolve: ({ target }) => (target(new Flow({ score: 80 }), (flow) => flow.Routing()))
+      }
     })
     expect(Machine.planInitial).type.not.toBeCallableWith(incomplete)
     const complete = incomplete.handle({
       Flow: {
         states: {
           Routing: {
-            choice: {
-              targets: ["Flow.Approved", "Flow.Rejected"],
-              transition: (context) => {
+            choice: Machine.transition({
+              target: (to) => to.local.Approved(),
+              resolve: (context) => {
                 expect(context).type.not.toHaveProperty("state")
                 expect(context.containingState).type.toBe<Flow>()
                 expect(context.ancestors.Flow).type.toBe<Flow>()
                 expect(context.event).type.toBe<Machine.Machine.LifecycleEvent<readonly []>>()
-                return context.target.local.Approved(new Approved({}))
+                return context.target(new Approved({}))
               }
-            }
+            })
           }
         }
       }
@@ -62,24 +65,20 @@ describe("Machine choice pseudo-states", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(),
-      initial: () => States.initial.Flow(new Flow({ score: 80 }), (flow) => flow.Routing())
-    })
-    expect(machine.handle).type.not.toBeCallableWith({
-      Flow: {
-        states: {
-          Routing: {
-            choice: {
-              targets: ["Flow.Approved"],
-              transition: ({ target }: Machine.Machine.ChoiceContext<
-                typeof States.states,
-                readonly [],
-                readonly [],
-                "Flow.Routing"
-              >) => Effect.succeed(target.local.Approved(new Approved({})))
-            }
-          }
-        }
+      initial: {
+        target: (to) => to.Flow.initial(),
+        resolve: ({ target }) => (target(new Flow({ score: 80 }), (flow) => flow.Routing()))
       }
+    })
+    const target = (to: Machine.Machine.TargetSelector<typeof States.states, "Flow.Routing">) => to.local.Approved()
+    expect(Machine.transition).type.not.toBeCallableWith({
+      target,
+      resolve: (
+        { target: selectedTarget }: Machine.Machine.TransitionResolveContext<
+          Machine.Machine.ChoiceContext<typeof States.states, readonly [], readonly [], "Flow.Routing">,
+          ReturnType<typeof target>
+        >
+      ) => Effect.succeed(selectedTarget(new Approved({})))
     })
   })
 
@@ -104,7 +103,10 @@ describe("Machine choice pseudo-states", () => {
     const base = Machine.make({
       states: States.states,
       events: Machine.events(),
-      initial: () => States.initial.Flow(new Flow({ score: 80 }), (flow) => flow.Routing())
+      initial: {
+        target: (to) => to.Flow.initial(),
+        resolve: ({ target }) => (target(new Flow({ score: 80 }), (flow) => flow.Routing()))
+      }
     })
     const invalidHandlers = [
       { entry: () => undefined },
@@ -123,35 +125,35 @@ describe("Machine choice pseudo-states", () => {
     }
   })
 
-  it("rejects void and undeclared choice results", () => {
+  it("requires Machine.transition and validates the selected result", () => {
     const base = Machine.make({
       states: States.states,
       events: Machine.events(),
-      initial: () => States.initial.Flow(new Flow({ score: 80 }), (flow) => flow.Routing())
+      initial: {
+        target: (to) => to.Flow.initial(),
+        resolve: ({ target }) => (target(new Flow({ score: 80 }), (flow) => flow.Routing()))
+      }
     })
-    expect(base.handle).type.not.toBeCallableWith({
+    const target = (to: Machine.Machine.TargetSelector<typeof States.states, "Flow.Routing">) => to.local.Rejected()
+    base.handle({
       Flow: {
         states: {
-          Routing: { choice: { targets: ["Flow.Approved"], transition: () => undefined } }
+          Routing: {
+            choice: Machine.transition({
+              target,
+              resolve: ({ target: selectedTarget }) => {
+                expect(selectedTarget).type.not.toBeCallableWith(new Approved({}))
+                return selectedTarget(new Rejected({}))
+              }
+            })
+          }
         }
       }
     })
     expect(base.handle).type.not.toBeCallableWith({
       Flow: {
         states: {
-          Routing: {
-            choice: {
-              targets: ["Flow.Approved"],
-              transition: (
-                { target }: Machine.Machine.ChoiceContext<
-                  typeof States.states,
-                  readonly [],
-                  readonly [],
-                  "Flow.Routing"
-                >
-              ) => target.local.Rejected(new Rejected({}))
-            }
-          }
+          Routing: { choice: () => undefined }
         }
       }
     })

--- a/typetest/machine/DeepHandlers.tst.ts
+++ b/typetest/machine/DeepHandlers.tst.ts
@@ -161,8 +161,11 @@ const makeDeepMachine = () =>
   Machine.make({
     states: DeepStates.states,
     events: Machine.events(Advance),
-    initial: (): never => {
-      throw new Error("type-only")
+    initial: {
+      target: (to) => to.Root.initial(),
+      resolve: (): never => {
+        throw new Error("type-only")
+      }
     }
   })
 
@@ -242,28 +245,6 @@ describe("deep handler trees", () => {
     }))
     expect(machine.handle).type.not.toBeCallableWith(atHub({
       onDone: () => undefined
-    }))
-    expect(machine.handle).type.not.toBeCallableWith(atHub({
-      states: {
-        Idle: {
-          on: {
-            Advance: {
-              targets: ["Root.L1.L2.L3.L4.L5.L6.L7.L8.L9.L10.Hub.Idle"],
-              transition: (
-                { target }: Machine.Machine.HandlerContext<
-                  typeof DeepStates.states,
-                  readonly [typeof Advance],
-                  readonly [],
-                  "Root.L1.L2.L3.L4.L5.L6.L7.L8.L9.L10.Hub.Idle",
-                  "Advance",
-                  never,
-                  never
-                >
-              ) => target.local.Done(new Done({ value: "invalid-bound" }))
-            }
-          }
-        }
-      }
     }))
   })
 
@@ -428,8 +409,11 @@ describe("deep handler trees", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(),
-      initial: (): never => {
-        throw new Error("type-only")
+      initial: {
+        target: (to) => to.n0.initial(),
+        resolve: (): never => {
+          throw new Error("type-only")
+        }
       }
     }).handle({
       n0: {

--- a/typetest/machine/EventByTag.tst.ts
+++ b/typetest/machine/EventByTag.tst.ts
@@ -35,26 +35,35 @@ describe("Machine.EventByTag", () => {
     Machine.make({
       states: states.states,
       events: Machine.events(FiniteUnion),
-      initial: () => states.initial.Idle(new Idle({}))
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ target }) => (target(new Idle({})))
+      }
     }).handle({
       Idle: {
         on: {
-          Alpha: ({ event, target }) => {
-            expect(event).type.toBe<{
-              readonly _tag: "Alpha"
-              readonly payload: string
-              readonly count: number
-            }>()
-            return target.none()
-          },
-          Beta: ({ event, target }) => {
-            expect(event).type.toBe<{
-              readonly _tag: "Beta"
-              readonly payload: string
-              readonly count: number
-            }>()
-            return target.none()
-          }
+          Alpha: Machine.transition({
+            target: (to) => to.none(),
+            resolve: ({ event }) => {
+              expect(event).type.toBe<{
+                readonly _tag: "Alpha"
+                readonly payload: string
+                readonly count: number
+              }>()
+              return undefined
+            }
+          }),
+          Beta: Machine.transition({
+            target: (to) => to.none(),
+            resolve: ({ event }) => {
+              expect(event).type.toBe<{
+                readonly _tag: "Beta"
+                readonly payload: string
+                readonly count: number
+              }>()
+              return undefined
+            }
+          })
         }
       }
     })

--- a/typetest/machine/EventConstructors.tst.ts
+++ b/typetest/machine/EventConstructors.tst.ts
@@ -33,7 +33,10 @@ describe("Machine event constructor collections", () => {
     states: states.states,
     events,
     internalEvents,
-    initial: () => states.initial.Idle.from()
+    initial: {
+      target: (to) => to.Idle(),
+      resolve: ({ target }) => (target.from())
+    }
   })
 
   it("derives public constructors and their schema make inputs", () => {
@@ -74,13 +77,17 @@ describe("Machine event constructor collections", () => {
     expect(Machine.make).type.not.toBeCallableWith({
       states: states.states,
       events: internalEvents,
-      initial: () => states.initial.Idle.from()
+      initial: {
+        target: (to: Machine.Machine.InitialSelector<typeof states.states>) => to.Idle()
+      }
     })
     expect(Machine.make).type.not.toBeCallableWith({
       states: states.states,
       events,
       internalEvents: events,
-      initial: () => states.initial.Idle.from()
+      initial: {
+        target: (to: Machine.Machine.InitialSelector<typeof states.states>) => to.Idle()
+      }
     })
 
     const Reset = Schema.TaggedStruct("Reset", {})
@@ -93,7 +100,10 @@ describe("Machine event constructor collections", () => {
     const openMachine = Machine.make({
       states: states.states,
       events: openEvents,
-      initial: () => states.initial.Idle.from()
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ target }) => (target.from())
+      }
     })
 
     expect(openEvents.Dynamic).type.toRaiseError()
@@ -113,18 +123,24 @@ describe("Machine event constructor collections", () => {
             Machine.invoke({
               id: "load",
               effect: () => Effect.succeed("ready"),
-              onDone: ({ output, target }, enqueue) => {
-                enqueue.raise(internalEvents.Loaded({ value: output }))
-                return target.none()
-              }
+              onDone: Machine.transition({
+                target: (to) => to.none(),
+                resolve: ({ output }, enqueue) => {
+                  enqueue.raise(internalEvents.Loaded({ value: output }))
+                  return undefined
+                }
+              })
             }),
             Machine.invoke({
               id: "timeout",
               after: "1 second",
-              onDone: ({ target }, enqueue) => {
-                enqueue.raise(internalEvents.Failed())
-                return target.none()
-              }
+              onDone: Machine.transition({
+                target: (to) => to.none(),
+                resolve: (_, enqueue) => {
+                  enqueue.raise(internalEvents.Failed())
+                  return undefined
+                }
+              })
             })
           ]
         }

--- a/typetest/machine/History.tst.ts
+++ b/typetest/machine/History.tst.ts
@@ -142,19 +142,27 @@ describe("Machine history states", () => {
     >()
   })
 
-  it("excludes history pseudo-states from snapshots and initial builders", () => {
+  it("excludes history pseudo-states from snapshots and initial selectors", () => {
     type Snapshot = Machine.Machine.Snapshot<typeof States.states>
     expect<"checkout.recent">().type.not.toBeAssignableTo<Snapshot["path"]>()
-    States.initial.checkout(
-      new Checkout({ orderId: "order-1" }),
-      (checkout) => {
-        expect(checkout).type.not.toHaveProperty("recent")
-        expect(checkout).type.not.toHaveProperty("exact")
-        return checkout.shipping(new Shipping({ address: "Main Street" }))
+    Machine.make({
+      states: States.states,
+      events: Machine.events(),
+      initial: {
+        target: (to) => {
+          expect(to).type.not.toHaveProperty("recent")
+          expect(to).type.not.toHaveProperty("exact")
+          return to.checkout.initial()
+        },
+        resolve: ({ target }) =>
+          target(
+            new Checkout({ orderId: "order-1" }),
+            (checkout) => checkout.shipping(new Shipping({ address: "Main Street" }))
+          )
       }
-    )
+    })
     expect(States.get).type.not.toBeCallableWith(
-      States.initial.support(new Support({})),
+      { path: "support" as const, value: new Support({}) },
       "checkout.recent"
     )
   })
@@ -163,19 +171,27 @@ describe("Machine history states", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(Resume),
-      initial: () => States.initial.support(new Support({}))
+      initial: {
+        target: (to) => to.support(),
+        resolve: ({ target }) => (target(new Support({})))
+      }
     }).handle({
       support: {
         on: {
-          Resume: ({ target }) => {
-            expect(target.history.checkout.recent).type.toBeCallableWith()
-            expect(target.history.checkout.recent).type.not.toBeCallableWith(new Checkout({ orderId: "new" }))
-            expect(target.history.checkout.exact).type.toBeCallableWith()
-            expect(target.full).type.not.toHaveProperty("recent")
-            expect(target.local).type.not.toHaveProperty("recent")
-            expect(target.branch).type.not.toHaveProperty("recent")
-            return target.history.checkout.exact()
-          }
+          Resume: Machine.transition({
+            target: (to) => {
+              expect(to.history.checkout.recent).type.toBeCallableWith()
+              expect(to.history.checkout.recent).type.not.toBeCallableWith(new Checkout({ orderId: "new" }))
+              expect(to.full.checkout).type.not.toHaveProperty("recent")
+              expect(to.local).type.not.toHaveProperty("recent")
+              expect(to.branch).type.not.toHaveProperty("recent")
+              return to.history.checkout.exact()
+            },
+            resolve: ({ target }) => {
+              expect(target).type.toBeCallableWith()
+              return target()
+            }
+          })
         }
       }
     })
@@ -189,11 +205,17 @@ describe("Machine history states", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(Resume),
-      initial: () => States.initial.support(new Support({}))
+      initial: {
+        target: (to) => to.support(),
+        resolve: ({ target }) => (target(new Support({})))
+      }
     }).handle({
       support: {
         on: {
-          Resume: ({ target }) => target.history.checkout.recent()
+          Resume: Machine.transition({
+            target: (to) => to.history.checkout.recent(),
+            resolve: ({ target }) => target()
+          })
         }
       }
     })
@@ -209,15 +231,15 @@ describe("Machine history states", () => {
               expect(target).type.toBe<
                 Machine.Machine.HistoryDefaultTargetBuilder<typeof States.states, "checkout">
               >()
-              return States.initial.checkout(
+              return target.checkout(
                 new Checkout({ orderId: "fallback" }),
                 (checkout) => checkout.shipping(new Shipping({ address: "" }))
               )
             }
           },
           exact: {
-            default: () =>
-              States.initial.checkout(
+            default: ({ target }) =>
+              target.checkout(
                 new Checkout({ orderId: "fallback" }),
                 (checkout) => checkout.shipping(new Shipping({ address: "" }))
               )
@@ -243,17 +265,30 @@ describe("Machine history states", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(Resume),
-      initial: () => States.initial.support(new Support({}))
+      initial: {
+        target: (to) => to.support(),
+        resolve: ({ target }) => (target(new Support({})))
+      }
     })
 
-    expect(machine.handle).type.not.toBeCallableWith({
+    machine.handle({
       checkout: {
         history: {
           recent: {
-            default: () => States.initial.support(new Support({}))
+            default: ({ target }) => {
+              expect(target).type.not.toHaveProperty("support")
+              return target.checkout(
+                new Checkout({ orderId: "fallback" }),
+                (checkout) => checkout.shipping(new Shipping({ address: "" }))
+              )
+            }
           },
           exact: {
-            default: () => States.initial.support(new Support({}))
+            default: ({ target }) =>
+              target.checkout(
+                new Checkout({ orderId: "fallback" }),
+                (checkout) => checkout.shipping(new Shipping({ address: "" }))
+              )
           }
         }
       }
@@ -289,7 +324,10 @@ describe("Machine history states", () => {
     const machine = Machine.make({
       states: NestedStates.states,
       events: Machine.events(Resume),
-      initial: () => NestedStates.initial.Closed(new Closed({}))
+      initial: {
+        target: (to) => to.Closed(),
+        resolve: ({ target }) => (target(new Closed({})))
+      }
     })
 
     const complete = machine.handle({
@@ -415,7 +453,10 @@ describe("Machine history states", () => {
     const machine = Machine.make({
       states: NestedStates.states,
       events: Machine.events(Resume),
-      initial: () => NestedStates.initial.Closed(new Closed({}))
+      initial: {
+        target: (to) => to.Closed(),
+        resolve: ({ target }) => (target(new Closed({})))
+      }
     })
     expect(machine.handle).type.not.toBeCallableWith({
       App: {
@@ -436,21 +477,24 @@ describe("Machine history states", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(Resume),
-      initial: () => States.initial.support(new Support({}))
+      initial: {
+        target: (to) => to.support(),
+        resolve: ({ target }) => (target(new Support({})))
+      }
     })
     const afterDefaults = machine.handle({
       checkout: {
         history: {
           recent: {
-            default: () =>
-              States.initial.checkout(
+            default: ({ target }) =>
+              target.checkout(
                 new Checkout({ orderId: "fallback" }),
                 (checkout) => checkout.shipping(new Shipping({ address: "" }))
               )
           },
           exact: {
-            default: () =>
-              States.initial.checkout(
+            default: ({ target }) =>
+              target.checkout(
                 new Checkout({ orderId: "fallback" }),
                 (checkout) => checkout.shipping(new Shipping({ address: "" }))
               )
@@ -502,7 +546,10 @@ describe("Machine history states", () => {
     const machine = Machine.make({
       states: DeepOnlyStates.states,
       events: Machine.events(Resume),
-      initial: () => DeepOnlyStates.initial.support(new Support({}))
+      initial: {
+        target: (to) => to.support(),
+        resolve: ({ target }) => (target(new Support({})))
+      }
     }).handle({
       checkout: {
         history: {
@@ -553,14 +600,17 @@ describe("Machine history states", () => {
     const machine = Machine.make({
       states: ParallelStates.states,
       events: Machine.events(Resume),
-      initial: () => ParallelStates.initial.support(new Support({}))
+      initial: {
+        target: (to) => to.support(),
+        resolve: ({ target }) => (target(new Support({})))
+      }
     })
     const complete = machine.handle({
       outer: {
         history: {
           recent: {
-            default: () =>
-              ParallelStates.initial.outer(
+            default: ({ target }) =>
+              target.outer(
                 new Checkout({ orderId: "fallback" }),
                 (outer) =>
                   outer.all(

--- a/typetest/machine/InitialEntry.tst.ts
+++ b/typetest/machine/InitialEntry.tst.ts
@@ -20,7 +20,10 @@ const States = Machine.defineStates({
 const base = Machine.make({
   states: States.states,
   events: Machine.events(Open),
-  initial: () => States.initial.closed(new Closed({}))
+  initial: {
+    target: (to) => to.closed(),
+    resolve: ({ target }) => (target(new Closed({})))
+  }
 })
 
 type Events = readonly [typeof Open]
@@ -33,6 +36,14 @@ type ClosedContext = Machine.Machine.HandlerContext<
   never,
   never
 >
+type ClosedTransition = Machine.Machine.TransitionConfig<
+  typeof States.states,
+  Events,
+  readonly [],
+  "closed",
+  ClosedContext,
+  true
+>
 type OpenedInitializeContext = Machine.Machine.StateInitializeContext<
   typeof States.states,
   Events,
@@ -42,19 +53,27 @@ type OpenedInitializeContext = Machine.Machine.StateInitializeContext<
 
 describe("declared initial entry types", () => {
   it("requires initialize at the handle call that returns an initial target", () => {
+    const invalid = Machine.transition({
+      target: (to) => to.full.opened.initial(),
+      resolve: ({ target }) => target(new Opened({ id: "team-1" }))
+    }) satisfies ClosedTransition
     expect(base.handle).type.not.toBeCallableWith({
       closed: {
         on: {
-          Open: ({ target }: ClosedContext) => target.full.opened.initial(new Opened({ id: "team-1" }))
+          Open: invalid
         }
       },
       opened: {}
     })
 
+    const initial = Machine.transition({
+      target: (to) => to.full.opened.initial(),
+      resolve: ({ target }) => target.from({ id: "team-1" })
+    }) satisfies ClosedTransition
     expect(base.handle).type.toBeCallableWith({
       closed: {
         on: {
-          Open: ({ target }: ClosedContext) => target.full.opened.initial.from({ id: "team-1" })
+          Open: initial
         }
       },
       opened: {
@@ -62,14 +81,18 @@ describe("declared initial entry types", () => {
       }
     })
 
+    const explicit = Machine.transition({
+      target: (to) => to.full.opened(),
+      resolve: ({ target }) =>
+        target(
+          new Opened({ id: "team-1" }),
+          (opened) => opened.loading(new Loading({}))
+        )
+    }) satisfies ClosedTransition
     expect(base.handle).type.toBeCallableWith({
       closed: {
         on: {
-          Open: ({ target }: ClosedContext) =>
-            target.full.opened(
-              new Opened({ id: "team-1" }),
-              (opened) => opened.loading(new Loading({}))
-            )
+          Open: explicit
         }
       },
       opened: {}
@@ -80,17 +103,19 @@ describe("declared initial entry types", () => {
     base.handle({
       closed: {
         on: {
-          Open: ({ target }) => {
-            expect(target.full.closed).type.not.toHaveProperty("initial")
-            expect(target.full.opened).type.toHaveProperty("initial")
-            expect(target.full.opened.initial).type.not.toBeCallableWith()
-            expect(target.full.opened.initial).type.toBeCallableWith(new Opened({ id: "team-1" }))
-            expect(target.full.opened.initial.from).type.toBeCallableWith({ id: "team-1" })
-            return target.full.opened(
-              new Opened({ id: "team-1" }),
-              (opened) => opened.loading(new Loading({}))
-            )
-          }
+          Open: Machine.transition({
+            target: (to) => to.full.opened(),
+            resolve: ({ target }) => {
+              expect(target).type.toHaveProperty("initial")
+              expect(target.initial).type.not.toBeCallableWith()
+              expect(target.initial).type.toBeCallableWith(new Opened({ id: "team-1" }))
+              expect(target.initial.from).type.toBeCallableWith({ id: "team-1" })
+              return target(
+                new Opened({ id: "team-1" }),
+                (opened) => opened.loading(new Loading({}))
+              )
+            }
+          })
         }
       }
     })

--- a/typetest/machine/Inspection.tst.ts
+++ b/typetest/machine/Inspection.tst.ts
@@ -18,15 +18,25 @@ describe("Machine inspection", () => {
       }
     }
   })
-  const initial = States.initial.root(new Root({}), (root) => root.idle(new Idle({})))
+  const initial: Machine.Machine.Snapshot<typeof States.states> = {
+    path: "root",
+    value: new Root({}),
+    state: { path: "root.idle", value: new Idle({}) }
+  }
   const machine = Machine.make({
     states: States.states,
     events: Machine.events(Reset),
-    initial: () => initial
+    initial: {
+      target: (to) => to.root.initial(),
+      resolve: ({ target }) => target(new Root({}), (root) => root.idle(new Idle({})))
+    }
   }).handle({
     root: {
       on: {
-        Reset: ({ target }) => target.none()
+        Reset: Machine.transition({
+          target: (to) => to.none(),
+          resolve: () => undefined
+        })
       }
     }
   })
@@ -36,8 +46,20 @@ describe("Machine inspection", () => {
     const executable = Machine.make({
       states: FlatStates.states,
       events: Machine.events(Reset),
-      initial: () => FlatStates.initial.Idle(new Idle({}))
-    }).handle({ Idle: { on: { Reset: ({ target }) => target.none() } } })
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ target }) => (target(new Idle({})))
+      }
+    }).handle({
+      Idle: {
+        on: {
+          Reset: Machine.transition({
+            target: (to) => to.none(),
+            resolve: () => undefined
+          })
+        }
+      }
+    })
     Effect.gen(function*() {
       const prepared = yield* Machine.prepare(executable)
       expect(prepared.inspection).type.toBe<Stream.Stream<Machine.Inspection.Event>>()
@@ -137,7 +159,10 @@ describe("Machine inspection", () => {
     const choiceMachine = Machine.make({
       states: ChoiceStates.states,
       events: Machine.events(),
-      initial: () => ChoiceStates.initial.Flow(new Root({}), (flow) => flow.Routing())
+      initial: {
+        target: (to) => to.Flow.initial(),
+        resolve: ({ target }) => (target(new Root({}), (flow) => flow.Routing()))
+      }
     })
     const flow = Machine.stateNodes(choiceMachine).find((node) => node.type === "compound")!
     const routing = Machine.stateNodes(choiceMachine).find((node) => node.type === "choice")!
@@ -165,129 +190,35 @@ describe("Machine inspection", () => {
     if (definition.trigger.type === "event") {
       expect(definition.trigger.event).type.toBe<"Reset">()
     }
-    expect(definition.targets).type.toBe<
-      | { readonly type: "dynamic" }
-      | { readonly type: "declared"; readonly paths: ReadonlyArray<"root" | "root.idle" | "root.recent"> }
+    expect(definition.branches).type.toBe<
+      ReadonlyArray<Machine.Machine.TransitionBranch<"root" | "root.idle" | "root.recent">>
     >()
   })
 
-  it("checks inferred transition results against declared targets", () => {
+  it("requires statically selected transitions", () => {
     const FlatStates = Machine.defineStates({ idle: Idle, running: Running })
     const flat = Machine.make({
       states: FlatStates.states,
       events: Machine.events(Reset),
-      initial: () => FlatStates.initial.idle(new Idle({}))
+      initial: {
+        target: (to) => to.idle(),
+        resolve: ({ target }) => (target(new Idle({})))
+      }
     })
-    const target = flat.makeTargetBuilder("idle")
+    flat.handle({
+      idle: {
+        on: {
+          Reset: Machine.transition({
+            target: (to) => to.full.running(),
+            resolve: ({ target }) => target(new Running({}))
+          })
+        }
+      }
+    })
 
-    const direct = {
-      idle: {
-        on: {
-          Reset: {
-            targets: ["running"],
-            transition: () => target.full.running(new Running({}))
-          }
-        }
-      }
-    } as const
-    const effectful = {
-      idle: {
-        on: {
-          Reset: {
-            targets: ["running"],
-            transition: () => Effect.succeed(target.full.running(new Running({})))
-          }
-        }
-      }
-    } as const
-    const constructed = {
-      idle: {
-        on: {
-          Reset: {
-            targets: ["running"],
-            transition: () => target.full.running.from()
-          }
-        }
-      }
-    } as const
-    const undeclared = {
-      idle: {
-        on: {
-          Reset: {
-            targets: ["idle"],
-            transition: () => target.full.running(new Running({}))
-          }
-        }
-      }
-    } as const
-    const multiple = {
-      idle: {
-        on: {
-          Reset: {
-            targets: ["idle", "running"],
-            transition: () =>
-              Math.random() > 0.5
-                ? target.full.idle(new Idle({}))
-                : target.full.running(new Running({}))
-          }
-        }
-      }
-    } as const
-    const partiallyUndeclared = {
-      idle: {
-        on: {
-          Reset: {
-            targets: ["running"],
-            transition: () =>
-              Math.random() > 0.5
-                ? target.full.idle(new Idle({}))
-                : target.full.running(new Running({}))
-          }
-        }
-      }
-    } as const
-    const always = {
-      idle: {
-        always: {
-          targets: ["running"],
-          transition: () => target.full.running(new Running({}))
-        }
-      }
-    } as const
-    const undeclaredAlways = {
-      idle: {
-        always: {
-          targets: ["idle"],
-          transition: () => target.full.running(new Running({}))
-        }
-      }
-    } as const
-    const onDone = {
-      idle: {
-        onDone: {
-          targets: ["running"],
-          transition: () => Effect.succeed(target.full.running(new Running({})))
-        }
-      }
-    } as const
-    const undeclaredOnDone = {
-      idle: {
-        onDone: {
-          targets: ["idle"],
-          transition: () => target.full.running(new Running({}))
-        }
-      }
-    } as const
-
-    expect(flat.handle).type.toBeCallableWith(direct)
-    expect(flat.handle).type.not.toBeCallableWith(effectful)
-    expect(flat.handle).type.toBeCallableWith(constructed)
-    expect(flat.handle).type.toBeCallableWith(multiple)
-    expect(flat.handle).type.toBeCallableWith(always)
-    expect(flat.handle).type.not.toBeCallableWith(onDone)
-    expect(flat.handle).type.not.toBeCallableWith(undeclared)
-    expect(flat.handle).type.not.toBeCallableWith(partiallyUndeclared)
-    expect(flat.handle).type.not.toBeCallableWith(undeclaredAlways)
-    expect(flat.handle).type.not.toBeCallableWith(undeclaredOnDone)
+    expect(flat.handle).type.not.toBeCallableWith({ idle: { on: { Reset: () => undefined } } })
+    expect(flat.handle).type.not.toBeCallableWith({
+      idle: { on: { Reset: { target: () => undefined, resolve: () => undefined } } }
+    })
   })
 })

--- a/typetest/machine/Machine.tst.ts
+++ b/typetest/machine/Machine.tst.ts
@@ -132,6 +132,13 @@ describe("Machine", () => {
     : never
   type IsCallable<A> = A extends (...args: ReadonlyArray<any>) => any ? true : false
 
+  type UpInitialSelection = ReturnType<
+    Machine.Machine.InitialSelector<typeof UpStates.states>["up"]["initial"]
+  >
+  type DownInitialSelection = ReturnType<Machine.Machine.InitialSelector<typeof UpStates.states>["down"]>
+  const UpInitial = null as unknown as Machine.Machine.SelectionBuilder<UpInitialSelection>
+  const DownInitial = null as unknown as Machine.Machine.SelectionBuilder<DownInitialSelection>
+
   type SignInContext = Machine.Machine.HandlerContext<
     typeof UpStates.states,
     readonly [typeof SignIn],
@@ -211,7 +218,10 @@ describe("Machine", () => {
       states: States.states,
       events: Events,
       internalEvents: InternalEvents,
-      initial: () => States.initial.State.from()
+      initial: {
+        target: (to) => to.State(),
+        resolve: ({ target }) => (target.from())
+      }
     })
 
     expect(Events.Tick({ amount: 1 })).type.toBe<
@@ -311,7 +321,7 @@ describe("Machine", () => {
   })
 
   it("defineStates selects state values and snapshots with type-safe paths", () => {
-    const snapshot = UpStates.initial.up(
+    const snapshot = UpInitial(
       new Up({ id: "up-1" }),
       (up) =>
         up
@@ -378,9 +388,9 @@ describe("Machine", () => {
     expect(UpStates.matches).type.not.toBeCallableWith(authSnapshot, "signedOut")
     expect(UpStates.matches).type.not.toBeCallableWith(authSnapshot, "down")
 
-    const other = Machine.defineStates({ other: Down })
-    expect(UpStates.get).type.not.toBeCallableWith(other.initial.other(new Down({})), "up")
-    expect(UpStates.getWithParents).type.not.toBeCallableWith(other.initial.other(new Down({})), "up")
+    const other = { path: "other" as const, value: new Down({}) }
+    expect(UpStates.get).type.not.toBeCallableWith(other, "up")
+    expect(UpStates.getWithParents).type.not.toBeCallableWith(other, "up")
   })
 
   it("defineStates preserves declared compound initial keys", () => {
@@ -392,7 +402,10 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     })
 
     expect(machine.states).type.toBe<typeof UpStates.states>()
@@ -410,10 +423,13 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     })
 
-    const encoded = Machine.encodeSnapshot(machine, UpStates.initial.down(new Down({})))
+    const encoded = Machine.encodeSnapshot(machine, DownInitial(new Down({})))
     expect<Effect.Success<typeof encoded>>().type.toBe<Machine.Machine.EncodedSnapshot>()
     expect<Effect.Error<typeof encoded>>().type.toBe<Machine.MachineSchemaEncodeError>()
     expect<Effect.Services<typeof encoded>>().type.toBe<never>()
@@ -431,7 +447,10 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     }).handle({
       down: {
         entry: () => {}
@@ -443,10 +462,19 @@ describe("Machine", () => {
     expect<Effect.Services<typeof planned>>().type.toBe<never>()
     expect<Effect.Success<typeof planned>["commands"]>().type.toBe<ReadonlyArray<Machine.Command>>()
 
+    const selectDown = (to: Machine.Machine.InitialSelector<typeof UpStates.states>) => to.down()
     expect(Machine.make).type.not.toBeCallableWith({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => Effect.succeed(UpStates.initial.down(new Down({})))
+      initial: {
+        target: selectDown,
+        resolve: (
+          { target }: {
+            readonly input: void
+            readonly target: Machine.Machine.SelectionBuilder<ReturnType<typeof selectDown>>
+          }
+        ) => Effect.succeed(target(new Down({})))
+      }
     })
     expect(machine.handle).type.not.toBeCallableWith({
       down: { entry: () => Effect.void }
@@ -459,21 +487,27 @@ describe("Machine", () => {
       states: UpStates.states,
       events: Machine.events(SignIn),
       emittedEvents: Machine.emittedEvents(SignInCompleted),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     }).handle({
       down: {
         on: {
-          SignIn: ({ event, target }, enqueue) => {
-            expect(enqueue.raise).type.toBeCallableWith(event)
-            expect(enqueue.raise).type.not.toBeCallableWith(new Down({}))
-            expect(enqueue.emit).type.toBeCallableWith(new SignInCompleted({ userId: event.userId }))
-            expect(enqueue.emit).type.not.toBeCallableWith(event)
-            expect(enqueue.sendTo).type.toBeCallableWith(worker, event)
-            expect(enqueue.sendTo).type.not.toBeCallableWith(worker, new Down({}))
-            expect(enqueue.stop).type.toBeCallableWith(worker)
-            expect(enqueue.stop).type.not.toBeCallableWith("worker")
-            return target.full.down(new Down({}))
-          }
+          SignIn: Machine.transition({
+            target: (to) => to.full.down(),
+            resolve: ({ event, target }, enqueue) => {
+              expect(enqueue.raise).type.toBeCallableWith(event)
+              expect(enqueue.raise).type.not.toBeCallableWith(new Down({}))
+              expect(enqueue.emit).type.toBeCallableWith(new SignInCompleted({ userId: event.userId }))
+              expect(enqueue.emit).type.not.toBeCallableWith(event)
+              expect(enqueue.sendTo).type.toBeCallableWith(worker, event)
+              expect(enqueue.sendTo).type.not.toBeCallableWith(worker, new Down({}))
+              expect(enqueue.stop).type.toBeCallableWith(worker)
+              expect(enqueue.stop).type.not.toBeCallableWith("worker")
+              return target(new Down({}))
+            }
+          })
         }
       }
     })
@@ -497,7 +531,7 @@ describe("Machine", () => {
       initial: (scope) => {
         const worker = Machine.childAddress<SignIn>("worker")
         const incompatibleWorker = Machine.childAddress<Down>("incompatible-worker")
-        const child = Machine.transition(0, (_state: number, _event: SignIn) => Effect.succeed(1))
+        const child = Machine.logic<number, SignIn>({ initial: 0, run: () => Effect.never })
 
         expect(scope).type.toBe<Machine.Logic.Scope<SignIn>>()
         expect(scope.self).type.toBe<Machine.Logic.Address<SignIn>>()
@@ -521,19 +555,21 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     })
 
     machine.handle({
       down: {
-        invoke: Machine.invoke({
+        invoke: machine.invoke({
           id: "valid",
           effect: () => Effect.succeed(1),
-          onDone: ({ output, state, target }) => {
-            expect(output).type.toBe<number>()
-            expect(state).type.toBe<Down>()
-            return target.full.down(new Down({}))
-          }
+          onDone: Machine.transition({
+            target: (to) => to.full.down(),
+            resolve: ({ target }) => target(new Down({}))
+          })
         })
       }
     })
@@ -548,23 +584,29 @@ describe("Machine", () => {
     })
   })
 
-  it("contextually types dynamic Effect sources on direct inline objects", () => {
+  it("contextually types dynamic Effect sources through the bound constructor", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     })
 
     machine.handle({
       down: {
-        invoke: {
+        invoke: machine.invoke({
           id: "dynamic",
           effect: ({ state }) => {
             expect(state).type.toBe<Down>()
             return Effect.succeed(state._tag)
           },
-          onDone: () => UpStates.initial.down(new Down({}))
-        }
+          onDone: Machine.transition({
+            target: (to) => to.full.down(),
+            resolve: ({ target }) => target(new Down({}))
+          })
+        })
       }
     })
   })
@@ -577,25 +619,28 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     })
 
     machine.handle({
       down: {
-        invoke: Machine.invoke({
+        invoke: machine.invoke({
           id: "dynamic",
           effect: ({ state }) => {
             expect(state).type.toBe<Down>()
             return load(state._tag)
           },
-          onDone: ({ output, target }) => {
-            expect(output).type.toBe<{ userId: string }>()
-            return target.none()
-          },
-          onFailure: ({ error, target }) => {
-            expect(error).type.toBe<LoadFailure>()
-            return target.none()
-          }
+          onDone: Machine.transition({
+            target: (to) => to.none(),
+            resolve: () => undefined
+          }),
+          onFailure: Machine.transition({
+            target: (to) => to.none(),
+            resolve: () => undefined
+          })
         })
       }
     })
@@ -608,39 +653,42 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     })
 
     machine.handle({
       down: {
         invoke: [
-          Machine.invoke({
+          machine.invoke({
             id: "success",
             effect: ({ state }) => Effect.succeed(state._tag),
-            onDone: ({ output, target }) => {
-              expect(output).type.toBe<"Down">()
-              return target.none()
-            }
+            onDone: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            })
           }),
-          Machine.invoke({
+          machine.invoke({
             id: "failure",
             effect: ({ state }) => Effect.fail(new LoadFailure()).pipe(Effect.annotateLogs("state", state._tag)),
-            onFailure: ({ error, target }) => {
-              expect(error).type.toBe<LoadFailure>()
-              return target.none()
-            }
+            onFailure: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            })
           }),
-          Machine.invoke({
+          machine.invoke({
             id: "never",
             effect: ({ state }) => Effect.never.pipe(Effect.annotateLogs("state", state._tag))
           }),
-          Machine.invoke({
+          machine.invoke({
             id: "requirements",
             effect: ({ state }) => Effect.as(EntryRequirement, state._tag),
-            onDone: ({ output, target }) => {
-              expect(output).type.toBe<"Down">()
-              return target.none()
-            }
+            onDone: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            })
           })
         ]
       }
@@ -648,13 +696,13 @@ describe("Machine", () => {
 
     const requirementsHandled = machine.handle({
       down: {
-        invoke: Machine.invoke({
+        invoke: machine.invoke({
           id: "requirements-only",
           effect: ({ state }) => Effect.as(EntryRequirement, state._tag),
-          onDone: ({ output, target }) => {
-            expect(output).type.toBe<"Down">()
-            return target.none()
-          }
+          onDone: Machine.transition({
+            target: (to) => to.none(),
+            resolve: () => undefined
+          })
         })
       }
     })
@@ -712,18 +760,27 @@ describe("Machine", () => {
       states: UpStates.states,
       events: Machine.events(SignIn),
       internalEvents: Machine.internalEvents(SignInCompleted),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     }).handle({
       down: {
         on: {
-          SignIn: ({ event, target }) => {
-            expect(event).type.toBe<SignIn>()
-            return target.none()
-          },
-          SignInCompleted: ({ event, target }) => {
-            expect(event).type.toBe<SignInCompleted>()
-            return target.none()
-          }
+          SignIn: Machine.transition({
+            target: (to) => to.none(),
+            resolve: ({ event }) => {
+              expect(event).type.toBe<SignIn>()
+              return undefined
+            }
+          }),
+          SignInCompleted: Machine.transition({
+            target: (to) => to.none(),
+            resolve: ({ event }) => {
+              expect(event).type.toBe<SignInCompleted>()
+              return undefined
+            }
+          })
         }
       }
     })
@@ -738,12 +795,12 @@ describe("Machine", () => {
     expect<Parameters<Ref["send"]>[0]>().type.toBe<Machine.Machine.EventInput<SignIn>>()
     expect(Machine.plan).type.toBeCallableWith(
       machine,
-      UpStates.initial.down(new Down({})),
+      DownInitial(new Down({})),
       new SignIn({ userId: "user-1" })
     )
     expect(Machine.plan).type.not.toBeCallableWith(
       machine,
-      UpStates.initial.down(new Down({})),
+      DownInitial(new Down({})),
       new SignInCompleted({ userId: "user-1" })
     )
     const publicEvents = Machine.events(SignIn)
@@ -752,7 +809,9 @@ describe("Machine", () => {
       states: UpStates.states,
       events: publicEvents,
       internalEvents: overlappingInternalEvents,
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to: Machine.Machine.InitialSelector<typeof UpStates.states>) => to.down()
+      }
     })
     expect(Machine.events).type.not.toBeCallableWith(SignIn, SignIn)
     expect(Machine.internalEvents).type.not.toBeCallableWith(SignInCompleted, SignInCompleted)
@@ -765,7 +824,10 @@ describe("Machine", () => {
       states: UpStates.states,
       events: Machine.events(SignIn),
       internalEvents: Machine.internalEvents(SignInCompleted),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     })
 
     expect(Machine.invoke).type.not.toBeCallableWith({
@@ -784,13 +846,13 @@ describe("Machine", () => {
     })
     machine.handle({
       down: {
-        invoke: Machine.invoke({
+        invoke: machine.invoke({
           id: "erased-failure",
           effect: erasedFailure,
-          onFailure: ({ error, target }) => {
-            expect(error).type.toBe<any>()
-            return target.none()
-          }
+          onFailure: Machine.transition({
+            target: (to) => to.none(),
+            resolve: () => undefined
+          })
         })
       }
     })
@@ -801,17 +863,23 @@ describe("Machine", () => {
     Machine.make({
       states: states.states,
       events: Machine.events(SignIn),
-      initial: () => states.initial.source(new Up({ id: "up-1" }))
+      initial: {
+        target: (to) => to.source(),
+        resolve: ({ target }) => (target(new Up({ id: "up-1" })))
+      }
     }).handle({
       source: {
         on: {
-          SignIn: ({ state, target }) => {
-            const { _tag: _, ...fields } = state
-            expect(target.full.target.from).type.toBeCallableWith({ ...fields, attempt: 1 })
-            expect(target.full.target.from).type.not.toBeCallableWith(fields)
-            expect(target.full.target.from).type.not.toBeCallableWith({ ...fields, attempt: "invalid" })
-            return target.full.target.from({ ...fields, attempt: 1 })
-          }
+          SignIn: Machine.transition({
+            target: (to) => to.full.target(),
+            resolve: ({ state, target }) => {
+              const { _tag: _, ...fields } = state
+              expect(target.from).type.toBeCallableWith({ ...fields, attempt: 1 })
+              expect(target.from).type.not.toBeCallableWith(fields)
+              expect(target.from).type.not.toBeCallableWith({ ...fields, attempt: "invalid" })
+              return target.from({ ...fields, attempt: 1 })
+            }
+          })
         }
       }
     })
@@ -831,7 +899,10 @@ describe("Machine", () => {
       events: Machine.events(SignIn),
       emittedEvents: Machine.emittedEvents(SignIn),
       input: ChildInput,
-      initial: () => childStates.initial.done(new Down({}))
+      initial: {
+        target: (to) => to.done(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     }).handle({
       done: {
         output: () => new SignIn({ userId: "child" })
@@ -843,23 +914,43 @@ describe("Machine", () => {
     const parent = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
+    })
+
+    type ChildArgs = Machine.Machine.ChildInvokeArgs<
+      typeof UpStates.states,
+      readonly [typeof SignIn],
+      readonly [],
+      "down",
+      typeof Child.machine,
+      typeof Child
+    >
+    const onSnapshot: NonNullable<ChildArgs["onSnapshot"]> = Machine.transition({
+      target: (to) => to.none(),
+      resolve: ({ snapshot }) => {
+        expect(snapshot.state).type.toBe<Machine.Machine.Snapshot<typeof childStates.states>>()
+        return undefined
+      }
+    })
+    const onDone: ChildArgs["onDone"] = Machine.transition({
+      target: (to) => to.none(),
+      resolve: ({ output, state }) => {
+        expect(output).type.toBe<SignIn>()
+        expect(state).type.toBe<Down>()
+        return undefined
+      }
     })
 
     parent.handle({
       down: {
-        invoke: Machine.invoke({
+        invoke: parent.invoke({
           child: Child,
           input: { userId: "child" },
-          onSnapshot: ({ snapshot, target }) => {
-            expect(snapshot.state).type.toBe<Machine.Machine.Snapshot<typeof childStates.states>>()
-            return target.none()
-          },
-          onDone: ({ output, state, target }) => {
-            expect(output).type.toBe<SignIn>()
-            expect(state).type.toBe<Down>()
-            return target.none()
-          }
+          onSnapshot,
+          onDone
         })
       }
     })
@@ -872,7 +963,10 @@ describe("Machine", () => {
       events: Machine.events(SignIn),
       emittedEvents: Machine.emittedEvents(Down),
       input: ChildInput,
-      initial: () => childStates.initial.done(new Down({}))
+      initial: {
+        target: (to) => to.done(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     }).handle({
       done: {
         output: () => new SignIn({ userId: "child" })
@@ -912,7 +1006,10 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     })
 
     machine.handle({
@@ -921,14 +1018,13 @@ describe("Machine", () => {
           auth: {
             states: {
               signedOut: {
-                invoke: Machine.invoke({
+                invoke: machine.invoke({
                   id: "nested",
                   effect: () => Effect.succeed(Option.some(1)),
-                  onDone: ({ output, state, target }) => {
-                    expect(output).type.toBe<Option.Option<number>>()
-                    expect(state).type.toBe<SignedOut>()
-                    return target.none()
-                  }
+                  onDone: Machine.transition({
+                    target: (to) => to.none(),
+                    resolve: () => undefined
+                  })
                 })
               }
             }
@@ -942,7 +1038,7 @@ describe("Machine", () => {
   it("typed child addresses enforce their event protocol", () => {
     const worker = Machine.childAddress<SignIn>("worker")
     const inert = Machine.childAddress("inert")
-    const child = Machine.transition(0, (_state: number, _event: SignIn) => Effect.succeed(1))
+    const child = Machine.logic<number, SignIn>({ initial: 0, run: () => Effect.never })
 
     expect(Machine.child).type.not.toBeCallableWith("worker")
     expect<Machine.ChildAddress.Event<typeof inert>>().type.toBe<never>()
@@ -954,7 +1050,7 @@ describe("Machine", () => {
     expect(Machine.stopChild).type.not.toBeCallableWith("worker")
     expect(Machine.spawn).type.toBeCallableWith(child, { id: worker })
     expect(Machine.spawn).type.not.toBeCallableWith(
-      Machine.transition(0, (_state: number, _event: Down) => Effect.succeed(1)),
+      Machine.logic<number, Down>({ initial: 0, run: () => Effect.never }),
       { id: worker }
     )
   })
@@ -976,11 +1072,17 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     }).handle({
       down: {
         on: {
-          SignIn: ({ target }) => target.full.down(new Down({}))
+          SignIn: Machine.transition({
+            target: (to) => to.full.down(),
+            resolve: ({ target }) => target(new Down({}))
+          })
         }
       }
     })
@@ -1006,34 +1108,40 @@ describe("Machine", () => {
       | Machine.MachineSchemaDecodeError
       | Machine.StoppedError
     >()
-    const invocation = Machine.invoke({ child: Child, onDone: ({ target }) => target.none() })
-    expect<Machine.Machine.InvokeRuntimeError<typeof invocation>>().type.toBe<never>()
+    expect<Machine.Machine.InvokeRuntimeError<{ readonly child: typeof Child }>>().type.toBe<
+      | Machine.InfiniteTransitionError
+      | Machine.MachineSchemaDecodeError
+      | Machine.StoppedError
+    >()
   })
 
   it("plan and getters require snapshots", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     })
 
     expect(Machine.plan).type.toBeCallableWith(
       machine,
-      UpStates.initial.down(new Down({})),
+      DownInitial(new Down({})),
       new SignIn({
         userId: "user-1"
       })
     )
     const planned = Machine.plan(
       machine,
-      UpStates.initial.down(new Down({})),
+      DownInitial(new Down({})),
       new SignIn({ userId: "user-1" })
     )
     expect<Effect.Error<typeof planned>>().type.toBe<
       Machine.InfiniteTransitionError | Machine.MachineSchemaDecodeError
     >()
-    expect(Machine.enabled).type.toBeCallableWith(machine, UpStates.initial.down(new Down({})))
-    expect(Machine.isFinal).type.toBeCallableWith(machine, UpStates.initial.down(new Down({})))
+    expect(Machine.enabled).type.toBeCallableWith(machine, DownInitial(new Down({})))
+    expect(Machine.isFinal).type.toBeCallableWith(machine, DownInitial(new Down({})))
 
     expect(Machine.plan).type.not.toBeCallableWith(machine, new Down({}), new SignIn({ userId: "user-1" }))
     expect(Machine.enabled).type.not.toBeCallableWith(machine, new Down({}))
@@ -1044,7 +1152,10 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     })
 
     expect<IsCallable<typeof machine.handle>>().type.toBe<true>()
@@ -1064,11 +1175,77 @@ describe("Machine", () => {
     })
   })
 
+  it("conditional transitions infer match values and each selected target", () => {
+    const standaloneWhen = (event: SignIn) =>
+      event.userId.length > 0
+        ? Option.some({ userId: event.userId, recognized: true as const })
+        : Option.none()
+    type StandaloneMatch = ReturnType<typeof standaloneWhen> extends Option.Option<infer Match> ? Match : never
+    expect<StandaloneMatch>().type.toBe<{ userId: string; recognized: true }>()
+
+    const machine = Machine.make({
+      states: UpStates.states,
+      events: Machine.events(SignIn),
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => target(new Down({}))
+      }
+    })
+
+    machine.handle({
+      down: {
+        on: {
+          SignIn: Machine.transition({
+            cases: [
+              {
+                title: "recognized user",
+                when: ({ event, state }) => {
+                  expect(event).type.toBe<SignIn>()
+                  expect(state).type.toBe<Down>()
+                  return event.userId.length > 0
+                    ? Option.some({ userId: event.userId, recognized: true as const })
+                    : Option.none()
+                },
+                target: (to) => to.full.down(),
+                resolve: ({ match, target }) => {
+                  expect(match).type.toBe<{ userId: string; recognized: true }>()
+                  expect(target).type.toBeCallableWith(new Down({}))
+                  return target(new Down({}))
+                }
+              },
+              {
+                title: "measured user id",
+                when: ({ event }) => event.userId.length > 0 ? Option.some(event.userId.length) : Option.none(),
+                target: (to) => to.none(),
+                resolve: (context) => {
+                  expect(context.match).type.toBe<number>()
+                  expect(context).type.not.toHaveProperty("target")
+                  return undefined
+                }
+              }
+            ],
+            otherwise: {
+              target: (to) => to.none(),
+              resolve: (context) => {
+                expect(context).type.not.toHaveProperty("target")
+                return undefined
+              }
+            },
+            reenter: true
+          })
+        }
+      }
+    })
+  })
+
   it("handle accepts nested states through reserved states objects", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     })
 
     machine.handle({
@@ -1078,11 +1255,14 @@ describe("Machine", () => {
             states: {
               signedOut: {
                 on: {
-                  SignIn: ({ event, state, target }) => {
-                    expect(event).type.toBe<SignIn>()
-                    expect(state).type.toBe<SignedOut>()
-                    return target.local.signedIn(new SignedIn({ userId: event.userId }))
-                  }
+                  SignIn: Machine.transition({
+                    target: (to) => to.local.signedIn(),
+                    resolve: ({ event, state, target }) => {
+                      expect(event).type.toBe<SignIn>()
+                      expect(state).type.toBe<SignedOut>()
+                      return target(new SignedIn({ userId: event.userId }))
+                    }
+                  })
                 }
               }
             }
@@ -1096,7 +1276,10 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     })
 
     machine.handle({
@@ -1111,16 +1294,22 @@ describe("Machine", () => {
           }
           void id
         },
-        always: ({ event, target }) => {
-          expect(event).type.toBe<SignIn | Machine.InitialEvent>()
-          return target.none()
-        },
+        always: Machine.transition({
+          target: (to) => to.none(),
+          resolve: ({ event }) => {
+            expect(event).type.toBe<SignIn | Machine.InitialEvent>()
+            return undefined
+          }
+        }),
         states: {
           auth: {
             states: {
               signedOut: {
                 on: {
-                  SignIn: ({ event, target }) => target.local.signedIn(new SignedIn({ userId: event.userId }))
+                  SignIn: Machine.transition({
+                    target: (to) => to.local.signedIn(),
+                    resolve: ({ event, target }) => target(new SignedIn({ userId: event.userId }))
+                  })
                 }
               }
             }
@@ -1144,8 +1333,9 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () =>
-        UpStates.initial.up(
+      initial: {
+        target: (to) => to.up.initial(),
+        resolve: ({ target }) => (target(
           new Up({ id: "up-1" }),
           (up) =>
             up
@@ -1157,17 +1347,21 @@ describe("Machine", () => {
                 new Sync({ enabled: true }),
                 (sync) => sync.idle(new SyncIdle({}))
               )
-        )
+        ))
+      }
     }).handle({
       up: {
         states: {
           auth: {
-            onDone: ({ event, output, state, target }) => {
-              expect(event).type.toBe<SignIn | Machine.InitialEvent>()
-              expect(output).type.toBe<undefined>()
-              expect(state).type.toBe<Auth>()
-              return target.full.down(new Down({}))
-            },
+            onDone: Machine.transition({
+              target: (to) => to.full.down(),
+              resolve: ({ event, output, state, target }) => {
+                expect(event).type.toBe<SignIn | Machine.InitialEvent>()
+                expect(output).type.toBe<undefined>()
+                expect(state).type.toBe<Auth>()
+                return target(new Down({}))
+              }
+            }),
             states: {
               signedIn: {}
             }
@@ -1178,7 +1372,7 @@ describe("Machine", () => {
 
     const planned = Machine.plan(
       machine,
-      UpStates.initial.up(
+      UpInitial(
         new Up({ id: "up-1" }),
         (up) =>
           up
@@ -1201,7 +1395,10 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     })
 
     expect(machine.handle).type.not.toHaveProperty("up")
@@ -1221,10 +1418,12 @@ describe("Machine", () => {
         }
       },
       events: Machine.events(SignIn),
-      initial: () =>
-        Machine.defineStates({ down: { schema: Down, type: "final", output: Schema.Void } }).initial.down(
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(
           new Down({})
-        )
+        ))
+      }
     }).handle({
       down: {
         output: ({ event }) => {
@@ -1248,7 +1447,10 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(SignIn),
-      initial: () => States.initial.signedIn(new SignedIn({ userId: "user-1" }))
+      initial: {
+        target: (to) => to.signedIn(),
+        resolve: ({ target }) => (target(new SignedIn({ userId: "user-1" })))
+      }
     }).handle({
       signedIn: {
         output: ({ state }) => state.userId
@@ -1279,7 +1481,10 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(SignIn),
-      initial: () => States.initial.signedIn(new SignedIn({ userId: "user-1" }))
+      initial: {
+        target: (to) => to.signedIn(),
+        resolve: ({ target }) => (target(new SignedIn({ userId: "user-1" })))
+      }
     })
     type ForgedCompleteMachine = Machine.Machine<
       typeof States.states,
@@ -1341,7 +1546,10 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(SignIn),
-      initial: () => States.initial.active(new Down({}))
+      initial: {
+        target: (to) => to.active(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     }).handle({
       succeeded: {
         output: ({ state }) => state.userId
@@ -1353,7 +1561,10 @@ describe("Machine", () => {
     const activeOnly = Machine.make({
       states: { active: Down },
       events: Machine.events(SignIn),
-      initial: () => Machine.defineStates({ active: Down }).initial.active(new Down({}))
+      initial: {
+        target: (to) => to.active(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     })
     const activeRef = Machine.start(activeOnly)
     expect<Effect.Success<Effect.Success<typeof activeRef>["join"]>>().type.toBe<never>()
@@ -1379,15 +1590,21 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(SignIn),
-      initial: () => States.initial.auth(new Auth({ userId: "user-1" }), (auth) => auth.signedOut(new SignedOut({})))
+      initial: {
+        target: (to) => to.auth.initial(),
+        resolve: ({ target }) => (target(new Auth({ userId: "user-1" }), (auth) => auth.signedOut(new SignedOut({}))))
+      }
     })
 
     machine.handle({
       auth: {
-        onDone: ({ output, target }) => {
-          expect(output).type.toBe<string>()
-          return target.full.down(new Down({}))
-        },
+        onDone: Machine.transition({
+          target: (to) => to.full.down(),
+          resolve: ({ output, target }) => {
+            expect(output).type.toBe<string>()
+            return target(new Down({}))
+          }
+        }),
         states: {
           signedIn: {
             output: ({ state }) => state.userId
@@ -1415,7 +1632,10 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(SignIn),
-      initial: () => States.initial.auth(new Auth({ userId: "user-1" }), (auth) => auth.signedOut(new SignedOut({})))
+      initial: {
+        target: (to) => to.auth.initial(),
+        resolve: ({ target }) => (target(new Auth({ userId: "user-1" }), (auth) => auth.signedOut(new SignedOut({}))))
+      }
     })
 
     expect(machine.handle).type.not.toBeCallableWith({
@@ -1454,20 +1674,26 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(SignIn),
-      initial: () => States.initial.payment(new Payment({}), (payment) => payment.pending(new PendingPayment({})))
+      initial: {
+        target: (to) => to.payment.initial(),
+        resolve: ({ target }) => (target(new Payment({}), (payment) => payment.pending(new PendingPayment({}))))
+      }
     })
 
     machine.handle({
       payment: {
-        onDone: ({ output, target }) => {
-          expect(output.status).type.toBe<"approved" | "declined">()
-          if (output.status === "approved") {
-            expect(output.authId).type.toBe<string>()
-          } else {
-            expect(output.reason).type.toBe<string>()
+        onDone: Machine.transition({
+          target: (to) => to.none(),
+          resolve: ({ output }) => {
+            expect(output.status).type.toBe<"approved" | "declined">()
+            if (output.status === "approved") {
+              expect(output.authId).type.toBe<string>()
+            } else {
+              expect(output.reason).type.toBe<string>()
+            }
+            return undefined
           }
-          return target.none()
-        },
+        }),
         states: {
           approved: {
             output: ({ state }) => ({
@@ -1526,14 +1752,16 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(SignIn),
-      initial: () =>
-        States.initial.up(
+      initial: {
+        target: (to) => to.up.initial(),
+        resolve: ({ target }) => (target(
           new Up({ id: "up-1" }),
           (up) =>
             up
               .auth(new Auth({ userId: "user-1" }), (auth) => auth.signedOut(new SignedOut({})))
               .sync(new Sync({ enabled: true }), (sync) => sync.idle(new SyncIdle({})))
-        )
+        ))
+      }
     })
 
     const complete = machine.handle({
@@ -1546,11 +1774,14 @@ describe("Machine", () => {
             requestId: outputs.sync.requestId
           }
         },
-        onDone: ({ output, target }) => {
-          expect(output.userId).type.toBe<string>()
-          expect(output.requestId).type.toBe<string>()
-          return target.none()
-        },
+        onDone: Machine.transition({
+          target: (to) => to.none(),
+          resolve: ({ output }) => {
+            expect(output.userId).type.toBe<string>()
+            expect(output.requestId).type.toBe<string>()
+            return undefined
+          }
+        }),
         states: {
           auth: {
             states: {
@@ -1602,11 +1833,13 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(SignIn),
-      initial: () =>
-        States.initial.up(
+      initial: {
+        target: (to) => to.up.initial(),
+        resolve: ({ target }) => (target(
           new Up({ id: "up-1" }),
           (up) => up.auth(new Auth({ userId: "user-1" }), (auth) => auth.signedOut(new SignedOut({})))
-        )
+        ))
+      }
     })
 
     expect(machine.handle).type.not.toBeCallableWith({
@@ -1628,7 +1861,7 @@ describe("Machine", () => {
   })
 
   it("initial builder constructs typed initial snapshots", () => {
-    const snapshot = UpStates.initial.up(
+    const snapshot = UpInitial(
       new Up({ id: "up-1" }),
       (up) =>
         up
@@ -1654,9 +1887,9 @@ describe("Machine", () => {
   })
 
   it("initial builder rejects incomplete parallel callbacks", () => {
-    expect(UpStates.initial.up).type.not.toBeCallableWith(
+    expect(UpInitial).type.not.toBeCallableWith(
       new Up({ id: "up-1" }),
-      (up: ChildBuilder<typeof UpStates.initial.up>) =>
+      (up: ChildBuilder<typeof UpInitial>) =>
         up.auth(
           new Auth({ userId: "guest" }),
           (auth) => auth.signedOut(new SignedOut({}))
@@ -1665,7 +1898,7 @@ describe("Machine", () => {
   })
 
   it("initial builder exposes only the declared compound initial child", () => {
-    const up = null as unknown as ChildBuilder<typeof UpStates.initial.up>
+    const up = null as unknown as ChildBuilder<typeof UpInitial>
     const auth = null as unknown as ChildBuilder<typeof up.auth>
 
     expect(auth.signedOut).type.toBeCallableWith(new SignedOut({}))
@@ -1673,13 +1906,13 @@ describe("Machine", () => {
   })
 
   it("initial builder checks values at parent and leaf nodes", () => {
-    const up = null as unknown as ChildBuilder<typeof UpStates.initial.up>
+    const up = null as unknown as ChildBuilder<typeof UpInitial>
     const sync = null as unknown as ChildBuilder<typeof up.sync>
 
-    expect(UpStates.initial.down).type.not.toBeCallableWith(new Up({ id: "up-1" }))
-    expect(UpStates.initial.up).type.not.toBeCallableWith(
+    expect(DownInitial).type.not.toBeCallableWith(new Up({ id: "up-1" }))
+    expect(UpInitial).type.not.toBeCallableWith(
       new Auth({ userId: "guest" }),
-      (up: ChildBuilder<typeof UpStates.initial.up>) =>
+      (up: ChildBuilder<typeof UpInitial>) =>
         up
           .auth(
             new Auth({ userId: "guest" }),
@@ -1698,7 +1931,7 @@ describe("Machine", () => {
   })
 
   it("initial builder removes parallel region methods after they are called", () => {
-    const up = null as unknown as ChildBuilder<typeof UpStates.initial.up>
+    const up = null as unknown as ChildBuilder<typeof UpInitial>
     const afterAuth = up.auth(
       new Auth({ userId: "guest" }),
       (auth) => auth.signedOut(new SignedOut({}))
@@ -1739,7 +1972,7 @@ describe("Machine", () => {
   })
 
   it("state builders construct from exact schema make input", () => {
-    const initial = UpStates.initial.up.from(
+    const initial = UpInitial.from(
       { id: "up-1" },
       (up) =>
         up
@@ -1789,9 +2022,9 @@ describe("Machine", () => {
     >()
     expect(full).type.not.toHaveProperty("value")
 
-    expect(UpStates.initial.up.from).type.not.toBeCallableWith(
+    expect(UpInitial.from).type.not.toBeCallableWith(
       { id: 1 },
-      (up: ChildBuilder<typeof UpStates.initial.up>) =>
+      (up: ChildBuilder<typeof UpInitial>) =>
         up
           .auth.from({ userId: "guest" }, (auth) => auth.signedOut.from({}))
           .sync.from({ enabled: true }, (sync) => sync.idle.from({}))
@@ -1890,15 +2123,27 @@ describe("Machine", () => {
     >
     const context = null as unknown as Context
     const parallelContext = null as unknown as ParallelContext
+    const FlowInitial = null as unknown as Machine.Machine.SelectionBuilder<
+      ReturnType<Machine.Machine.InitialSelector<typeof States.states>["Flow"]["initial"]>
+    >
+    const RequiredInitial = null as unknown as Machine.Machine.SelectionBuilder<
+      ReturnType<Machine.Machine.InitialSelector<typeof States.states>["Required"]>
+    >
+    const DefaultOnlyInitial = null as unknown as Machine.Machine.SelectionBuilder<
+      ReturnType<Machine.Machine.InitialSelector<typeof States.states>["DefaultOnly"]>
+    >
+    const ParallelInitial = null as unknown as Machine.Machine.SelectionBuilder<
+      ReturnType<Machine.Machine.InitialSelector<typeof ParallelStates.states>["Parallel"]["initial"]>
+    >
 
-    const initial = States.initial.Flow.from((flow) => flow.Idle.from())
-    const defaulted = States.initial.DefaultOnly.from()
+    const initial = FlowInitial.from((flow) => flow.Idle.from())
+    const defaulted = DefaultOnlyInitial.from()
     const local = context.target.local.Running.from()
     const localWith = context.target.local.with.from((flow) => flow.Running.from())
     const branch = context.target.branch.Flow.Nested.from((nested) => nested.NestedIdle.from())
     const full = context.target.full.Flow.from((flow) => flow.Nested.from((nested) => nested.NestedIdle.from()))
     const final = context.target.local.Done.from()
-    const parallel = ParallelStates.initial.Parallel.from((root) =>
+    const parallel = ParallelInitial.from((root) =>
       root
         .left.from((left) => left.LeftIdle.from())
         .right.from((right) => right.RightIdle.from())
@@ -1937,14 +2182,14 @@ describe("Machine", () => {
       Machine.Machine.StateConstruction<Machine.Machine.SnapshotByIdentifier<typeof ParallelStates.states, "Parallel">>
     >()
 
-    expect(States.initial.Required.from).type.not.toBeCallableWith()
+    expect(RequiredInitial.from).type.not.toBeCallableWith()
     expect(context.target.full.Required.from).type.not.toBeCallableWith()
-    expect(States.initial.Flow.from).type.not.toBeCallableWith()
-    expect(ParallelStates.initial.Parallel.from).type.not.toBeCallableWith()
+    expect(FlowInitial.from).type.not.toBeCallableWith()
+    expect(ParallelInitial.from).type.not.toBeCallableWith()
 
     const requiredContext = null as unknown as SignedOutContext
-    expect(UpStates.initial.up.from).type.not.toBeCallableWith(
-      (up: ChildBuilder<typeof UpStates.initial.up>) =>
+    expect(UpInitial.from).type.not.toBeCallableWith(
+      (up: ChildBuilder<typeof UpInitial>) =>
         up
           .auth.from({ userId: "guest" }, (auth) => auth.signedOut.from())
           .sync.from({ enabled: true }, (sync) => sync.idle.from())
@@ -2020,7 +2265,13 @@ describe("Machine", () => {
       Idle: State.cases.Idle,
       Active: State.cases.Active
     })
-    const initial = States.initial.Idle.from({})
+    const IdleInitial = null as unknown as Machine.Machine.SelectionBuilder<
+      ReturnType<Machine.Machine.InitialSelector<typeof States.states>["Idle"]>
+    >
+    const ActiveInitial = null as unknown as Machine.Machine.SelectionBuilder<
+      ReturnType<Machine.Machine.InitialSelector<typeof States.states>["Active"]>
+    >
+    const initial = IdleInitial.from({})
 
     expect(initial).type.toBeAssignableTo<
       Machine.Machine.StateConstruction<
@@ -2028,9 +2279,9 @@ describe("Machine", () => {
       >
     >()
     expect(initial).type.not.toHaveProperty("value")
-    expect(States.initial.Active.from).type.toBeCallableWith({ requestId: "request-1" })
-    expect(States.initial.Active.from).type.not.toBeCallableWith({})
-    expect(States.initial.Active.from).type.not.toBeCallableWith({ requestId: 1 })
+    expect(ActiveInitial.from).type.toBeCallableWith({ requestId: "request-1" })
+    expect(ActiveInitial.from).type.not.toBeCallableWith({})
+    expect(ActiveInitial.from).type.not.toBeCallableWith({ requestId: 1 })
   })
 
   it("target.full requires every parallel region", () => {
@@ -2248,11 +2499,14 @@ describe("Machine", () => {
     expect(context.target.none()).type.toBe<Machine.Machine.NoTarget>()
   })
 
-  it("requires explicit targetless results and permits them with declared targets", () => {
+  it("requires explicit targetless transitions", () => {
     const definition = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: () => UpStates.initial.down(new Down({}))
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => (target(new Down({})))
+      }
     })
 
     expect(definition.handle).type.not.toBeCallableWith({
@@ -2262,10 +2516,10 @@ describe("Machine", () => {
       definition.handle({
         down: {
           on: {
-            SignIn: {
-              targets: ["up.auth.signedIn"],
-              transition: ({ target }) => target.none()
-            }
+            SignIn: Machine.transition({
+              target: (to) => to.none(),
+              resolve: () => undefined
+            })
           }
         }
       })

--- a/typetest/machine/MachineReferences.tst.ts
+++ b/typetest/machine/MachineReferences.tst.ts
@@ -32,11 +32,17 @@ describe("machine reference event channels", () => {
     internalEvents: InternalEvents,
     parentEvents: ParentEvents,
     emittedEvents: Emissions,
-    initial: () => states.initial.Idle(new Idle({}))
+    initial: {
+      target: (to) => to.Idle(),
+      resolve: ({ target }) => (target(new Idle({})))
+    }
   }).handle({
     Idle: {
       on: {
-        Ping: ({ target }) => target.none()
+        Ping: Machine.transition({
+          target: (to) => to.none(),
+          resolve: () => undefined
+        })
       }
     }
   })
@@ -57,27 +63,33 @@ describe("machine reference event channels", () => {
       internalEvents: InternalEvents,
       parentEvents: ParentEvents,
       emittedEvents: Emissions,
-      initial: () => states.initial.Idle(new Idle({}))
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ target }) => (target(new Idle({})))
+      }
     }).handle({
       Idle: {
         on: {
-          Ping: ({ parent, self, target }, enqueue) => {
-            expect(self.send).type.toBeCallableWith(Events.Ping())
-            expect(self.send).type.not.toBeCallableWith(InternalEvents.Local())
-            expect(enqueue.sendTo).type.toBeCallableWith(self, Events.Ping())
-            expect(enqueue.sendTo).type.not.toBeCallableWith(self, ParentEvents.ParentNotice({ value: 1 }))
+          Ping: Machine.transition({
+            target: (to) => to.none(),
+            resolve: ({ parent, self }, enqueue) => {
+              expect(self.send).type.toBeCallableWith(Events.Ping())
+              expect(self.send).type.not.toBeCallableWith(InternalEvents.Local())
+              expect(enqueue.sendTo).type.toBeCallableWith(self, Events.Ping())
+              expect(enqueue.sendTo).type.not.toBeCallableWith(self, ParentEvents.ParentNotice({ value: 1 }))
 
-            if (parent !== undefined) {
-              expect(enqueue.sendTo).type.toBeCallableWith(parent, ParentEvents.ParentNotice({ value: 1 }))
-              expect(enqueue.sendTo).type.not.toBeCallableWith(parent, Events.Ping())
+              if (parent !== undefined) {
+                expect(enqueue.sendTo).type.toBeCallableWith(parent, ParentEvents.ParentNotice({ value: 1 }))
+                expect(enqueue.sendTo).type.not.toBeCallableWith(parent, Events.Ping())
+              }
+
+              expect(enqueue.raise).type.toBeCallableWith(InternalEvents.Local())
+              expect(enqueue.emit).type.toBeCallableWith(Emissions.Published())
+              expect(enqueue.emit).type.toBeCallableWith(Emissions.ValuedPublished({ value: 1 }))
+              expect(enqueue.emit).type.not.toBeCallableWith(Events.Ping())
+              return undefined
             }
-
-            expect(enqueue.raise).type.toBeCallableWith(InternalEvents.Local())
-            expect(enqueue.emit).type.toBeCallableWith(Emissions.Published())
-            expect(enqueue.emit).type.toBeCallableWith(Emissions.ValuedPublished({ value: 1 }))
-            expect(enqueue.emit).type.not.toBeCallableWith(Events.Ping())
-            return target.none()
-          }
+          })
         }
       }
     })
@@ -87,33 +99,24 @@ describe("machine reference event channels", () => {
     const compatible = Machine.make({
       states: states.states,
       events: Machine.events(Ping, ParentEvents),
-      initial: () => states.initial.Idle(new Idle({}))
-    })
-    compatible.handle({
-      Idle: {
-        invoke: {
-          child: Child,
-          onDone: () => states.initial.Idle(new Idle({})),
-          onFailure: () => states.initial.Idle(new Idle({})),
-          onSnapshot: () => states.initial.Idle(new Idle({}))
-        }
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ target }) => (target(new Idle({})))
       }
     })
+    compatible.invoke({ child: Child })
 
     const incompatible = Machine.make({
       states: states.states,
       events: Machine.events(Ping, OtherParentEvent),
-      initial: () => states.initial.Idle(new Idle({}))
-    })
-    expect(incompatible.handle).type.not.toBeCallableWith({
-      Idle: {
-        invoke: {
-          child: Child,
-          onDone: () => states.initial.Idle(new Idle({})),
-          onFailure: () => states.initial.Idle(new Idle({})),
-          onSnapshot: () => states.initial.Idle(new Idle({}))
-        }
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ target }) => (target(new Idle({})))
       }
+    })
+    const incompatibleChild = incompatible.invoke({ child: Child })
+    expect(incompatible.handle).type.not.toBeCallableWith({
+      Idle: { invoke: incompatibleChild }
     })
   })
 
@@ -151,7 +154,10 @@ describe("machine reference event channels", () => {
       internalEvents: InternalEvents,
       parentEvents: ParentEvents,
       emittedEvents: Emissions,
-      initial: () => states.initial.Idle(new Idle({}))
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ target }) => (target(new Idle({})))
+      }
     })
 
     definition.handle({
@@ -167,13 +173,16 @@ describe("machine reference event channels", () => {
             }
             return Effect.void
           },
-          onDone: ({ parent, self, target }) => {
-            expect(self.send).type.toBeCallableWith(Events.Ping())
-            if (parent !== undefined) {
-              expect(parent.send).type.toBeCallableWith(ParentEvents.ParentNotice({ value: 1 }))
+          onDone: Machine.transition({
+            target: (to) => to.none(),
+            resolve: ({ parent, self }) => {
+              expect(self.send).type.toBeCallableWith(Events.Ping())
+              if (parent !== undefined) {
+                expect(parent.send).type.toBeCallableWith(ParentEvents.ParentNotice({ value: 1 }))
+              }
+              return undefined
             }
-            return target.none()
-          }
+          })
         })
       }
     })
@@ -189,7 +198,10 @@ describe("machine reference event channels", () => {
             }
             return Effect.void
           },
-          onDone: ({ target }) => target.none()
+          onDone: Machine.transition({
+            target: (to) => to.none(),
+            resolve: () => undefined
+          })
         })
       }
     })

--- a/typetest/machine/Readiness.tst.ts
+++ b/typetest/machine/Readiness.tst.ts
@@ -26,9 +26,12 @@ const choiceStates = Machine.defineStates({
 const choiceIncomplete = Machine.make({
   states: choiceStates.states,
   events: Machine.events(Tick),
-  initial: () => choiceStates.initial.Ready(new Ready({}))
+  initial: {
+    target: (to) => to.Ready(),
+    resolve: ({ target }) => (target(new Ready({})))
+  }
 })
-const choiceSnapshot = choiceStates.initial.Ready(new Ready({}))
+const choiceSnapshot = { path: "Ready" as const, value: new Ready({}) }
 
 const historyStates = Machine.defineStates({
   Ready,
@@ -45,9 +48,12 @@ const historyStates = Machine.defineStates({
 const historyIncomplete = Machine.make({
   states: historyStates.states,
   events: Machine.events(Tick),
-  initial: () => historyStates.initial.Ready(new Ready({}))
+  initial: {
+    target: (to) => to.Ready(),
+    resolve: ({ target }) => (target(new Ready({})))
+  }
 })
-const historySnapshot = historyStates.initial.Ready(new Ready({}))
+const historySnapshot = { path: "Ready" as const, value: new Ready({}) }
 
 const outputStates = Machine.defineStates({
   Ready,
@@ -61,9 +67,12 @@ const outputStates = Machine.defineStates({
 const outputIncomplete = Machine.make({
   states: outputStates.states,
   events: Machine.events(Tick),
-  initial: () => outputStates.initial.Ready(new Ready({}))
+  initial: {
+    target: (to) => to.Ready(),
+    resolve: ({ target }) => (target(new Ready({})))
+  }
 })
-const outputSnapshot = outputStates.initial.Ready(new Ready({}))
+const outputSnapshot = { path: "Ready" as const, value: new Ready({}) }
 
 const bound = null as unknown as AtomMachine.Bound<never>
 
@@ -138,7 +147,10 @@ describe("executable machine readiness", () => {
     const complete = Machine.make({
       states: completeStates.states,
       events: Machine.events(Tick),
-      initial: () => completeStates.initial.Ready(new Ready({}))
+      initial: {
+        target: (to) => to.Ready(),
+        resolve: ({ target }) => (target(new Ready({})))
+      }
     }).handle({
       Flow: {
         history: {
@@ -152,10 +164,10 @@ describe("executable machine readiness", () => {
         },
         states: {
           Route: {
-            choice: {
-              targets: ["Flow.Idle"],
-              transition: ({ target }) => target.local.Idle(new Idle({}))
-            }
+            choice: Machine.transition({
+              target: (to) => to.local.Idle(),
+              resolve: ({ target }) => target(new Idle({}))
+            })
           },
           Done: {
             output: ({ state }) => state.value
@@ -163,16 +175,12 @@ describe("executable machine readiness", () => {
         }
       }
     })
-    const completeSnapshot = completeStates.initial.Ready(new Ready({}))
+    const completeSnapshot = { path: "Ready" as const, value: new Ready({}) }
 
     const plannedInitial = Machine.planInitial(complete)
     const planned = Machine.plan(complete, completeSnapshot, new Tick({}))
     const started = Machine.start(complete)
     const resumed = Machine.resume(complete, completeSnapshot)
-    const invocation = Machine.invoke({
-      child: Machine.child("complete", complete),
-      onDone: ({ target }) => target.none()
-    })
     const trace = MachineTest.run(complete, { events: [new Tick({})] })
     const atom = AtomMachine.make(complete)
     const resumedAtom = AtomMachine.resume(complete, completeSnapshot)
@@ -199,7 +207,6 @@ describe("executable machine readiness", () => {
     expect<Effect.Success<typeof resumed>["send"]>().type.toBe<
       (event: Machine.Machine.EventInput<Tick>) => Effect.Effect<void, Machine.StoppedError>
     >()
-    expect(invocation).type.toBeAssignableTo<Machine.Machine.InvokeConfig<any, any, any, any>>()
     expect<Effect.Success<typeof trace>>().type.toBe<MachineTest.Trace<typeof complete>>()
     expect<AtomChannels<typeof atom>>().type.toBe<
       readonly [

--- a/typetest/machine/Resume.tst.ts
+++ b/typetest/machine/Resume.tst.ts
@@ -14,16 +14,22 @@ const machine = Machine.make({
   states: States.states,
   events: Machine.events(Tick),
   input: Schema.Struct({ seed: Schema.Number }),
-  initial: (input) => States.initial.Idle(new Idle({ value: input.seed }))
+  initial: {
+    target: (to) => to.Idle(),
+    resolve: ({ input: input, target }) => (target(new Idle({ value: input.seed })))
+  }
 }).handle({
   Idle: {
     on: {
-      Tick: ({ state, target }) => target.full.Idle(new Idle({ value: state.value + 1 }))
+      Tick: Machine.transition({
+        target: (to) => to.full.Idle(),
+        resolve: ({ state, target }) => target(new Idle({ value: state.value + 1 }))
+      })
     }
   }
 })
 
-const snapshot = States.initial.Idle(new Idle({ value: 3 }))
+const snapshot: Snapshot = { path: "Idle", value: new Idle({ value: 3 }) }
 
 describe("Machine logical resumption", () => {
   it("excludes input while preserving synchronous runtime inference", () => {

--- a/typetest/machine/SnapshotContext.tst.ts
+++ b/typetest/machine/SnapshotContext.tst.ts
@@ -37,37 +37,48 @@ describe("Machine transition snapshot context", () => {
     Machine.make({
       states: States.states,
       events: Machine.events(Advance),
-      initial: () =>
-        States.initial.Root(
+      initial: {
+        target: (to) => to.Root.initial(),
+        resolve: ({ target }) => (target(
           new Root({}),
           (root) =>
             root
               .Left(new Left({}), (left) => left.LeftIdle(new LeftIdle({})))
               .Right(new Right({}), (right) => right.RightIdle(new RightIdle({})))
-        )
+        ))
+      }
     }).handle({
       Root: {
         states: {
           Left: {
-            onDone: ({ snapshot, target }) => {
-              expect(snapshot).type.toBe<Machine.Machine.Snapshot<typeof States.states>>()
-              expect(States.matches).type.toBeCallableWith(snapshot, "Root.Right.RightIdle")
-              expect(States.get).type.toBeCallableWith(snapshot, "Root.Right.RightIdle")
-              expect(States.getSnapshot).type.toBeCallableWith(snapshot, "Root.Right.RightIdle")
-              return target.local.LeftIdle(new LeftIdle({}))
-            },
+            onDone: Machine.transition({
+              target: (to) => to.local.LeftIdle(),
+              resolve: ({ snapshot, target }) => {
+                expect(snapshot).type.toBe<Machine.Machine.Snapshot<typeof States.states>>()
+                expect(States.matches).type.toBeCallableWith(snapshot, "Root.Right.RightIdle")
+                expect(States.get).type.toBeCallableWith(snapshot, "Root.Right.RightIdle")
+                expect(States.getSnapshot).type.toBeCallableWith(snapshot, "Root.Right.RightIdle")
+                return target(new LeftIdle({}))
+              }
+            }),
             states: {
               LeftIdle: {
-                always: ({ snapshot, target }) => {
-                  expect(snapshot).type.toBe<Machine.Machine.Snapshot<typeof States.states>>()
-                  return target.none()
-                },
-                on: {
-                  Advance: ({ snapshot, target }) => {
+                always: Machine.transition({
+                  target: (to) => to.none(),
+                  resolve: ({ snapshot }) => {
                     expect(snapshot).type.toBe<Machine.Machine.Snapshot<typeof States.states>>()
-                    expect(States.matches(snapshot, "Root.Right.RightIdle")).type.toBe<boolean>()
-                    return target.local.LeftDone(new LeftDone({}))
+                    return undefined
                   }
+                }),
+                on: {
+                  Advance: Machine.transition({
+                    target: (to) => to.local.LeftDone(),
+                    resolve: ({ snapshot, target }) => {
+                      expect(snapshot).type.toBe<Machine.Machine.Snapshot<typeof States.states>>()
+                      expect(States.matches(snapshot, "Root.Right.RightIdle")).type.toBe<boolean>()
+                      return target(new LeftDone({}))
+                    }
+                  })
                 }
               }
             }
@@ -93,7 +104,10 @@ describe("Machine transition snapshot context", () => {
     Machine.make({
       states: choiceStates.states,
       events: Machine.events(),
-      initial: () => choiceStates.initial.Flow(new Flow({}), (flow) => flow.Routing())
+      initial: {
+        target: (to) => to.Flow.initial(),
+        resolve: ({ target }) => (target(new Flow({}), (flow) => flow.Routing()))
+      }
     }).handle({
       Flow: {
         entry: (context) => {
@@ -101,13 +115,13 @@ describe("Machine transition snapshot context", () => {
         },
         states: {
           Routing: {
-            choice: {
-              targets: ["Flow.Active"],
-              transition: (context) => {
+            choice: Machine.transition({
+              target: (to) => to.local.Active(),
+              resolve: (context) => {
                 expect(context).type.not.toHaveProperty("snapshot")
-                return context.target.local.Active(new Active({}))
+                return context.target(new Active({}))
               }
-            }
+            })
           }
         }
       }

--- a/typetest/machine/StructuralStates.tst.ts
+++ b/typetest/machine/StructuralStates.tst.ts
@@ -71,35 +71,41 @@ describe("structural active state types", () => {
   })
 
   it("requires values only for schema-backed snapshot builders", () => {
-    States.initial.player.from((player) =>
-      player
-        .transport.from((transport) => transport.Empty.from())
-        .settings.from((settings) => settings.Audible.from({ volume: 1 }))
-    )
+    Machine.make({
+      states: States.states,
+      events: Machine.events(),
+      initial: {
+        target: (to) => to.player.initial(),
+        resolve: ({ target }) => {
+          expect(target.from).type.not.toBeCallableWith({}, () => undefined)
+          expect<typeof target extends (...args: ReadonlyArray<any>) => any ? true : false>().type.toBe<false>()
 
-    expect(States.initial.player.from).type.not.toBeCallableWith({}, () => undefined)
-    expect<typeof States.initial.player extends (...args: ReadonlyArray<any>) => any ? true : false>().type.toBe<
-      false
-    >()
+          type PlayerBuilder = Parameters<typeof target.from>[0] extends (builder: infer Builder) => unknown ? Builder
+            : never
+          const player = null as unknown as PlayerBuilder
+          expect(player.transport.from).type.not.toBeCallableWith((transport: unknown) => transport)
 
-    type PlayerBuilder = Parameters<typeof States.initial.player.from>[0] extends (builder: infer Builder) => unknown
-      ? Builder
-      : never
-    const player = null as unknown as PlayerBuilder
-    expect(player.transport.from).type.not.toBeCallableWith((transport: unknown) => transport)
+          type TransportBuilder = Parameters<typeof player.transport.from>[0] extends
+            (builder: infer Builder) => unknown ? Builder
+            : never
+          const transport = null as unknown as TransportBuilder
+          expect(transport.Empty.from).type.toBeCallableWith()
+          expect(transport.Empty.from).type.not.toBeCallableWith({})
+          type SettingsBuilder = Parameters<typeof player.settings.from>[0] extends
+            (builder: infer Builder) => unknown ? Builder
+            : never
+          const settings = null as unknown as SettingsBuilder
+          expect(settings.Audible.from).type.toBeCallableWith({ volume: 1 })
+          expect(settings.Audible.from).type.not.toBeCallableWith()
 
-    type TransportBuilder = Parameters<typeof player.transport.from>[0] extends (builder: infer Builder) => unknown
-      ? Builder
-      : never
-    const transport = null as unknown as TransportBuilder
-    expect(transport.Empty.from).type.toBeCallableWith()
-    expect(transport.Empty.from).type.not.toBeCallableWith({})
-    type SettingsBuilder = Parameters<typeof player.settings.from>[0] extends (builder: infer Builder) => unknown
-      ? Builder
-      : never
-    const settings = null as unknown as SettingsBuilder
-    expect(settings.Audible.from).type.toBeCallableWith({ volume: 1 })
-    expect(settings.Audible.from).type.not.toBeCallableWith()
+          return target.from((player) =>
+            player
+              .transport.from((transport) => transport.Empty.from())
+              .settings.from((settings) => settings.Audible.from({ volume: 1 }))
+          )
+        }
+      }
+    })
   })
 
   it("restricts value access while retaining structural snapshot queries", () => {
@@ -123,12 +129,14 @@ describe("structural active state types", () => {
     Machine.make({
       states: States.states,
       events: Machine.events(Select, Loaded, Play),
-      initial: () =>
-        States.initial.player.from((player) =>
+      initial: {
+        target: (to) => to.player.initial(),
+        resolve: ({ target }) => (target.from((player) =>
           player
             .transport.from((transport) => transport.Empty.from())
             .settings.from((settings) => settings.Audible.from({ volume: 1 }))
-        )
+        ))
+      }
     }).handle({
       player: {
         states: {
@@ -139,43 +147,47 @@ describe("structural active state types", () => {
                   expect(state).type.toBe<undefined>()
                 },
                 on: {
-                  Select: ({ containingState, ancestors, state, target }) => {
-                    expect(state).type.toBe<undefined>()
-                    expect(containingState).type.toBe<undefined>()
-                    expect(ancestors).type.toBe<{}>()
-                    expect(target.local).type.not.toHaveProperty("with")
-                    expect(target.local.Empty.from).type.toBeCallableWith()
-                    expect(target.local.Empty.from).type.not.toBeCallableWith({})
-                    expect(target.local.Loading.from).type.toBeCallableWith({ url: "/song.mp3" })
-                    expect(target.local.Loading.from).type.not.toBeCallableWith()
-                    return target.local.Loading.from({ url: "/song.mp3" })
-                  }
+                  Select: Machine.transition({
+                    target: (to) => to.local.Loading(),
+                    resolve: ({ containingState, ancestors, state, target }) => {
+                      expect(state).type.toBe<undefined>()
+                      expect(containingState).type.toBe<undefined>()
+                      expect(ancestors).type.toBe<{}>()
+                      expect(target.from).type.toBeCallableWith({ url: "/song.mp3" })
+                      expect(target.from).type.not.toBeCallableWith()
+                      return target.from({ url: "/song.mp3" })
+                    }
+                  })
                 }
               },
               Loading: {
                 on: {
-                  Loaded: ({ event, target }) =>
-                    target.local.Ready.from(
-                      { duration: event.duration },
-                      (ready) => ready.Paused.from()
-                    )
+                  Loaded: Machine.transition({
+                    target: (to) => to.local.Ready(),
+                    resolve: ({ event, target }) =>
+                      target.from(
+                        { duration: event.duration },
+                        (ready) => ready.Paused.from()
+                      )
+                  })
                 }
               },
               Ready: {
                 states: {
                   Paused: {
                     on: {
-                      Play: ({ containingState, ancestors, state, target }) => {
-                        expect(state).type.toBe<undefined>()
-                        expect(containingState).type.toBe<Ready>()
-                        expect(ancestors).type.toBe<{ readonly "player.transport.Ready": Ready }>()
-                        expect(target.local).type.toHaveProperty("with")
-                        expect(target.local.Playing.from).type.toBeCallableWith({ position: 0 })
-                        return target.local.with.from(
-                          { duration: containingState.duration },
-                          (ready) => ready.Playing.from({ position: 0 })
-                        )
-                      }
+                      Play: Machine.transition({
+                        target: (to) => to.local.with(),
+                        resolve: ({ containingState, ancestors, state, target }) => {
+                          expect(state).type.toBe<undefined>()
+                          expect(containingState).type.toBe<Ready>()
+                          expect(ancestors).type.toBe<{ readonly "player.transport.Ready": Ready }>()
+                          return target.from(
+                            { duration: containingState.duration },
+                            (ready) => ready.Playing.from({ position: 0 })
+                          )
+                        }
+                      })
                     }
                   }
                 }

--- a/typetest/testing/Coverage.tst.ts
+++ b/typetest/testing/Coverage.tst.ts
@@ -14,14 +14,17 @@ describe("MachineTest coverage and observed graph", () => {
   const machine = Machine.make({
     states: States.states,
     events: Machine.events(Start),
-    initial: () => States.initial.idle(new Idle({}))
+    initial: {
+      target: (to) => to.idle(),
+      resolve: ({ target }) => (target(new Idle({})))
+    }
   }).handle({
     idle: {
       on: {
-        Start: {
-          targets: ["done"],
-          transition: ({ target }) => target.full.done(new Done({}))
-        }
+        Start: Machine.transition({
+          target: (to) => to.full.done(),
+          resolve: ({ target }) => target(new Done({}))
+        })
       }
     },
     done: {}

--- a/typetest/testing/Exploration.tst.ts
+++ b/typetest/testing/Exploration.tst.ts
@@ -15,12 +15,21 @@ describe("MachineTest exploration", () => {
     events: Machine.events(Increment),
     internalEvents: Machine.internalEvents(Internal),
     input: Input,
-    initial: ({ seed }) => States.initial.counter(new Counter({ count: seed }))
+    initial: {
+      target: (to) => to.counter(),
+      resolve: ({ input, target }) => target(new Counter({ count: input.seed }))
+    }
   }).handle({
     counter: {
       on: {
-        Increment: ({ target }) => target.none(),
-        Internal: ({ target }) => target.none()
+        Increment: Machine.transition({
+          target: (to) => to.none(),
+          resolve: () => undefined
+        }),
+        Internal: Machine.transition({
+          target: (to) => to.none(),
+          resolve: () => undefined
+        })
       }
     }
   })
@@ -66,7 +75,10 @@ describe("MachineTest exploration", () => {
     const noInput = Machine.make({
       states: States.states,
       events: Machine.events(Increment),
-      initial: () => States.initial.counter(new Counter({ count: 0 }))
+      initial: {
+        target: (to) => to.counter(),
+        resolve: ({ target }) => (target(new Counter({ count: 0 })))
+      }
     }).handle({ counter: {} })
     type Options = MachineTest.ExploreOptions<typeof noInput, string>
     expect<Options["input"]>().type.toBe<undefined>()

--- a/typetest/testing/Invariant.tst.ts
+++ b/typetest/testing/Invariant.tst.ts
@@ -13,12 +13,21 @@ describe("MachineTest invariants", () => {
     states: States.states,
     events: Machine.events(Tick),
     internalEvents: Machine.internalEvents(Internal),
-    initial: () => States.initial.idle(new Idle({ count: 0 }))
+    initial: {
+      target: (to) => to.idle(),
+      resolve: ({ target }) => (target(new Idle({ count: 0 })))
+    }
   }).handle({
     idle: {
       on: {
-        Tick: ({ target }) => target.none(),
-        Internal: ({ target }) => target.none()
+        Tick: Machine.transition({
+          target: (to) => to.none(),
+          resolve: () => undefined
+        }),
+        Internal: Machine.transition({
+          target: (to) => to.none(),
+          resolve: () => undefined
+        })
       }
     }
   })

--- a/typetest/testing/MachineTest.tst.ts
+++ b/typetest/testing/MachineTest.tst.ts
@@ -18,12 +18,21 @@ describe("MachineTest", () => {
     events: Machine.events(PublicEvent),
     internalEvents: Machine.internalEvents(InternalEvent),
     input: Input,
-    initial: () => States.initial.idle(new Idle({}))
+    initial: {
+      target: (to) => to.idle(),
+      resolve: ({ target }) => (target(new Idle({})))
+    }
   }).handle({
     idle: {
       on: {
-        PublicEvent: ({ target }) => target.none(),
-        InternalEvent: ({ target }) => target.none()
+        PublicEvent: Machine.transition({
+          target: (to) => to.none(),
+          resolve: () => undefined
+        }),
+        InternalEvent: Machine.transition({
+          target: (to) => to.none(),
+          resolve: () => undefined
+        })
       }
     }
   })
@@ -51,7 +60,10 @@ describe("MachineTest", () => {
     const noInput = Machine.make({
       states: States.states,
       events: Machine.events(PublicEvent),
-      initial: () => States.initial.idle(new Idle({}))
+      initial: {
+        target: (to) => to.idle(),
+        resolve: ({ target }) => (target(new Idle({})))
+      }
     }).handle({ idle: {} })
     type Scenario = MachineTest.Scenario<typeof noInput>
     type Options = MachineTest.ScenarioOptions<typeof noInput>
@@ -97,7 +109,10 @@ describe("MachineTest", () => {
     const invokedMachine = Machine.make({
       states: States.states,
       events: Machine.events(PublicEvent),
-      initial: () => States.initial.idle(new Idle({}))
+      initial: {
+        target: (to) => to.idle(),
+        resolve: ({ target }) => (target(new Idle({})))
+      }
     }).handle({
       idle: {
         invoke: Machine.invoke({
@@ -106,7 +121,10 @@ describe("MachineTest", () => {
             Effect.gen(function*() {
               yield* InvokeRequirement
             }),
-          onDone: ({ target }) => target.none()
+          onDone: Machine.transition({
+            target: (to) => to.none(),
+            resolve: () => undefined
+          })
         })
       }
     })

--- a/typetest/testing/Probe.tst.ts
+++ b/typetest/testing/Probe.tst.ts
@@ -15,12 +15,21 @@ describe("MachineTest probe", () => {
     states: states.states,
     events: Machine.events(PublicEvent),
     internalEvents: Machine.internalEvents(InternalEvent),
-    initial: () => states.initial.State(new State({ count: 0 }))
+    initial: {
+      target: (to) => to.State(),
+      resolve: ({ target }) => (target(new State({ count: 0 })))
+    }
   }).handle({
     State: {
       on: {
-        PublicEvent: ({ target }) => target.none(),
-        InternalEvent: ({ target }) => target.none()
+        PublicEvent: Machine.transition({
+          target: (to) => to.none(),
+          resolve: () => undefined
+        }),
+        InternalEvent: Machine.transition({
+          target: (to) => to.none(),
+          resolve: () => undefined
+        })
       }
     }
   })

--- a/typetest/testing/Verification.tst.ts
+++ b/typetest/testing/Verification.tst.ts
@@ -11,7 +11,10 @@ describe("MachineTest.verify", () => {
   const machine = Machine.make({
     states: States.states,
     events: Machine.events(Tick),
-    initial: () => States.initial.idle(new Idle({}))
+    initial: {
+      target: (to) => to.idle(),
+      resolve: ({ target }) => (target(new Idle({})))
+    }
   }).handle({ idle: {} })
 
   const trace = {} as MachineTest.Trace<typeof machine>

--- a/typetest/unstable/cluster/ClusterMachine.tst.ts
+++ b/typetest/unstable/cluster/ClusterMachine.tst.ts
@@ -46,12 +46,21 @@ describe("ClusterMachine", () => {
     id: "Counter",
     states: states.states,
     events: Machine.events(Increment, Reset),
-    initial: () => states.initial.Count(new Count({ value: 0 }))
+    initial: {
+      target: (to) => to.Count(),
+      resolve: ({ target }) => (target(new Count({ value: 0 })))
+    }
   }).handle({
     Count: {
       on: {
-        Increment: ({ event, state }) => states.initial.Count(new Count({ value: state.value + event.by })),
-        Reset: () => states.initial.Count(new Count({ value: 0 }))
+        Increment: Machine.transition({
+          target: (to) => to.full.Count(),
+          resolve: ({ event, state, target }) => target(new Count({ value: state.value + event.by }))
+        }),
+        Reset: Machine.transition({
+          target: (to) => to.full.Count(),
+          resolve: ({ target }) => target(new Count({ value: 0 }))
+        })
       }
     }
   })
@@ -67,7 +76,10 @@ describe("ClusterMachine", () => {
       states: states.states,
       events: Machine.events(Increment),
       internalEvents: Machine.internalEvents(Reset),
-      initial: () => states.initial.Count(new Count({ value: 0 }))
+      initial: {
+        target: (to) => to.Count(),
+        resolve: ({ target }) => (target(new Count({ value: 0 })))
+      }
     })
     const internalBridge = ClusterMachine.make("InternalCounterEntity", internalMachine, {
       version: "1"
@@ -89,7 +101,10 @@ describe("ClusterMachine", () => {
       states: states.states,
       events: Machine.events(Reset),
       input: Input,
-      initial: (input) => states.initial.Count(new Count({ value: input.value }))
+      initial: {
+        target: (to) => to.Count(),
+        resolve: ({ input: input, target }) => (target(new Count({ value: input.value })))
+      }
     })
 
     expect(ClusterMachine.make).type.not.toBeCallableWith(
@@ -120,7 +135,10 @@ describe("ClusterMachine", () => {
     const incomplete = Machine.make({
       states: outputStates.states,
       events: Machine.events(Reset),
-      initial: () => outputStates.initial.Done(new Done({ value: "done" }))
+      initial: {
+        target: (to) => to.Done(),
+        resolve: ({ target }) => (target(new Done({ value: "done" })))
+      }
     })
 
     expect(ClusterMachine.make).type.not.toBeCallableWith(
@@ -159,7 +177,10 @@ describe("ClusterMachine", () => {
     const contextualMachine = Machine.make({
       states: contextualStates.states,
       events: Machine.events(Reset),
-      initial: () => contextualStates.initial.ContextualCount(new ContextualCount({ value: 0 }))
+      initial: {
+        target: (to) => to.ContextualCount(),
+        resolve: ({ target }) => (target(new ContextualCount({ value: 0 })))
+      }
     })
     const layer = ClusterMachine.make("ContextualCounter", contextualMachine, { version: "1" }).toLayer()
 

--- a/typetest/unstable/reactivity/AtomMachine.tst.ts
+++ b/typetest/unstable/reactivity/AtomMachine.tst.ts
@@ -110,7 +110,10 @@ const makeMachine = () =>
   Machine.make({
     states: States.states,
     events: Machine.events(Tick),
-    initial: () => States.initial.Idle(new Idle({}))
+    initial: {
+      target: (to) => to.Idle(),
+      resolve: ({ target }) => (target(new Idle({})))
+    }
   }).handle({
     Idle: {}
   })
@@ -122,7 +125,10 @@ describe("AtomMachine", () => {
     const parentMachine = Machine.make({
       states: States.states,
       events: Machine.events(),
-      initial: () => States.initial.Idle(new Idle({}))
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ target }) => (target(new Idle({})))
+      }
     }).handle({
       Idle: {
         invoke: Machine.invoke({ child: Child })
@@ -278,12 +284,21 @@ describe("AtomMachine", () => {
       states: States.states,
       events: Machine.events(Tick),
       internalEvents: Machine.internalEvents(InternalTick),
-      initial: () => States.initial.Idle(new Idle({}))
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ target }) => (target(new Idle({})))
+      }
     }).handle({
       Idle: {
         on: {
-          Tick: () => States.initial.Idle(new Idle({})),
-          InternalTick: () => States.initial.Idle(new Idle({}))
+          Tick: Machine.transition({
+            target: (to) => to.full.Idle(),
+            resolve: ({ target }) => target(new Idle({}))
+          }),
+          InternalTick: Machine.transition({
+            target: (to) => to.full.Idle(),
+            resolve: ({ target }) => target(new Idle({}))
+          })
         }
       }
     })
@@ -306,7 +321,10 @@ describe("AtomMachine", () => {
     const incomplete = Machine.make({
       states: OutputStates.states,
       events: Machine.events(Tick),
-      initial: () => OutputStates.initial.Idle(new Idle({}))
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ target }) => (target(new Idle({})))
+      }
     })
     const runtime = Atom.runtime(Layer.empty)
     const bound = AtomMachine.bind(runtime)


### PR DESCRIPTION
## Summary

- require every event, lifecycle, choice, and invocation transition to use `Machine.transition`, with a statically selected target and a separately inferred resolver
- add titled `Option`-based conditional branches with an explicit `otherwise`, and expose exact branch targets through transition topology for complete visualization
- move initial construction to the same `target` / `resolve` shape, remove `DefinedStates.initial`, and rename reusable process construction from `Machine.transition` to `Machine.logic`
- migrate documentation, tests, consumers, performance fixtures, and all examples to the new API

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required

<!--
The type- and runtime-performance workflows measure only relevant changes and post their base-versus-PR comparisons automatically.
Do not copy a manually measured table into this description.
-->
