### PR TITLE
Support unbounded conditional transition cases

### DIFF
--- a/.changeset/unbounded-transition-cases.md
+++ b/.changeset/unbounded-transition-cases.md
@@ -1,0 +1,24 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Allow conditional `Machine.transition` definitions to infer any number of heterogeneous cases. Define `cases` with its locally supplied `branch` constructor so each predicate match and selected target remain exact in the corresponding resolver:
+
+```ts
+Machine.transition({
+  cases: (branch) => [
+    branch({
+      title: "cached",
+      when: ({ event }) => event.cached,
+      target: (to) => to.full.Ready(),
+      resolve: ({ match, target }) => target.from({ data: match })
+    })
+  ],
+  otherwise: {
+    target: (to) => to.full.Loading(),
+    resolve: ({ target }) => target.from()
+  }
+})
+```
+
+Replace each object previously written directly in the `cases` array with `branch({ ... })` inside the `cases: (branch) => [...]` factory. Direct transitions and `otherwise` keep their existing shape.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -496,15 +496,17 @@ microstep, before any selected transition is applied:
 
 ```ts
 BufferReady: Machine.transition({
-  cases: [{
-    title: "online",
-    when: ({ snapshot }) =>
-      States.matches(snapshot, "Player.Network.Online")
-        ? Option.some(undefined)
-        : Option.none(),
-    target: (to) => to.local.Playing(),
-    resolve: ({ target }) => target.from()
-  }],
+  cases: (branch) => [
+    branch({
+      title: "online",
+      when: ({ snapshot }) =>
+        States.matches(snapshot, "Player.Network.Online")
+          ? Option.some(undefined)
+          : Option.none(),
+      target: (to) => to.local.Playing(),
+      resolve: ({ target }) => target.from()
+    })
+  ],
   otherwise: {
     target: (to) => to.none(),
     resolve: () => undefined
@@ -564,12 +566,14 @@ synchronously:
 
 ```ts
 Submit: Machine.transition({
-  cases: [{
-    title: "valid",
-    when: ({ state }) => state.valid ? Option.some(state.draft) : Option.none(),
-    target: (to) => to.local.Saving(),
-    resolve: ({ match, target }) => target.from({ draft: match })
-  }],
+  cases: (branch) => [
+    branch({
+      title: "valid",
+      when: ({ state }) => state.valid ? Option.some(state.draft) : Option.none(),
+      target: (to) => to.local.Saving(),
+      resolve: ({ match, target }) => target.from({ draft: match })
+    })
+  ],
   otherwise: {
     target: (to) => to.none(),
     resolve: () => undefined
@@ -580,9 +584,12 @@ Submit: Machine.transition({
 Every installed event, `always`, `onDone`, choice, and invoke lifecycle handler
 must use `Machine.transition`. Each direct branch declares one `target`; a
 conditional transition declares ordered `cases` and a required `otherwise`.
-`when` returns `Option.some(match)` to select a case and infer `match` in its
-resolver. Selecting `to.none()` handles the transition without a destination,
-while retaining queued commands, raised events, and emitted events.
+Construct each case with the locally supplied `branch` function. Every call
+independently infers its `when` match and target, so a transition may declare
+any number of heterogeneous cases without losing resolver inference. `when`
+returns `Option.some(match)` to select a case and expose `match` in its resolver.
+Selecting `to.none()` handles the transition without a destination, while
+retaining queued commands, raised events, and emitted events.
 
 `reenter: true` remains meaningful with `to.none()`: the source exits and
 enters again while its logical configuration is retained.

--- a/examples/platformer/src/machine.ts
+++ b/examples/platformer/src/machine.ts
@@ -207,12 +207,12 @@ export const CharacterMachine = definition.handle({
                   Standing: {
                     on: {
                       Move: Machine.transition({
-                        cases: [{
+                        cases: (branch) => [branch({
                           title: "moving",
                           when: ({ event }) => event.axis === 0 ? Option.none() : Option.some(event),
                           target: (to) => to.local.Running(),
                           resolve: ({ match, target }) => target.from({ startedAt: match.at })
-                        }],
+                        })],
                         otherwise: {
                           target: (to) => to.none(),
                           resolve: () => undefined
@@ -227,12 +227,12 @@ export const CharacterMachine = definition.handle({
                   Running: {
                     on: {
                       Move: Machine.transition({
-                        cases: [{
+                        cases: (branch) => [branch({
                           title: "stopped",
                           when: ({ event }) => event.axis === 0 ? Option.some(undefined) : Option.none(),
                           target: (to) => to.local.Standing(),
                           resolve: ({ target }) => target.from()
-                        }],
+                        })],
                         otherwise: {
                           target: (to) => to.none(),
                           resolve: () => undefined
@@ -247,12 +247,12 @@ export const CharacterMachine = definition.handle({
                   Ducking: {
                     on: {
                       DownReleased: Machine.transition({
-                        cases: [{
+                        cases: (branch) => [branch({
                           title: "stopped",
                           when: ({ event }) => event.axis === 0 ? Option.some(undefined) : Option.none(),
                           target: (to) => to.local.Standing(),
                           resolve: ({ target }) => target.from()
-                        }],
+                        })],
                         otherwise: {
                           target: (to) => to.local.Running(),
                           resolve: ({ event, target }) => target.from({ startedAt: event.at })
@@ -274,12 +274,12 @@ export const CharacterMachine = definition.handle({
                     }),
                     on: {
                       LandingSettled: Machine.transition({
-                        cases: [{
+                        cases: (branch) => [branch({
                           title: "stopped",
                           when: ({ state }) => state.resumeAxis === 0 ? Option.some(undefined) : Option.none(),
                           target: (to) => to.local.Standing(),
                           resolve: ({ target }) => target.from()
-                        }],
+                        })],
                         otherwise: {
                           target: (to) => to.local.Running(),
                           resolve: ({ state, target }) => target.from({ startedAt: state.landedAt + 140 })
@@ -423,21 +423,21 @@ export const CharacterMachine = definition.handle({
           Left: {
             on: {
               Move: Machine.transition({
-                cases: [{
+                cases: (branch) => [branch({
                   title: "right",
                   when: ({ event }) => event.axis === 1 ? Option.some(undefined) : Option.none(),
                   target: (to) => to.local.Right(),
                   resolve: ({ target }) => target.from()
-                }],
+                })],
                 otherwise: { target: (to) => to.none(), resolve: () => undefined }
               }),
               WallJump: Machine.transition({
-                cases: [{
+                cases: (branch) => [branch({
                   title: "right",
                   when: ({ event }) => event.push === 1 ? Option.some(undefined) : Option.none(),
                   target: (to) => to.local.Right(),
                   resolve: ({ target }) => target.from()
-                }],
+                })],
                 otherwise: { target: (to) => to.none(), resolve: () => undefined }
               })
             }
@@ -445,21 +445,21 @@ export const CharacterMachine = definition.handle({
           Right: {
             on: {
               Move: Machine.transition({
-                cases: [{
+                cases: (branch) => [branch({
                   title: "left",
                   when: ({ event }) => event.axis === -1 ? Option.some(undefined) : Option.none(),
                   target: (to) => to.local.Left(),
                   resolve: ({ target }) => target.from()
-                }],
+                })],
                 otherwise: { target: (to) => to.none(), resolve: () => undefined }
               }),
               WallJump: Machine.transition({
-                cases: [{
+                cases: (branch) => [branch({
                   title: "left",
                   when: ({ event }) => event.push === -1 ? Option.some(undefined) : Option.none(),
                   target: (to) => to.local.Left(),
                   resolve: ({ target }) => target.from()
-                }],
+                })],
                 otherwise: { target: (to) => to.none(), resolve: () => undefined }
               })
             }
@@ -469,17 +469,20 @@ export const CharacterMachine = definition.handle({
       contact: {
         on: {
           WallContact: Machine.transition({
-            cases: [{
-              title: "left wall",
-              when: ({ event }) => event.wall === -1 ? Option.some(undefined) : Option.none(),
-              target: (to) => to.local.LeftWall(),
-              resolve: ({ target }) => target.from()
-            }, {
-              title: "right wall",
-              when: ({ event }) => event.wall === 1 ? Option.some(undefined) : Option.none(),
-              target: (to) => to.local.RightWall(),
-              resolve: ({ target }) => target.from()
-            }],
+            cases: (branch) => [
+              branch({
+                title: "left wall",
+                when: ({ event }) => event.wall === -1 ? Option.some(undefined) : Option.none(),
+                target: (to) => to.local.LeftWall(),
+                resolve: ({ target }) => target.from()
+              }),
+              branch({
+                title: "right wall",
+                when: ({ event }) => event.wall === 1 ? Option.some(undefined) : Option.none(),
+                target: (to) => to.local.RightWall(),
+                resolve: ({ target }) => target.from()
+              })
+            ],
             otherwise: {
               target: (to) => to.local.NoWall(),
               resolve: ({ target }) => target.from()

--- a/examples/playground/src/examples/microwave/machine.ts
+++ b/examples/playground/src/examples/microwave/machine.ts
@@ -58,7 +58,7 @@ export const MicrowaveMachine = definition.handle({
           Idle: {
             on: {
               PowerPressed: Machine.transition({
-                cases: [{
+                cases: (branch) => [branch({
                   title: "door closed",
                   when: ({ snapshot }) =>
                     MicrowaveStates.matches(snapshot, "Oven.door.Closed")
@@ -66,7 +66,7 @@ export const MicrowaveMachine = definition.handle({
                       : Option.none(),
                   target: (to) => to.local.Cooking(),
                   resolve: ({ target }) => target.from({ elapsedSeconds: 0 })
-                }],
+                })],
                 otherwise: { target: (to) => to.none(), resolve: () => undefined }
               })
             }

--- a/examples/playground/src/examples/worker-tabs/machine.ts
+++ b/examples/playground/src/examples/worker-tabs/machine.ts
@@ -46,12 +46,12 @@ export const SharedMachine = definition.handle({
         resolve: ({ target }) => target.from({ count: 0 })
       }),
       Synchronized: Machine.transition({
-        cases: [{
+        cases: (branch) => [branch({
           title: "active",
           when: ({ event }) => event.active ? Option.some(event.count) : Option.none(),
           target: (to) => to.full.Active(),
           resolve: ({ match, target }) => target.from({ count: match })
-        }],
+        })],
         otherwise: {
           target: (to) => to.full.Idle(),
           resolve: ({ event, target }) => target.from({ count: event.count })
@@ -74,12 +74,12 @@ export const SharedMachine = definition.handle({
         resolve: ({ state, target }) => target.from({ count: state.count })
       }),
       Synchronized: Machine.transition({
-        cases: [{
+        cases: (branch) => [branch({
           title: "active",
           when: ({ event }) => event.active ? Option.some(event.count) : Option.none(),
           target: (to) => to.full.Active(),
           resolve: ({ match, target }) => target.from({ count: match })
-        }],
+        })],
         otherwise: {
           target: (to) => to.full.Idle(),
           resolve: ({ event, target }) => target.from({ count: event.count })

--- a/examples/pokemon/src/machines/selection.ts
+++ b/examples/pokemon/src/machines/selection.ts
@@ -132,12 +132,12 @@ export const SelectionMachine = definition.handle({
             }),
             on: {
               SearchResult: Machine.transition({
-                cases: [{
+                cases: (branch) => [branch({
                   title: "found",
                   when: ({ event }) => event.result,
                   target: (to) => to.local.WithPokemon(),
                   resolve: ({ match, target }) => target.from({ pokemon: match })
-                }],
+                })],
                 otherwise: {
                   target: (to) => to.local.NoPokemon(),
                   resolve: ({ target }) => target.from()
@@ -160,12 +160,12 @@ export const SelectionMachine = definition.handle({
           Selected: {
             on: {
               SelectPokemon: Machine.transition({
-                cases: [{
+                cases: (branch) => [branch({
                   title: "already selected",
                   when: ({ event, state }) => state.id === event.id ? Option.some(undefined) : Option.none(),
                   target: (to) => to.local.Unselected(),
                   resolve: ({ target }) => target.from()
-                }],
+                })],
                 otherwise: {
                   target: (to) => to.local.Selected(),
                   resolve: ({ event, target }) => target.from({ id: event.id })

--- a/perf/types/conditional-cases-control.ts
+++ b/perf/types/conditional-cases-control.ts
@@ -1,0 +1,20 @@
+import { Machine } from "@typeonce/effect-machine"
+import { Schema } from "effect"
+
+export const State = Schema.TaggedUnion({
+  Idle: {},
+  Text: { value: Schema.String },
+  Count: { value: Schema.Number }
+})
+
+export const Route = Schema.TaggedStruct("Route", { value: Schema.String })
+export const States = Machine.defineStates(State.cases)
+
+export const machine = Machine.make({
+  states: States.states,
+  events: Machine.events(Route),
+  initial: {
+    target: (to) => to.Idle(),
+    resolve: ({ target }) => target(State.cases.Idle.make({}))
+  }
+})

--- a/perf/types/conditional-cases.ts
+++ b/perf/types/conditional-cases.ts
@@ -1,0 +1,86 @@
+import { Machine } from "@typeonce/effect-machine"
+import { Option } from "effect"
+import { machine, State } from "./conditional-cases-control.js"
+
+const handled = machine.handle({
+  Idle: {
+    on: {
+      Route: Machine.transition({
+        cases: (branch) => [
+          branch({
+            title: "length 1",
+            when: ({ event }) => event.value.length === 1 ? Option.some(event.value) : Option.none(),
+            target: (to) => to.full.Text(),
+            resolve: ({ match, target }) => target(State.cases.Text.make({ value: match }))
+          }),
+          branch({
+            title: "length 2",
+            when: ({ event }) => event.value.length === 2 ? Option.some(event.value.length) : Option.none(),
+            target: (to) => to.full.Count(),
+            resolve: ({ match, target }) => target(State.cases.Count.make({ value: match }))
+          }),
+          branch({
+            title: "length 3",
+            when: ({ event }) => event.value.length === 3 ? Option.some({ value: event.value }) : Option.none(),
+            target: (to) => to.full.Text(),
+            resolve: ({ match, target }) => target(State.cases.Text.make(match))
+          }),
+          branch({
+            title: "length 4",
+            when: ({ event }) => event.value.length === 4 ? Option.some([event.value.length] as const) : Option.none(),
+            target: (to) => to.full.Count(),
+            resolve: ({ match, target }) => target(State.cases.Count.make({ value: match[0] }))
+          }),
+          branch({
+            title: "length 5",
+            when: ({ event }) => event.value.length === 5 ? Option.some(event) : Option.none(),
+            target: (to) => to.full.Text(),
+            resolve: ({ match, target }) => target(State.cases.Text.make({ value: match.value }))
+          }),
+          branch({
+            title: "length 6",
+            when: ({ event }) => event.value.length === 6 ? Option.some(true) : Option.none(),
+            target: (to) => to.none(),
+            resolve: ({ match }) => {
+              const confirmed: boolean = match
+              void confirmed
+              return undefined
+            }
+          }),
+          branch({
+            title: "length 7",
+            when: ({ event }) => event.value.length === 7 ? Option.some({ size: event.value.length }) : Option.none(),
+            target: (to) => to.full.Count(),
+            resolve: ({ match, target }) => target(State.cases.Count.make({ value: match.size }))
+          }),
+          branch({
+            title: "length 8",
+            when: ({ event }) => event.value.length === 8 ? Option.some(event.value.toUpperCase()) : Option.none(),
+            target: (to) => to.full.Text(),
+            resolve: ({ match, target }) => target(State.cases.Text.make({ value: match }))
+          }),
+          branch({
+            title: "length 9",
+            when: ({ event }) => event.value.length === 9 ? Option.some(event.value.length as 9) : Option.none(),
+            target: (to) => to.full.Count(),
+            resolve: ({ match, target }) => target(State.cases.Count.make({ value: match }))
+          }),
+          branch({
+            title: "length 10",
+            when: ({ event }) => event.value.length === 10 ? Option.some(undefined) : Option.none(),
+            target: (to) => to.full.Idle(),
+            resolve: ({ target }) => target(State.cases.Idle.make({}))
+          })
+        ],
+        otherwise: {
+          target: (to) => to.none(),
+          resolve: () => undefined
+        }
+      })
+    }
+  },
+  Text: {},
+  Count: {}
+})
+
+void Machine.planInitial(handled)

--- a/scripts/fixtures/consumer/consumer.ts
+++ b/scripts/fixtures/consumer/consumer.ts
@@ -2,7 +2,11 @@ import { Machine } from "@typeonce/effect-machine"
 import { ClusterMachine } from "@typeonce/effect-machine/cluster"
 import { AtomMachine } from "@typeonce/effect-machine/reactivity"
 import { MachineTest } from "@typeonce/effect-machine/testing"
-import { Effect, Schema } from "effect"
+import { Effect, Option, Schema } from "effect"
+
+type Equal<Left, Right> = (<Type>() => Type extends Left ? 1 : 2) extends <Type>() => Type extends Right ? 1 : 2 ? true
+  : false
+type Expect<Type extends true> = Type
 
 const State = Schema.TaggedUnion({
   Idle: {},
@@ -35,8 +39,52 @@ const machine = Machine.make({
   Idle: {
     on: {
       Start: Machine.transition({
-        target: (to) => to.full.Loading(),
-        resolve: ({ target }) => target(State.cases.Loading.make({}))
+        cases: (branch) => [
+          branch({
+            title: "cached",
+            when: () => Option.some({ source: "cache" as const }),
+            target: (to) => to.full.Loading(),
+            resolve: ({ match, target }) => {
+              type MatchIsExact = Expect<Equal<typeof match, { source: "cache" }>>
+              void (true as MatchIsExact)
+              return target(State.cases.Loading.make({}))
+            }
+          }),
+          branch({
+            title: "measured",
+            when: () => Option.some(1),
+            target: (to) => to.none(),
+            resolve: ({ match }) => {
+              type MatchIsExact = Expect<Equal<typeof match, number>>
+              void (true as MatchIsExact)
+              return undefined
+            }
+          }),
+          branch({
+            title: "named",
+            when: () => Option.some("ready"),
+            target: (to) => to.full.Done(),
+            resolve: ({ match, target }) => {
+              type MatchIsExact = Expect<Equal<typeof match, string>>
+              void (true as MatchIsExact)
+              return target(State.cases.Done.make({ value: match }))
+            }
+          }),
+          branch({
+            title: "confirmed",
+            when: () => Option.some(true),
+            target: (to) => to.full.Idle(),
+            resolve: ({ match, target }) => {
+              type MatchIsExact = Expect<Equal<typeof match, boolean>>
+              void (true as MatchIsExact)
+              return target(State.cases.Idle.make({}))
+            }
+          })
+        ],
+        otherwise: {
+          target: (to) => to.full.Loading(),
+          resolve: ({ target }) => target(State.cases.Loading.make({}))
+        }
       })
     }
   },

--- a/scripts/invoke-autocomplete.test.mjs
+++ b/scripts/invoke-autocomplete.test.mjs
@@ -77,7 +77,7 @@ definition.handle({
 definition.handle({
   Loading: {
     always: Machine.transition({
-      cases: [{
+      cases: (branch) => [branch({
         title: "ready",
         when: ({ /*case-when-context*/ }) => Option.some("ready" as const),
         target: (to) => to.full.Done(),
@@ -85,7 +85,21 @@ definition.handle({
           const exact: "ready" = context.match
           return context.target.from()
         }
-      }],
+      })],
+      otherwise: {
+        target: (to) => to.none(),
+        resolve: () => undefined
+      }
+    })
+  }
+})
+
+definition.handle({
+  Loading: {
+    always: Machine.transition({
+      cases: (branch) => [branch({
+        /*case-properties*/
+      })],
       otherwise: {
         target: (to) => to.none(),
         resolve: () => undefined
@@ -178,5 +192,11 @@ test("contextually completes transition definitions while authoring", () => {
   const resolve = completions("case-resolve-context")
   assert.equal(resolve.has("match"), true)
   assert.equal(resolve.has("target"), true)
+
+  const caseProperties = completions("case-properties")
+  assert.equal(caseProperties.has("title"), true)
+  assert.equal(caseProperties.has("when"), true)
+  assert.equal(caseProperties.has("target"), true)
+  assert.equal(caseProperties.has("resolve"), true)
 
 })

--- a/scripts/type-performance.mjs
+++ b/scripts/type-performance.mjs
@@ -77,6 +77,20 @@ const scenarios = [
     maxMarginalInstantiations: 56_000
   },
   {
+    id: "conditional-cases-control",
+    label: "conditional transition control",
+    file: "conditional-cases-control.ts",
+    hidden: true
+  },
+  {
+    id: "conditional-cases",
+    label: "Machine.transition (10 conditional cases)",
+    file: "conditional-cases.ts",
+    control: "conditional-cases-control",
+    maxInstantiations: 160_000,
+    maxMarginalInstantiations: 145_000
+  },
+  {
     id: "dynamic-invoke-control",
     label: "dynamic Machine.invoke control",
     file: "dynamic-invoke-control.ts",

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -53,6 +53,7 @@ declare const MachineTypeId: unique symbol
 declare const EventConstructionTypeId: unique symbol
 declare const EmittedEventConstructionTypeId: unique symbol
 declare const EventProtocolTypeId: unique symbol
+declare const TransitionCaseTypeId: unique symbol
 
 const ChildMachineLogicTypeId: typeof internal.ChildMachineLogicTypeId = internal.ChildMachineLogicTypeId
 
@@ -5128,12 +5129,12 @@ export declare namespace Machine {
     StateId extends StateNodeIdentifier<States>,
     Context,
     Reenter extends boolean,
-    Cases extends readonly [object, ...ReadonlyArray<object>],
+    Cases extends readonly [TransitionCaseTyped, ...ReadonlyArray<TransitionCaseTyped>],
     OtherwiseSelection extends TargetSelection<any, any, any>
   > = {
     readonly target?: never
     readonly resolve?: never
-    readonly cases: Cases
+    readonly cases: (branch: TransitionCaseConstructor<States, Events, Emits, StateId, Context>) => Cases
     readonly otherwise: TransitionDirectInput<
       States,
       Events,
@@ -7478,6 +7479,29 @@ type BoundEffectInvokeResult<
     never
   >
 
+/** Type evidence retained for a case created by a conditional transition's local builder. */
+interface TransitionCaseTyped {
+  readonly [TransitionCaseTypeId]: true
+}
+
+/** Locally bound constructor that preserves each conditional transition case independently. */
+interface TransitionCaseConstructor<
+  States extends Machine.StateSchemas,
+  Events extends ReadonlyArray<Machine.TaggedSchema>,
+  Emits extends ReadonlyArray<Machine.TaggedSchema>,
+  StateId extends Machine.StateNodeIdentifier<States>,
+  Context
+> {
+  <
+    const Selection extends Machine.TargetSelection<any, any, any>,
+    const Match
+  >(
+    config: Machine.TransitionCaseInput<States, Events, Emits, StateId, Context, Selection, Match>
+  ):
+    & Machine.TransitionCaseInput<States, Events, Emits, StateId, Context, Selection, Match>
+    & TransitionCaseTyped
+}
+
 /**
  * Captures one exact transition topology while preserving handler inference.
  *
@@ -7491,37 +7515,27 @@ type ConditionalTransitionResult<
   StateId extends Machine.StateNodeIdentifier<States>,
   Context,
   Reenter extends boolean,
-  Cases extends readonly [object, ...ReadonlyArray<object>],
+  Cases extends readonly [
+    TransitionCaseTyped,
+    ...ReadonlyArray<TransitionCaseTyped>
+  ],
   OtherwiseSelection extends Machine.TargetSelection<any, any, any>
 > =
-  & Machine.TransitionConditionalInput<
-    States,
-    Events,
-    Emits,
-    StateId,
-    Context,
-    Reenter,
-    Cases,
-    OtherwiseSelection
-  >
-  & Machine.TransitionTyped<States, Events, Emits, StateId, Context, Reenter>
-
-type OptionValue<Value> = Value extends Option.Option<infer Match> ? Match : never
-
-type TransitionCaseFromWhen<
-  States extends Machine.StateSchemas,
-  Events extends ReadonlyArray<Machine.TaggedSchema>,
-  Emits extends ReadonlyArray<Machine.TaggedSchema>,
-  StateId extends Machine.StateNodeIdentifier<States>,
-  Context,
-  Selection extends Machine.TargetSelection<any, any, any>,
-  When extends (context: Omit<Context, "target">) => any
-> =
   & Omit<
-    Machine.TransitionCaseInput<States, Events, Emits, StateId, Context, Selection, OptionValue<ReturnType<When>>>,
-    "when"
+    Machine.TransitionConditionalInput<
+      States,
+      Events,
+      Emits,
+      StateId,
+      Context,
+      Reenter,
+      Cases,
+      OtherwiseSelection
+    >,
+    "cases"
   >
-  & { readonly when: When }
+  & { readonly cases: Cases }
+  & Machine.TransitionTyped<States, Events, Emits, StateId, Context, Reenter>
 
 /**
  * Contextually types direct and conditional transition definitions.
@@ -7550,86 +7564,10 @@ export interface TransitionConstructor {
     const Emits extends ReadonlyArray<Machine.TaggedSchema>,
     StateId extends Machine.StateNodeIdentifier<States>,
     Context,
-    const Selection1 extends Machine.TargetSelection<any, any, any>,
-    const When1 extends (context: Omit<Context, "target">) => any,
-    const OtherwiseSelection extends Machine.TargetSelection<any, any, any>,
-    Reenter extends boolean = never
-  >(
-    config: Machine.TransitionConditionalInput<
-      States,
-      Events,
-      Emits,
-      StateId,
-      Context,
-      Reenter,
-      readonly [TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection1, When1>],
-      OtherwiseSelection
-    >,
-    ..._validation: ReturnType<When1> extends Option.Option<unknown> ? [] : ["when must return Option"]
-  ): ConditionalTransitionResult<
-    States,
-    Events,
-    Emits,
-    StateId,
-    Context,
-    Reenter,
-    readonly [TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection1, When1>],
-    OtherwiseSelection
-  >
-  <
-    const States extends Machine.StateSchemas,
-    const Events extends ReadonlyArray<Machine.TaggedSchema>,
-    const Emits extends ReadonlyArray<Machine.TaggedSchema>,
-    StateId extends Machine.StateNodeIdentifier<States>,
-    Context,
-    const Selection1 extends Machine.TargetSelection<any, any, any>,
-    const When1 extends (context: Omit<Context, "target">) => any,
-    const Selection2 extends Machine.TargetSelection<any, any, any>,
-    const When2 extends (context: Omit<Context, "target">) => any,
-    const OtherwiseSelection extends Machine.TargetSelection<any, any, any>,
-    Reenter extends boolean = never
-  >(
-    config: Machine.TransitionConditionalInput<
-      States,
-      Events,
-      Emits,
-      StateId,
-      Context,
-      Reenter,
-      readonly [
-        TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection1, When1>,
-        TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection2, When2>
-      ],
-      OtherwiseSelection
-    >,
-    ..._validation: ReturnType<When1> extends Option.Option<unknown> ?
-      ReturnType<When2> extends Option.Option<unknown> ? [] : ["when must return Option"]
-      : ["when must return Option"]
-  ): ConditionalTransitionResult<
-    States,
-    Events,
-    Emits,
-    StateId,
-    Context,
-    Reenter,
-    readonly [
-      TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection1, When1>,
-      TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection2, When2>
+    const Cases extends readonly [
+      TransitionCaseTyped,
+      ...ReadonlyArray<TransitionCaseTyped>
     ],
-    OtherwiseSelection
-  >
-  <
-    const States extends Machine.StateSchemas,
-    const Events extends ReadonlyArray<Machine.TaggedSchema>,
-    const Emits extends ReadonlyArray<Machine.TaggedSchema>,
-    StateId extends Machine.StateNodeIdentifier<States>,
-    Context,
-    const Selection1 extends Machine.TargetSelection<any, any, any>,
-    const When1 extends (context: Omit<Context, "target">) => any,
-    const Selection2 extends Machine.TargetSelection<any, any, any>,
-    const When2 extends (context: Omit<Context, "target">) => any,
-    const Selection3 extends Machine.TargetSelection<any, any, any>,
-    const When3 extends (context: Omit<Context, "target">) => any,
     const OtherwiseSelection extends Machine.TargetSelection<any, any, any>,
     Reenter extends boolean = never
   >(
@@ -7640,18 +7578,9 @@ export interface TransitionConstructor {
       StateId,
       Context,
       Reenter,
-      readonly [
-        TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection1, When1>,
-        TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection2, When2>,
-        TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection3, When3>
-      ],
+      Cases,
       OtherwiseSelection
-    >,
-    ..._validation: ReturnType<When1> extends Option.Option<unknown> ?
-      ReturnType<When2> extends Option.Option<unknown> ?
-        ReturnType<When3> extends Option.Option<unknown> ? [] : ["when must return Option"]
-      : ["when must return Option"]
-      : ["when must return Option"]
+    >
   ): ConditionalTransitionResult<
     States,
     Events,
@@ -7659,11 +7588,7 @@ export interface TransitionConstructor {
     StateId,
     Context,
     Reenter,
-    readonly [
-      TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection1, When1>,
-      TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection2, When2>,
-      TransitionCaseFromWhen<States, Events, Emits, StateId, Context, Selection3, When3>
-    ],
+    Cases,
     OtherwiseSelection
   >
 }
@@ -7671,21 +7596,44 @@ export interface TransitionConstructor {
 /**
  * Defines a statically inspectable transition.
  *
- * This constructor is an identity at runtime. It is required for every event,
- * lifecycle, choice, and invocation transition so the destination selected by
- * `target` can contextually type the corresponding resolver.
+ * It is required for every event, lifecycle, choice, and invocation transition
+ * so the destination selected by `target` can contextually type the
+ * corresponding resolver. Conditional transitions use the locally bound
+ * `branch` constructor so every case independently infers its matched value and
+ * selected destination, with no limit on the number of cases.
  *
  * ```ts
  * Machine.transition({
  *   target: (to) => to.full.Ready(),
  *   resolve: ({ target }) => target.from()
  * })
+ *
+ * Machine.transition({
+ *   cases: (branch) => [
+ *     branch({
+ *       title: "has cached data",
+ *       when: ({ event }) => event.cached,
+ *       target: (to) => to.full.Ready(),
+ *       resolve: ({ match, target }) => target.from({ data: match })
+ *     })
+ *   ],
+ *   otherwise: {
+ *     target: (to) => to.full.Loading(),
+ *     resolve: ({ target }) => target.from()
+ *   }
+ * })
  * ```
  *
  * @category constructors
  * @since 0.14.0
  */
-export const transition: TransitionConstructor = ((config: unknown) => config) as TransitionConstructor
+export const transition: TransitionConstructor = ((config: unknown) => {
+  if (!hasProperty(config, "cases") || typeof config.cases !== "function") return config
+  return {
+    ...config,
+    cases: config.cases(<Case extends object>(branch: Case): Case => branch)
+  }
+}) as TransitionConstructor
 
 /**
  * Machine-bound invocation constructor that preserves the owning machine's

--- a/test/internal/machine/strategyDifferential.test.ts
+++ b/test/internal/machine/strategyDifferential.test.ts
@@ -733,12 +733,12 @@ describe("machine planner and runtime strategies", () => {
             Machine.Machine.ParentEvents<typeof definition>
           >
         > = Machine.transition({
-          cases: [{
+          cases: (branch) => [branch({
             title: "worker is stale",
             when: ({ snapshot }) => snapshot.state === "stale" ? Option.some(snapshot) : Option.none(),
             target: (to) => to.full.Failed(),
             resolve: ({ target }) => target(new Failed({}))
-          }],
+          })],
           otherwise: { target: (to) => to.none(), resolve: () => undefined }
         })
         const machine = definition.handle({

--- a/test/machine/Choice.test.ts
+++ b/test/machine/Choice.test.ts
@@ -20,6 +20,8 @@ const States = Machine.defineStates({
   }
 })
 
+let caseFactoryCalls = 0
+
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(Recheck),
@@ -32,14 +34,38 @@ const machine = Machine.make({
     states: {
       Routing: {
         choice: Machine.transition({
-          cases: [
-            {
-              title: "score is at least 70",
-              when: ({ containingState }) => containingState.score >= 70 ? Option.some(containingState) : Option.none(),
-              target: (to) => to.local.Approved(),
-              resolve: ({ target }) => target(new Approved({}))
-            }
-          ],
+          cases: (branch) => {
+            caseFactoryCalls += 1
+            return [
+              branch({
+                title: "score is perfect",
+                when: ({ containingState }) =>
+                  containingState.score === 100 ? Option.some(containingState) : Option.none(),
+                target: (to) => to.local.Approved(),
+                resolve: ({ target }) => target(new Approved({}))
+              }),
+              branch({
+                title: "score is negative",
+                when: ({ containingState }) =>
+                  containingState.score < 0 ? Option.some(containingState.score) : Option.none(),
+                target: (to) => to.local.Rejected(),
+                resolve: ({ target }) => target(new Rejected({}))
+              }),
+              branch({
+                title: "score is zero",
+                when: ({ containingState }) => containingState.score === 0 ? Option.some(undefined) : Option.none(),
+                target: (to) => to.local.Rejected(),
+                resolve: ({ target }) => target(new Rejected({}))
+              }),
+              branch({
+                title: "score is at least 70",
+                when: ({ containingState }) =>
+                  containingState.score >= 70 ? Option.some(containingState) : Option.none(),
+                target: (to) => to.local.Approved(),
+                resolve: ({ target }) => target(new Approved({}))
+              })
+            ]
+          },
           otherwise: {
             target: (to) => to.local.Rejected(),
             resolve: ({ target }) => target(new Rejected({}))
@@ -70,6 +96,15 @@ describe("Machine choice pseudo-states", () => {
       ])
       assert.strictEqual(plan.microsteps[0]?.transitions[0]?.source, "Flow.Routing")
       assert.strictEqual(Machine.isInitialEvent(plan.microsteps[0]!.event), true)
+      assert.strictEqual(caseFactoryCalls, 1)
+      const choice = Machine.transitionDefinitions(machine).find(({ source }) => source === "Flow.Routing")
+      assert.deepStrictEqual(choice?.branches, [
+        { type: "case", title: "score is perfect", target: "Flow.Approved" },
+        { type: "case", title: "score is negative", target: "Flow.Rejected" },
+        { type: "case", title: "score is zero", target: "Flow.Rejected" },
+        { type: "case", title: "score is at least 70", target: "Flow.Approved" },
+        { type: "otherwise", target: "Flow.Rejected" }
+      ])
       assert.deepStrictEqual(Machine.stateNodes(machine).map(({ path, type }) => ({ path, type })), [
         { path: "Flow" as const, type: "compound" },
         { path: "Flow.Routing" as const, type: "choice" },
@@ -560,6 +595,9 @@ describe("Machine choice pseudo-states", () => {
         trigger: { type: "choice" },
         reenter: false,
         branches: [
+          { type: "case", title: "score is perfect", target: "Flow.Approved" },
+          { type: "case", title: "score is negative", target: "Flow.Rejected" },
+          { type: "case", title: "score is zero", target: "Flow.Rejected" },
           { type: "case", title: "score is at least 70", target: "Flow.Approved" },
           { type: "otherwise", target: "Flow.Rejected" }
         ]

--- a/test/machine/Machine.test.ts
+++ b/test/machine/Machine.test.ts
@@ -5479,12 +5479,12 @@ describe("Machine", () => {
           Machine.Machine.ParentEvents<typeof definition>
         >
       > = Machine.transition({
-        cases: [{
+        cases: (branch) => [branch({
           title: "request is ready",
           when: ({ snapshot }) => snapshot.state === "ready" ? Option.some(snapshot) : Option.none(),
           target: (to) => to.full.Success(),
           resolve: ({ snapshot, target }) => target(new Success({ requestId: snapshot.state }))
-        }],
+        })],
         otherwise: { target: (to) => to.none(), resolve: () => undefined }
       })
       const machine = definition.handle({

--- a/test/machine/SnapshotContext.test.ts
+++ b/test/machine/SnapshotContext.test.ts
@@ -69,7 +69,7 @@ describe("Machine transition snapshot context", () => {
                 Buffering: {
                   on: {
                     BufferReady: Machine.transition({
-                      cases: [{
+                      cases: (branch) => [branch({
                         title: "network is online",
                         when: ({ snapshot }) => {
                           captured = snapshot
@@ -79,7 +79,7 @@ describe("Machine transition snapshot context", () => {
                         },
                         target: (to) => to.local.Playing(),
                         resolve: ({ target }) => target(new Playing({}))
-                      }],
+                      })],
                       otherwise: { target: (to) => to.none(), resolve: () => undefined }
                     })
                   }
@@ -170,7 +170,7 @@ describe("Machine transition snapshot context", () => {
               states: {
                 Buffering: {
                   always: Machine.transition({
-                    cases: [{
+                    cases: (branch) => [branch({
                       title: "network is online",
                       when: ({ snapshot }) => {
                         captured = snapshot
@@ -178,7 +178,7 @@ describe("Machine transition snapshot context", () => {
                       },
                       target: (to) => to.local.Playing(),
                       resolve: ({ target }) => target(new Playing({}))
-                    }],
+                    })],
                     otherwise: { target: (to) => to.none(), resolve: () => undefined }
                   })
                 }

--- a/test/testing/Coverage.test.ts
+++ b/test/testing/Coverage.test.ts
@@ -64,12 +64,12 @@ const startupMachine = Machine.make({
 }).handle({
   count: {
     always: Machine.transition({
-      cases: [{
+      cases: (branch) => [branch({
         title: "count is zero",
         when: ({ state }) => state.value === 0 ? Option.some(state) : Option.none(),
         target: (to) => to.full.count(),
         resolve: ({ target }) => target(new Count({ value: 1 }))
-      }],
+      })],
       otherwise: { target: (to) => to.none(), resolve: () => undefined }
     }),
     on: {

--- a/typetest/machine/Machine.tst.ts
+++ b/typetest/machine/Machine.tst.ts
@@ -1175,7 +1175,7 @@ describe("Machine", () => {
     })
   })
 
-  it("conditional transitions infer match values and each selected target", () => {
+  it("conditional transitions infer unbounded match values and each selected target", () => {
     const standaloneWhen = (event: SignIn) =>
       event.userId.length > 0
         ? Option.some({ userId: event.userId, recognized: true as const })
@@ -1196,8 +1196,8 @@ describe("Machine", () => {
       down: {
         on: {
           SignIn: Machine.transition({
-            cases: [
-              {
+            cases: (branch) => [
+              branch({
                 title: "recognized user",
                 when: ({ event, state }) => {
                   expect(event).type.toBe<SignIn>()
@@ -1212,8 +1212,8 @@ describe("Machine", () => {
                   expect(target).type.toBeCallableWith(new Down({}))
                   return target(new Down({}))
                 }
-              },
-              {
+              }),
+              branch({
                 title: "measured user id",
                 when: ({ event }) => event.userId.length > 0 ? Option.some(event.userId.length) : Option.none(),
                 target: (to) => to.none(),
@@ -1222,7 +1222,27 @@ describe("Machine", () => {
                   expect(context).type.not.toHaveProperty("target")
                   return undefined
                 }
-              }
+              }),
+              branch({
+                title: "named user",
+                when: ({ event }) => event.userId.length > 0 ? Option.some(event.userId) : Option.none(),
+                target: (to) => to.full.down(),
+                resolve: ({ match, target }) => {
+                  expect(match).type.toBe<string>()
+                  expect(target).type.toBeCallableWith(new Down({}))
+                  return target(new Down({}))
+                }
+              }),
+              branch({
+                title: "active user",
+                when: ({ event }) => event.userId.length > 0 ? Option.some({ active: true as const }) : Option.none(),
+                target: (to) => to.none(),
+                resolve: (context) => {
+                  expect(context.match).type.toBe<{ active: true }>()
+                  expect(context).type.not.toHaveProperty("target")
+                  return undefined
+                }
+              })
             ],
             otherwise: {
               target: (to) => to.none(),
@@ -1235,6 +1255,48 @@ describe("Machine", () => {
           })
         }
       }
+    })
+
+    const target = (to: Machine.Machine.TargetSelector<typeof UpStates.states, "down">) => to.none()
+    type ConditionalInput = Machine.Machine.TransitionConditionalInput<
+      typeof UpStates.states,
+      readonly [typeof SignIn],
+      readonly [],
+      "down",
+      SignInContext,
+      never,
+      readonly [never],
+      ReturnType<typeof target>
+    >
+    const branch = null as unknown as Parameters<ConditionalInput["cases"]>[0]
+    expect(branch).type.not.toBeCallableWith({
+      title: "invalid predicate",
+      when: () => true,
+      target: (to: Machine.Machine.TargetSelector<typeof UpStates.states, "down">) => to.none(),
+      resolve: () => undefined
+    })
+
+    const otherwise: Machine.Machine.TransitionDirectInput<
+      typeof UpStates.states,
+      readonly [typeof SignIn],
+      readonly [],
+      "down",
+      SignInContext,
+      never,
+      ReturnType<typeof target>
+    > = { target, resolve: () => undefined }
+    expect(Machine.transition).type.not.toBeCallableWith({
+      cases: () => [{
+        title: "raw case",
+        when: () => Option.some("raw"),
+        target,
+        resolve: () => undefined
+      }],
+      otherwise
+    })
+    expect(Machine.transition).type.not.toBeCallableWith({
+      cases: (_branch: typeof branch) => [],
+      otherwise
     })
   })
 


### PR DESCRIPTION
## Summary

- replace fixed one-to-three conditional transition overloads with a locally bound `branch` constructor that infers each case independently
- normalize the case factory once into the existing static transition representation, preserving ordered runtime selection and diagram topology
- migrate examples and documentation, and cover four-case declaration inference, autocomplete, packed consumers, runtime inspection, and a ten-case type-performance budget

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required

The type comparison leaves existing scenarios unchanged or improves them by roughly 0.2–0.7%; the new ten-case scenario records 116,110 total and 106,181 marginal instantiations. The runtime guard found no large, noise-adjusted throughput or heap regressions, with heap slopes effectively unchanged.