### PR TITLE
Prepare core transition evidence for MachineTest

### DIFF
--- a/.changeset/retain-transition-branch-evidence.md
+++ b/.changeset/retain-transition-branch-evidence.md
@@ -1,0 +1,7 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Retain exact static and runtime transition evidence for testing and visualization. Transition branch inspection now includes the selected target kind and scope, retained planner transitions identify the zero-based branch that executed, and `Machine.initialDefinition` exposes the root startup selection without executing its resolver.
+
+Use `branchIndex` to associate a retained transition with the corresponding entry in `Machine.transitionDefinitions(machine).branches`. Direct transitions use index `0`; conditional cases retain their declaration index and `otherwise` follows the final case.

--- a/examples/platformer/src/machine.test.ts
+++ b/examples/platformer/src/machine.test.ts
@@ -164,7 +164,12 @@ describe("platformer history integration", () => {
         reenter: true,
         branches: [{
           type: "direct",
-          target: "Character.locomotion.Playing.Airborne.airJump.AirJumpWallLock"
+          target: "Character.locomotion.Playing.Airborne.airJump.AirJumpWallLock",
+          selection: {
+            path: "Character.locomotion.Playing.Airborne.airJump.AirJumpWallLock",
+            kind: "state",
+            scope: "local"
+          }
         }]
       })
       expect(definitions.every(({ branches }) => branches.length > 0)).toBe(true)

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -259,6 +259,8 @@ export interface Machine<
 
   /** @internal */
   readonly initial: (...args: [...Machine.InputArgs<Input>]) => Machine.InitialResult<States, InitialE, InitialR>
+  /** @internal */
+  readonly initialDefinition: Machine.InitialDefinition
 }
 
 export {
@@ -2413,6 +2415,8 @@ export declare namespace Machine {
     readonly invoke: any
     /** @internal */
     readonly initial: any
+    /** @internal */
+    readonly initialDefinition: InitialDefinition
   }
 
   /**
@@ -3157,21 +3161,41 @@ export declare namespace Machine {
       readonly outcome: "done" | "failure" | "snapshot"
     }
 
+  /** Static topology selected by a transition branch. */
+  export interface TransitionTargetSelection<
+    Path extends string | undefined = string | undefined,
+    Kind extends Topology.TargetSelectionKind = Topology.TargetSelectionKind,
+    Scope extends Topology.TargetSelectionScope | undefined = Topology.TargetSelectionScope | undefined
+  > {
+    readonly path: Path
+    readonly kind: Kind
+    readonly scope: Scope
+  }
+
   /** One statically captured branch of a transition definition. */
   export type TransitionBranch<Path extends string = string> =
     | {
       readonly type: "direct"
       readonly target: Path | undefined
+      readonly selection: TransitionTargetSelection<Path | undefined>
     }
     | {
       readonly type: "case"
       readonly title: string
       readonly target: Path | undefined
+      readonly selection: TransitionTargetSelection<Path | undefined>
     }
     | {
       readonly type: "otherwise"
       readonly target: Path | undefined
+      readonly selection: TransitionTargetSelection<Path | undefined>
     }
+
+  /** The statically selected root entry for machine startup. */
+  export interface InitialDefinition<Path extends string = string> {
+    readonly target: Path
+    readonly selection: TransitionTargetSelection<Path, "state" | "initial", "initial">
+  }
 
   /**
    * Inspectable registration for a transition handler.
@@ -3223,6 +3247,8 @@ export declare namespace Machine {
     readonly source: SourcePath
     readonly trigger: TransitionTrigger<EventTag>
     readonly reenter: boolean
+    /** Zero-based index of the selected static branch. */
+    readonly branchIndex: number
     /** Path returned by the handler, including a history pseudo-state. */
     readonly target: TargetPath | undefined
     /** Concrete path used after resolving history, otherwise equal to `target`. */
@@ -8231,6 +8257,20 @@ export const stateNodes: <M extends Machine.Any>(machine: M) => ReadonlyArray<
     Machine.ChoiceIdentifier<Machine.States<M>>
   >
 > = internal.stateNodes
+
+/**
+ * Returns the statically selected root entry used during machine startup.
+ *
+ * This function does not execute the initial resolver or require machine
+ * input. `kind: "initial"` means that the selected root enters its declared
+ * initial configuration.
+ *
+ * @category getters
+ * @since 0.14.0
+ */
+export const initialDefinition: <M extends Machine.Any>(machine: M) => Machine.InitialDefinition<
+  Machine.RootStateIdentifier<Machine.StateIdentifier<Machine.States<M>>>
+> = internal.initialDefinition
 
 /**
  * Returns every registered transition handler in state definition order.

--- a/src/internal/machine/executionPlan.ts
+++ b/src/internal/machine/executionPlan.ts
@@ -424,12 +424,13 @@ export interface ExecutionMacrostep<State = unknown> {
 const collectIndexedTransition = (
   machine: Machine.Any,
   transition: TransitionHandler<any, any, any, any>,
-  context: any
+  context: any,
+  evaluate?: NonNullable<MicrostepTransition<any, any, any, any>["evaluate"]>
 ) => {
   let commands: Array<RuntimeCommand> | undefined
   let raisedEvents: Array<any> | undefined
   let emittedEvents: Array<unknown> | undefined
-  const result = transition(context, {
+  const enqueue = {
     raise: (event: unknown) => {
       ;(raisedEvents ??= []).push(decodeEventSync(machine, event))
     },
@@ -442,9 +443,13 @@ const collectIndexedTransition = (
     stop: (child: unknown) => {
       ;(commands ??= []).push({ _tag: "Stop", child: child as any })
     }
-  })
+  }
+  const evaluated = evaluate === undefined
+    ? { result: transition(context, enqueue), branchIndex: 0 }
+    : evaluate(context, enqueue)
   return {
-    state: isNoTarget(result) ? undefined : result,
+    state: isNoTarget(evaluated.result) ? undefined : evaluated.result,
+    branchIndex: evaluated.branchIndex,
     commands: commands ?? emptyExecutionValues,
     raisedEvents: raisedEvents ?? emptyExecutionValues,
     emittedEvents: emittedEvents ?? emptyExecutionValues
@@ -531,7 +536,12 @@ const collectIndexedEvaluatedTransition = (
   state: OwnedIndexedState,
   selection: IndexedSelectedTransition
 ): IndexedEvaluatedTransition => {
-  const transitionResult = collectIndexedTransition(machine, selection.transition.transition, selection.context)
+  const transitionResult = collectIndexedTransition(
+    machine,
+    selection.transition.transition,
+    selection.context,
+    selection.transition.evaluate
+  )
   const unresolvedTarget = transitionResult.state
   validateDeclaredTransitionTarget(
     selection.sourcePath,
@@ -558,6 +568,7 @@ const collectIndexedEvaluatedTransition = (
   if (!changed) {
     return {
       selection,
+      branchIndex: transitionResult.branchIndex,
       unresolvedTarget: unresolvedTarget as any,
       target: target as any,
       next,
@@ -581,6 +592,7 @@ const collectIndexedEvaluatedTransition = (
     : naturalBoundary
   return {
     selection,
+    branchIndex: transitionResult.branchIndex,
     unresolvedTarget: unresolvedTarget as any,
     target: target as any,
     next,
@@ -606,6 +618,7 @@ const indexedMicrostep = (
     source: transition.selection.sourcePath,
     trigger: transition.selection.trigger,
     reenter: transition.selection.transition.reenter,
+    branchIndex: transition.branchIndex,
     target: transition.unresolvedTarget === undefined ? undefined : getTargetNodePath(transition.unresolvedTarget),
     resolvedTarget: transition.target === undefined ? undefined : getTargetNodePath(transition.target)
   })
@@ -740,7 +753,8 @@ const planIndexedFlatState = (
           event,
           snapshot: snapshotFromIndexedState(descriptor, current),
           target: getTargetBuilder(machine, sourcePath)
-        }
+        },
+        transition.evaluate
       )
       const target = transitionResult.state
       validateDeclaredTransitionTarget(
@@ -789,6 +803,7 @@ const planIndexedFlatState = (
               source: sourcePath,
               trigger: { type: "event", event: event._tag },
               reenter: transition.reenter,
+              branchIndex: transitionResult.branchIndex,
               target: target === undefined ? undefined : getTargetNodePath(target as any),
               resolvedTarget: target === undefined ? undefined : getTargetNodePath(target as any)
             }]

--- a/src/internal/machine/machine.ts
+++ b/src/internal/machine/machine.ts
@@ -119,6 +119,7 @@ const cloneWithHandlers = (
   machine.input = self.input
   machine.id = self.id
   machine.initial = self.initial
+  machine.initialDefinition = self.initialDefinition
   machine.stateNodes = self.stateNodes
   machine.makeTargetBuilder = self.makeTargetBuilder
   machine.handlers = handlers
@@ -138,6 +139,15 @@ type DefinitionBranch = {
 type CapturedBranch = DefinitionBranch & {
   readonly selection: Topology.TargetSelection
 }
+
+const transitionTargetSelection = (
+  selection: Topology.TargetSelection
+): Machine.TransitionTargetSelection =>
+  Object.freeze({
+    path: selection.path,
+    kind: selection.kind,
+    scope: selection.scope
+  })
 
 const makeSelectionMethod = (
   kind: Topology.TargetSelectionKind,
@@ -349,6 +359,27 @@ const captureTransition = (
       return captured
     })
     const otherwise = captureDefinitionBranch(definition.otherwise, selector, path, trigger)
+    const evaluate = (context: Record<string, any>, enqueue: unknown) => {
+      const predicateContext = { ...context }
+      delete predicateContext.target
+      for (let branchIndex = 0; branchIndex < cases.length; branchIndex++) {
+        const branch = cases[branchIndex]!
+        const result = branch.when!(predicateContext)
+        if (!Option.isOption(result)) {
+          throw new Error(`Machine conditional transition case "${branch.title}" must return Option`)
+        }
+        if (Option.isSome(result)) {
+          return {
+            result: runCapturedBranch(branch, context, enqueue, stateNodes, path, { value: result.value }),
+            branchIndex
+          }
+        }
+      }
+      return {
+        result: runCapturedBranch(otherwise, context, enqueue, stateNodes, path),
+        branchIndex: cases.length
+      }
+    }
     return {
       reenter,
       targets: [
@@ -357,32 +388,37 @@ const captureTransition = (
         )
       ],
       branches: [
-        ...cases.map((branch) => ({ type: "case" as const, title: branch.title!, target: branch.selection.path })),
-        { type: "otherwise" as const, target: otherwise.selection.path }
-      ],
-      transition: (context: Record<string, any>, enqueue: unknown) => {
-        const predicateContext = { ...context }
-        delete predicateContext.target
-        for (const branch of cases) {
-          const result = branch.when!(predicateContext)
-          if (!Option.isOption(result)) {
-            throw new Error(`Machine conditional transition case "${branch.title}" must return Option`)
-          }
-          if (Option.isSome(result)) {
-            return runCapturedBranch(branch, context, enqueue, stateNodes, path, { value: result.value })
-          }
+        ...cases.map((branch) => ({
+          type: "case" as const,
+          title: branch.title!,
+          target: branch.selection.path,
+          selection: transitionTargetSelection(branch.selection)
+        })),
+        {
+          type: "otherwise" as const,
+          target: otherwise.selection.path,
+          selection: transitionTargetSelection(otherwise.selection)
         }
-        return runCapturedBranch(otherwise, context, enqueue, stateNodes, path)
-      }
+      ],
+      evaluate,
+      transition: (context: Record<string, any>, enqueue: unknown) => evaluate(context, enqueue).result
     }
   }
   const branch = captureDefinitionBranch(transition, selector, path, trigger)
+  const evaluate = (context: Record<string, any>, enqueue: unknown) => ({
+    result: runCapturedBranch(branch, context, enqueue, stateNodes, path),
+    branchIndex: 0
+  })
   return {
     reenter,
     targets: branch.selection.path === undefined ? [] : [branch.selection.path],
-    branches: [{ type: "direct" as const, target: branch.selection.path }],
-    transition: (context: Record<string, any>, enqueue: unknown) =>
-      runCapturedBranch(branch, context, enqueue, stateNodes, path)
+    branches: [{
+      type: "direct" as const,
+      target: branch.selection.path,
+      selection: transitionTargetSelection(branch.selection)
+    }],
+    evaluate,
+    transition: (context: Record<string, any>, enqueue: unknown) => evaluate(context, enqueue).result
   }
 }
 
@@ -1067,19 +1103,28 @@ const compileInitial = (
   definition: unknown,
   states: Machine.StateTree,
   stateNodes: Machine.StateNodes
-): (input?: unknown) => unknown => {
+): {
+  readonly initial: (input?: unknown) => unknown
+  readonly definition: Machine.InitialDefinition
+} => {
   if (typeof definition !== "object" || definition === null) {
     throw new Error("Machine initial definition must be an object")
   }
   const selector = makeInitialSelector(stateNodes)
   const initialBuilder = makeSnapshotBuilder(states, { mode: "initial", prefix: "" }) as Record<string, any>
   const branch = captureInitialBranch(definition, selector, initialBuilder)
-  return (input?: unknown) => {
-    const result = branch.resolve === undefined
-      ? branch.builder()
-      : branch.resolve({ input, target: branch.builder }, undefined)
-    validateInitialSelection(result, branch.selection)
-    return result
+  return {
+    initial: (input?: unknown) => {
+      const result = branch.resolve === undefined
+        ? branch.builder()
+        : branch.resolve({ input, target: branch.builder }, undefined)
+      validateInitialSelection(result, branch.selection)
+      return result
+    },
+    definition: Object.freeze({
+      target: branch.selection.path!,
+      selection: transitionTargetSelection(branch.selection) as Machine.InitialDefinition["selection"]
+    })
   }
 }
 
@@ -1221,7 +1266,9 @@ export const make: Make = (<
   self.input = config.input
   self.id = config.id
   self.stateNodes = Topology.compileStateNodes(config.states)
-  self.initial = compileInitial(config.initial, config.states, self.stateNodes)
+  const compiledInitial = compileInitial(config.initial, config.states, self.stateNodes)
+  self.initial = compiledInitial.initial
+  self.initialDefinition = compiledInitial.definition
   self.makeTargetBuilder = makeTargetBuilder(config.states, self.stateNodes)
   self.handlers = Object.create(null)
   self.handle = makeHandle(self)
@@ -1425,6 +1472,15 @@ export const stateNodes = <M extends Machine.Any>(
       Machine.HistoryIdentifier<Machine.States<M>>,
       Machine.ChoiceIdentifier<Machine.States<M>>
     >
+  >
+
+export const initialDefinition = <M extends Machine.Any>(
+  machine: M
+): Machine.InitialDefinition<
+  Machine.RootStateIdentifier<Machine.StateIdentifier<Machine.States<M>>>
+> =>
+  machine.initialDefinition as Machine.InitialDefinition<
+    Machine.RootStateIdentifier<Machine.StateIdentifier<Machine.States<M>>>
   >
 
 export const transitionDefinitions = <M extends Machine.Any>(

--- a/src/internal/machine/planner.ts
+++ b/src/internal/machine/planner.ts
@@ -70,6 +70,7 @@ export type MicrostepPlan<State, Event, E, R> = {
     readonly source: string
     readonly trigger: Machine.TransitionTrigger
     readonly reenter: boolean
+    readonly branchIndex: number
     readonly target: string | undefined
     readonly resolvedTarget: string | undefined
   }>
@@ -103,6 +104,16 @@ export type TransitionHandler<States extends Machine.StateSchemas, E, R, Context
   context: Context,
   enqueue: Enqueue<any, any>
 ) => Machine.HandlerResult<States, E, R>
+
+type TransitionEvaluation<States extends Machine.StateSchemas, E, R> = {
+  readonly result: Machine.HandlerResult<States, E, R>
+  readonly branchIndex: number
+}
+
+type TransitionEvaluator<States extends Machine.StateSchemas, E, R, Context> = (
+  context: Context,
+  enqueue: Enqueue<any, any>
+) => TransitionEvaluation<States, E, R>
 
 const rootMachineReferences = new WeakMap<Machine.Any, MachineReferences<any, any>>()
 const scopedMachineReferences = new WeakMap<Machine.Any, MachineReferences<any, any>>()
@@ -142,12 +153,14 @@ type EventTransition<States extends Machine.StateSchemas, E, R, Context> =
     readonly reenter?: boolean
     readonly targets?: ReadonlyArray<string>
     readonly transition: TransitionHandler<States, E, R, Context>
+    readonly evaluate?: TransitionEvaluator<States, E, R, Context>
   }
 
 export type MicrostepTransition<States extends Machine.StateSchemas, E, R, Context> = {
   readonly reenter: boolean
   readonly targets: ReadonlyArray<string> | undefined
   readonly transition: TransitionHandler<States, E, R, Context>
+  readonly evaluate: TransitionEvaluator<States, E, R, Context> | undefined
 }
 
 export const normalizeTransition = <States extends Machine.StateSchemas, E, R, Context>(
@@ -157,11 +170,12 @@ export const normalizeTransition = <States extends Machine.StateSchemas, E, R, C
     return undefined
   }
   return typeof transition === "function"
-    ? { reenter: false, targets: undefined, transition }
+    ? { reenter: false, targets: undefined, transition, evaluate: undefined }
     : {
       reenter: transition.reenter === true,
       targets: transition.targets,
-      transition: transition.transition
+      transition: transition.transition,
+      evaluate: transition.evaluate
     }
 }
 
@@ -195,12 +209,16 @@ const collectTransition = <
 >(
   machine: Machine.Any,
   transition: TransitionHandler<States, E, R, Context>,
-  context: Context
+  context: Context,
+  evaluate?: TransitionEvaluator<States, E, R, Context>
 ) => {
   const collected = makeCollector<Event>(machine)
-  const result = transition(context, collected.enqueue)
+  const evaluated = evaluate === undefined
+    ? { result: transition(context, collected.enqueue), branchIndex: 0 }
+    : evaluate(context, collected.enqueue)
   return {
-    state: isNoTarget(result) ? undefined : result,
+    state: isNoTarget(evaluated.result) ? undefined : evaluated.result,
+    branchIndex: evaluated.branchIndex,
     commands: collected.commands,
     raisedEvents: collected.raisedEvents,
     emittedEvents: collected.emittedEvents
@@ -504,6 +522,7 @@ export type SelectedTransition<States extends Machine.StateSchemas, E, R, Contex
 
 export type EvaluatedTransition<States extends Machine.StateSchemas, Event, E, R, Context> = {
   readonly selection: SelectedTransition<States, E, R, Context>
+  readonly branchIndex: number
   readonly unresolvedTarget:
     | Machine.Snapshot<States>
     | Machine.Target<States, Machine.StateIdentifier<States>>
@@ -524,6 +543,7 @@ export type EvaluatedTransition<States extends Machine.StateSchemas, Event, E, R
     readonly source: string
     readonly trigger: Machine.TransitionTrigger
     readonly reenter: false
+    readonly branchIndex: number
     readonly target: string
     readonly resolvedTarget: string
   }>
@@ -1129,6 +1149,7 @@ interface ResolvedChoiceTransition {
   readonly source: string
   readonly trigger: Machine.TransitionTrigger
   readonly reenter: false
+  readonly branchIndex: number
   readonly target: string
   readonly resolvedTarget: string
 }
@@ -1183,13 +1204,18 @@ function resolveChoiceTarget(
         history: configuration.history,
         ...(configuration.machineReferences === undefined ? {} : { machineReferences: configuration.machineReferences })
       }
-      const collected = collectTransition(machine, choice.transition, {
-        ...resolveMachineReferences(machine, provisional),
-        containingState: getParentValue(machine, provisional, node.path),
-        ancestors: getParentValues(machine, provisional, node.path),
-        event,
-        target: getTargetBuilder(machine, node.path)
-      })
+      const collected = collectTransition(
+        machine,
+        choice.transition,
+        {
+          ...resolveMachineReferences(machine, provisional),
+          containingState: getParentValue(machine, provisional, node.path),
+          ancestors: getParentValues(machine, provisional, node.path),
+          event,
+          target: getTargetBuilder(machine, node.path)
+        },
+        choice.evaluate
+      )
       if (collected.state === undefined) {
         throw new Error(`Machine choice resolver for "${node.path}" must return a target`)
       }
@@ -1201,6 +1227,7 @@ function resolveChoiceTarget(
         source: node.path,
         trigger: { type: "choice" },
         reenter: false,
+        branchIndex: collected.branchIndex,
         target: returnedPath,
         resolvedTarget: nested?.target.path ?? returnedPath
       })
@@ -1240,7 +1267,8 @@ const collectEvaluatedTransition = <
   const transitionResult = collectTransition<States, Event, E, R, Context>(
     machine,
     selection.transition.transition,
-    selection.context
+    selection.context,
+    selection.transition.evaluate
   )
   const unresolvedTarget = transitionResult.state === undefined
     ? undefined
@@ -1369,6 +1397,7 @@ const collectEvaluatedTransition = <
   if (!changed) {
     return {
       selection,
+      branchIndex: transitionResult.branchIndex,
       unresolvedTarget,
       target,
       commands: [
@@ -1414,6 +1443,7 @@ const collectEvaluatedTransition = <
 
   return {
     selection,
+    branchIndex: transitionResult.branchIndex,
     unresolvedTarget,
     target,
     commands: [
@@ -1768,6 +1798,7 @@ const microstep = <
       source: transition.selection.sourcePath,
       trigger: transition.selection.trigger,
       reenter: transition.selection.transition.reenter,
+      branchIndex: transition.branchIndex,
       target: transition.unresolvedTarget === undefined ? undefined : getTargetNodePath(transition.unresolvedTarget),
       resolvedTarget: transition.target === undefined ? undefined : getTargetNodePath(transition.target)
     },

--- a/test/internal/machine/strategyDifferential.test.ts
+++ b/test/internal/machine/strategyDifferential.test.ts
@@ -23,6 +23,9 @@ class Noop extends Schema.TaggedClass<Noop>("StrategyNoop")("Noop", {}) {}
 class Increment extends Schema.TaggedClass<Increment>("StrategyIncrement")("Increment", {}) {}
 class Reenter extends Schema.TaggedClass<Reenter>("StrategyReenter")("Reenter", {}) {}
 class Finish extends Schema.TaggedClass<Finish>("StrategyFinish")("Finish", {}) {}
+class Select extends Schema.TaggedClass<Select>("StrategySelect")("Select", {
+  value: Schema.Number
+}) {}
 
 const makeFlatMachine = () => {
   const states = Machine.defineStates({
@@ -63,6 +66,56 @@ describe("machine planner and runtime strategies", () => {
       expected: "indexed-flat",
       label: "flat strategy"
     }))
+
+  it.effect("retains the selected conditional branch across generic and indexed-flat planning", () => {
+    const states = Machine.defineStates({ Count })
+    const machine = Machine.make({
+      states: states.states,
+      events: Machine.events(Select),
+      initial: {
+        target: (to) => to.Count(),
+        resolve: ({ target }) => target(new Count({ value: 0 }))
+      }
+    }).handle({
+      Count: {
+        on: {
+          Select: Machine.transition({
+            cases: (branch) => [
+              branch({
+                title: "negative",
+                when: ({ event }) => event.value < 0 ? Option.some(event.value) : Option.none(),
+                target: (to) => to.none(),
+                resolve: () => undefined
+              }),
+              branch({
+                title: "zero",
+                when: ({ event }) => event.value === 0 ? Option.some(event.value) : Option.none(),
+                target: (to) => to.none(),
+                resolve: () => undefined
+              })
+            ],
+            otherwise: { target: (to) => to.none(), resolve: () => undefined }
+          })
+        }
+      }
+    })
+    const events = [new Select({ value: -1 }), new Select({ value: 0 }), new Select({ value: 1 })]
+
+    return Effect.gen(function*() {
+      yield* verifyPlannerStrategies({
+        machine,
+        events,
+        expected: "indexed-flat",
+        label: "conditional branch identity"
+      })
+
+      const initial = yield* Machine.planInitial(machine)
+      for (let branchIndex = 0; branchIndex < events.length; branchIndex++) {
+        const planned = yield* Machine.plan(machine, initial.state, events[branchIndex]!)
+        assert.strictEqual(planned.microsteps[0]?.transitions[0]?.branchIndex, branchIndex)
+      }
+    })
+  })
 
   it.effect("reenters the source when an explicit targetless transition requests reentry", () =>
     Effect.gen(function*() {

--- a/test/machine/Choice.test.ts
+++ b/test/machine/Choice.test.ts
@@ -95,15 +95,40 @@ describe("Machine choice pseudo-states", () => {
         "Flow.Approved"
       ])
       assert.strictEqual(plan.microsteps[0]?.transitions[0]?.source, "Flow.Routing")
+      assert.strictEqual(plan.microsteps[0]?.transitions[0]?.branchIndex, 3)
       assert.strictEqual(Machine.isInitialEvent(plan.microsteps[0]!.event), true)
       assert.strictEqual(caseFactoryCalls, 1)
       const choice = Machine.transitionDefinitions(machine).find(({ source }) => source === "Flow.Routing")
       assert.deepStrictEqual(choice?.branches, [
-        { type: "case", title: "score is perfect", target: "Flow.Approved" },
-        { type: "case", title: "score is negative", target: "Flow.Rejected" },
-        { type: "case", title: "score is zero", target: "Flow.Rejected" },
-        { type: "case", title: "score is at least 70", target: "Flow.Approved" },
-        { type: "otherwise", target: "Flow.Rejected" }
+        {
+          type: "case",
+          title: "score is perfect",
+          target: "Flow.Approved",
+          selection: { path: "Flow.Approved", kind: "state", scope: "local" }
+        },
+        {
+          type: "case",
+          title: "score is negative",
+          target: "Flow.Rejected",
+          selection: { path: "Flow.Rejected", kind: "state", scope: "local" }
+        },
+        {
+          type: "case",
+          title: "score is zero",
+          target: "Flow.Rejected",
+          selection: { path: "Flow.Rejected", kind: "state", scope: "local" }
+        },
+        {
+          type: "case",
+          title: "score is at least 70",
+          target: "Flow.Approved",
+          selection: { path: "Flow.Approved", kind: "state", scope: "local" }
+        },
+        {
+          type: "otherwise",
+          target: "Flow.Rejected",
+          selection: { path: "Flow.Rejected", kind: "state", scope: "local" }
+        }
       ])
       assert.deepStrictEqual(Machine.stateNodes(machine).map(({ path, type }) => ({ path, type })), [
         { path: "Flow" as const, type: "compound" },
@@ -586,23 +611,65 @@ describe("Machine choice pseudo-states", () => {
           { source: "Flow.Routing", trigger: "choice" }
         ]
       )
+      const historyDefinition = Machine.transitionDefinitions(historyChoice).find(
+        ({ source, trigger }) =>
+          source === "Outside" && trigger.type === "event" && trigger.event === "FallbackChoiceResume"
+      )
+      assert.deepStrictEqual(historyDefinition?.branches[0]?.selection, {
+        path: "Flow.Recent",
+        kind: "history",
+        scope: "full"
+      })
     }))
 
   it("inspects declared choice edges without executing the resolver", () => {
-    assert.deepStrictEqual(Machine.transitionDefinitions(machine).filter(({ trigger }) => trigger.type === "choice"), [
+    const definitions = Machine.transitionDefinitions(machine)
+    assert.deepStrictEqual(definitions.filter(({ trigger }) => trigger.type === "choice"), [
       {
         source: "Flow.Routing",
         trigger: { type: "choice" },
         reenter: false,
         branches: [
-          { type: "case", title: "score is perfect", target: "Flow.Approved" },
-          { type: "case", title: "score is negative", target: "Flow.Rejected" },
-          { type: "case", title: "score is zero", target: "Flow.Rejected" },
-          { type: "case", title: "score is at least 70", target: "Flow.Approved" },
-          { type: "otherwise", target: "Flow.Rejected" }
+          {
+            type: "case",
+            title: "score is perfect",
+            target: "Flow.Approved",
+            selection: { path: "Flow.Approved", kind: "state", scope: "local" }
+          },
+          {
+            type: "case",
+            title: "score is negative",
+            target: "Flow.Rejected",
+            selection: { path: "Flow.Rejected", kind: "state", scope: "local" }
+          },
+          {
+            type: "case",
+            title: "score is zero",
+            target: "Flow.Rejected",
+            selection: { path: "Flow.Rejected", kind: "state", scope: "local" }
+          },
+          {
+            type: "case",
+            title: "score is at least 70",
+            target: "Flow.Approved",
+            selection: { path: "Flow.Approved", kind: "state", scope: "local" }
+          },
+          {
+            type: "otherwise",
+            target: "Flow.Rejected",
+            selection: { path: "Flow.Rejected", kind: "state", scope: "local" }
+          }
         ]
       }
     ])
+    const recheck = definitions.find(
+      ({ source, trigger }) => source === "Flow.Approved" && trigger.type === "event" && trigger.event === "Recheck"
+    )
+    assert.deepStrictEqual(recheck?.branches[0]?.selection, {
+      path: "Flow",
+      kind: "initial",
+      scope: "branch"
+    })
   })
 
   it.effect("attributes choice microsteps in MachineTest traces and coverage", () =>

--- a/test/machine/InitialEntry.test.ts
+++ b/test/machine/InitialEntry.test.ts
@@ -287,12 +287,14 @@ describe("declared initial entry", () => {
         source: "outside",
         trigger: { type: "event", event: "EnterFlow" },
         reenter: false,
+        branchIndex: 0,
         target: "flow",
         resolvedTarget: "flow"
       }, {
         source: "flow.routing",
         trigger: { type: "choice" },
         reenter: false,
+        branchIndex: 0,
         target: "flow.approved",
         resolvedTarget: "flow.approved"
       }])

--- a/test/machine/Invoke.test.ts
+++ b/test/machine/Invoke.test.ts
@@ -43,7 +43,11 @@ describe("inline invoke", () => {
         source: "Loading",
         trigger: { type: "invoke", id: "load", outcome: "done" },
         reenter: false,
-        branches: [{ type: "direct", target: "Complete" }]
+        branches: [{
+          type: "direct",
+          target: "Complete",
+          selection: { path: "Complete", kind: "state", scope: "full" }
+        }]
       }])
 
       const ref = yield* Machine.start(machine)

--- a/test/machine/LiveInspection.test.ts
+++ b/test/machine/LiveInspection.test.ts
@@ -87,6 +87,7 @@ describe("Machine live inspection", () => {
           source: "Idle",
           trigger: { type: "event", event: "Increment" },
           reenter: false,
+          branchIndex: 0,
           target: "Idle",
           resolvedTarget: "Idle"
         }])

--- a/test/machine/Machine.test.ts
+++ b/test/machine/Machine.test.ts
@@ -131,7 +131,11 @@ describe("Machine", () => {
         source: "Stable",
         trigger: { type: "event", event: "Ping" },
         reenter: false,
-        branches: [{ type: "direct", target: undefined }]
+        branches: [{
+          type: "direct",
+          target: undefined,
+          selection: { path: undefined, kind: "none", scope: "local" }
+        }]
       }])
 
       const initial = yield* Machine.planInitial(machine)

--- a/test/machine/Visualization.test.ts
+++ b/test/machine/Visualization.test.ts
@@ -169,6 +169,25 @@ const renderLifecycleMachine = makeTextRenderer<
 >(Machine)
 
 describe("Machine structural visualization", () => {
+  it("exposes the static root initial selection without executing the resolver", () => {
+    const inspectOnly = Machine.make({
+      states: States.states,
+      events: Machine.events(),
+      input: Schema.String,
+      initial: {
+        target: (to) => to.application.initial(),
+        resolve: () => {
+          throw new Error("initial resolver unexpectedly executed during inspection")
+        }
+      }
+    })
+
+    assert.deepStrictEqual(Machine.initialDefinition(inspectOnly), {
+      target: "application",
+      selection: { path: "application", kind: "initial", scope: "initial" }
+    })
+  })
+
   it("exposes every state node in definition order", () => {
     assert.deepStrictEqual(Machine.stateNodes(machine).map(({ path, type }) => ({ path, type })), [
       { path: "application" as const, type: "parallel" },
@@ -201,19 +220,31 @@ describe("Machine structural visualization", () => {
         source: "application.workflow.idle",
         trigger: { type: "event", event: "Start" },
         reenter: false,
-        branches: [{ type: "direct", target: "application.workflow.running" }]
+        branches: [{
+          type: "direct",
+          target: "application.workflow.running",
+          selection: { path: "application.workflow.running", kind: "state", scope: "local" }
+        }]
       },
       {
         source: "application.workflow.idle",
         trigger: { type: "event", event: "Refresh" },
         reenter: false,
-        branches: [{ type: "direct", target: undefined }]
+        branches: [{
+          type: "direct",
+          target: undefined,
+          selection: { path: undefined, kind: "none", scope: "local" }
+        }]
       },
       {
         source: "application.connection.online",
         trigger: { type: "event", event: "Disconnect" },
         reenter: false,
-        branches: [{ type: "direct", target: "application.connection.offline" }]
+        branches: [{
+          type: "direct",
+          target: "application.connection.offline",
+          selection: { path: "application.connection.offline", kind: "state", scope: "local" }
+        }]
       }
     ])
   })
@@ -241,19 +272,31 @@ describe("Machine structural visualization", () => {
         source: "idle",
         trigger: { type: "event", event: "Refresh" },
         reenter: true,
-        branches: [{ type: "direct", target: undefined }]
+        branches: [{
+          type: "direct",
+          target: undefined,
+          selection: { path: undefined, kind: "none", scope: "local" }
+        }]
       },
       {
         source: "idle",
         trigger: { type: "always" },
         reenter: false,
-        branches: [{ type: "direct", target: undefined }]
+        branches: [{
+          type: "direct",
+          target: undefined,
+          selection: { path: undefined, kind: "none", scope: "local" }
+        }]
       },
       {
         source: "idle",
         trigger: { type: "done" },
         reenter: false,
-        branches: [{ type: "direct", target: undefined }]
+        branches: [{
+          type: "direct",
+          target: undefined,
+          selection: { path: undefined, kind: "none", scope: "local" }
+        }]
       }
     ])
   })
@@ -270,13 +313,21 @@ describe("Machine structural visualization", () => {
           source: "idle",
           trigger: { type: "always" },
           reenter: false,
-          branches: [{ type: "direct", target: "workflow" }]
+          branches: [{
+            type: "direct",
+            target: "workflow",
+            selection: { path: "workflow", kind: "state", scope: "full" }
+          }]
         },
         {
           source: "workflow",
           trigger: { type: "done" },
           reenter: false,
-          branches: [{ type: "direct", target: "disabled" }]
+          branches: [{
+            type: "direct",
+            target: "disabled",
+            selection: { path: "disabled", kind: "state", scope: "full" }
+          }]
         }
       ])
       assert.strictEqual(

--- a/test/testing/MachineTest.test.ts
+++ b/test/testing/MachineTest.test.ts
@@ -259,6 +259,7 @@ describe("MachineTest", () => {
         source: "app.left.idle",
         trigger: { type: "event", event: "Stop" },
         reenter: false,
+        branchIndex: 0,
         target: "disabled",
         resolvedTarget: "disabled"
       }])

--- a/typetest/machine/Inspection.tst.ts
+++ b/typetest/machine/Inspection.tst.ts
@@ -185,6 +185,12 @@ describe("Machine inspection", () => {
   })
 
   it("preserves source paths and event tags for transition inspection", () => {
+    const initialDefinition = Machine.initialDefinition(machine)
+    expect(initialDefinition.target).type.toBe<"root">()
+    expect(initialDefinition.selection.path).type.toBe<"root">()
+    expect(initialDefinition.selection.kind).type.toBe<"state" | "initial">()
+    expect(initialDefinition.selection.scope).type.toBe<"initial">()
+
     const definition = Machine.transitionDefinitions(machine)[0]!
     expect(definition.source).type.toBe<"root" | "root.idle" | "root.recent">()
     if (definition.trigger.type === "event") {
@@ -193,6 +199,7 @@ describe("Machine inspection", () => {
     expect(definition.branches).type.toBe<
       ReadonlyArray<Machine.Machine.TransitionBranch<"root" | "root.idle" | "root.recent">>
     >()
+    expect(definition.branches[0]!.selection.path).type.toBe<"root" | "root.idle" | "root.recent" | undefined>()
   })
 
   it("requires statically selected transitions", () => {


### PR DESCRIPTION
## Summary

- retain the selected transition branch index in generic and optimized planner evidence
- expose exact target selection kind and scope for every static transition branch
- expose the root startup selection through `Machine.initialDefinition` without evaluating its resolver
- add focused public, type-level, and generic-versus-optimized differential coverage

This prepares the core machine contract for branch-aware `MachineTest` coverage, topology construction, and guided exploration without changing the machine authoring API.

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required

Additional validation: `examples/platformer` passed `pnpm check`.
