### PR TITLE
Make MachineTest transition evidence exact

### DIFF
--- a/.changeset/exact-machine-test-evidence.md
+++ b/.changeset/exact-machine-test-evidence.md
@@ -1,0 +1,7 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Make `MachineTest.coverage` report transition definitions and their exact branches separately. Read definition coverage through `coverage.transitions.definitions` and conditional branch coverage through `coverage.transitions.branches`.
+
+Replace the `targetBounds` verification law group with `definitions`. The new laws validate the declared startup root, transition registration, retained `branchIndex`, and the selected branch's exact target kind and scope.

--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ encoded snapshot.
 The testing entrypoint provides complementary layers:
 
 - `MachineTest.run` and `verify` inspect pure planner traces;
+- `coverage` reports exact transition-definition and conditional-branch hits;
 - invariants and generated scenarios check application laws;
 - `explore` performs bounded breadth-first state-space exploration;
 - `probe` causally acknowledges live runtime commands;

--- a/examples/playground/src/examples/media-player/machine.test.ts
+++ b/examples/playground/src/examples/media-player/machine.test.ts
@@ -103,7 +103,8 @@ describe("media-player statechart model", () => {
 
       assert.strictEqual(coverage.events.hit, everyPublicEvent.length)
       assert.strictEqual(coverage.events.missing, 0)
-      assert.strictEqual(coverage.transitions.hit > 0, true)
+      assert.strictEqual(coverage.transitions.definitions.hit > 0, true)
+      assert.strictEqual(coverage.transitions.branches.hit > 0, true)
 
       const activated = new Set(coverage.states.activation.hits.map(({ path }) => path))
       assert.strictEqual(activated.has("Player.transport.Empty"), true)

--- a/src/internal/testing/machine/verification.ts
+++ b/src/internal/testing/machine/verification.ts
@@ -29,7 +29,8 @@ import type {
   StateCoverageItem,
   Trace,
   TraceStep,
-  TransitionCoverageItem,
+  TransitionBranchCoverageItem,
+  TransitionDefinitionCoverageItem,
   VerificationLaw,
   VerificationLawGroup,
   VerificationViolation,
@@ -469,21 +470,33 @@ const normalizeTraces = <M extends AnyMachine>(
 ): ReadonlyArray<Trace<M>> =>
   Array.isArray(traceOrTraces) ? traceOrTraces as ReadonlyArray<Trace<M>> : [traceOrTraces as Trace<M>]
 
-const sameCoverageTrigger = (
+const sameTransitionTrigger = (
   left: Machine.Machine.TransitionTrigger,
   right: Machine.Machine.TransitionTrigger
-): boolean =>
-  left.type === right.type && (left.type !== "event" || right.type === "event" && left.event === right.event)
+): boolean => {
+  if (left.type !== right.type) return false
+  if (left.type === "event") return right.type === "event" && left.event === right.event
+  if (left.type === "invoke") {
+    return right.type === "invoke" && left.id === right.id && left.outcome === right.outcome
+  }
+  return true
+}
 
-const targetWithinDeclaredBranches = (
+const targetWithinSelection = (
   target: string | undefined,
-  branches: ReadonlyArray<Machine.Machine.TransitionBranch>
-): boolean =>
-  branches.some((branch) =>
-    branch.target === undefined ?
-      target === undefined
-      : target !== undefined && (target === branch.target || target.startsWith(`${branch.target}.`))
-  )
+  branch: Machine.Machine.TransitionBranch,
+  nodeByPath: ReadonlyMap<string, Machine.Machine.StateNode>
+): boolean => {
+  const selection = branch.selection
+  if (selection.kind === "none") return target === undefined
+  if (target === undefined || selection.path === undefined) return false
+  if (target === selection.path) return true
+  const selectedNode = nodeByPath.get(selection.path)
+  return selection.kind === "state" &&
+    (selection.scope === "local" || selection.scope === "branch") &&
+    (selectedNode?.type === "compound" || selectedNode?.type === "parallel") &&
+    target.startsWith(`${selection.path}.`)
+}
 
 const finiteTagValues = (ast: SchemaAST.AST): ReadonlyArray<PropertyKey> | undefined => {
   if (SchemaAST.isLiteral(ast)) {
@@ -567,12 +580,12 @@ export const coverage = <M extends AnyMachine>(
     (
       definition,
       index
-    ): TransitionCoverageItem<
+    ): TransitionDefinitionCoverageItem<
       StateNodePath<M>,
       Machine.Machine.TagOf<Machine.Machine.Events<M>[number]>,
       StateNodePath<M>
     > => ({
-      id: `transition:${index}:${formatValue(definition)}`,
+      id: `transition:${index}`,
       index,
       source: definition.source,
       trigger: definition.trigger,
@@ -581,6 +594,30 @@ export const coverage = <M extends AnyMachine>(
     })
   )
   const transitionHits = new Set<number>()
+  const branchOffsets: Array<number> = []
+  const branches: Array<
+    TransitionBranchCoverageItem<
+      StateNodePath<M>,
+      Machine.Machine.TagOf<Machine.Machine.Events<M>[number]>,
+      StateNodePath<M>
+    >
+  > = []
+  for (let definitionIndex = 0; definitionIndex < definitions.length; definitionIndex++) {
+    branchOffsets.push(branches.length)
+    const definition = definitions[definitionIndex]!
+    definition.branches.forEach((branch, branchIndex) => {
+      branches.push({
+        id: `transition:${definitionIndex}:branch:${branchIndex}`,
+        definitionIndex,
+        branchIndex,
+        source: definition.source,
+        trigger: definition.trigger,
+        reenter: definition.reenter,
+        branch
+      })
+    })
+  }
+  const branchHits = new Set<number>()
 
   const declaredEvents = publicEventTags(machine)
   const declaredEventTags = declaredEvents.tags
@@ -658,10 +695,17 @@ export const coverage = <M extends AnyMachine>(
       const definitionIndex = definitions.findIndex((definition) =>
         definition.source === retained.source &&
         definition.reenter === retained.reenter &&
-        sameCoverageTrigger(definition.trigger, retained.trigger) &&
-        targetWithinDeclaredBranches(retained.target, definition.branches)
+        sameTransitionTrigger(definition.trigger, retained.trigger)
       )
-      if (definitionIndex !== -1) transitionHits.add(definitionIndex)
+      if (definitionIndex === -1) continue
+      transitionHits.add(definitionIndex)
+      const definition = definitions[definitionIndex]!
+      if (
+        Number.isSafeInteger(retained.branchIndex) && retained.branchIndex >= 0 &&
+        retained.branchIndex < definition.branches.length
+      ) {
+        branchHits.add(branchOffsets[definitionIndex]! + retained.branchIndex)
+      }
     }
   }
 
@@ -701,7 +745,10 @@ export const coverage = <M extends AnyMachine>(
       entry: coverageSummary(activeNodes, entryHits),
       exit: coverageSummary(activeNodes, exitHits)
     },
-    transitions: coverageSummary(definitions, transitionHits),
+    transitions: {
+      definitions: coverageSummary(definitions, transitionHits),
+      branches: coverageSummary(branches, branchHits)
+    },
     events: declaredEvents.diagnostics.length === 0
       ? {
         available: true,
@@ -969,12 +1016,6 @@ const sameValue = (left: unknown, right: unknown): boolean => formatValue(left) 
 const samePaths = (left: ReadonlyArray<string>, right: ReadonlyArray<string>): boolean =>
   left.length === right.length && left.every((path, index) => path === right[index])
 
-const sameTrigger = (
-  left: Machine.Machine.TransitionTrigger,
-  right: Machine.Machine.TransitionTrigger
-): boolean =>
-  left.type === right.type && (left.type !== "event" || right.type === "event" && left.event === right.event)
-
 const makeNodeUtilities = (nodes: ReadonlyArray<PublicStateNode>) => {
   const byPath = new Map(nodes.map((node) => [node.path, node]))
   const depth = (path: string): number => {
@@ -1018,9 +1059,10 @@ export const verify = <M extends AnyMachine>(
   options: VerifyOptions = {}
 ): Effect.Effect<void, VerificationError> => {
   const selected = new Set<VerificationLawGroup>(
-    options.laws ?? ["configuration", "microsteps", "completion", "history", "targetBounds"]
+    options.laws ?? ["configuration", "microsteps", "completion", "history", "definitions"]
   )
   const nodes = Machine.stateNodes(machine) as ReadonlyArray<PublicStateNode>
+  const initialDefinition = Machine.initialDefinition(machine)
   const definitions = Machine.transitionDefinitions(machine)
   const { ancestors, byPath, depth, isDescendantOrSelf } = makeNodeUtilities(nodes)
   const violations: Array<VerificationViolation> = []
@@ -1496,33 +1538,47 @@ export const verify = <M extends AnyMachine>(
       return direction === "entry" ? leftOrder - rightOrder : rightOrder - leftOrder
     })
 
-  const validateTransitionBounds = (
+  const validateTransitionDefinition = (
     transition: Microstep<M>["transitions"][number],
     location: VerificationLocation
   ): void => {
-    if (!selected.has("targetBounds")) return
+    if (!selected.has("definitions")) return
     const definition = definitions.find((candidate) =>
       candidate.source === transition.source && candidate.reenter === transition.reenter &&
-      sameTrigger(candidate.trigger, transition.trigger)
+      sameTransitionTrigger(candidate.trigger, transition.trigger)
     )
     if (definition === undefined) {
       add(
-        "targetBounds.definition",
+        "definitions.transition",
         location,
         `retained transition from "${transition.source}" has no public definition`,
         transition.source
       )
       return
     }
-    if (targetWithinDeclaredBranches(transition.target, definition.branches)) return
-    const targets = definition.branches.flatMap((branch) => branch.target === undefined ? [] : [branch.target])
-    if (!targets.some((bound) => isDescendantOrSelf(String(transition.target), String(bound)))) {
+    if (
+      !Number.isSafeInteger(transition.branchIndex) || transition.branchIndex < 0 ||
+      transition.branchIndex >= definition.branches.length
+    ) {
       add(
-        "targetBounds.target",
+        "definitions.branchIndex",
         location,
-        `transition target "${String(transition.target)}" is outside declared bounds ` +
-          `[${targets.join(", ")}]`,
-        String(transition.target)
+        `retained transition from "${transition.source}" selected invalid branch index ${transition.branchIndex}`,
+        transition.source
+      )
+      return
+    }
+    const branch = definition.branches[transition.branchIndex]!
+    if (!targetWithinSelection(transition.target, branch, byPath)) {
+      const expected = branch.selection.kind === "none"
+        ? "an explicitly targetless result"
+        : `selection ${branch.selection.kind}:${branch.selection.scope}:${String(branch.selection.path)}`
+      add(
+        "definitions.selection",
+        location,
+        `transition branch ${transition.branchIndex} from "${transition.source}" returned ` +
+          `target "${String(transition.target)}" outside ${expected}`,
+        transition.target === undefined ? transition.source : String(transition.target)
       )
     }
   }
@@ -1679,7 +1735,7 @@ export const verify = <M extends AnyMachine>(
         }
       }
     }
-    for (const transition of microstep.transitions) validateTransitionBounds(transition, location)
+    for (const transition of microstep.transitions) validateTransitionDefinition(transition, location)
   }
 
   const validatePlanCompletion = (
@@ -1715,6 +1771,18 @@ export const verify = <M extends AnyMachine>(
 
   const initialLocation: VerificationLocation = { eventIndex: undefined }
   const starting = inspectSnapshot(trace.initial.startingState, initialLocation, "initial starting state")
+  if (selected.has("definitions")) {
+    const startingRoots = starting.paths.filter((path) => byPath.get(path)?.parent === undefined)
+    if (startingRoots.length !== 1 || startingRoots[0] !== initialDefinition.target) {
+      add(
+        "definitions.initial",
+        initialLocation,
+        `initial starting state selected roots [${startingRoots.join(", ")}] instead of ` +
+          `declared root "${initialDefinition.target}"`,
+        startingRoots[0] ?? initialDefinition.target
+      )
+    }
+  }
   validateSnapshotMetadata(starting, initialLocation, "initial starting state")
   validateTraceConfiguration(
     starting,
@@ -1849,6 +1917,7 @@ const formatMicrosteps = <M extends AnyMachine>(microsteps: ReadonlyArray<Micros
       source: transition.source,
       trigger: transition.trigger,
       reenter: transition.reenter,
+      branchIndex: transition.branchIndex,
       target: transition.target,
       resolvedTarget: transition.resolvedTarget
     }))

--- a/src/testing/MachineTest.ts
+++ b/src/testing/MachineTest.ts
@@ -1677,9 +1677,9 @@ export interface StateCoverage<Path extends string = string> {
  * One stable transition-definition identity in definition order.
  *
  * @category models
- * @since 0.4.0
+ * @since 0.14.0
  */
-export interface TransitionCoverageItem<
+export interface TransitionDefinitionCoverageItem<
   SourcePath extends string = string,
   EventTag extends PropertyKey = PropertyKey,
   TargetPath extends string = SourcePath
@@ -1690,6 +1690,42 @@ export interface TransitionCoverageItem<
   readonly trigger: Machine.Machine.TransitionTrigger<EventTag>
   readonly reenter: boolean
   readonly branches: ReadonlyArray<Machine.Machine.TransitionBranch<TargetPath>>
+}
+
+/**
+ * One statically declared transition branch together with its owning
+ * definition identity.
+ *
+ * @category models
+ * @since 0.14.0
+ */
+export interface TransitionBranchCoverageItem<
+  SourcePath extends string = string,
+  EventTag extends PropertyKey = PropertyKey,
+  TargetPath extends string = SourcePath
+> {
+  readonly id: string
+  readonly definitionIndex: number
+  readonly branchIndex: number
+  readonly source: SourcePath
+  readonly trigger: Machine.Machine.TransitionTrigger<EventTag>
+  readonly reenter: boolean
+  readonly branch: Machine.Machine.TransitionBranch<TargetPath>
+}
+
+/**
+ * Definition-level and exact branch-level transition coverage.
+ *
+ * @category models
+ * @since 0.14.0
+ */
+export interface TransitionCoverage<
+  SourcePath extends string = string,
+  EventTag extends PropertyKey = PropertyKey,
+  TargetPath extends string = SourcePath
+> {
+  readonly definitions: CoverageSummary<TransitionDefinitionCoverageItem<SourcePath, EventTag, TargetPath>>
+  readonly branches: CoverageSummary<TransitionBranchCoverageItem<SourcePath, EventTag, TargetPath>>
 }
 
 /**
@@ -1812,12 +1848,10 @@ export interface HistoryCoverageEvidence<Path extends string = string> {
  */
 export interface Coverage<M extends AnyMachine> {
   readonly states: StateCoverage<StatePath<M>>
-  readonly transitions: CoverageSummary<
-    TransitionCoverageItem<
-      StateNodePath<M>,
-      Machine.Machine.TagOf<Machine.Machine.Events<M>[number]>,
-      StateNodePath<M>
-    >
+  readonly transitions: TransitionCoverage<
+    StateNodePath<M>,
+    Machine.Machine.TagOf<Machine.Machine.Events<M>[number]>,
+    StateNodePath<M>
   >
   readonly events: EventCoverage<Machine.Machine.TagOf<Machine.Machine.InputEvents<M>[number]>>
   readonly scenarios: ScenarioCoverage
@@ -1832,10 +1866,10 @@ export interface Coverage<M extends AnyMachine> {
 }
 
 /**
- * Computes deterministic, definition-aware coverage from completed planner
- * traces. Finite declared sets report hits and misses; scenarios and logical
- * configurations report observations only because their complete spaces are
- * generally infinite.
+ * Computes deterministic, definition- and branch-aware coverage from
+ * completed planner traces. Finite declared sets report hits and misses;
+ * scenarios and logical configurations report observations only because their
+ * complete spaces are generally infinite.
  *
  * **Example**
  *
@@ -1979,7 +2013,7 @@ export type VerificationLawGroup =
   | "microsteps"
   | "completion"
   | "history"
-  | "targetBounds"
+  | "definitions"
 
 /**
  * Stable identifiers for individual planner laws.
@@ -2012,8 +2046,10 @@ export type VerificationLaw =
   | "history.value"
   | "history.shallow"
   | "history.deep"
-  | "targetBounds.definition"
-  | "targetBounds.target"
+  | "definitions.initial"
+  | "definitions.transition"
+  | "definitions.branchIndex"
+  | "definitions.selection"
 
 /**
  * One independently observed violation in a planner trace.
@@ -2050,7 +2086,9 @@ export interface VerifyOptions {
 
 /**
  * Verifies an executed trace using only public machine inspection and raw
- * snapshot data. The verifier deliberately does not reuse planner
+ * snapshot data. Retained transitions are checked against their exact static
+ * branch and target selection, and startup is checked against the declared
+ * initial root. The verifier deliberately does not reuse planner
  * normalization, encoding, finality, or other internal helpers.
  *
  * Every selected law is evaluated and returned in one structured error so a

--- a/test/machine/Choice.test.ts
+++ b/test/machine/Choice.test.ts
@@ -677,6 +677,14 @@ describe("Machine choice pseudo-states", () => {
       const trace = yield* MachineTest.run(machine, { events: [new Recheck({ score: 10 })] })
       const coverage = MachineTest.coverage(machine, trace)
       assert.strictEqual(coverage.microsteps.choiceTriggered, 2)
+      const choiceBranches = coverage.transitions.branches.hits.filter(({ trigger }) => trigger.type === "choice")
+      assert.deepStrictEqual(choiceBranches.map(({ branchIndex }) => branchIndex), [3, 4])
+      assert.deepStrictEqual(
+        coverage.transitions.branches.misses
+          .filter(({ trigger }) => trigger.type === "choice")
+          .map(({ branchIndex }) => branchIndex),
+        [0, 1, 2]
+      )
       assert.deepStrictEqual(
         [trace.initial.plan, ...trace.steps.map(({ plan }) => plan)]
           .flatMap(({ microsteps }) => microsteps)

--- a/test/testing/Coverage.test.ts
+++ b/test/testing/Coverage.test.ts
@@ -81,6 +81,41 @@ const startupMachine = Machine.make({
   }
 })
 
+class Select extends Schema.TaggedClass<Select>("CoverageSelect")("Select", {
+  value: Schema.Int
+}) {}
+
+const branchMachine = Machine.make({
+  states: StartupStates.states,
+  events: Machine.events(Select),
+  initial: {
+    target: (to) => to.count(),
+    resolve: ({ target }) => target(new Count({ value: 0 }))
+  }
+}).handle({
+  count: {
+    on: {
+      Select: Machine.transition({
+        cases: (branch) => [
+          branch({
+            title: "negative",
+            when: ({ event }) => event.value < 0 ? Option.some(event.value) : Option.none(),
+            target: (to) => to.none(),
+            resolve: () => undefined
+          }),
+          branch({
+            title: "zero",
+            when: ({ event }) => event.value === 0 ? Option.some(event.value) : Option.none(),
+            target: (to) => to.none(),
+            resolve: () => undefined
+          })
+        ],
+        otherwise: { target: (to) => to.none(), resolve: () => undefined }
+      })
+    }
+  }
+})
+
 const Tick = Symbol.for("MachineTestCoverage/Tick")
 const TickEvent = Schema.Struct({ _tag: Schema.UniqueSymbol(Tick) })
 const ChoiceEvent = Schema.Struct({
@@ -210,10 +245,13 @@ describe("MachineTest trace coverage", () => {
       assert.strictEqual(partial.events.available, true)
       if (!partial.events.available) return
       assert.deepStrictEqual(partial.states.activation.misses.map(({ path }) => path), ["done"])
-      assert.deepStrictEqual(partial.transitions.misses.map(({ source, trigger }) => ({ source, trigger })), [{
-        source: "count",
-        trigger: { type: "event", event: "Finish" }
-      }])
+      assert.deepStrictEqual(
+        partial.transitions.definitions.misses.map(({ source, trigger }) => ({ source, trigger })),
+        [{
+          source: "count",
+          trigger: { type: "event", event: "Finish" }
+        }]
+      )
       assert.deepStrictEqual(partial.events.misses, [{ tag: "Finish", count: 0 }])
       assert.strictEqual(partial.logicalConfigurations.hit, 2)
 
@@ -221,12 +259,41 @@ describe("MachineTest trace coverage", () => {
       assert.strictEqual(combined.events.available, true)
       if (!combined.events.available) return
       assert.strictEqual(combined.states.activation.missing, 0)
-      assert.strictEqual(combined.transitions.missing, 0)
+      assert.strictEqual(combined.transitions.definitions.missing, 0)
+      assert.strictEqual(combined.transitions.branches.missing, 0)
       assert.strictEqual(combined.events.missing, 0)
       assert.ok(combined.states.exit.hits.some(({ path }) => path === "count"))
       assert.ok(combined.states.entry.hits.some(({ path }) => path === "done"))
       assert.strictEqual(combined.scenarios.traces, 2)
       assert.strictEqual(combined.scenarios.events, 2)
+    }))
+
+  it.effect("attributes identical targetless results to their exact conditional branches", () =>
+    Effect.gen(function*() {
+      const negative = yield* MachineTest.run(branchMachine, { events: [new Select({ value: -1 })] })
+      const zero = yield* MachineTest.run(branchMachine, { events: [new Select({ value: 0 })] })
+      const positive = yield* MachineTest.run(branchMachine, { events: [new Select({ value: 1 })] })
+
+      const partial = MachineTest.coverage(branchMachine, negative)
+      assert.strictEqual(partial.transitions.definitions.hit, 1)
+      assert.deepStrictEqual(partial.transitions.branches.hits.map(({ branchIndex }) => branchIndex), [0])
+      assert.deepStrictEqual(partial.transitions.branches.misses.map(({ branchIndex }) => branchIndex), [1, 2])
+
+      const complete = MachineTest.coverage(branchMachine, [negative, zero, positive])
+      assert.strictEqual(complete.transitions.definitions.missing, 0)
+      assert.strictEqual(complete.transitions.branches.missing, 0)
+      assert.deepStrictEqual(
+        complete.transitions.branches.hits.map(({ id, branchIndex, branch }) => ({
+          id,
+          branchIndex,
+          type: branch.type
+        })),
+        [
+          { id: "transition:0:branch:0", branchIndex: 0, type: "case" },
+          { id: "transition:0:branch:1", branchIndex: 1, type: "case" },
+          { id: "transition:0:branch:2", branchIndex: 2, type: "otherwise" }
+        ]
+      )
     }))
 
   it.effect("covers finite decoded symbol and union tags and diagnoses open tag spaces", () =>
@@ -263,6 +330,7 @@ describe("MachineTest trace coverage", () => {
       assert.ok(parallelCoverage.completion.paths.includes("workflow"))
       assert.ok(parallelCoverage.completion.paths.includes("workflow.left"))
       assert.strictEqual(parallelCoverage.microsteps.eventTriggered, 2)
+      assert.strictEqual(parallelCoverage.transitions.branches.hit, 2)
 
       const historyMachine = MachineTest.compileModel(historyModel)
       const history = yield* MachineTest.run(historyMachine, {
@@ -273,6 +341,9 @@ describe("MachineTest trace coverage", () => {
       assert.deepStrictEqual(historyCoverage.history.recorded, [{ path: "owner.exact" as const, modes: ["deep"] }])
       assert.strictEqual(historyCoverage.history.targets, 1)
       assert.strictEqual(historyCoverage.history.resolvedTargets, 1)
+      assert.ok(
+        historyCoverage.transitions.branches.hits.some(({ branch }) => branch.selection.kind === "history")
+      )
     }))
 })
 

--- a/test/testing/Verification.test.ts
+++ b/test/testing/Verification.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Schema } from "effect"
+import { Effect, Option, Schema } from "effect"
 import { Machine } from "../../src/index.js"
 import { MachineTest } from "../../src/testing/index.js"
 
@@ -14,6 +14,9 @@ class Counter extends Schema.TaggedClass<Counter>("Counter")("Counter", {
 class Increment extends Schema.TaggedClass<Increment>("Increment")("Increment", {}) {}
 class Noop extends Schema.TaggedClass<Noop>("Noop")("Noop", {}) {}
 class Restart extends Schema.TaggedClass<Restart>("Restart")("Restart", {}) {}
+class Select extends Schema.TaggedClass<Select>("VerificationSelect")("Select", {
+  value: Schema.Int
+}) {}
 
 const NavigationStates = Machine.defineStates({
   off: Off,
@@ -88,6 +91,61 @@ const counterMachine = Machine.make({
         resolve: () => undefined
       })
     }
+  }
+})
+
+const conditionalMachine = Machine.make({
+  states: CounterStates.states,
+  events: Machine.events(Select),
+  initial: {
+    target: (to) => to.counter(),
+    resolve: ({ target }) => target(new Counter({ count: 0 }))
+  }
+}).handle({
+  counter: {
+    on: {
+      Select: Machine.transition({
+        cases: (branch) => [
+          branch({
+            title: "negative",
+            when: ({ event }) => event.value < 0 ? Option.some(event.value) : Option.none(),
+            target: (to) => to.none(),
+            resolve: () => undefined
+          }),
+          branch({
+            title: "zero",
+            when: ({ event }) => event.value === 0 ? Option.some(event.value) : Option.none(),
+            target: (to) => to.full.counter(),
+            resolve: ({ target }) => target(new Counter({ count: 0 }))
+          })
+        ],
+        otherwise: { target: (to) => to.none(), resolve: () => undefined }
+      })
+    }
+  }
+})
+
+const invokedMachine = Machine.make({
+  states: CounterStates.states,
+  events: Machine.events(),
+  initial: {
+    target: (to) => to.counter(),
+    resolve: ({ target }) => target(new Counter({ count: 0 }))
+  }
+}).handle({
+  counter: {
+    invoke: [
+      Machine.invoke({
+        id: "first",
+        effect: () => Effect.succeed(1),
+        onDone: Machine.transition({ target: (to) => to.none(), resolve: () => undefined })
+      }),
+      Machine.invoke({
+        id: "second",
+        effect: () => Effect.succeed(2),
+        onDone: Machine.transition({ target: (to) => to.none(), resolve: () => undefined })
+      })
+    ]
   }
 })
 
@@ -736,7 +794,7 @@ describe("MachineTest.verify", () => {
       ))
     }))
 
-  it.effect("reports requested targets outside declared bounds", () =>
+  it.effect("binds retained targets to the exact selected branch and selection scope", () =>
     Effect.gen(function*() {
       const trace = yield* MachineTest.run(navigationMachine, { events: [new Go({})] })
       const step = trace.steps[0]!
@@ -750,19 +808,138 @@ describe("MachineTest.verify", () => {
             ...step.plan,
             microsteps: [{
               ...microstep,
-              transitions: [{ ...transition, target: "off" }]
+              transitions: [{ ...transition, target: "app.two" }]
             }]
           }
         }]
       } as typeof trace
 
       const error = yield* MachineTest.verify(navigationMachine, corrupted, {
-        laws: ["targetBounds"]
+        laws: ["definitions"]
       }).pipe(Effect.flip)
-      const violation = error.violations.find(({ law }) => law === "targetBounds.target")
+      const violation = error.violations.find(({ law }) => law === "definitions.selection")
       assert.strictEqual(violation?.eventIndex, 0)
       assert.strictEqual(violation?.microstepIndex, 0)
-      assert.strictEqual(violation?.path, "off")
+      assert.strictEqual(violation?.path, "app.two")
+    }))
+
+  it.effect("rejects invalid and cross-branch conditional evidence", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(conditionalMachine, { events: [new Select({ value: -1 })] })
+      const step = trace.steps[0]!
+      const microstep = step.plan.microsteps[0]!
+      const transition = microstep.transitions[0]!
+
+      const invalidIndex = {
+        ...trace,
+        steps: [{
+          ...step,
+          plan: {
+            ...step.plan,
+            microsteps: [{
+              ...microstep,
+              transitions: [{ ...transition, branchIndex: 99 }]
+            }]
+          }
+        }]
+      } as typeof trace
+      const indexError = yield* MachineTest.verify(conditionalMachine, invalidIndex, {
+        laws: ["definitions"]
+      }).pipe(Effect.flip)
+      assert.include(laws(indexError), "definitions.branchIndex")
+
+      const crossBranch = {
+        ...trace,
+        steps: [{
+          ...step,
+          plan: {
+            ...step.plan,
+            microsteps: [{
+              ...microstep,
+              transitions: [{ ...transition, branchIndex: 1 }]
+            }]
+          }
+        }]
+      } as typeof trace
+      const branchError = yield* MachineTest.verify(conditionalMachine, crossBranch, {
+        laws: ["definitions"]
+      }).pipe(Effect.flip)
+      assert.include(laws(branchError), "definitions.selection")
+    }))
+
+  it.effect("binds startup to the statically selected root", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(navigationMachine, { events: [new Go({})] })
+      const corrupted = {
+        ...trace,
+        initial: {
+          ...trace.initial,
+          startingState: trace.final
+        }
+      } as typeof trace
+
+      const error = yield* MachineTest.verify(navigationMachine, corrupted, {
+        laws: ["definitions"]
+      }).pipe(Effect.flip)
+      const violation = error.violations.find(({ law }) => law === "definitions.initial")
+      assert.strictEqual(violation?.eventIndex, undefined)
+      assert.strictEqual(violation?.path, "app")
+    }))
+
+  it.effect("distinguishes invoke definitions by lifecycle id and outcome", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(invokedMachine, { events: [] })
+      const transition = {
+        source: "counter" as const,
+        trigger: { type: "invoke" as const, id: "second", outcome: "done" as const },
+        reenter: false,
+        branchIndex: 0,
+        target: undefined,
+        resolvedTarget: undefined
+      }
+      const microstep: MachineTest.Microstep<typeof invokedMachine> = {
+        next: trace.initial.startingState,
+        event: Machine.InitialEvent,
+        transitions: [transition],
+        commands: [],
+        raisedEvents: [],
+        emittedEvents: [],
+        exitPaths: [],
+        entryPaths: [],
+        changed: false
+      }
+      const withInvoke = {
+        ...trace,
+        initial: {
+          ...trace.initial,
+          plan: {
+            ...trace.initial.plan,
+            microsteps: [microstep]
+          }
+        }
+      }
+      yield* MachineTest.verify(invokedMachine, withInvoke, { laws: ["definitions"] })
+
+      const wrongId = {
+        ...withInvoke,
+        initial: {
+          ...withInvoke.initial,
+          plan: {
+            ...withInvoke.initial.plan,
+            microsteps: [{
+              ...microstep,
+              transitions: [{
+                ...transition,
+                trigger: { ...transition.trigger, id: "missing" }
+              }]
+            }]
+          }
+        }
+      } as typeof withInvoke
+      const error = yield* MachineTest.verify(invokedMachine, wrongId, {
+        laws: ["definitions"]
+      }).pipe(Effect.flip)
+      assert.include(laws(error), "definitions.transition")
     }))
 
   const generatedNavigation = MachineTest.scenarios(navigationMachine, {

--- a/typetest/testing/Coverage.tst.ts
+++ b/typetest/testing/Coverage.tst.ts
@@ -37,8 +37,13 @@ describe("MachineTest coverage and observed graph", () => {
     expect(result).type.toBe<MachineTest.Coverage<typeof machine>>()
     if (result.events.available) expect(result.events.hits[0]!.tag).type.toBe<"Start">()
     expect(result.states.activation.hits[0]!.path).type.toBe<"idle" | "done">()
-    expect(result.transitions.hits[0]!.source).type.toBe<"idle" | "done">()
-    expect(result.transitions.hits[0]!.trigger).type.toBe<Machine.Machine.TransitionTrigger<"Start">>()
+    expect(result.transitions.definitions.hits[0]!.source).type.toBe<"idle" | "done">()
+    expect(result.transitions.definitions.hits[0]!.trigger).type.toBe<Machine.Machine.TransitionTrigger<"Start">>()
+    expect(result.transitions.branches.hits[0]!.source).type.toBe<"idle" | "done">()
+    expect(result.transitions.branches.hits[0]!.trigger).type.toBe<Machine.Machine.TransitionTrigger<"Start">>()
+    expect(result.transitions.branches.hits[0]!.branch).type.toBe<
+      Machine.Machine.TransitionBranch<"idle" | "done">
+    >()
   })
 
   it("returns an Effect graph with typed nodes and concrete edge evidence", () => {

--- a/typetest/testing/Verification.tst.ts
+++ b/typetest/testing/Verification.tst.ts
@@ -34,7 +34,7 @@ describe("MachineTest.verify", () => {
 
   it("accepts only canonical law groups", () => {
     const options: MachineTest.VerifyOptions = {
-      laws: ["configuration", "microsteps", "completion", "history", "targetBounds"]
+      laws: ["configuration", "microsteps", "completion", "history", "definitions"]
     }
     expect(options.laws).type.toBe<ReadonlyArray<MachineTest.VerificationLawGroup> | undefined>()
   })


### PR DESCRIPTION
## Summary

- report transition definitions and exact conditional branches as separate coverage dimensions
- verify startup roots, transition registration, retained `branchIndex`, and exact branch selection semantics from public core metadata
- cover targetless same-result cases, choice, history, parallel transitions, invoke identity, and public type inference

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required

The affected playground example passed its own `pnpm check`. Local `pnpm perf:types` and `pnpm perf:runtime` checks also passed; CI remains authoritative for base-versus-PR comparisons.