### PR TITLE
Verify routed transition evidence

### DIFF
--- a/.changeset/verify-routed-transition-evidence.md
+++ b/.changeset/verify-routed-transition-evidence.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Make `MachineTest.verify` accept startup roots reached through exact retained initial-choice routes and reject retained targets whose choice, initial, or history resolution is inconsistent with their selected static branch. Resolution failures are reported as `definitions.resolution`.

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -3249,9 +3249,12 @@ export declare namespace Machine {
     readonly reenter: boolean
     /** Zero-based index of the selected static branch. */
     readonly branchIndex: number
-    /** Path returned by the handler, including a history pseudo-state. */
+    /** Path returned by the handler, including a choice or history pseudo-state. */
     readonly target: TargetPath | undefined
-    /** Concrete path used after resolving history, otherwise equal to `target`. */
+    /**
+     * Concrete path used after resolving choice, initial, or history routing.
+     * Choice microsteps retain each intermediate pseudo-state edge separately.
+     */
     readonly resolvedTarget: TargetPath | undefined
   }
 

--- a/src/internal/testing/machine/verification.ts
+++ b/src/internal/testing/machine/verification.ts
@@ -1538,11 +1538,24 @@ export const verify = <M extends AnyMachine>(
       return direction === "entry" ? leftOrder - rightOrder : rightOrder - leftOrder
     })
 
+  const transitionBranch = (
+    transition: Microstep<M>["transitions"][number]
+  ): Machine.Machine.TransitionBranch | undefined => {
+    const definition = definitions.find((candidate) =>
+      candidate.source === transition.source && candidate.reenter === transition.reenter &&
+      sameTransitionTrigger(candidate.trigger, transition.trigger)
+    )
+    return definition === undefined || !Number.isSafeInteger(transition.branchIndex) || transition.branchIndex < 0 ||
+        transition.branchIndex >= definition.branches.length
+      ? undefined
+      : definition.branches[transition.branchIndex]
+  }
+
   const validateTransitionDefinition = (
     transition: Microstep<M>["transitions"][number],
     location: VerificationLocation
-  ): void => {
-    if (!selected.has("definitions")) return
+  ): Machine.Machine.TransitionBranch | undefined => {
+    if (!selected.has("definitions")) return undefined
     const definition = definitions.find((candidate) =>
       candidate.source === transition.source && candidate.reenter === transition.reenter &&
       sameTransitionTrigger(candidate.trigger, transition.trigger)
@@ -1554,7 +1567,7 @@ export const verify = <M extends AnyMachine>(
         `retained transition from "${transition.source}" has no public definition`,
         transition.source
       )
-      return
+      return undefined
     }
     if (
       !Number.isSafeInteger(transition.branchIndex) || transition.branchIndex < 0 ||
@@ -1566,7 +1579,7 @@ export const verify = <M extends AnyMachine>(
         `retained transition from "${transition.source}" selected invalid branch index ${transition.branchIndex}`,
         transition.source
       )
-      return
+      return undefined
     }
     const branch = definition.branches[transition.branchIndex]!
     if (!targetWithinSelection(transition.target, branch, byPath)) {
@@ -1581,6 +1594,141 @@ export const verify = <M extends AnyMachine>(
         transition.target === undefined ? transition.source : String(transition.target)
       )
     }
+    return branch
+  }
+
+  const validateTransitionResolutions = (
+    transitions: Microstep<M>["transitions"],
+    branches: ReadonlyArray<Machine.Machine.TransitionBranch | undefined>,
+    location: VerificationLocation
+  ): void => {
+    if (!selected.has("definitions")) return
+
+    const choiceResolution = (
+      start: string,
+      afterIndex: number,
+      nested: boolean
+    ): { readonly found: boolean; readonly target: string | undefined } => {
+      const seen = new Set<string>()
+      let choice = start
+      let cursor = afterIndex + 1
+      let first = true
+      while (!seen.has(choice)) {
+        seen.add(choice)
+        let choiceIndex = -1
+        for (let index = cursor; index < transitions.length; index++) {
+          const candidate = transitions[index]!
+          if (
+            candidate.trigger.type === "choice" &&
+            (candidate.source === choice || first && nested && isDescendantOrSelf(String(candidate.source), choice))
+          ) {
+            choiceIndex = index
+            break
+          }
+        }
+        if (choiceIndex === -1) return { found: false, target: undefined }
+        const transition = transitions[choiceIndex]!
+        if (branches[choiceIndex] === undefined) return { found: false, target: undefined }
+        const target = transition.target === undefined ? undefined : String(transition.target)
+        if (target === undefined) return { found: true, target: undefined }
+        const targetNode = byPath.get(target)
+        if (targetNode?.type === "choice") {
+          choice = target
+          cursor = choiceIndex + 1
+          first = false
+          continue
+        }
+        return {
+          found: true,
+          target: targetNode?.type === "history" ? targetNode.parent : target
+        }
+      }
+      return { found: false, target: undefined }
+    }
+
+    transitions.forEach((transition, index) => {
+      if (branches[index] === undefined) return
+      const target = transition.target === undefined ? undefined : String(transition.target)
+      const resolvedTarget = transition.resolvedTarget === undefined ? undefined : String(transition.resolvedTarget)
+      const targetNode = target === undefined ? undefined : byPath.get(target)
+      let expected = target
+      let explanation = target === undefined ? "an unresolved targetless transition" : `target "${target}"`
+
+      if (transition.trigger.type === "choice") {
+        explanation = target === undefined ? "a targetless choice edge" : `choice edge target "${target}"`
+      } else if (targetNode?.type === "history") {
+        expected = targetNode.parent
+        explanation = `history owner "${String(targetNode.parent)}"`
+      } else if (targetNode?.type === "choice") {
+        const resolution = choiceResolution(targetNode.path, index, false)
+        if (!resolution.found) {
+          add(
+            "definitions.resolution",
+            location,
+            `transition from "${transition.source}" targets choice "${target}" without an exact retained route`,
+            target
+          )
+          return
+        }
+        expected = resolution.target
+        explanation = expected === undefined ?
+          `targetless route from choice "${target}"` :
+          `choice route from "${target}" to "${expected}"`
+      } else if (
+        resolvedTarget !== target &&
+        (targetNode?.type === "compound" || targetNode?.type === "parallel")
+      ) {
+        const resolution = choiceResolution(targetNode.path, index, true)
+        if (resolution.found) {
+          expected = resolution.target
+          explanation = expected === undefined ?
+            `targetless nested choice route from "${target}"` :
+            `nested choice route from "${target}" to "${expected}"`
+        }
+      }
+
+      if (resolvedTarget !== expected) {
+        add(
+          "definitions.resolution",
+          location,
+          `transition branch ${transition.branchIndex} from "${transition.source}" resolved to ` +
+            `"${String(transition.resolvedTarget)}" instead of ${explanation}`,
+          resolvedTarget ?? target ?? String(transition.source)
+        )
+      }
+    })
+  }
+
+  const initialChoiceRouteRoot = (): string | undefined => {
+    const routing = trace.initial.plan.microsteps[0]
+    if (
+      routing === undefined || routing.changed ||
+      routing.transitions.length === 0 ||
+      !routing.transitions.every((transition) => transition.trigger.type === "choice")
+    ) {
+      return undefined
+    }
+
+    const reachableScopes: Array<string> = [initialDefinition.target]
+    let terminalRoot: string | undefined
+    for (const transition of routing.transitions) {
+      const source = String(transition.source)
+      const branch = transitionBranch(transition)
+      if (
+        branch === undefined || !targetWithinSelection(transition.target, branch, byPath) ||
+        !reachableScopes.some((scope) => isDescendantOrSelf(source, scope))
+      ) {
+        return undefined
+      }
+      const target = transition.target === undefined ? undefined : String(transition.target)
+      if (target === undefined) return undefined
+      const targetNode = byPath.get(target)
+      const scope = targetNode?.type === "history" ? targetNode.parent : target
+      if (scope === undefined) return undefined
+      reachableScopes.push(scope)
+      terminalRoot = ancestors(scope)[0]
+    }
+    return terminalRoot
   }
 
   const validateMicrostep = (
@@ -1735,7 +1883,8 @@ export const verify = <M extends AnyMachine>(
         }
       }
     }
-    for (const transition of microstep.transitions) validateTransitionDefinition(transition, location)
+    const branches = microstep.transitions.map((transition) => validateTransitionDefinition(transition, location))
+    validateTransitionResolutions(microstep.transitions, branches, location)
   }
 
   const validatePlanCompletion = (
@@ -1773,11 +1922,17 @@ export const verify = <M extends AnyMachine>(
   const starting = inspectSnapshot(trace.initial.startingState, initialLocation, "initial starting state")
   if (selected.has("definitions")) {
     const startingRoots = starting.paths.filter((path) => byPath.get(path)?.parent === undefined)
-    if (startingRoots.length !== 1 || startingRoots[0] !== initialDefinition.target) {
+    const routedRoot = startingRoots.length === 1 && startingRoots[0] !== initialDefinition.target
+      ? initialChoiceRouteRoot()
+      : undefined
+    if (
+      startingRoots.length !== 1 ||
+      startingRoots[0] !== initialDefinition.target && startingRoots[0] !== routedRoot
+    ) {
       add(
         "definitions.initial",
         initialLocation,
-        `initial starting state selected roots [${startingRoots.join(", ")}] instead of ` +
+        `initial starting state selected roots [${startingRoots.join(", ")}] without an exact route from ` +
           `declared root "${initialDefinition.target}"`,
         startingRoots[0] ?? initialDefinition.target
       )

--- a/src/testing/MachineTest.ts
+++ b/src/testing/MachineTest.ts
@@ -2050,6 +2050,7 @@ export type VerificationLaw =
   | "definitions.transition"
   | "definitions.branchIndex"
   | "definitions.selection"
+  | "definitions.resolution"
 
 /**
  * One independently observed violation in a planner trace.
@@ -2087,8 +2088,9 @@ export interface VerifyOptions {
 /**
  * Verifies an executed trace using only public machine inspection and raw
  * snapshot data. Retained transitions are checked against their exact static
- * branch and target selection, and startup is checked against the declared
- * initial root. The verifier deliberately does not reuse planner
+ * branch, target selection, and resolved route. Startup is checked against
+ * the declared initial root or an exact retained initial-choice route. The
+ * verifier deliberately does not reuse planner
  * normalization, encoding, finality, or other internal helpers.
  *
  * Every selected law is evaluated and returned in one structured error so a

--- a/test/machine/Choice.test.ts
+++ b/test/machine/Choice.test.ts
@@ -501,6 +501,8 @@ describe("Machine choice pseudo-states", () => {
       assert.strictEqual(resumed.next.path, "Flow")
       if (resumed.next.path === "Flow") assert.strictEqual(resumed.next.state.path, "Flow.Active")
       assert.deepStrictEqual(resumed.microsteps[0]?.transitions.map(({ trigger }) => trigger.type), ["event", "choice"])
+      const trace = yield* MachineTest.run(history, { events: [new Leave({}), new Resume({})] })
+      yield* MachineTest.verify(history, trace, { laws: ["definitions"] })
     }))
 
   it.effect("uses a history default when an initial choice targets history", () =>
@@ -548,6 +550,8 @@ describe("Machine choice pseudo-states", () => {
 
       const plan = yield* Machine.planInitial(initialHistory)
       assert.strictEqual(plan.state.state.path, "Flow.Active")
+      const trace = yield* MachineTest.run(initialHistory, { events: [] })
+      yield* MachineTest.verify(initialHistory, trace, { laws: ["definitions"] })
     }))
 
   it.effect("resolves a nested choice inside a first-use history fallback", () =>

--- a/test/testing/Verification.test.ts
+++ b/test/testing/Verification.test.ts
@@ -14,6 +14,7 @@ class Counter extends Schema.TaggedClass<Counter>("Counter")("Counter", {
 class Increment extends Schema.TaggedClass<Increment>("Increment")("Increment", {}) {}
 class Noop extends Schema.TaggedClass<Noop>("Noop")("Noop", {}) {}
 class Restart extends Schema.TaggedClass<Restart>("Restart")("Restart", {}) {}
+class Route extends Schema.TaggedClass<Route>("VerificationRoute")("Route", {}) {}
 class Select extends Schema.TaggedClass<Select>("VerificationSelect")("Select", {
   value: Schema.Int
 }) {}
@@ -149,6 +150,100 @@ const invokedMachine = Machine.make({
   }
 })
 
+class StartupA extends Schema.TaggedClass<StartupA>("StartupA")("StartupA", {}) {}
+class StartupB extends Schema.TaggedClass<StartupB>("StartupB")("StartupB", {}) {}
+
+const RoutedStartupStates = Machine.defineStates({
+  a: {
+    schema: StartupA,
+    initial: "route",
+    states: {
+      route: { type: "choice" },
+      second: { type: "choice" }
+    }
+  },
+  b: StartupB
+})
+
+const routedStartupMachine = Machine.make({
+  states: RoutedStartupStates.states,
+  events: Machine.events(),
+  initial: {
+    target: (to) => to.a.initial(),
+    resolve: ({ target }) => target(new StartupA({}), (a) => a.route())
+  }
+}).handle({
+  a: {
+    states: {
+      route: {
+        choice: Machine.transition({
+          target: (to) => to.local.second(),
+          resolve: ({ target }) => target()
+        })
+      },
+      second: {
+        choice: Machine.transition({
+          target: (to) => to.full.b(),
+          resolve: ({ target }) => target(new StartupB({}))
+        })
+      }
+    }
+  },
+  b: {}
+})
+
+class ChoiceFlow extends Schema.TaggedClass<ChoiceFlow>("ChoiceFlow")("ChoiceFlow", {}) {}
+class ChoiceReady extends Schema.TaggedClass<ChoiceReady>("ChoiceReady")("ChoiceReady", {}) {}
+class ChoiceRouted extends Schema.TaggedClass<ChoiceRouted>("ChoiceRouted")("ChoiceRouted", {}) {}
+
+const ChoiceResolutionStates = Machine.defineStates({
+  flow: {
+    schema: ChoiceFlow,
+    initial: "ready",
+    states: {
+      ready: ChoiceReady,
+      first: { type: "choice" },
+      second: { type: "choice" },
+      routed: ChoiceRouted
+    }
+  }
+})
+
+const choiceResolutionMachine = Machine.make({
+  states: ChoiceResolutionStates.states,
+  events: Machine.events(Route),
+  initial: {
+    target: (to) => to.flow.initial(),
+    resolve: ({ target }) => target(new ChoiceFlow({}), (flow) => flow.ready(new ChoiceReady({})))
+  }
+}).handle({
+  flow: {
+    states: {
+      ready: {
+        on: {
+          Route: Machine.transition({
+            target: (to) => to.local.first(),
+            resolve: ({ target }) => target()
+          })
+        }
+      },
+      first: {
+        choice: Machine.transition({
+          target: (to) => to.local.second(),
+          resolve: ({ target }) => target()
+        })
+      },
+      second: {
+        choice: Machine.transition({
+          target: (to) => to.local.routed(),
+          resolve: ({ target }) => target(new ChoiceRouted({}))
+        })
+      },
+      routed: {}
+    }
+  }
+})
+
 const reentryMachine = Machine.make({
   states: NavigationStates.states,
   events: Machine.events(Restart),
@@ -207,6 +302,7 @@ class Editing extends Schema.TaggedClass<Editing>("Editing")("Editing", {
 }) {}
 class Away extends Schema.TaggedClass<Away>("Away")("Away", {}) {}
 class Leave extends Schema.TaggedClass<Leave>("Leave")("Leave", {}) {}
+class Resume extends Schema.TaggedClass<Resume>("Resume")("Resume", {}) {}
 
 const HistoryStates = Machine.defineStates({
   workspace: {
@@ -234,7 +330,7 @@ const HistoryStates = Machine.defineStates({
 
 const historyMachine = Machine.make({
   states: HistoryStates.states,
-  events: Machine.events(Leave),
+  events: Machine.events(Leave, Resume),
   initial: {
     target: (to) => to.workspace.initial(),
     resolve: ({ target }) =>
@@ -283,6 +379,14 @@ const historyMachine = Machine.make({
       editor: {
         initialize: ({ builder }) => builder(new Editing({ revision: 0 }))
       }
+    }
+  },
+  away: {
+    on: {
+      Resume: Machine.transition({
+        target: (to) => to.history.workspace.exact(),
+        resolve: ({ target }) => target()
+      })
     }
   }
 })
@@ -867,7 +971,27 @@ describe("MachineTest.verify", () => {
       assert.include(laws(branchError), "definitions.selection")
     }))
 
-  it.effect("binds startup to the statically selected root", () =>
+  it.effect("accepts an exact initial choice route to another root", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(routedStartupMachine, { events: [] })
+
+      assert.deepStrictEqual(trace.initial.startingConfiguration, ["b"])
+      assert.deepStrictEqual(
+        trace.initial.plan.microsteps[0]?.transitions.map(({ branchIndex, source, target, trigger }) => ({
+          branchIndex,
+          source: String(source),
+          target,
+          trigger: trigger.type
+        })),
+        [
+          { branchIndex: 0, source: "a.route", target: "a.second", trigger: "choice" },
+          { branchIndex: 0, source: "a.second", target: "b", trigger: "choice" }
+        ]
+      )
+      yield* MachineTest.verify(routedStartupMachine, trace, { laws: ["definitions"] })
+    }))
+
+  it.effect("rejects a startup root without an exact initial choice route", () =>
     Effect.gen(function*() {
       const trace = yield* MachineTest.run(navigationMachine, { events: [new Go({})] })
       const corrupted = {
@@ -884,6 +1008,195 @@ describe("MachineTest.verify", () => {
       const violation = error.violations.find(({ law }) => law === "definitions.initial")
       assert.strictEqual(violation?.eventIndex, undefined)
       assert.strictEqual(violation?.path, "app")
+    }))
+
+  it.effect("binds resolved targets to direct and chained choice evidence", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(choiceResolutionMachine, { events: [new Route({})] })
+      const step = trace.steps[0]!
+      const microstep = step.plan.microsteps[0]!
+      assert.deepStrictEqual(
+        microstep.transitions.map(({ resolvedTarget, source, target }) => ({
+          resolvedTarget,
+          source: String(source),
+          target
+        })),
+        [
+          { source: "flow.ready", target: "flow.first", resolvedTarget: "flow.routed" },
+          { source: "flow.first", target: "flow.second", resolvedTarget: "flow.second" },
+          { source: "flow.second", target: "flow.routed", resolvedTarget: "flow.routed" }
+        ]
+      )
+      yield* MachineTest.verify(choiceResolutionMachine, trace, { laws: ["definitions"] })
+
+      const transition = microstep.transitions[0]!
+      const corrupted = {
+        ...trace,
+        steps: [{
+          ...step,
+          plan: {
+            ...step.plan,
+            microsteps: [{
+              ...microstep,
+              transitions: [{ ...transition, resolvedTarget: "flow" }, ...microstep.transitions.slice(1)]
+            }]
+          }
+        }]
+      } as typeof trace
+      const error = yield* MachineTest.verify(choiceResolutionMachine, corrupted, {
+        laws: ["definitions"]
+      }).pipe(Effect.flip)
+      assert.include(laws(error), "definitions.resolution")
+
+      const missingRoute = {
+        ...trace,
+        steps: [{
+          ...step,
+          plan: {
+            ...step.plan,
+            microsteps: [{ ...microstep, transitions: [transition] }]
+          }
+        }]
+      } as typeof trace
+      const missingRouteError = yield* MachineTest.verify(choiceResolutionMachine, missingRoute, {
+        laws: ["definitions"]
+      }).pipe(Effect.flip)
+      assert.ok(missingRouteError.violations.some(({ law, message }) =>
+        law === "definitions.resolution" && message.includes("without an exact retained route")
+      ))
+    }))
+
+  it.effect("rejects a wrong active descendant as a resolved state target", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(navigationMachine, { events: [new Go({})] })
+      const step = trace.steps[0]!
+      const microstep = step.plan.microsteps[0]!
+      const transition = microstep.transitions[0]!
+      const corrupted = {
+        ...trace,
+        steps: [{
+          ...step,
+          plan: {
+            ...step.plan,
+            microsteps: [{
+              ...microstep,
+              transitions: [{ ...transition, resolvedTarget: "app.one" }]
+            }]
+          }
+        }]
+      } as typeof trace
+
+      const error = yield* MachineTest.verify(navigationMachine, corrupted, {
+        laws: ["definitions"]
+      }).pipe(Effect.flip)
+      const violation = error.violations.find(({ law }) => law === "definitions.resolution")
+      assert.strictEqual(violation?.path, "app.one")
+    }))
+
+  it.effect("validates every simultaneous transition resolution independently", () =>
+    Effect.gen(function*() {
+      const machine = MachineTest.compileModel({
+        roots: [{
+          _tag: "Parallel",
+          key: "workflow",
+          value: 0,
+          output: "done",
+          states: [
+            {
+              _tag: "Compound",
+              key: "left",
+              value: 1,
+              initial: "idle",
+              states: [
+                { _tag: "Atomic", key: "idle", value: 2 },
+                { _tag: "Atomic", key: "done", value: 3 }
+              ]
+            },
+            {
+              _tag: "Compound",
+              key: "right",
+              value: 4,
+              initial: "idle",
+              states: [
+                { _tag: "Atomic", key: "idle", value: 5 },
+                { _tag: "Atomic", key: "done", value: 6 }
+              ]
+            }
+          ]
+        }],
+        initial: "workflow",
+        events: ["Advance"],
+        transitions: [
+          {
+            source: "workflow.left.idle",
+            trigger: { type: "event", event: "Advance" },
+            target: "workflow.left.done",
+            reenter: false
+          },
+          {
+            source: "workflow.right.idle",
+            trigger: { type: "event", event: "Advance" },
+            target: "workflow.right.done",
+            reenter: false
+          }
+        ]
+      })
+      const trace = yield* MachineTest.run(machine, { events: [{ _tag: "Advance" }] })
+      const step = trace.steps[0]!
+      const microstep = step.plan.microsteps[0]!
+      assert.strictEqual(microstep.transitions.length, 2)
+
+      const corrupted = {
+        ...trace,
+        steps: [{
+          ...step,
+          plan: {
+            ...step.plan,
+            microsteps: [{
+              ...microstep,
+              transitions: [
+                { ...microstep.transitions[0]!, resolvedTarget: "workflow.left" },
+                microstep.transitions[1]!
+              ]
+            }]
+          }
+        }]
+      } as typeof trace
+      const error = yield* MachineTest.verify(machine, corrupted, {
+        laws: ["definitions"]
+      }).pipe(Effect.flip)
+      assert.include(laws(error), "definitions.resolution")
+    }))
+
+  it.effect("binds history resolution to the declared owner", () =>
+    Effect.gen(function*() {
+      const trace = yield* MachineTest.run(historyMachine, { events: [new Leave({}), new Resume({})] })
+      const step = trace.steps[1]!
+      const microstep = step.plan.microsteps[0]!
+      const transition = microstep.transitions[0]!
+      assert.deepStrictEqual(
+        { target: transition.target, resolvedTarget: transition.resolvedTarget },
+        { target: "workspace.exact", resolvedTarget: "workspace" }
+      )
+      yield* MachineTest.verify(historyMachine, trace, { laws: ["definitions"] })
+
+      const corrupted = {
+        ...trace,
+        steps: [trace.steps[0]!, {
+          ...step,
+          plan: {
+            ...step.plan,
+            microsteps: [{
+              ...microstep,
+              transitions: [{ ...transition, resolvedTarget: "workspace.editor" }]
+            }]
+          }
+        }]
+      } as typeof trace
+      const error = yield* MachineTest.verify(historyMachine, corrupted, {
+        laws: ["definitions"]
+      }).pipe(Effect.flip)
+      assert.include(laws(error), "definitions.resolution")
     }))
 
   it.effect("distinguishes invoke definitions by lifecycle id and outcome", () =>

--- a/typetest/testing/Verification.tst.ts
+++ b/typetest/testing/Verification.tst.ts
@@ -38,4 +38,8 @@ describe("MachineTest.verify", () => {
     }
     expect(options.laws).type.toBe<ReadonlyArray<MachineTest.VerificationLawGroup> | undefined>()
   })
+
+  it("exposes exact transition resolution violations", () => {
+    expect<"definitions.resolution">().type.toBeAssignableTo<MachineTest.VerificationLaw>()
+  })
 })


### PR DESCRIPTION
## Summary

- accept startup configurations that cross roots through an exact retained initial-choice route
- verify each retained resolved target against its selected static branch and retained choice or history route
- cover chained choices, history, simultaneous transitions, and generic/optimized choice-history traces

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (no examples changed)
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required

Local `pnpm perf:types` and `pnpm perf:runtime` checks passed; CI comparisons remain authoritative.