### PR TITLE
Retain transition coverage in exploration

### DIFF
--- a/.changeset/exploration-transition-coverage.md
+++ b/.changeset/exploration-transition-coverage.md
@@ -1,0 +1,5 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Add exact `transitionCoverage` to `MachineTest.Exploration`. Coverage includes startup and every concretely planned event, including state-limit candidates, while unplanned depth- and transition-limit frontiers remain misses.

--- a/README.md
+++ b/README.md
@@ -549,7 +549,8 @@ The testing entrypoint provides complementary layers:
 - `MachineTest.run` and `verify` inspect pure planner traces;
 - `coverage` reports exact transition-definition and conditional-branch hits;
 - invariants and generated scenarios check application laws;
-- `explore` performs bounded breadth-first state-space exploration;
+- `explore` performs bounded breadth-first state-space exploration and retains
+  exact transition-definition and branch coverage for every plan it computes;
 - `probe` causally acknowledges live runtime commands;
 - runtime command models cover timers, invokes, bursts, and scheduling.
 

--- a/src/internal/testing/machine/exploration.ts
+++ b/src/internal/testing/machine/exploration.ts
@@ -30,6 +30,7 @@ import type {
 import type { EnsureExecutable } from "../../machine/readiness.js"
 import { assertInvariants, type InvariantError } from "./invariant.js"
 import { appendTrace, run } from "./trace.js"
+import { makeTransitionCoverageCollector } from "./transitionCoverage.js"
 
 type AnyMachine = Machine.Machine.Any
 
@@ -119,6 +120,10 @@ export const explore = <M extends AnyMachine, Key extends ExplorationKey>(
 
     const initialContext = stateContext(machine, initialTrace)
     const initialKey = validateKey(options.stateKey(initialContext))
+    const transitionCoverage = makeTransitionCoverageCollector<M>(machine)
+    for (const microstep of initialTrace.initial.plan.microsteps) {
+      transitionCoverage.observeMicrostep(microstep)
+    }
     const nodes: Array<ExplorationNode<M, Key>> = [{ ...initialContext, key: initialKey }]
     const nodeDraftsByKey = new Map<Key, number>([[initialKey, 0]])
     const edges: Array<ExplorationEdgeDraft<M>> = []
@@ -165,6 +170,8 @@ export const explore = <M extends AnyMachine, Key extends ExplorationKey>(
         const scenario = scenarioWithEvent(source.trace, event)
         const targetTrace = yield* appendTrace(machine, source.trace, event, scenario)
         plannedTransitions += 1
+        const step = targetTrace.steps[targetTrace.steps.length - 1]!
+        for (const microstep of step.plan.microsteps) transitionCoverage.observeMicrostep(microstep)
         if (invariants.length > 0) {
           yield* assertInvariants(machine, targetTrace, invariants)
         }
@@ -178,7 +185,7 @@ export const explore = <M extends AnyMachine, Key extends ExplorationKey>(
             target: existing,
             edge: {
               event,
-              step: targetTrace.steps[targetTrace.steps.length - 1]!,
+              step,
               discovered: false
             }
           })
@@ -207,7 +214,7 @@ export const explore = <M extends AnyMachine, Key extends ExplorationKey>(
           target: targetIndex,
           edge: {
             event,
-            step: targetTrace.steps[targetTrace.steps.length - 1]!,
+            step,
             discovered: true
           }
         })
@@ -243,6 +250,7 @@ export const explore = <M extends AnyMachine, Key extends ExplorationKey>(
         retainedEdges: edges.length,
         maxDepth: nodes.reduce((maximum, node) => Math.max(maximum, node.depth), 0)
       },
+      transitionCoverage: transitionCoverage.summary(),
       completeness
     }
   })

--- a/src/internal/testing/machine/transitionCoverage.ts
+++ b/src/internal/testing/machine/transitionCoverage.ts
@@ -1,0 +1,116 @@
+/**
+ * Exact transition-definition and branch coverage collected from retained
+ * planner microsteps.
+ *
+ * @since 0.14.0
+ */
+
+import * as Machine from "../../../Machine.js"
+import type {
+  CoverageSummary,
+  Microstep,
+  TransitionBranchCoverageItem,
+  TransitionCoverage,
+  TransitionDefinitionCoverageItem
+} from "../../../testing/MachineTest.js"
+
+type AnyMachine = Machine.Machine.Any
+
+type StateNodePath<M extends AnyMachine> = Machine.Machine.StateNodeIdentifier<Machine.Machine.States<M>>
+
+type EventTag<M extends AnyMachine> = Machine.Machine.TagOf<Machine.Machine.Events<M>[number]>
+
+type MachineTransitionCoverage<M extends AnyMachine> = TransitionCoverage<
+  StateNodePath<M>,
+  EventTag<M>,
+  StateNodePath<M>
+>
+
+const coverageSummary = <Item>(declared: ReadonlyArray<Item>, hit: ReadonlySet<number>): CoverageSummary<Item> => {
+  const hits: Array<Item> = []
+  const misses: Array<Item> = []
+  declared.forEach((item, index) => (hit.has(index) ? hits : misses).push(item))
+  return {
+    total: declared.length,
+    hit: hits.length,
+    missing: misses.length,
+    hits,
+    misses
+  }
+}
+
+export const sameTransitionTrigger = (
+  left: Machine.Machine.TransitionTrigger,
+  right: Machine.Machine.TransitionTrigger
+): boolean => {
+  if (left.type !== right.type) return false
+  if (left.type === "event") return right.type === "event" && left.event === right.event
+  if (left.type === "invoke") {
+    return right.type === "invoke" && left.id === right.id && left.outcome === right.outcome
+  }
+  return true
+}
+
+export interface TransitionCoverageCollector<M extends AnyMachine> {
+  readonly observeMicrostep: (microstep: Microstep<M, unknown>) => void
+  readonly summary: () => MachineTransitionCoverage<M>
+}
+
+export const makeTransitionCoverageCollector = <M extends AnyMachine>(
+  machine: M
+): TransitionCoverageCollector<M> => {
+  const definitions = Machine.transitionDefinitions(machine).map(
+    (definition, index): TransitionDefinitionCoverageItem<StateNodePath<M>, EventTag<M>, StateNodePath<M>> => ({
+      id: `transition:${index}`,
+      index,
+      source: definition.source,
+      trigger: definition.trigger,
+      reenter: definition.reenter,
+      branches: definition.branches
+    })
+  )
+  const definitionHits = new Set<number>()
+  const branchOffsets: Array<number> = []
+  const branches: Array<TransitionBranchCoverageItem<StateNodePath<M>, EventTag<M>, StateNodePath<M>>> = []
+  for (let definitionIndex = 0; definitionIndex < definitions.length; definitionIndex++) {
+    branchOffsets.push(branches.length)
+    const definition = definitions[definitionIndex]!
+    definition.branches.forEach((branch, branchIndex) => {
+      branches.push({
+        id: `transition:${definitionIndex}:branch:${branchIndex}`,
+        definitionIndex,
+        branchIndex,
+        source: definition.source,
+        trigger: definition.trigger,
+        reenter: definition.reenter,
+        branch
+      })
+    })
+  }
+  const branchHits = new Set<number>()
+
+  return {
+    observeMicrostep(microstep) {
+      for (const retained of microstep.transitions) {
+        const definitionIndex = definitions.findIndex((definition) =>
+          definition.source === retained.source &&
+          definition.reenter === retained.reenter &&
+          sameTransitionTrigger(definition.trigger, retained.trigger)
+        )
+        if (definitionIndex === -1) continue
+        definitionHits.add(definitionIndex)
+        const definition = definitions[definitionIndex]!
+        if (
+          Number.isSafeInteger(retained.branchIndex) && retained.branchIndex >= 0 &&
+          retained.branchIndex < definition.branches.length
+        ) {
+          branchHits.add(branchOffsets[definitionIndex]! + retained.branchIndex)
+        }
+      }
+    },
+    summary: () => ({
+      definitions: coverageSummary(definitions, definitionHits),
+      branches: coverageSummary(branches, branchHits)
+    })
+  }
+}

--- a/src/internal/testing/machine/verification.ts
+++ b/src/internal/testing/machine/verification.ts
@@ -29,8 +29,6 @@ import type {
   StateCoverageItem,
   Trace,
   TraceStep,
-  TransitionBranchCoverageItem,
-  TransitionDefinitionCoverageItem,
   VerificationLaw,
   VerificationLawGroup,
   VerificationViolation,
@@ -41,6 +39,7 @@ import { toArbitraryWithReport } from "./arbitrary.js"
 import type { FiniteModel } from "./finiteModel.js"
 import * as ReferenceModel from "./referenceModel.js"
 import { rawConfigurationPaths, run } from "./trace.js"
+import { makeTransitionCoverageCollector, sameTransitionTrigger } from "./transitionCoverage.js"
 
 export {
   advanceCommand,
@@ -470,18 +469,6 @@ const normalizeTraces = <M extends AnyMachine>(
 ): ReadonlyArray<Trace<M>> =>
   Array.isArray(traceOrTraces) ? traceOrTraces as ReadonlyArray<Trace<M>> : [traceOrTraces as Trace<M>]
 
-const sameTransitionTrigger = (
-  left: Machine.Machine.TransitionTrigger,
-  right: Machine.Machine.TransitionTrigger
-): boolean => {
-  if (left.type !== right.type) return false
-  if (left.type === "event") return right.type === "event" && left.event === right.event
-  if (left.type === "invoke") {
-    return right.type === "invoke" && left.id === right.id && left.outcome === right.outcome
-  }
-  return true
-}
-
 const targetWithinSelection = (
   target: string | undefined,
   branch: Machine.Machine.TransitionBranch,
@@ -576,48 +563,7 @@ export const coverage = <M extends AnyMachine>(
   const entryHits = new Set<number>()
   const exitHits = new Set<number>()
 
-  const definitions = Machine.transitionDefinitions(machine).map(
-    (
-      definition,
-      index
-    ): TransitionDefinitionCoverageItem<
-      StateNodePath<M>,
-      Machine.Machine.TagOf<Machine.Machine.Events<M>[number]>,
-      StateNodePath<M>
-    > => ({
-      id: `transition:${index}`,
-      index,
-      source: definition.source,
-      trigger: definition.trigger,
-      reenter: definition.reenter,
-      branches: definition.branches
-    })
-  )
-  const transitionHits = new Set<number>()
-  const branchOffsets: Array<number> = []
-  const branches: Array<
-    TransitionBranchCoverageItem<
-      StateNodePath<M>,
-      Machine.Machine.TagOf<Machine.Machine.Events<M>[number]>,
-      StateNodePath<M>
-    >
-  > = []
-  for (let definitionIndex = 0; definitionIndex < definitions.length; definitionIndex++) {
-    branchOffsets.push(branches.length)
-    const definition = definitions[definitionIndex]!
-    definition.branches.forEach((branch, branchIndex) => {
-      branches.push({
-        id: `transition:${definitionIndex}:branch:${branchIndex}`,
-        definitionIndex,
-        branchIndex,
-        source: definition.source,
-        trigger: definition.trigger,
-        reenter: definition.reenter,
-        branch
-      })
-    })
-  }
-  const branchHits = new Set<number>()
+  const transitionCoverage = makeTransitionCoverageCollector(machine)
 
   const declaredEvents = publicEventTags(machine)
   const declaredEventTags = declaredEvents.tags
@@ -675,6 +621,7 @@ export const coverage = <M extends AnyMachine>(
   }
 
   const observeMicrostep = (microstep: Microstep<M, any>): void => {
+    transitionCoverage.observeMicrostep(microstep)
     microsteps += 1
     if (microstep.changed) changedMicrosteps += 1
     raisedEvents += microstep.raisedEvents.length
@@ -691,20 +638,6 @@ export const coverage = <M extends AnyMachine>(
       if (retained.target !== undefined && nodeByPath.get(retained.target)?.type === "history") {
         historyTargets += 1
         if (retained.resolvedTarget !== undefined) resolvedHistoryTargets += 1
-      }
-      const definitionIndex = definitions.findIndex((definition) =>
-        definition.source === retained.source &&
-        definition.reenter === retained.reenter &&
-        sameTransitionTrigger(definition.trigger, retained.trigger)
-      )
-      if (definitionIndex === -1) continue
-      transitionHits.add(definitionIndex)
-      const definition = definitions[definitionIndex]!
-      if (
-        Number.isSafeInteger(retained.branchIndex) && retained.branchIndex >= 0 &&
-        retained.branchIndex < definition.branches.length
-      ) {
-        branchHits.add(branchOffsets[definitionIndex]! + retained.branchIndex)
       }
     }
   }
@@ -745,10 +678,7 @@ export const coverage = <M extends AnyMachine>(
       entry: coverageSummary(activeNodes, entryHits),
       exit: coverageSummary(activeNodes, exitHits)
     },
-    transitions: {
-      definitions: coverageSummary(definitions, transitionHits),
-      branches: coverageSummary(branches, branchHits)
-    },
+    transitions: transitionCoverage.summary(),
     events: declaredEvents.diagnostics.length === 0
       ? {
         available: true,

--- a/src/testing/MachineTest.ts
+++ b/src/testing/MachineTest.ts
@@ -1375,6 +1375,17 @@ export interface Exploration<M extends AnyMachine, Key extends ExplorationKey = 
   readonly start: Graph.NodeIndex
   readonly limits: ResolvedExplorationLimits
   readonly stats: ExplorationStats
+  /**
+   * Exact declared transition branches witnessed by concretely planned work.
+   * This is observed evidence, not a claim that every reachable branch was
+   * explored. Startup and state-limit plans count; unplanned depth- and
+   * transition-limit frontiers do not.
+   */
+  readonly transitionCoverage: TransitionCoverage<
+    StateNodePath<M>,
+    Machine.Machine.TagOf<Machine.Machine.Events<M>[number]>,
+    StateNodePath<M>
+  >
   readonly completeness: ExplorationCompleteness<M, Key>
 }
 
@@ -1409,7 +1420,10 @@ export type ExploreOptions<M extends AnyMachine, Key extends ExplorationKey = Ex
  *
  * Invariants are checked against startup and every concretely planned edge,
  * so a failure retains a shortest discovered counterexample. Staged actions
- * and runtime activities are not executed.
+ * and runtime activities are not executed. `transitionCoverage` includes
+ * startup and every event plan that was actually computed, including a plan
+ * retained at a state-limit frontier. Depth- and transition-limit frontiers
+ * have no plan and therefore contribute no transition hits.
  *
  * **Example**
  *

--- a/test/testing/Exploration.test.ts
+++ b/test/testing/Exploration.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Schema } from "effect"
+import { Effect, Option, Schema } from "effect"
 import { Machine } from "../../src/index.js"
 import { MachineTest } from "../../src/testing/index.js"
 
@@ -10,6 +10,9 @@ class Counter extends Schema.TaggedClass<Counter>("Counter")("Counter", {
 class Increment extends Schema.TaggedClass<Increment>("Increment")("Increment", {}) {}
 class Reset extends Schema.TaggedClass<Reset>("Reset")("Reset", {}) {}
 class Corrupt extends Schema.TaggedClass<Corrupt>("Corrupt")("Corrupt", {}) {}
+class Select extends Schema.TaggedClass<Select>("ExplorationSelect")("Select", {
+  value: Schema.Int
+}) {}
 class Seed extends Schema.Class<Seed>("Seed")({ count: Schema.Int }) {}
 
 const States = Machine.defineStates({ counter: Counter })
@@ -42,6 +45,37 @@ const machine = Machine.make({
 
 const finiteEvents = ({ snapshot }: MachineTest.ExplorationStateContext<typeof machine>) =>
   snapshot.value.count < 2 ? [new Increment({})] : [new Reset({})]
+
+const branchMachine = Machine.make({
+  states: States.states,
+  events: Machine.events(Select),
+  initial: {
+    target: (to) => to.counter(),
+    resolve: ({ target }) => target(new Counter({ count: 0 }))
+  }
+}).handle({
+  counter: {
+    on: {
+      Select: Machine.transition({
+        cases: (branch) => [
+          branch({
+            title: "negative",
+            when: ({ event }) => event.value < 0 ? Option.some(event.value) : Option.none(),
+            target: (to) => to.none(),
+            resolve: () => undefined
+          }),
+          branch({
+            title: "zero",
+            when: ({ event }) => event.value === 0 ? Option.some(event.value) : Option.none(),
+            target: (to) => to.none(),
+            resolve: () => undefined
+          })
+        ],
+        otherwise: { target: (to) => to.none(), resolve: () => undefined }
+      })
+    }
+  }
+})
 
 describe("MachineTest bounded exploration", () => {
   it.effect("builds a complete breadth-first graph with shortest traces", () =>
@@ -87,6 +121,118 @@ describe("MachineTest bounded exploration", () => {
         "counter three",
         ({ snapshot }) => snapshot.value.count === 3
       )
+    }))
+
+  it.effect("retains exact branch coverage when outcomes collapse to one state", () =>
+    Effect.gen(function*() {
+      const explored = yield* MachineTest.explore(branchMachine, {
+        events: () => [new Select({ value: -1 }), new Select({ value: 0 }), new Select({ value: 1 })],
+        stateKey: ({ snapshot }) => snapshot.value.count
+      })
+
+      assert.strictEqual(explored.nodes.length, 1)
+      assert.strictEqual(explored.stats.plannedTransitions, 3)
+      assert.strictEqual(explored.stats.retainedEdges, 3)
+      assert.strictEqual(explored.transitionCoverage.definitions.hit, 1)
+      assert.deepStrictEqual(
+        explored.transitionCoverage.branches.hits.map(({ branch, branchIndex }) => ({
+          branchIndex,
+          title: branch.type === "case" ? branch.title : undefined,
+          type: branch.type
+        })),
+        [
+          { branchIndex: 0, title: "negative", type: "case" },
+          { branchIndex: 1, title: "zero", type: "case" },
+          { branchIndex: 2, title: undefined, type: "otherwise" }
+        ]
+      )
+    }))
+
+  it.effect("includes startup choices and simultaneous planner transitions", () =>
+    Effect.gen(function*() {
+      const startupMachine = MachineTest.compileModel({
+        roots: [{
+          _tag: "Compound",
+          key: "flow",
+          value: 0,
+          initial: "route",
+          states: [
+            {
+              _tag: "Choice",
+              key: "route",
+              targets: ["flow.ready"],
+              selected: "flow.ready"
+            },
+            { _tag: "Atomic", key: "ready", value: 1 }
+          ]
+        }],
+        initial: "flow",
+        events: ["Unused"],
+        transitions: []
+      })
+      const startup = yield* MachineTest.explore(startupMachine, {
+        events: () => [],
+        stateKey: ({ configuration }) => configuration.join("|")
+      })
+      assert.strictEqual(startup.stats.plannedTransitions, 0)
+      assert.deepStrictEqual(
+        startup.transitionCoverage.definitions.hits.map(({ source, trigger }) => ({ source, trigger: trigger.type })),
+        [{ source: "flow.route", trigger: "choice" }]
+      )
+
+      const parallelMachine = MachineTest.compileModel({
+        roots: [{
+          _tag: "Parallel",
+          key: "workflow",
+          value: 0,
+          output: "done",
+          states: [
+            {
+              _tag: "Compound",
+              key: "left",
+              value: 1,
+              initial: "idle",
+              states: [
+                { _tag: "Atomic", key: "idle", value: 2 },
+                { _tag: "Atomic", key: "done", value: 3 }
+              ]
+            },
+            {
+              _tag: "Compound",
+              key: "right",
+              value: 4,
+              initial: "idle",
+              states: [
+                { _tag: "Atomic", key: "idle", value: 5 },
+                { _tag: "Atomic", key: "done", value: 6 }
+              ]
+            }
+          ]
+        }],
+        initial: "workflow",
+        events: ["Advance"],
+        transitions: [
+          {
+            source: "workflow.left.idle",
+            trigger: { type: "event", event: "Advance" },
+            target: "workflow.left.done",
+            reenter: false
+          },
+          {
+            source: "workflow.right.idle",
+            trigger: { type: "event", event: "Advance" },
+            target: "workflow.right.done",
+            reenter: false
+          }
+        ]
+      })
+      const parallel = yield* MachineTest.explore(parallelMachine, {
+        events: ({ depth }) => depth === 0 ? [{ _tag: "Advance" }] : [],
+        stateKey: ({ configuration }) => configuration.join("|")
+      })
+      assert.strictEqual(parallel.stats.plannedTransitions, 1)
+      assert.strictEqual(parallel.transitionCoverage.definitions.hit, 2)
+      assert.strictEqual(parallel.transitionCoverage.branches.hit, 2)
     }))
 
   it.effect("checks invariants against the shortest discovered counterexample", () =>
@@ -169,6 +315,45 @@ describe("MachineTest bounded exploration", () => {
         assert.deepStrictEqual(transitionLimited.completeness.reasons, ["transitions"])
         assert.strictEqual(transitionLimited.completeness.frontier[0]?._tag, "TransitionLimit")
       }
+    }))
+
+  it.effect("counts only limit-boundary events that were concretely planned", () =>
+    Effect.gen(function*() {
+      const boundaryEvents = ({ snapshot }: MachineTest.ExplorationStateContext<typeof machine>) =>
+        snapshot.value.count === 0 ? [new Increment({})] : [new Corrupt({})]
+      const eventHits = (explored: MachineTest.Exploration<typeof machine, number>) =>
+        explored.transitionCoverage.definitions.hits.flatMap(({ trigger }) =>
+          trigger.type === "event" ? [trigger.event] : []
+        )
+
+      const stateLimited = yield* MachineTest.explore(machine, {
+        events: boundaryEvents,
+        stateKey: ({ snapshot }) => snapshot.value.count,
+        limits: { maxStates: 2 }
+      })
+      assert.deepStrictEqual(eventHits(stateLimited), ["Increment", "Corrupt"])
+      assert.strictEqual(stateLimited.stats.plannedTransitions, 2)
+      assert.strictEqual(stateLimited.stats.retainedEdges, 1)
+      assert.strictEqual(stateLimited.completeness._tag, "Truncated")
+      if (stateLimited.completeness._tag === "Truncated") {
+        assert.strictEqual(stateLimited.completeness.frontier[0]?._tag, "StateLimit")
+      }
+
+      const depthLimited = yield* MachineTest.explore(machine, {
+        events: boundaryEvents,
+        stateKey: ({ snapshot }) => snapshot.value.count,
+        limits: { maxDepth: 1 }
+      })
+      assert.deepStrictEqual(eventHits(depthLimited), ["Increment"])
+      assert.strictEqual(depthLimited.stats.plannedTransitions, 1)
+
+      const transitionLimited = yield* MachineTest.explore(machine, {
+        events: boundaryEvents,
+        stateKey: ({ snapshot }) => snapshot.value.count,
+        limits: { maxTransitions: 1 }
+      })
+      assert.deepStrictEqual(eventHits(transitionLimited), ["Increment"])
+      assert.strictEqual(transitionLimited.stats.plannedTransitions, 1)
     }))
 
   it.effect("treats state-key collisions as an explicit exploration abstraction", () =>

--- a/typetest/testing/Exploration.tst.ts
+++ b/typetest/testing/Exploration.tst.ts
@@ -54,6 +54,15 @@ describe("MachineTest exploration", () => {
       | MachineTest.InvariantError<typeof machine>
     >()
     expect<Effect.Services<typeof explored>>().type.toBe<never>()
+
+    type Exploration = Effect.Success<typeof explored>
+    expect<Exploration["transitionCoverage"]["definitions"]["hits"][number]["source"]>().type.toBe<"counter">()
+    expect<Exploration["transitionCoverage"]["branches"]["hits"][number]["trigger"]>().type.toBe<
+      Machine.Machine.TransitionTrigger<"Increment" | "Internal">
+    >()
+    expect<Exploration["transitionCoverage"]["branches"]["hits"][number]["branch"]>().type.toBe<
+      Machine.Machine.TransitionBranch<"counter">
+    >()
   })
 
   it("keeps reachability witnesses and errors machine-specific", () => {


### PR DESCRIPTION
## Summary

- expose exact definition- and branch-level transition coverage on every `MachineTest.Exploration`
- reuse one retained-transition collector across trace coverage and bounded exploration
- count startup, collapsed/self-loop, simultaneous, and state-limit plans while excluding unplanned depth/transition frontiers

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (no examples changed)
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required

Local `pnpm perf:types` and `pnpm perf:runtime` checks passed; CI comparisons remain authoritative.