### PR TITLE
Fix local compound targets and add machine diagrams

### DIFF
--- a/.changeset/fix-local-with-selector.md
+++ b/.changeset/fix-local-with-selector.md
@@ -1,0 +1,7 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Fix `to.local.with()` so schema-backed compound scopes can select and rebuild their local value from both direct handlers and nested invoke outcomes.
+
+Expand the inspection examples with text and Mermaid state diagrams built from `Machine.stateNodes`, `Machine.initialDefinition`, `Machine.transitionDefinitions`, `Machine.activityDefinitions`, and live configuration. The examples render concrete conditional branches, reentry, choices, history and final states, activities, and safely escaped user-defined labels.

--- a/examples/platformer/src/machine.test.ts
+++ b/examples/platformer/src/machine.test.ts
@@ -2,6 +2,7 @@ import { Machine } from "@typeonce/effect-machine"
 import { MachineTest } from "@typeonce/effect-machine/testing"
 import { Effect } from "effect"
 import { describe, expect, it } from "vitest"
+import { makeMermaidRenderer } from "../../../test/machine/visualization/mermaid.ts"
 import { makeTextRenderer } from "../../../test/machine/visualization/text.ts"
 import {
   airJumpMode,
@@ -15,6 +16,7 @@ import {
 } from "./machine.ts"
 
 const renderMachine = makeTextRenderer<typeof CharacterMachine, CharacterSnapshot>(Machine)
+const renderMermaid = makeMermaidRenderer<typeof CharacterMachine, CharacterSnapshot>(Machine)
 
 const playingSnapshot = (snapshot: CharacterSnapshot) => {
   const locomotion = snapshot.states.locomotion.state
@@ -156,6 +158,7 @@ describe("platformer history integration", () => {
       const initial = yield* Machine.planInitial(CharacterMachine)
       const definitions = Machine.transitionDefinitions(CharacterMachine)
       const rendered = renderMachine(CharacterMachine, initial.state)
+      const mermaid = renderMermaid(CharacterMachine, initial.state)
 
       expect(definitions).toHaveLength(28)
       expect(definitions).toContainEqual({
@@ -173,11 +176,18 @@ describe("platformer history integration", () => {
         }]
       })
       expect(definitions.every(({ branches }) => branches.length > 0)).toBe(true)
-      expect(rendered).toContain("◇ on: WallJump [reenter] → AirJumpWallLock")
+      expect(rendered).toContain("◇ on: WallJump [reenter]")
+      expect(rendered).toContain("└┄ → AirJumpWallLock")
+      expect(rendered).not.toContain("[otherwise] → ∅")
       expect(rendered).toContain(
         "Candidate events: Move, DownPressed, JumpPressed, Pause, WallJump, WallContact, Reset"
       )
       expect(rendered).not.toContain("Observed event samples")
+      expect(mermaid).toMatch(/^stateDiagram-v2\n  direction LR/)
+      expect(mermaid).toContain("state_13 --> state_15: WallJump [reenter]")
+      expect(mermaid).toContain("state_23 --> state_25: WallContact [left wall]")
+      expect(mermaid).toContain("state_23 --> state_24: WallContact [otherwise]")
+      expect(mermaid).not.toContain("∅")
     }))
   })
 

--- a/src/internal/machine/machine.ts
+++ b/src/internal/machine/machine.ts
@@ -220,7 +220,13 @@ const makeTargetSelector = (
   branch[root.key] = makeSelectionNode(stateNodes, root.path, "branch")
   const local: Record<string, unknown> = {}
   const localScope = getLocalTargetScope(stateNodes, source)
-  if (localScope !== undefined) addSelectionChildren(local, stateNodes, localScope, "local")
+  if (localScope !== undefined) {
+    const localScopeNode = getTargetBuilderNode(stateNodes, localScope)
+    if (localScopeNode.schema !== undefined) {
+      local.with = makeSelectionMethod("state", localScope, "local")
+    }
+    addSelectionChildren(local, stateNodes, localScope, "local")
+  }
   return {
     none: makeSelectionMethod("none", undefined, "local"),
     local,
@@ -263,7 +269,14 @@ const getSelectionBuilder = (
   } else if (selection.scope === "local") {
     builder = target.local
     const scope = getLocalTargetScope(stateNodes, source)
-    if (scope !== undefined) parts = selection.path!.slice(scope.length + 1).split(".")
+    if (scope !== undefined) {
+      if (selection.path === scope) {
+        builder = builder.with
+        parts = []
+      } else {
+        parts = selection.path!.slice(scope.length + 1).split(".")
+      }
+    }
   } else if (selection.scope === "branch") {
     builder = target.branch
   } else {

--- a/test/internal/machine/activities.test.ts
+++ b/test/internal/machine/activities.test.ts
@@ -3,6 +3,7 @@ import { Duration, Effect, Schema } from "effect"
 import { FastCheck } from "effect/testing"
 import { Machine } from "../../../src/index.js"
 import { activityDefinitions } from "../../../src/internal/machine/activities.js"
+import { makeMermaidRenderer } from "../../machine/visualization/mermaid.js"
 import { makeTextRenderer } from "../../machine/visualization/text.js"
 
 class Loading extends Schema.TaggedClass<Loading>("Loading")("Loading", {}) {}
@@ -79,6 +80,10 @@ const activityMachine = Machine.make({
 })
 
 const renderActivityMachine = makeTextRenderer<
+  typeof activityMachine,
+  Machine.Machine.Snapshot<typeof activityStates.states>
+>(Machine)
+const renderMermaidActivityMachine = makeMermaidRenderer<
   typeof activityMachine,
   Machine.Machine.Snapshot<typeof activityStates.states>
 >(Machine)
@@ -282,12 +287,9 @@ describe("machine activity metadata", () => {
       renderActivityMachine(activityMachine, { path: "Loading" as const, value: new Loading({}) }),
       [
         "activity-inspection",
-        "● active  ○ inactive  ◇ transition (→ target, ∅ none)  ◆ activity",
+        "● active  ○ inactive  ◇ transition  ┄ branch → target  ◆ activity",
         "",
         "├─ ● Loading",
-        "│  ├─ ◇ invoke load-document done → ∅",
-        "│  ├─ ◇ invoke load-document failure → ∅",
-        "│  ├─ ◇ invoke load-timeout done → ∅",
         "│  ├─ ◆ process: poll-server",
         "│  ├─ ◆ effect: load-document [success: dynamic, failure: dynamic]",
         "│  ├─ ◆ timer: load-timeout [10s]",
@@ -298,5 +300,19 @@ describe("machine activity metadata", () => {
         "Candidate events: none"
       ].join("\n")
     )
+  })
+
+  it("renders state-owned activities inside their Mermaid state", () => {
+    const rendered = renderMermaidActivityMachine(activityMachine, {
+      path: "Loading" as const,
+      value: new Loading({})
+    })
+
+    assert.include(
+      rendered,
+      "state_0: process / poll-server · effect / load-document · timer / load-timeout (10s) · machine / child → document-worker"
+    )
+    assert.notInclude(rendered, "success: dynamic")
+    assert.notInclude(rendered, "note right of")
   })
 })

--- a/test/machine/AnnotationsVisualization.test.ts
+++ b/test/machine/AnnotationsVisualization.test.ts
@@ -1,6 +1,7 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Schema } from "effect"
 import { Machine } from "../../src/index.js"
+import { makeMermaidRenderer } from "./visualization/mermaid.js"
 import { makeTextRenderer } from "./visualization/text.js"
 
 class Workflow extends Schema.TaggedClass<Workflow>("Workflow")("Workflow", {}) {}
@@ -43,6 +44,10 @@ const renderMachine = makeTextRenderer<
   typeof machine,
   Machine.Machine.Snapshot<typeof States.states>
 >(Machine)
+const renderMermaid = makeMermaidRenderer<
+  typeof machine,
+  Machine.Machine.Snapshot<typeof States.states>
+>(Machine)
 
 describe("Machine annotation visualization", () => {
   it("uses titles for active, choice, and history display while preserving structural keys", () => {
@@ -50,7 +55,7 @@ describe("Machine annotation visualization", () => {
       renderMachine(machine),
       [
         "Machine",
-        "● active  ○ inactive  ◇ transition (→ target, ∅ none)",
+        "● active  ○ inactive  ◇ transition  ┄ branch → target",
         "",
         "└─ ○ Document workflow (Workflow) [compound, initial: Idle]",
         "   ├─ ○ Waiting for edits (Idle)",
@@ -59,5 +64,15 @@ describe("Machine annotation visualization", () => {
         "   └─ ○ Done"
       ].join("\n")
     )
+  })
+
+  it("renders titled choice, history, and final states as Mermaid", () => {
+    const rendered = renderMermaid(machine)
+
+    assert.include(rendered, "state \"○ Document workflow (Workflow)\" as state_0")
+    assert.include(rendered, "state \"○ Select persistence route (Routing)\" as state_2")
+    assert.include(rendered, "state state_2 <<choice>>")
+    assert.include(rendered, "state \"○ Previous workflow state (Recent) [history: deep]\" as state_3")
+    assert.include(rendered, "state \"○ Done\" as state_4")
   })
 })

--- a/test/machine/LocalTargetWith.test.ts
+++ b/test/machine/LocalTargetWith.test.ts
@@ -1,0 +1,204 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Schema } from "effect"
+import { Machine } from "../../src/index.js"
+
+describe("local compound target selection", () => {
+  it.effect("captures and plans local.with from the compound scope", () =>
+    Effect.gen(function*() {
+      const State = Schema.TaggedUnion({
+        Search: { query: Schema.String },
+        Idle: {},
+        Updated: {}
+      })
+      const Events = Schema.TaggedUnion({
+        UpdateQuery: { query: Schema.String },
+        Reset: {}
+      })
+      const states = Machine.defineStates({
+        search: {
+          schema: State.cases.Search,
+          initial: "Idle",
+          states: {
+            Idle: {},
+            Updated: {}
+          }
+        }
+      })
+      const machine = Machine.make({
+        states: states.states,
+        events: Machine.events(Events),
+        initial: {
+          target: (to) => to.search.initial(),
+          resolve: ({ target }) => target.from({ query: "" }, (search) => search.Idle.from())
+        }
+      }).handle({
+        search: {
+          on: {
+            UpdateQuery: Machine.transition({
+              target: (to) => to.local.with(),
+              resolve: ({ event, target }) => target.from({ query: event.query }, (search) => search.Updated.from()),
+              reenter: true
+            })
+          },
+          states: {
+            Idle: {},
+            Updated: {
+              on: {
+                Reset: Machine.transition({
+                  target: (to) => to.local.Idle(),
+                  resolve: ({ target }) => target.from()
+                })
+              }
+            }
+          }
+        }
+      })
+
+      assert.deepStrictEqual(Machine.transitionDefinitions(machine), [{
+        source: "search",
+        trigger: { type: "event", event: "UpdateQuery" },
+        reenter: true,
+        branches: [{
+          type: "direct",
+          target: "search",
+          selection: { path: "search", kind: "state", scope: "local" }
+        }]
+      }, {
+        source: "search.Updated",
+        trigger: { type: "event", event: "Reset" },
+        reenter: false,
+        branches: [{
+          type: "direct",
+          target: "search.Idle",
+          selection: { path: "search.Idle", kind: "state", scope: "local" }
+        }]
+      }])
+
+      const initial = yield* Machine.planInitial(machine)
+      const updated = yield* Machine.plan(machine, initial.state, Events.cases.UpdateQuery.make({ query: "next" }))
+
+      assert.deepStrictEqual(updated.next, {
+        path: "search",
+        value: State.cases.Search.make({ query: "next" }),
+        state: {
+          path: "search.Updated",
+          value: undefined
+        }
+      })
+
+      const reset = yield* Machine.plan(machine, updated.next, Events.cases.Reset.make({}))
+      assert.deepStrictEqual(reset.next, {
+        path: "search",
+        value: State.cases.Search.make({ query: "next" }),
+        state: {
+          path: "search.Idle",
+          value: undefined
+        }
+      })
+    }))
+
+  it.effect("resolves local.with from a descendant invoke source", () =>
+    Effect.gen(function*() {
+      const State = Schema.TaggedUnion({
+        Search: { query: Schema.String },
+        Searching: {},
+        Updated: {}
+      })
+      const states = Machine.defineStates({
+        search: {
+          schema: State.cases.Search,
+          initial: "Searching",
+          states: {
+            Searching: {},
+            Updated: {}
+          }
+        }
+      })
+      const machine = Machine.make({
+        states: states.states,
+        events: Machine.events(),
+        initial: {
+          target: (to) => to.search.initial(),
+          resolve: ({ target }) => target.from({ query: "pending" }, (search) => search.Searching.from())
+        }
+      }).handle({
+        search: {
+          states: {
+            Searching: {
+              invoke: Machine.invoke({
+                id: "search",
+                effect: () => Effect.succeed("resolved"),
+                onDone: Machine.transition({
+                  target: (to) => to.local.with(),
+                  resolve: ({ output, target }) => target.from({ query: output }, (search) => search.Updated.from())
+                })
+              })
+            },
+            Updated: {}
+          }
+        }
+      })
+
+      assert.deepStrictEqual(Machine.transitionDefinitions(machine), [{
+        source: "search.Searching",
+        trigger: { type: "invoke", id: "search", outcome: "done" },
+        reenter: false,
+        branches: [{
+          type: "direct",
+          target: "search",
+          selection: { path: "search", kind: "state", scope: "local" }
+        }]
+      }])
+
+      const ref = yield* Machine.start(machine)
+      for (let index = 0; index < 5; index += 1) yield* Effect.yieldNow
+
+      assert.deepStrictEqual(yield* ref.state, {
+        path: "search",
+        value: State.cases.Search.make({ query: "resolved" }),
+        state: {
+          path: "search.Updated",
+          value: undefined
+        }
+      })
+    }))
+
+  it("does not install local.with for a schema-less compound scope", () => {
+    const Event = Schema.TaggedUnion({ Advance: {} })
+    const states = Machine.defineStates({
+      flow: {
+        initial: "Idle",
+        states: {
+          Idle: {},
+          Updated: {}
+        }
+      }
+    })
+
+    Machine.make({
+      states: states.states,
+      events: Machine.events(Event),
+      initial: {
+        target: (to) => to.flow.initial(),
+        resolve: ({ target }) => target.from((flow) => flow.Idle.from())
+      }
+    }).handle({
+      flow: {
+        states: {
+          Idle: {
+            on: {
+              Advance: Machine.transition({
+                target: (to) => {
+                  assert.notProperty(to.local, "with")
+                  return to.local.Updated()
+                },
+                resolve: ({ target }) => target.from()
+              })
+            }
+          },
+          Updated: {}
+        }
+      }
+    })
+  })
+})

--- a/test/machine/MermaidVisualization.test.ts
+++ b/test/machine/MermaidVisualization.test.ts
@@ -1,0 +1,75 @@
+import { assert, describe, it } from "@effect/vitest"
+import { makeMermaidRenderer } from "./visualization/mermaid.js"
+import type { InspectionApi, StateNode } from "./visualization/model.js"
+
+interface TestMachine {
+  readonly id: string | undefined
+}
+
+const states: ReadonlyArray<StateNode> = [
+  {
+    path: "Root",
+    key: "Root",
+    annotations: { title: "Quoted \"root\" %%" },
+    type: "compound",
+    history: undefined,
+    parent: undefined,
+    children: ["Root.Route", "Root.Done"],
+    initial: "Root.Route"
+  },
+  {
+    path: "Root.Route",
+    key: "Route",
+    annotations: { title: "Choose\nroute" },
+    type: "choice",
+    history: undefined,
+    parent: "Root",
+    children: [],
+    initial: undefined
+  },
+  {
+    path: "Root.Done",
+    key: "Done",
+    annotations: undefined,
+    type: "final",
+    history: undefined,
+    parent: "Root",
+    children: [],
+    initial: undefined
+  }
+]
+
+const inspection: InspectionApi<TestMachine, { readonly active: boolean }> = {
+  stateNodes: () => states,
+  initialDefinition: () => ({ target: "Root" }),
+  transitionDefinitions: () => [{
+    source: "Root.Route",
+    trigger: { type: "choice" },
+    reenter: false,
+    branches: [
+      { type: "case", title: "approved %%\nnow", target: "Root.Done" },
+      { type: "otherwise", target: undefined }
+    ]
+  }],
+  activityDefinitions: () => [{ source: "Root.Route", id: "worker %%\nend note", type: "process" }],
+  configuration: () => states.slice(0, 2),
+  enabled: () => ["Continue %%\nnow"]
+}
+
+const render = makeMermaidRenderer<TestMachine, { readonly active: boolean }>(inspection)
+
+describe("Mermaid visualization", () => {
+  it("uses safe ids and escapes user-controlled labels without losing topology", () => {
+    const rendered = render({ id: "Unsafe %%\nMachine" }, { active: true })
+
+    assert.notInclude(rendered, "%%")
+    assert.include(rendered, "accTitle: Unsafe #37;#37; Machine")
+    assert.include(rendered, "state \"● Quoted #quot;root#quot; #37;#37; (Root)\" as state_0")
+    assert.include(rendered, "state \"● Choose route (Route)\" as state_1")
+    assert.include(rendered, "state state_1 <<choice>>")
+    assert.include(rendered, "state_1 --> state_2: choice [approved #37;#37; now]")
+    assert.notMatch(rendered, /state_1 --> .*otherwise/)
+    assert.include(rendered, "state_1: process / worker #37;#37; end note")
+    assert.notInclude(rendered, "Candidate events")
+  })
+})

--- a/test/machine/Visualization.test.ts
+++ b/test/machine/Visualization.test.ts
@@ -1,6 +1,7 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Cause, Effect, Schema } from "effect"
 import { Machine } from "../../src/index.js"
+import { makeMermaidRenderer } from "./visualization/mermaid.js"
 import { makeTextRenderer } from "./visualization/text.js"
 
 class Application extends Schema.TaggedClass<Application>("Application")("Application", {}) {}
@@ -124,6 +125,7 @@ const machine = Machine.make({
 })
 
 const renderMachine = makeTextRenderer<typeof machine, typeof initial>(Machine)
+const renderMermaidMachine = makeMermaidRenderer<typeof machine, typeof initial>(Machine)
 
 const LifecycleStates = Machine.defineStates({
   idle: Idle,
@@ -334,12 +336,14 @@ describe("Machine structural visualization", () => {
         renderLifecycleMachine(lifecycleMachine, planned.state),
         [
           "lifecycle-inspection",
-          "● active  ○ inactive  ◇ transition (→ target, ∅ none)",
+          "● active  ○ inactive  ◇ transition  ┄ branch → target",
           "",
           "├─ ○ idle",
-          "│  └─ ◇ always → workflow",
+          "│  └─ ◇ always",
+          "│     └┄ → workflow",
           "├─ ○ workflow [compound, initial: complete]",
-          "│  ├─ ◇ done → disabled",
+          "│  ├─ ◇ done",
+          "│  │  └┄ → disabled",
           "│  └─ ○ complete [final]",
           "└─ ● disabled",
           "",
@@ -353,25 +357,43 @@ describe("Machine structural visualization", () => {
       renderMachine(machine, initial),
       [
         "inspection-example",
-        "● active  ○ inactive  ◇ transition (→ target, ∅ none)",
+        "● active  ○ inactive  ◇ transition  ┄ branch → target",
         "",
         "├─ ● application [parallel]",
         "│  ├─ ● workflow [compound, initial: idle]",
         "│  │  ├─ ● idle",
-        "│  │  │  └─ ◇ on: Start → running, Refresh → ∅",
+        "│  │  │  └─ ◇ on: Start",
+        "│  │  │     └┄ → running",
         "│  │  ├─ ○ running [compound, initial: editing]",
         "│  │  │  ├─ ○ editing",
         "│  │  │  └─ ○ complete [final]",
         "│  │  └─ ○ recent [history, shallow]",
         "│  └─ ● connection [compound, initial: online]",
         "│     ├─ ● online",
-        "│     │  └─ ◇ on: Disconnect → offline",
+        "│     │  └─ ◇ on: Disconnect",
+        "│     │     └┄ → offline",
         "│     └─ ○ offline",
         "└─ ○ disabled",
         "",
         "Candidate events: Start, Refresh, Disconnect"
       ].join("\n")
     )
+  })
+
+  it("renders the full structure and concrete transitions as Mermaid", () => {
+    const rendered = renderMermaidMachine(machine, initial)
+
+    assert.isTrue(rendered.startsWith("stateDiagram-v2\n  direction LR"))
+    assert.include(rendered, "state \"● application [parallel]\" as state_0")
+    assert.include(rendered, "state \"● workflow\" as state_1")
+    assert.include(rendered, "[*] --> state_2")
+    assert.include(rendered, "state_5 --> [*]")
+    assert.include(rendered, "state \"○ recent [history: shallow]\" as state_6")
+    assert.include(rendered, "[*] --> state_0")
+    assert.include(rendered, "state_2 --> state_3: Start")
+    assert.include(rendered, "state_8 --> state_9: Disconnect")
+    assert.notMatch(rendered, /state_\d+ --> state_\d+: Refresh/)
+    assert.notInclude(rendered, "Candidate events")
   })
 
   it.effect("accepts a concrete leaf beneath a declared compound target", () =>

--- a/test/machine/visualization/mermaid.ts
+++ b/test/machine/visualization/mermaid.ts
@@ -1,0 +1,170 @@
+import type { ActivityDefinition, InspectionApi, MachineValue, StateNode, TransitionDefinition } from "./model.js"
+
+const indent = (depth: number): string => "  ".repeat(depth)
+
+const escapeText = (value: string): string =>
+  value
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/["#%&<>]/g, (character) => {
+      switch (character) {
+        case "\"":
+          return "#quot;"
+        case "#":
+          return "#35;"
+        case "%":
+          return "#37;"
+        case "&":
+          return "#38;"
+        case "<":
+          return "#60;"
+        case ">":
+          return "#62;"
+        default:
+          return character
+      }
+    })
+
+const stateLabel = (node: StateNode, active: ReadonlySet<string>): string => {
+  const status = active.has(node.path) ? "●" : "○"
+  const title = node.annotations?.title === undefined ? node.key : `${node.annotations.title} (${node.key})`
+  const details = node.type === "final" ?
+    " [final]" :
+    node.type === "history" ?
+    ` [history: ${node.history ?? "shallow"}]` :
+    node.type === "parallel" ?
+    " [parallel]" :
+    ""
+  return escapeText(`${status} ${title}${details}`)
+}
+
+const triggerLabel = (definition: TransitionDefinition): string => {
+  const trigger = definition.trigger.type === "event" ?
+    String(definition.trigger.event) :
+    definition.trigger.type === "invoke" ?
+    `invoke ${definition.trigger.id} ${definition.trigger.outcome}` :
+    definition.trigger.type
+  return `${trigger}${definition.reenter ? " [reenter]" : ""}`
+}
+
+const branchLabel = (
+  definition: TransitionDefinition,
+  branch: TransitionDefinition["branches"][number]
+): string => {
+  const suffix = branch.type === "case" ?
+    ` [${branch.title}]` :
+    branch.type === "otherwise" ?
+    " [otherwise]" :
+    ""
+  return escapeText(`${triggerLabel(definition)}${suffix}`)
+}
+
+const activityLabel = (definition: ActivityDefinition): string => {
+  switch (definition.type) {
+    case "process":
+      return `process / ${definition.id}`
+    case "effect":
+      return `effect / ${definition.id}`
+    case "timer":
+      return `timer / ${definition.id} (${definition.duration})`
+    case "machine": {
+      const identity = definition.child.machineId === null ? definition.child.id : definition.child.machineId
+      return `machine / ${definition.id} → ${identity}`
+    }
+  }
+}
+
+/**
+ * Builds a Mermaid state diagram from a machine module's public inspection
+ * functions. Generated state ids are independent from user-defined paths so
+ * the result remains valid Mermaid for arbitrary state keys and titles.
+ */
+export const makeMermaidRenderer = <Machine extends MachineValue, Snapshot>(
+  inspection: InspectionApi<Machine, Snapshot>
+) =>
+(
+  machine: Machine,
+  snapshot?: Snapshot
+): string => {
+  const nodes = inspection.stateNodes(machine)
+  const initial = inspection.initialDefinition(machine)
+  const active = new Set(
+    snapshot === undefined ? [] : inspection.configuration(machine, snapshot).map((node) => node.path)
+  )
+  const ids = new Map(nodes.map((node, index) => [node.path, `state_${index}`] as const))
+  const children = new Map<string | undefined, Array<StateNode>>()
+  const activities = new Map<string, Array<ActivityDefinition>>()
+
+  for (const node of nodes) {
+    const siblings = children.get(node.parent) ?? []
+    siblings.push(node)
+    children.set(node.parent, siblings)
+  }
+  for (const definition of inspection.activityDefinitions?.(machine) ?? []) {
+    const registrations = activities.get(definition.source) ?? []
+    registrations.push(definition)
+    activities.set(definition.source, registrations)
+  }
+
+  const lines = [
+    "stateDiagram-v2",
+    "  direction LR",
+    `  accTitle: ${escapeText(machine.id ?? "Machine")}`,
+    `  accDescr: ${escapeText(`State machine configuration and transitions for ${machine.id ?? "Machine"}`)}`
+  ]
+
+  const renderState = (node: StateNode, depth: number): void => {
+    const id = ids.get(node.path)
+    if (id === undefined) return
+
+    lines.push(`${indent(depth)}state "${stateLabel(node, active)}" as ${id}`)
+    const ownedActivities = activities.get(node.path) ?? []
+    if (ownedActivities.length > 0) {
+      lines.push(
+        `${indent(depth)}${id}: ${ownedActivities.map((activity) => escapeText(activityLabel(activity))).join(" · ")}`
+      )
+    }
+    if (node.type === "choice") {
+      lines.push(`${indent(depth)}state ${id} <<choice>>`)
+      return
+    }
+
+    const descendants = children.get(node.path) ?? []
+    if (descendants.length > 0) {
+      lines.push(`${indent(depth)}state ${id} {`)
+      if (node.type === "parallel") {
+        descendants.forEach((child, index) => {
+          const childId = ids.get(child.path)
+          if (childId !== undefined) lines.push(`${indent(depth + 1)}[*] --> ${childId}`)
+          renderState(child, depth + 1)
+          if (index < descendants.length - 1) lines.push(`${indent(depth + 1)}--`)
+        })
+      } else {
+        const initialId = node.initial === undefined ? undefined : ids.get(node.initial)
+        if (initialId !== undefined) lines.push(`${indent(depth + 1)}[*] --> ${initialId}`)
+        for (const child of descendants) renderState(child, depth + 1)
+      }
+      lines.push(`${indent(depth)}}`)
+    }
+
+    if (node.type === "final") lines.push(`${indent(depth)}${id} --> [*]`)
+  }
+
+  const roots = children.get(undefined) ?? []
+  for (const root of roots) renderState(root, 1)
+
+  const initialId = ids.get(initial.target)
+  if (initialId !== undefined) lines.push(`  [*] --> ${initialId}`)
+
+  for (const definition of inspection.transitionDefinitions(machine)) {
+    const source = ids.get(definition.source)
+    if (source === undefined) continue
+    for (const branch of definition.branches) {
+      const target = branch.target === undefined ? undefined : ids.get(branch.target)
+      if (target !== undefined) lines.push(`  ${source} --> ${target}: ${branchLabel(definition, branch)}`)
+    }
+  }
+
+  return lines.join("\n")
+}

--- a/test/machine/visualization/model.ts
+++ b/test/machine/visualization/model.ts
@@ -1,0 +1,99 @@
+export interface StateNode {
+  readonly path: string
+  readonly key: string
+  readonly annotations: {
+    readonly title?: string | undefined
+  } | undefined
+  readonly type: "atomic" | "compound" | "parallel" | "final" | "history" | "choice"
+  readonly history: "shallow" | "deep" | undefined
+  readonly parent: string | undefined
+  readonly children: ReadonlyArray<string>
+  readonly initial: string | undefined
+}
+
+export interface MachineValue {
+  readonly id: string | undefined
+}
+
+export interface InitialDefinition {
+  readonly target: string
+}
+
+export interface TransitionDefinition {
+  readonly source: string
+  readonly trigger:
+    | {
+      readonly type: "event"
+      readonly event: PropertyKey
+    }
+    | {
+      readonly type: "always"
+    }
+    | {
+      readonly type: "done"
+    }
+    | {
+      readonly type: "choice"
+    }
+    | {
+      readonly type: "invoke"
+      readonly id: string
+      readonly outcome: "done" | "failure" | "snapshot"
+    }
+  readonly reenter: boolean
+  readonly branches: ReadonlyArray<
+    | {
+      readonly type: "direct"
+      readonly target: string | undefined
+    }
+    | {
+      readonly type: "case"
+      readonly title: string
+      readonly target: string | undefined
+    }
+    | {
+      readonly type: "otherwise"
+      readonly target: string | undefined
+    }
+  >
+}
+
+export type ActivityDefinition =
+  | {
+    readonly source: string
+    readonly id: string
+    readonly type: "process"
+  }
+  | {
+    readonly source: string
+    readonly id: string
+    readonly type: "effect"
+    readonly outcomes: {
+      readonly success: "dynamic"
+      readonly failure: "dynamic" | "none"
+    }
+  }
+  | {
+    readonly source: string
+    readonly id: string
+    readonly type: "timer"
+    readonly duration: string | "dynamic"
+  }
+  | {
+    readonly source: string
+    readonly id: string
+    readonly type: "machine"
+    readonly child: {
+      readonly id: string
+      readonly machineId: string | null
+    }
+  }
+
+export interface InspectionApi<Machine, Snapshot> {
+  readonly stateNodes: (machine: Machine) => ReadonlyArray<StateNode>
+  readonly initialDefinition: (machine: Machine) => InitialDefinition
+  readonly transitionDefinitions: (machine: Machine) => ReadonlyArray<TransitionDefinition>
+  readonly activityDefinitions?: (machine: Machine) => ReadonlyArray<ActivityDefinition>
+  readonly configuration: (machine: Machine, snapshot: Snapshot) => ReadonlyArray<StateNode>
+  readonly enabled: (machine: Machine, snapshot: Snapshot) => ReadonlyArray<PropertyKey>
+}

--- a/test/machine/visualization/text.ts
+++ b/test/machine/visualization/text.ts
@@ -1,97 +1,4 @@
-interface StateNode {
-  readonly path: string
-  readonly key: string
-  readonly annotations: {
-    readonly title?: string | undefined
-  } | undefined
-  readonly type: "atomic" | "compound" | "parallel" | "final" | "history" | "choice"
-  readonly history: "shallow" | "deep" | undefined
-  readonly parent: string | undefined
-  readonly children: ReadonlyArray<string>
-  readonly initial: string | undefined
-}
-
-interface MachineValue {
-  readonly id: string | undefined
-}
-
-interface TransitionDefinition {
-  readonly source: string
-  readonly trigger:
-    | {
-      readonly type: "event"
-      readonly event: PropertyKey
-    }
-    | {
-      readonly type: "always"
-    }
-    | {
-      readonly type: "done"
-    }
-    | {
-      readonly type: "choice"
-    }
-    | {
-      readonly type: "invoke"
-      readonly id: string
-      readonly outcome: "done" | "failure" | "snapshot"
-    }
-  readonly reenter: boolean
-  readonly branches: ReadonlyArray<
-    | {
-      readonly type: "direct"
-      readonly target: string | undefined
-    }
-    | {
-      readonly type: "case"
-      readonly title: string
-      readonly target: string | undefined
-    }
-    | {
-      readonly type: "otherwise"
-      readonly target: string | undefined
-    }
-  >
-}
-
-type ActivityDefinition =
-  | {
-    readonly source: string
-    readonly id: string
-    readonly type: "process"
-  }
-  | {
-    readonly source: string
-    readonly id: string
-    readonly type: "effect"
-    readonly outcomes: {
-      readonly success: "dynamic"
-      readonly failure: "dynamic" | "none"
-    }
-  }
-  | {
-    readonly source: string
-    readonly id: string
-    readonly type: "timer"
-    readonly duration: string | "dynamic"
-  }
-  | {
-    readonly source: string
-    readonly id: string
-    readonly type: "machine"
-    readonly child: {
-      readonly id: string
-      readonly machineId: string | null
-    }
-  }
-
-interface InspectionApi<Machine, Snapshot> {
-  readonly stateNodes: (machine: Machine) => ReadonlyArray<StateNode>
-  readonly transitionDefinitions: (machine: Machine) => ReadonlyArray<TransitionDefinition>
-  readonly activityDefinitions?: (machine: Machine) => ReadonlyArray<ActivityDefinition>
-  readonly configuration: (machine: Machine, snapshot: Snapshot) => ReadonlyArray<StateNode>
-  readonly enabled: (machine: Machine, snapshot: Snapshot) => ReadonlyArray<PropertyKey>
-}
+import type { ActivityDefinition, InspectionApi, MachineValue, StateNode, TransitionDefinition } from "./model.js"
 
 const nodeLabel = (node: StateNode, active: ReadonlySet<string>): string => {
   const status = active.has(node.path) ? "●" : "○"
@@ -106,42 +13,40 @@ const nodeLabel = (node: StateNode, active: ReadonlySet<string>): string => {
   return details.length === 0 ? `${status} ${label}` : `${status} ${label} [${details.join(", ")}]`
 }
 
-const triggerLabels = (definitions: ReadonlyArray<TransitionDefinition>): ReadonlyArray<string> => {
-  const labels: Array<string> = []
-  const target = (path: string | undefined): string =>
-    path === undefined ? " → ∅" : ` → ${path.slice(path.lastIndexOf(".") + 1)}`
-  const branches = (definition: TransitionDefinition): string =>
-    definition.branches.map((branch) =>
-      branch.type === "direct" ?
-        target(branch.target)
-        : branch.type === "case" ?
-        ` [${branch.title}]${target(branch.target)}`
-        : ` [otherwise]${target(branch.target)}`
-    ).join(" |")
-  const events = definitions.flatMap((definition) =>
-    definition.trigger.type === "event" ?
-      [
-        `${String(definition.trigger.event)}${definition.reenter ? " [reenter]" : ""}${branches(definition)}`
-      ]
-      : []
-  )
-
-  if (events.length > 0) {
-    labels.push(`◇ on: ${events.join(", ")}`)
-  }
-  for (const definition of definitions) {
-    if (definition.trigger.type === "always") {
-      labels.push(`◇ always${definition.reenter ? " [reenter]" : ""}${branches(definition)}`)
-    } else if (definition.trigger.type === "done") {
-      labels.push(`◇ done${definition.reenter ? " [reenter]" : ""}${branches(definition)}`)
-    } else if (definition.trigger.type === "choice") {
-      labels.push(`◇ choice${branches(definition)}`)
-    } else if (definition.trigger.type === "invoke") {
-      labels.push(`◇ invoke ${definition.trigger.id} ${definition.trigger.outcome}${branches(definition)}`)
-    }
-  }
-  return labels
+interface TransitionLabel {
+  readonly trigger: string
+  readonly branches: ReadonlyArray<string>
 }
+
+const triggerLabels = (definitions: ReadonlyArray<TransitionDefinition>): ReadonlyArray<TransitionLabel> =>
+  definitions.flatMap((definition) => {
+    const branches = definition.branches.flatMap((branch) => {
+      if (branch.target === undefined) return []
+
+      const target = branch.target.slice(branch.target.lastIndexOf(".") + 1)
+      return [
+        branch.type === "direct" ?
+          `→ ${target}` :
+          branch.type === "case" ?
+          `[${branch.title}] → ${target}` :
+          `[otherwise] → ${target}`
+      ]
+    })
+    if (branches.length === 0) return []
+
+    const reenter = definition.reenter ? " [reenter]" : ""
+    const trigger = definition.trigger.type === "event" ?
+      `◇ on: ${String(definition.trigger.event)}${reenter}`
+      : definition.trigger.type === "always" ?
+      `◇ always${reenter}`
+      : definition.trigger.type === "done" ?
+      `◇ done${reenter}`
+      : definition.trigger.type === "choice" ?
+      "◇ choice"
+      : `◇ invoke ${definition.trigger.id} ${definition.trigger.outcome}${reenter}`
+
+    return [{ trigger, branches }]
+  })
 
 const activityLabel = (definition: ActivityDefinition): string => {
   switch (definition.type) {
@@ -198,8 +103,8 @@ export const makeTextRenderer = <Machine extends MachineValue, Snapshot>(
   const lines = [
     machine.id ?? "Machine",
     activities.size === 0
-      ? "● active  ○ inactive  ◇ transition (→ target, ∅ none)"
-      : "● active  ○ inactive  ◇ transition (→ target, ∅ none)  ◆ activity",
+      ? "● active  ○ inactive  ◇ transition  ┄ branch → target"
+      : "● active  ○ inactive  ◇ transition  ┄ branch → target  ◆ activity",
     ""
   ]
   const visit = (node: StateNode, prefix: string, isLast: boolean): void => {
@@ -208,13 +113,23 @@ export const makeTextRenderer = <Machine extends MachineValue, Snapshot>(
     const registrations = transitions.get(node.path) ?? []
     const ownedActivities = activities.get(node.path) ?? []
     const childPrefix = `${prefix}${isLast ? "   " : "│  "}`
-    const labels = [...triggerLabels(registrations), ...ownedActivities.map(activityLabel)]
-    const itemCount = labels.length + descendants.length
-    labels.forEach((label, index) => {
-      lines.push(`${childPrefix}${index === itemCount - 1 ? "└─" : "├─"} ${label}`)
+    const transitionLabels = triggerLabels(registrations)
+    const activityLabels = ownedActivities.map(activityLabel)
+    const itemCount = transitionLabels.length + activityLabels.length + descendants.length
+    transitionLabels.forEach((label, index) => {
+      const isLastItem = index === itemCount - 1
+      lines.push(`${childPrefix}${isLastItem ? "└─" : "├─"} ${label.trigger}`)
+      const branchPrefix = `${childPrefix}${isLastItem ? "   " : "│  "}`
+      label.branches.forEach((branch, branchIndex) => {
+        lines.push(`${branchPrefix}${branchIndex === label.branches.length - 1 ? "└┄" : "├┄"} ${branch}`)
+      })
+    })
+    activityLabels.forEach((label, index) => {
+      const itemIndex = transitionLabels.length + index
+      lines.push(`${childPrefix}${itemIndex === itemCount - 1 ? "└─" : "├─"} ${label}`)
     })
     descendants.forEach((child, index) => {
-      visit(child, childPrefix, labels.length + index === itemCount - 1)
+      visit(child, childPrefix, transitionLabels.length + activityLabels.length + index === itemCount - 1)
     })
   }
 

--- a/typetest/machine/StructuralStates.tst.ts
+++ b/typetest/machine/StructuralStates.tst.ts
@@ -148,7 +148,10 @@ describe("structural active state types", () => {
                 },
                 on: {
                   Select: Machine.transition({
-                    target: (to) => to.local.Loading(),
+                    target: (to) => {
+                      expect(to.local).type.not.toHaveProperty("with")
+                      return to.local.Loading()
+                    },
                     resolve: ({ containingState, ancestors, state, target }) => {
                       expect(state).type.toBe<undefined>()
                       expect(containingState).type.toBe<undefined>()


### PR DESCRIPTION
## Summary

- fix definition-time and resolve-time handling for `to.local.with()` on schema-backed compound scopes, including descendant invoke sources
- add inspection-driven text and Mermaid visualization examples for concrete branches, state topology, activities, annotations, and safely escaped labels
- add planning, runtime, transition-evidence, schema-less type/runtime, and platformer integration coverage

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

Patch changeset: fixes the compatible `to.local.with()` runtime hole and documents the expanded public-inspection visualization examples.

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required

Local example checks:
- `examples/platformer: pnpm check`
- `examples/pokemon: pnpm check`

Local `pnpm perf:runtime` smoke test completed successfully. The CI base-versus-PR comparison is authoritative.
