### PR TITLE
Fix invoke owner protocol inference

### DIFF
--- a/.changeset/bright-invokes-listen.md
+++ b/.changeset/bright-invokes-listen.md
@@ -1,0 +1,7 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Fix `Machine.invoke(...)` inside `.handle(...)` so invocation sources and lifecycle handlers receive the owning machine's typed `self` and `parent` protocols.
+
+Event protocol examples now pass tagged unions directly to `Machine.events`, `Machine.internalEvents`, and `Machine.emittedEvents`, avoiding throwaway schema bindings.

--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ const State = Schema.TaggedUnion({
   Running: { count: Schema.Number }
 })
 
-const Event = Schema.TaggedUnion({
-  Start: {},
-  Increment: {},
-  Stop: {}
-})
-
 const States = Machine.defineStates(State.cases)
-const CounterEvent = Machine.events(Event)
+const CounterEvent = Machine.events(
+  Schema.TaggedUnion({
+    Start: {},
+    Increment: {},
+    Stop: {}
+  })
+)
 
 const CounterDefinition = Machine.make({
   id: "Counter",
@@ -110,13 +110,15 @@ const program = Effect.gen(function*() {
 
 Use this order to preserve inference and keep boundaries explicit:
 
-1. Define domain, state, public-event, internal-event, and emitted-event schemas.
-2. Declare topology with `Machine.defineStates`.
-3. Create public and internal event descriptors with `Machine.events` and
-   `Machine.internalEvents`.
-4. Create the machine protocol and initializer with `Machine.make`.
-5. Implement every active state with `.handle(...)`.
-6. Add runtime, Atom, testing, or cluster adapters at the application boundary.
+1. Define domain schemas used by state and by shared event fields.
+2. Declare topology with `Machine.defineStates`, naming a tagged state union
+   when its `.cases` are reused.
+3. Create event descriptors with `Machine.events`, `Machine.internalEvents`,
+   and `Machine.emittedEvents`, passing tagged unions or tagged classes directly.
+4. Create the machine and implement every active state with
+   `Machine.make({...}).handle({...})`.
+5. Add child descriptors, then runtime, Atom, testing, or cluster adapters at
+   the application boundary.
 
 ### Construct state through builders
 
@@ -178,19 +180,21 @@ belong in `internalEvents`. Ephemeral outward notifications have their own
 `emittedEvents` protocol:
 
 ```ts
-const Command = Schema.TaggedUnion({ Save: {} })
-const Internal = Schema.TaggedUnion({
-  Saved: { id: Schema.String },
-  SaveFailed: { message: Schema.String }
-})
-const Emitted = Schema.TaggedUnion({
-  SaveObserved: { id: Schema.String }
-})
-
-export const CommandEvent = Machine.events(Command)
+export const CommandEvent = Machine.events(
+  Schema.TaggedUnion({ Save: {} })
+)
 export type PublicCommandEvent = Machine.EventOf<typeof CommandEvent>
-const InternalEvent = Machine.internalEvents(Internal)
-const Emissions = Machine.emittedEvents(Emitted)
+const InternalEvent = Machine.internalEvents(
+  Schema.TaggedUnion({
+    Saved: { id: Schema.String },
+    SaveFailed: { message: Schema.String }
+  })
+)
+const Emissions = Machine.emittedEvents(
+  Schema.TaggedUnion({
+    SaveObserved: { id: Schema.String }
+  })
+)
 
 const definition = Machine.make({
   states: States.states,
@@ -446,31 +450,31 @@ invoke: Machine.invoke({
 })
 ```
 
-The standalone `Machine.invoke(...)` constructor does not know the owning
-definition, so its `self` and `parent` references are non-sendable. When an
-invocation callback sends through either reference, construct it through the
-owning definition so those references use its exact public input and
-`parentEvents` protocols:
+Inside `.handle(...)`, `Machine.invoke(...)` receives the owning machine's
+public input and `parentEvents` protocols contextually. Its source and lifecycle
+callbacks can send through `self` and `parent` while retaining the invoked
+Effect's output and error inference:
 
 ```ts
-const definition = Machine.make({
+const machine = Machine.make({
   events: Commands,
   internalEvents: InternalEvents,
   parentEvents: ParentEvents
   // ...
-})
-
-const machine = definition.handle({
+}).handle({
   Saving: {
-    invoke: definition.invoke({
+    invoke: Machine.invoke({
       id: "notify-parent",
-      effect: ({ parent }) =>
-        parent === undefined
-          ? Effect.void
-          : parent.send(ParentEvents.SaveStarted()),
+      effect: () => saveDocument,
       onDone: Machine.transition({
         target: (to) => to.none(),
-        resolve: () => undefined
+        resolve: ({ parent, self }, enqueue) => {
+          enqueue.sendTo(self, Commands.Save())
+          if (parent !== undefined) {
+            enqueue.sendTo(parent, ParentEvents.ChildFinished({ id: "job-1" }))
+          }
+          return undefined
+        }
       }),
       onFailure: Machine.transition({
         target: (to) => to.none(),
@@ -480,6 +484,9 @@ const machine = definition.handle({
   }
 })
 ```
+
+The machine-bound `definition.invoke(...)` form remains equivalent when a
+definition is already named; it is not required for `self` or `parent` typing.
 
 A direct `invoke: { ... }` object is also supported when its lifecycle handlers
 do not need source-derived context. Reuse one exported

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -35,15 +35,13 @@ currently coupled to the exact Effect peer version listed in its `package.json`.
 Use this order so inference has all schemas available when handlers are
 declared:
 
-1. Domain schemas used by state and event fields.
-2. Tagged schemas for states that own data.
-3. Tagged public-event, internal-event, parent-event, and emitted-event schemas.
-4. `Machine.defineStates`.
-5. `Machine.make`, including input, `events`, `internalEvents`, `parentEvents`,
-   `emittedEvents`, and the initial function.
-6. One or more `.handle(...)` calls.
-7. Child descriptors.
-8. Runtime, Atom, or Cluster adapters.
+1. Domain schemas used by state, and by event fields when they are shared.
+2. `Machine.defineStates`, using a tagged state union and `.cases` when state
+   schemas need to be reused.
+3. `Machine.events`, `Machine.internalEvents`, `Machine.emittedEvents`, and
+   `parentEvents`; pass `Schema.TaggedUnion({...})` or tagged classes directly.
+4. `Machine.make({...}).handle({...})`.
+5. Child descriptors, then runtime, Atom, or Cluster adapters.
 
 `Schema.TaggedUnion` avoids one class declaration per case:
 
@@ -54,22 +52,23 @@ const State = Schema.TaggedUnion({
   Failed: { message: Schema.String }
 })
 
-const Event = Schema.TaggedUnion({
-  Save: {}
-})
-
-const InternalEvent = Schema.TaggedUnion({
-  Saved: { id: Schema.String },
-  SaveFailed: { message: Schema.String }
-})
-
 const States = Machine.defineStates(State.cases)
-const Events = Machine.events(Event)
-const InternalEvents = Machine.internalEvents(InternalEvent)
+export const Event = Machine.events(
+  Schema.TaggedUnion({
+    Save: {}
+  })
+)
+export const Internal = Machine.internalEvents(
+  Schema.TaggedUnion({
+    Saved: { id: Schema.String },
+    SaveFailed: { message: Schema.String }
+  })
+)
 ```
 
-Pass these descriptors to `Machine.make` and export `Events` instead of the raw
-event schema. Construct new state values through the target or initial
+Pass these descriptors to `Machine.make`; the event descriptor is the public
+handle, so do not introduce a tagged-union binding used only by an event helper.
+Construct new state values through the target or initial
 builder's `.from(...)` method. Both event constructors and state `.from(...)`
 defer schema construction until planning, so validation failures remain typed
 machine errors. Use
@@ -121,9 +120,9 @@ its extra control is required:
 - Use one invocation object: `effect` for one-shot work, `after` for a timer,
   `logic` for reusable process logic, and `child` for a complete child
   statechart. `Machine.invoke({...})` preserves owner state and source channels
-  across sibling lifecycle handlers. Use `definition.invoke({...})` when a
-  callback uses `self` or `parent`; the bound constructor preserves the
-  definition's exact public input and `parentEvents` protocols.
+  across sibling lifecycle handlers. Inside `.handle(...)`, `self` and `parent`
+  use the owning definition's exact public input and `parentEvents` protocols.
+  The bound `definition.invoke({...})` form is equivalent, not required.
 - Use `Machine.child(id, machine)` for a complete statechart descriptor and
   `Machine.childAddress<Event>(id)` for a low-level process address. A logic
   invocation is addressable only when `Machine.invoke` receives that
@@ -764,8 +763,17 @@ an event for the parent. Both operations validate their schemas.
 union handled inside the statechart:
 
 ```ts
-const Events = Machine.events(Event)
-const InternalEvents = Machine.internalEvents(InternalEvent)
+const Events = Machine.events(
+  Schema.TaggedUnion({
+    Save: {}
+  })
+)
+const InternalEvents = Machine.internalEvents(
+  Schema.TaggedUnion({
+    Saved: { id: Schema.String },
+    SaveFailed: { message: Schema.String }
+  })
+)
 
 const definition = Machine.make({
   states: States.states,
@@ -871,29 +879,30 @@ invoke: Machine.invoke({
 })
 ```
 
-The standalone constructor cannot know the owning machine's input protocols,
-so its `self` and `parent` references are non-sendable. When a source sends
-through either reference, use the owning definition's bound constructor:
+Inside `.handle(...)`, the constructor receives the owning machine's public
+input and `parentEvents` protocols contextually. Sources and lifecycle handlers
+can send through `self` and `parent` without naming the definition:
 
 ```ts
-const definition = Machine.make({
+const machine = Machine.make({
   events: Commands,
   internalEvents: InternalEvents,
   parentEvents: ParentEvents,
   // ...
-})
-
-const machine = definition.handle({
+}).handle({
   Saving: {
-    invoke: definition.invoke({
+    invoke: Machine.invoke({
       id: "notify-parent",
-      effect: ({ parent }) =>
-        parent === undefined
-          ? Effect.void
-          : parent.send(ParentEvents.SaveStarted()),
+      effect: () => saveDocument,
       onDone: Machine.transition({
         target: (to) => to.none(),
-        resolve: () => undefined
+        resolve: ({ parent, self }, enqueue) => {
+          enqueue.sendTo(self, Commands.Save())
+          if (parent !== undefined) {
+            enqueue.sendTo(parent, ParentEvents.ChildFinished({ id: "job-1" }))
+          }
+          return undefined
+        }
       }),
       onFailure: Machine.transition({
         target: (to) => to.none(),
@@ -904,8 +913,9 @@ const machine = definition.handle({
 })
 ```
 
-A direct `invoke: { ... }` object remains available when lifecycle handlers do
-not need source-derived context.
+The machine-bound `definition.invoke(...)` form remains equivalent when the
+definition is already named. A direct `invoke: { ... }` object remains available
+when lifecycle handlers do not need source-derived context.
 
 A cancellable timer uses the same object:
 

--- a/examples/platformer/src/machine.ts
+++ b/examples/platformer/src/machine.ts
@@ -18,29 +18,30 @@ const State = Schema.TaggedUnion({
 })
 
 // Inputs and physics facts are one runtime-decoded, statically typed protocol.
-const Event = Schema.TaggedUnion({
-  Move: { axis: Axis, at: Schema.Number },
-  JumpPressed: { at: Schema.Number, y: Schema.Number, wall: Axis },
-  WallContact: { wall: Axis },
-  DownPressed: { at: Schema.Number },
-  DownReleased: { axis: Axis, at: Schema.Number },
-  ApexReached: { y: Schema.Number },
-  Landed: { impact: Schema.Number, axis: Axis, at: Schema.Number },
-  Pause: { at: Schema.Number },
-  Resume: {},
-  Reset: {}
-})
+export const CharacterEvents = Machine.events(
+  Schema.TaggedUnion({
+    Move: { axis: Axis, at: Schema.Number },
+    JumpPressed: { at: Schema.Number, y: Schema.Number, wall: Axis },
+    WallContact: { wall: Axis },
+    DownPressed: { at: Schema.Number },
+    DownReleased: { axis: Axis, at: Schema.Number },
+    ApexReached: { y: Schema.Number },
+    Landed: { impact: Schema.Number, axis: Axis, at: Schema.Number },
+    Pause: { at: Schema.Number },
+    Resume: {},
+    Reset: {}
+  })
+)
 
-const InternalEvent = Schema.TaggedUnion({
-  LandingSettled: {},
-  AirJumpUnlocked: {},
-  TryAirJump: { at: Schema.Number },
-  DoubleJump: { at: Schema.Number },
-  WallJump: { at: Schema.Number, push: Axis }
-})
-
-export const CharacterEvents = Machine.events(Event)
-const InternalEvents = Machine.internalEvents(InternalEvent)
+const InternalEvents = Machine.internalEvents(
+  Schema.TaggedUnion({
+    LandingSettled: {},
+    AirJumpUnlocked: {},
+    TryAirJump: { at: Schema.Number },
+    DoubleJump: { at: Schema.Number },
+    WallJump: { at: Schema.Number, push: Axis }
+  })
+)
 
 const awayFrom = (wall: Axis): Axis => (wall === -1 ? 1 : wall === 1 ? -1 : 0)
 
@@ -114,7 +115,7 @@ export const CharacterStates = Machine.defineStates({
   }
 })
 
-const definition = Machine.make({
+export const CharacterMachine = Machine.make({
   id: "PlatformerCharacter",
   states: CharacterStates.states,
   events: CharacterEvents,
@@ -131,9 +132,7 @@ const definition = Machine.make({
           .contact.from((contact) => contact.NoWall.from())
       )
   }
-})
-
-export const CharacterMachine = definition.handle({
+}).handle({
   Character: {
     on: {
       Reset: Machine.transition({
@@ -261,7 +260,7 @@ export const CharacterMachine = definition.handle({
                     }
                   },
                   Landing: {
-                    invoke: definition.invoke({
+                    invoke: Machine.invoke({
                       id: "landing-settle",
                       after: "140 millis",
                       onDone: Machine.transition({

--- a/examples/playground/src/examples/media-player/schemas.ts
+++ b/examples/playground/src/examples/media-player/schemas.ts
@@ -62,35 +62,36 @@ export const MediaPlayerState = Schema.TaggedUnion({
   Muted: soundSettingsFields
 })
 
-const MediaPlayerEvent = Schema.TaggedUnion({
-  SourceSelected: { url: Schema.String },
-  PlayRequested: {},
-  PauseRequested: {},
-  RestartRequested: {},
-  MediaWaiting: {},
-  MediaCanPlay: {},
-  PlaybackEnded: { currentTime: Schema.Number },
-  TimeUpdated: { currentTime: Schema.Number },
-  MediaFailed: { message: Schema.String },
-  VolumeChanged: { volume: Schema.Number },
-  PlaybackRateChanged: { playbackRate: Schema.Number },
-  MuteRequested: {},
-  UnmuteRequested: {}
-})
+export const MediaPlayerEvents = Machine.events(
+  Schema.TaggedUnion({
+    SourceSelected: { url: Schema.String },
+    PlayRequested: {},
+    PauseRequested: {},
+    RestartRequested: {},
+    MediaWaiting: {},
+    MediaCanPlay: {},
+    PlaybackEnded: { currentTime: Schema.Number },
+    TimeUpdated: { currentTime: Schema.Number },
+    MediaFailed: { message: Schema.String },
+    VolumeChanged: { volume: Schema.Number },
+    PlaybackRateChanged: { playbackRate: Schema.Number },
+    MuteRequested: {},
+    UnmuteRequested: {}
+  })
+)
 
-const MediaPlayerInternalEvent = Schema.TaggedUnion({
-  LoadSucceeded: {},
-  RestartSucceeded: {},
-  LoudnessMeasured: {
-    rms: Schema.Number,
-    peak: Schema.Number,
-    decibels: Schema.Number
-  },
-  OperationFailed: { message: Schema.String }
-})
-
-export const MediaPlayerEvents = Machine.events(MediaPlayerEvent)
-export const MediaPlayerInternalEvents = Machine.internalEvents(MediaPlayerInternalEvent)
+export const MediaPlayerInternalEvents = Machine.internalEvents(
+  Schema.TaggedUnion({
+    LoadSucceeded: {},
+    RestartSucceeded: {},
+    LoudnessMeasured: {
+      rms: Schema.Number,
+      peak: Schema.Number,
+      decibels: Schema.Number
+    },
+    OperationFailed: { message: Schema.String }
+  })
+)
 
 export const MediaPlayerStates = Machine.defineStates({
   Player: {

--- a/examples/playground/src/examples/microwave/machine.ts
+++ b/examples/playground/src/examples/microwave/machine.ts
@@ -5,13 +5,13 @@ export const MicrowaveState = Schema.TaggedUnion({
   Cooking: { elapsedSeconds: Schema.Number }
 })
 
-const MicrowaveEvent = Schema.TaggedUnion({
-  PowerPressed: {},
-  DoorOpened: {},
-  DoorClosed: {}
-})
-
-export const MicrowaveEvents = Machine.events(MicrowaveEvent)
+export const MicrowaveEvents = Machine.events(
+  Schema.TaggedUnion({
+    PowerPressed: {},
+    DoorOpened: {},
+    DoorClosed: {}
+  })
+)
 
 export const MicrowaveStates = Machine.defineStates({
   Oven: {
@@ -35,7 +35,7 @@ export const MicrowaveStates = Machine.defineStates({
   }
 })
 
-const definition = Machine.make({
+export const MicrowaveMachine = Machine.make({
   id: "Microwave",
   states: MicrowaveStates.states,
   events: MicrowaveEvents,
@@ -48,9 +48,7 @@ const definition = Machine.make({
           .door.from((door) => door.Closed.from())
       )
   }
-})
-
-export const MicrowaveMachine = definition.handle({
+}).handle({
   Oven: {
     states: {
       engine: {

--- a/examples/playground/src/examples/traffic-light/machine.ts
+++ b/examples/playground/src/examples/traffic-light/machine.ts
@@ -1,11 +1,11 @@
 import { Machine } from "@typeonce/effect-machine"
 import { Schema } from "effect"
 
-const TrafficLightEvent = Schema.TaggedUnion({
-  Reset: {}
-})
-
-export const TrafficLightEvents = Machine.events(TrafficLightEvent)
+export const TrafficLightEvents = Machine.events(
+  Schema.TaggedUnion({
+    Reset: {}
+  })
+)
 
 export const trafficLightDurations = {
   Red: 4_000,
@@ -21,7 +21,7 @@ export const TrafficLightStates = Machine.defineStates({
   Yellow: {}
 })
 
-const definition = Machine.make({
+export const TrafficLightMachine = Machine.make({
   id: "TrafficLight",
   states: TrafficLightStates.states,
   events: TrafficLightEvents,
@@ -29,9 +29,7 @@ const definition = Machine.make({
     target: (to) => to.Red(),
     resolve: ({ target }) => target.from()
   }
-})
-
-export const TrafficLightMachine = definition.handle({
+}).handle({
   Red: {
     invoke: Machine.invoke({
       id: "red-timer",

--- a/examples/playground/src/examples/turnstile/machine.ts
+++ b/examples/playground/src/examples/turnstile/machine.ts
@@ -1,19 +1,19 @@
 import { Machine } from "@typeonce/effect-machine"
 import { Schema } from "effect"
 
-const TurnstileEvent = Schema.TaggedUnion({
-  CoinInserted: {},
-  GatePushed: {}
-})
-
-export const TurnstileEvents = Machine.events(TurnstileEvent)
+export const TurnstileEvents = Machine.events(
+  Schema.TaggedUnion({
+    CoinInserted: {},
+    GatePushed: {}
+  })
+)
 
 export const TurnstileStates = Machine.defineStates({
   Locked: {},
   Unlocked: {}
 })
 
-const definition = Machine.make({
+export const TurnstileMachine = Machine.make({
   id: "Turnstile",
   states: TurnstileStates.states,
   events: TurnstileEvents,
@@ -21,9 +21,7 @@ const definition = Machine.make({
     target: (to) => to.Locked(),
     resolve: ({ target }) => target.from()
   }
-})
-
-export const TurnstileMachine = definition.handle({
+}).handle({
   Locked: {
     on: {
       CoinInserted: Machine.transition({

--- a/examples/playground/src/examples/worker-tabs/machine.ts
+++ b/examples/playground/src/examples/worker-tabs/machine.ts
@@ -11,16 +11,6 @@ export const SharedMachineState = Schema.TaggedUnion({
 
 export const SharedMachineStates = Machine.defineStates(SharedMachineState.cases)
 
-const definition = Machine.make({
-  id: "WorkerHostedMachine",
-  states: SharedMachineStates.states,
-  events: SharedMachineEvents,
-  initial: {
-    target: (to) => to.Idle(),
-    resolve: ({ target }) => target.from({ count: 0 })
-  }
-})
-
 // Worker and BroadcastChannel messages need decoded, cloneable data rather
 // than the opaque instructions returned by Machine.events.
 export const SharedTransportEvents = {
@@ -34,7 +24,15 @@ export const SharedTransportEvents = {
   })
 }
 
-export const SharedMachine = definition.handle({
+export const SharedMachine = Machine.make({
+  id: "WorkerHostedMachine",
+  states: SharedMachineStates.states,
+  events: SharedMachineEvents,
+  initial: {
+    target: (to) => to.Idle(),
+    resolve: ({ target }) => target.from({ count: 0 })
+  }
+}).handle({
   Idle: {
     on: {
       Started: Machine.transition({

--- a/examples/pokemon/src/machine.ts
+++ b/examples/pokemon/src/machine.ts
@@ -15,18 +15,16 @@ export const States = Machine.defineStates({ Loading: {}, ActiveTeam, Failed: {}
 export const SelectionChild = Machine.child("selection", SelectionMachine)
 export const ReplaceChild = Machine.child("replace", ReplaceMachine)
 
-const definition = Machine.make({
+const machine = Machine.make({
   states: States.states,
   events: TeamEvents,
   initial: {
     target: (to) => to.Loading(),
     resolve: ({ target }) => target.from()
   }
-})
-
-const machine = definition.handle({
+}).handle({
   Loading: {
-    invoke: definition.invoke({
+    invoke: Machine.invoke({
       id: "load-team",
       effect: () =>
         Effect.gen(function*() {
@@ -45,7 +43,7 @@ const machine = definition.handle({
   },
   ActiveTeam: {
     invoke: [
-      definition.invoke({
+      Machine.invoke({
         child: SelectionChild,
         onDone: Machine.transition({
           target: (to) => to.none(),
@@ -56,7 +54,7 @@ const machine = definition.handle({
           resolve: ({ target }) => target.from()
         })
       }),
-      definition.invoke({
+      Machine.invoke({
         child: ReplaceChild,
         onFailure: Machine.transition({
           target: (to) => to.full.Failed(),

--- a/examples/pokemon/src/machines/selection.ts
+++ b/examples/pokemon/src/machines/selection.ts
@@ -69,7 +69,7 @@ export const SelectionStates = Machine.defineStates({
 })
 
 export const SelectionEvents = Machine.events(SelectPokemon, UpdateSearchText, SearchResult, ReplacePokemon)
-const definition = Machine.make({
+export const SelectionMachine = Machine.make({
   states: SelectionStates.states,
   events: SelectionEvents,
   parentEvents: TeamEvents,
@@ -82,9 +82,7 @@ const definition = Machine.make({
           .selection.from((selection) => selection.Unselected.from())
       )
   }
-})
-
-export const SelectionMachine = definition.handle({
+}).handle({
   form: {
     states: {
       search: {
@@ -115,7 +113,7 @@ export const SelectionMachine = definition.handle({
             }
           },
           Searching: {
-            invoke: definition.invoke({
+            invoke: Machine.invoke({
               id: "search",
               effect: ({ ancestors }) => searchPokemon(ancestors["form.search"].searchText),
               onDone: Machine.transition({

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -249,9 +249,9 @@ export interface Machine<
   >
 
   /**
-   * Preserves invocation inference with this machine's public input and parent
-   * protocols. Prefer this bound constructor when an invocation source or
-   * lifecycle handler uses `self` or `parent`.
+   * Machine-bound equivalent of {@link invoke}. Both forms preserve this
+   * machine's public input and parent protocols in invocation callbacks;
+   * `Machine.invoke(...)` inside `handle(...)` is the canonical inline form.
    *
    * @since 0.11.0
    */
@@ -7104,9 +7104,14 @@ export type EventOf<Protocol extends Machine.EventProtocol.Any> = Machine.EventO
  * **Example**
  *
  * ```ts
- * const Events = Machine.events(Increment, Reset)
- * const machine = Machine.make({ events: Events, ... })
- * yield* ref.send(Events.Increment({ by: 1 }))
+ * export const Event = Machine.events(
+ *   Schema.TaggedUnion({
+ *     Increment: { by: Schema.Number },
+ *     Reset: {}
+ *   })
+ * )
+ * const machine = Machine.make({ events: Event, ... })
+ * yield* ref.send(Event.Increment({ by: 1 }))
  * ```
  *
  * @category constructors
@@ -7132,11 +7137,16 @@ export const events: {
  * **Example**
  *
  * ```ts
- * const InternalEvents = Machine.internalEvents(Loaded, Failed)
- * const machine = Machine.make({ internalEvents: InternalEvents, ... })
+ * const Internal = Machine.internalEvents(
+ *   Schema.TaggedUnion({
+ *     Loaded: { value: Schema.String },
+ *     Failed: { message: Schema.String }
+ *   })
+ * )
+ * const machine = Machine.make({ internalEvents: Internal, ... })
  *
  * // Inside a transition callback:
- * enqueue.raise(InternalEvents.Loaded({ value }))
+ * enqueue.raise(Internal.Loaded({ value }))
  * ```
  *
  * @category constructors
@@ -7156,6 +7166,17 @@ export const internalEvents: {
  * observers. Emitted events are separate from machine input and are never sent
  * implicitly to a parent machine. Observe them through `MachineRef.emissions` or
  * the AtomMachine emission stream adapters.
+ *
+ * **Example**
+ *
+ * ```ts
+ * const Emitted = Machine.emittedEvents(
+ *   Schema.TaggedUnion({
+ *     Saved: { id: Schema.String }
+ *   })
+ * )
+ * const machine = Machine.make({ emittedEvents: Emitted, ... })
+ * ```
  *
  * @category constructors
  * @since 0.10.0
@@ -7348,9 +7369,11 @@ type EffectInvokeSource<
   States extends Machine.StateSchemas,
   Events extends ReadonlyArray<Machine.TaggedSchema>,
   Emits extends ReadonlyArray<Machine.TaggedSchema>,
+  InputEvents extends ReadonlyArray<Machine.TaggedSchema>,
+  ParentEvents extends ReadonlyArray<Machine.TaggedSchema>,
   StateId extends Machine.StateIdentifier<States>,
   Source extends (
-    context: Machine.InvokeContext<States, Events, Emits, StateId, readonly [], readonly []>
+    context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
   ) => Effect.Effect<unknown, unknown, unknown>
 > = {
   readonly id: InvokeLifecycleId
@@ -7366,6 +7389,8 @@ type EffectDoneHandler<
   States extends Machine.StateSchemas,
   Events extends ReadonlyArray<Machine.TaggedSchema>,
   Emits extends ReadonlyArray<Machine.TaggedSchema>,
+  InputEvents extends ReadonlyArray<Machine.TaggedSchema>,
+  ParentEvents extends ReadonlyArray<Machine.TaggedSchema>,
   StateId extends Machine.StateIdentifier<States>,
   Source extends (...args: ReadonlyArray<never>) => Effect.Effect<unknown, unknown, unknown>
 > = Machine.InvokeTransition<
@@ -7379,8 +7404,8 @@ type EffectDoneHandler<
     Emits,
     StateId,
     Effect.Success<ReturnType<NoInfer<Source>>>,
-    readonly [],
-    readonly []
+    InputEvents,
+    ParentEvents
   >
 >
 
@@ -7388,6 +7413,8 @@ type EffectFailureHandler<
   States extends Machine.StateSchemas,
   Events extends ReadonlyArray<Machine.TaggedSchema>,
   Emits extends ReadonlyArray<Machine.TaggedSchema>,
+  InputEvents extends ReadonlyArray<Machine.TaggedSchema>,
+  ParentEvents extends ReadonlyArray<Machine.TaggedSchema>,
   StateId extends Machine.StateIdentifier<States>,
   Source extends (...args: ReadonlyArray<never>) => Effect.Effect<unknown, unknown, unknown>
 > = Machine.InvokeTransition<
@@ -7401,8 +7428,8 @@ type EffectFailureHandler<
     Emits,
     StateId,
     Effect.Error<ReturnType<NoInfer<Source>>>,
-    readonly [],
-    readonly []
+    InputEvents,
+    ParentEvents
   >
 >
 
@@ -7410,10 +7437,12 @@ type EffectInvokeResult<
   States extends Machine.StateSchemas,
   Events extends ReadonlyArray<Machine.TaggedSchema>,
   Emits extends ReadonlyArray<Machine.TaggedSchema>,
+  InputEvents extends ReadonlyArray<Machine.TaggedSchema>,
+  ParentEvents extends ReadonlyArray<Machine.TaggedSchema>,
   StateId extends Machine.StateIdentifier<States>,
   Source extends (...args: ReadonlyArray<never>) => Effect.Effect<unknown, unknown, unknown>
 > =
-  & Machine.InvokeConfig<States, Events, Emits, StateId, readonly [], readonly []>
+  & Machine.InvokeConfig<States, Events, Emits, StateId, InputEvents, ParentEvents>
   & Machine.InvokeTyped<
     Effect.Success<ReturnType<Source>>,
     Effect.Error<ReturnType<Source>>,
@@ -7897,11 +7926,10 @@ export interface Invoker<
  * `address`. Child descriptors already own their identity, so `id` and
  * `address` must not be repeated.
  *
- * Owner references are intentionally non-sendable here because this standalone
- * constructor does not know the owning definition. When a callback sends to
- * `self` or `parent`, use the bound constructor on the owning definition
- * (`definition.invoke(...)`) so the exact public input and `parentEvents`
- * protocols are available.
+ * Inside `handle(...)`, the owning definition contextually supplies its public
+ * input and `parentEvents` protocols. Invocation sources and lifecycle handlers
+ * can therefore send through `self` and `parent` without naming the definition.
+ * The bound `definition.invoke(...)` constructor remains an equivalent form.
  *
  * ```ts
  * invoke: Machine.invoke({
@@ -7932,14 +7960,16 @@ export const invoke: {
     const Emits extends ReadonlyArray<Machine.TaggedSchema>,
     StateId extends Machine.StateIdentifier<States>,
     const Source extends (
-      context: Machine.InvokeContext<States, Events, Emits, StateId, readonly [], readonly []>
-    ) => Effect.Effect<unknown, unknown, unknown>
+      context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    ) => Effect.Effect<unknown, unknown, unknown>,
+    const InputEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+    const ParentEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly []
   >(
     config:
-      & EffectInvokeSource<States, Events, Emits, StateId, Source>
+      & EffectInvokeSource<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
       & {
-        readonly onDone: EffectDoneHandler<States, Events, Emits, StateId, Source>
-        readonly onFailure: EffectFailureHandler<States, Events, Emits, StateId, Source>
+        readonly onDone: EffectDoneHandler<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+        readonly onFailure: EffectFailureHandler<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
       },
     ..._validation: InvokeChannelIsNever<Effect.Success<ReturnType<Source>>> extends true ? [
         "onDone must be omitted when the Effect output is never"
@@ -7948,71 +7978,79 @@ export const invoke: {
           "onFailure must be omitted when the Effect error is never"
         ]
       : []
-  ): EffectInvokeResult<States, Events, Emits, StateId, Source>
+  ): EffectInvokeResult<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
   <
     const States extends Machine.StateSchemas,
     const Events extends ReadonlyArray<Machine.TaggedSchema>,
     const Emits extends ReadonlyArray<Machine.TaggedSchema>,
     StateId extends Machine.StateIdentifier<States>,
     const Source extends (
-      context: Machine.InvokeContext<States, Events, Emits, StateId, readonly [], readonly []>
-    ) => Effect.Effect<unknown, never, unknown>
+      context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    ) => Effect.Effect<unknown, never, unknown>,
+    const InputEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+    const ParentEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly []
   >(
     config:
-      & EffectInvokeSource<States, Events, Emits, StateId, Source>
+      & EffectInvokeSource<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
       & {
-        readonly onDone: EffectDoneHandler<States, Events, Emits, StateId, Source>
+        readonly onDone: EffectDoneHandler<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
         readonly onFailure?: never
       },
     ..._validation: InvokeChannelIsNever<Effect.Success<ReturnType<Source>>> extends true ? [
         "onDone must be omitted when the Effect output is never"
       ]
       : []
-  ): EffectInvokeResult<States, Events, Emits, StateId, Source>
+  ): EffectInvokeResult<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
   <
     const States extends Machine.StateSchemas,
     const Events extends ReadonlyArray<Machine.TaggedSchema>,
     const Emits extends ReadonlyArray<Machine.TaggedSchema>,
     StateId extends Machine.StateIdentifier<States>,
     const Source extends (
-      context: Machine.InvokeContext<States, Events, Emits, StateId, readonly [], readonly []>
-    ) => Effect.Effect<never, unknown, unknown>
+      context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    ) => Effect.Effect<never, unknown, unknown>,
+    const InputEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+    const ParentEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly []
   >(
     config:
-      & EffectInvokeSource<States, Events, Emits, StateId, Source>
+      & EffectInvokeSource<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
       & {
         readonly onDone?: never
-        readonly onFailure: EffectFailureHandler<States, Events, Emits, StateId, Source>
+        readonly onFailure: EffectFailureHandler<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
       },
     ..._validation: InvokeChannelIsNever<Effect.Error<ReturnType<Source>>> extends true ? [
         "onFailure must be omitted when the Effect error is never"
       ]
       : []
-  ): EffectInvokeResult<States, Events, Emits, StateId, Source>
+  ): EffectInvokeResult<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
   <
     const States extends Machine.StateSchemas,
     const Events extends ReadonlyArray<Machine.TaggedSchema>,
     const Emits extends ReadonlyArray<Machine.TaggedSchema>,
     StateId extends Machine.StateIdentifier<States>,
     const Source extends (
-      context: Machine.InvokeContext<States, Events, Emits, StateId, readonly [], readonly []>
-    ) => Effect.Effect<never, never, unknown>
+      context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    ) => Effect.Effect<never, never, unknown>,
+    const InputEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+    const ParentEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly []
   >(
     config:
-      & EffectInvokeSource<States, Events, Emits, StateId, Source>
+      & EffectInvokeSource<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
       & {
         readonly onDone?: never
         readonly onFailure?: never
       }
-  ): EffectInvokeResult<States, Events, Emits, StateId, Source>
+  ): EffectInvokeResult<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
   <
     const States extends Machine.StateSchemas,
     const Events extends ReadonlyArray<Machine.TaggedSchema>,
     const Emits extends ReadonlyArray<Machine.TaggedSchema>,
     StateId extends Machine.StateIdentifier<States>,
-    const Config extends object
+    const Config extends object,
+    const InputEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+    const ParentEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly []
   >(
-    config: Config & Machine.TimerInvokeArgs<States, Events, Emits, StateId, readonly [], readonly []>
+    config: Config & Machine.TimerInvokeArgs<States, Events, Emits, StateId, InputEvents, ParentEvents>
   ): Config & Machine.InvokeOwned<States, Events, Emits, StateId> & Machine.InvokeTyped<void, never, never, never>
   <
     const States extends Machine.StateSchemas,
@@ -8025,7 +8063,9 @@ export const invoke: {
     ChildRequirements,
     ChildOutput,
     ChildInitialError,
-    Address extends ChildAddress<never>
+    Address extends ChildAddress<never>,
+    const InputEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+    const ParentEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly []
   >(
     config: Machine.LogicInvokeArgs<
       States,
@@ -8039,7 +8079,7 @@ export const invoke: {
       ChildOutput,
       ChildInitialError,
       Address,
-      (context: Machine.InvokeContext<States, Events, Emits, StateId, readonly [], readonly []>) => Logic<
+      (context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>) => Logic<
         ChildState,
         ChildEvent,
         ChildError,
@@ -8047,11 +8087,11 @@ export const invoke: {
         ChildOutput,
         ChildInitialError
       >,
-      readonly [],
-      readonly []
+      InputEvents,
+      ParentEvents
     >
   ):
-    & Machine.InvokeConfig<States, Events, Emits, StateId, readonly [], readonly []>
+    & Machine.InvokeConfig<States, Events, Emits, StateId, InputEvents, ParentEvents>
     & Machine.InvokeTyped<
       ChildOutput,
       ChildError,
@@ -8070,7 +8110,9 @@ export const invoke: {
     ChildOutput,
     ChildInitialError,
     Address extends ChildAddress<never>,
-    const Config extends object
+    const Config extends object,
+    const InputEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+    const ParentEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly []
   >(
     config:
       & Config
@@ -8087,8 +8129,8 @@ export const invoke: {
         ChildInitialError,
         Address,
         Logic<ChildState, ChildEvent, ChildError, ChildRequirements, ChildOutput, ChildInitialError>,
-        readonly [],
-        readonly []
+        InputEvents,
+        ParentEvents
       >
   ):
     & Config
@@ -8105,11 +8147,13 @@ export const invoke: {
     const Emits extends ReadonlyArray<Machine.TaggedSchema>,
     StateId extends Machine.StateIdentifier<States>,
     const Child extends ChildMachine.Any,
-    const Config extends object
+    const Config extends object,
+    const InputEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+    const ParentEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly []
   >(
     config:
       & Config
-      & Machine.ChildInvokeArgs<States, Events, Emits, StateId, Child["machine"], Child, readonly [], readonly []>
+      & Machine.ChildInvokeArgs<States, Events, Emits, StateId, Child["machine"], Child, InputEvents, ParentEvents>
   ):
     & Config
     & Machine.InvokeOwned<States, Events, Emits, StateId>

--- a/typetest/machine/MachineReferences.tst.ts
+++ b/typetest/machine/MachineReferences.tst.ts
@@ -114,9 +114,8 @@ describe("machine reference event channels", () => {
         resolve: ({ target }) => (target(new Idle({})))
       }
     })
-    const incompatibleChild = incompatible.invoke({ child: Child })
     expect(incompatible.handle).type.not.toBeCallableWith({
-      Idle: { invoke: incompatibleChild }
+      Idle: { invoke: Machine.invoke({ child: Child }) }
     })
   })
 
@@ -147,8 +146,8 @@ describe("machine reference event channels", () => {
     expect<Stream.Services<typeof atomEmissions>>().type.toBe<AtomRegistry.AtomRegistry>()
   })
 
-  it("binds invocation self and parent references to the owning machine protocols", () => {
-    const definition = Machine.make({
+  it("contextually binds Machine.invoke self and parent references to the owning machine protocols", () => {
+    Machine.make({
       states: states.states,
       events: Events,
       internalEvents: InternalEvents,
@@ -158,15 +157,14 @@ describe("machine reference event channels", () => {
         target: (to) => to.Idle(),
         resolve: ({ target }) => (target(new Idle({})))
       }
-    })
-
-    definition.handle({
+    }).handle({
       Idle: {
-        invoke: definition.invoke({
+        invoke: Machine.invoke({
           id: "notify-parent",
           effect: ({ parent, self }) => {
             expect(self.send).type.toBeCallableWith(Events.Ping())
             expect(self.send).type.not.toBeCallableWith(InternalEvents.Local())
+            expect(self.send).type.not.toBeCallableWith(ParentEvents.ParentNotice({ value: 1 }))
             if (parent !== undefined) {
               expect(parent.send).type.toBeCallableWith(ParentEvents.ParentNotice({ value: 1 }))
               expect(parent.send).type.not.toBeCallableWith(Events.Ping())
@@ -175,10 +173,11 @@ describe("machine reference event channels", () => {
           },
           onDone: Machine.transition({
             target: (to) => to.none(),
-            resolve: ({ parent, self }) => {
-              expect(self.send).type.toBeCallableWith(Events.Ping())
+            resolve: ({ parent, self }, enqueue) => {
+              enqueue.sendTo(self, Events.Ping())
               if (parent !== undefined) {
-                expect(parent.send).type.toBeCallableWith(ParentEvents.ParentNotice({ value: 1 }))
+                enqueue.sendTo(parent, ParentEvents.ParentNotice({ value: 1 }))
+                expect(enqueue.sendTo).type.not.toBeCallableWith(parent, Events.Ping())
               }
               return undefined
             }
@@ -187,20 +186,29 @@ describe("machine reference event channels", () => {
       }
     })
 
-    definition.handle({
+    Machine.make({
+      states: states.states,
+      events: Events,
+      parentEvents: ParentEvents,
+      initial: {
+        target: (to) => to.Idle(),
+        resolve: ({ target }) => target.from()
+      }
+    }).handle({
       Idle: {
         invoke: Machine.invoke({
-          id: "owner-independent",
-          effect: ({ parent, self }) => {
-            expect(self.send).type.not.toBeCallableWith(Events.Ping())
-            if (parent !== undefined) {
-              expect(parent.send).type.not.toBeCallableWith(ParentEvents.ParentNotice({ value: 1 }))
-            }
-            return Effect.void
-          },
-          onDone: Machine.transition({
+          id: "notify-parent-failure",
+          effect: () => Effect.fail("failed" as const),
+          onFailure: Machine.transition({
             target: (to) => to.none(),
-            resolve: () => undefined
+            resolve: ({ parent, self }, enqueue) => {
+              enqueue.sendTo(self, Events.Ping())
+              if (parent !== undefined) {
+                enqueue.sendTo(parent, ParentEvents.ParentNotice({ value: 1 }))
+                expect(enqueue.sendTo).type.not.toBeCallableWith(parent, Events.Ping())
+              }
+              return undefined
+            }
           })
         })
       }


### PR DESCRIPTION
## Summary

- contextually type `Machine.invoke` sources and lifecycle handlers with the owning machine public and parent protocols inside `.handle(...)`
- retain Effect output, failure, service, state, and child protocol inference while rejecting invalid parent or self sends
- teach direct event protocol construction in API docs, the agent guide, README, and examples

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

Patch changeset: compatible inference and documentation fix.

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required

Affected examples checked: playground, pokemon, and platformer. Local `pnpm perf:types` and `pnpm perf:runtime` smoke tests passed; CI base-versus-PR comparisons remain authoritative.