### PR TITLE
Add Stream invocation support

### DIFF
--- a/.changeset/stream-invocations.md
+++ b/.changeset/stream-invocations.md
@@ -1,0 +1,7 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Add `stream` sources to `Machine.invoke`. Stream values are handled through the typed `onElement` transition one committed parent macrostep at a time, while completion and typed failures use `onDone` and `onFailure`. Leaving the owning state interrupts the Stream and runs its finalizers.
+
+Add the direct `{ target: Machine.targetless, resolve }` transition shorthand for handlers that keep the current configuration and only enqueue commands.

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ synchronous. Conditions use ordinary TypeScript control flow. Callbacks may
 select state and enqueue explicit `raise`, `emit`, `sendTo`, or `stop` commands;
 arbitrary asynchronous Effects do not run inside planning.
 
-## Effects, timers, and child machines
+## Effects, Streams, timers, and child machines
 
 State-scoped work starts on entry and is interrupted on exit:
 
@@ -445,8 +445,9 @@ Waiting: {
 }
 ```
 
-Use `effect` for one Effect, `after` for a cancellable delay, `logic` for a
-reusable process, and `child` for a complete child statechart—all through
+Use `effect` for one Effect, `stream` for a sequence of externally produced
+values, `after` for a cancellable delay, `logic` for a reusable process, and
+`child` for a complete child statechart—all through
 `Machine.invoke({...})`. The helper is an identity at runtime and preserves
 owner-context and source-channel inference across lifecycle handlers, including
 for state-dependent Effects:
@@ -465,6 +466,33 @@ invoke: Machine.invoke({
   })
 })
 ```
+
+A Stream source remains independent of the parent event protocol. Each element
+is mapped by `onElement`, and the next element is not pulled until that parent
+macrostep commits:
+
+```ts
+invoke: Machine.invoke({
+  id: "channel",
+  stream: () => channelMessages,
+  onElement: {
+    target: Machine.targetless,
+    resolve: ({ element }, enqueue) => {
+      enqueue.raise(Events.MessageReceived({ message: element }))
+    }
+  },
+  onDone: { target: Machine.targetless },
+  onFailure: Machine.transition({
+    target: (to) => to.full.Failed(),
+    resolve: ({ error, target }) => target.from({ error })
+  })
+})
+```
+
+`target: Machine.targetless` is the direct shorthand for a non-reentering
+transition that keeps the current configuration. Its optional `resolve`
+callback may enqueue commands and must return `undefined`. Use
+`Machine.transition(...)` for transitions that select state or reenter.
 
 Inside `.handle(...)`, `Machine.invoke(...)` receives the owning machine's
 public input and `parentEvents` protocols contextually. Its source and lifecycle

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -123,8 +123,9 @@ its extra control is required:
 - Bind a shared Atom runtime once with `AtomMachine.bind(runtime)`, then use the
   returned `make` or `resume`. Use `AtomMachine.make(machine)` and
   `AtomMachine.resume(machine, snapshot)` for service-free machines.
-- Use one invocation object: `effect` for one-shot work, `after` for a timer,
-  `logic` for reusable process logic, and `child` for a complete child
+- Use one invocation object: `effect` for one-shot work, `stream` for repeated
+  externally produced values, `after` for a timer, `logic` for reusable process
+  logic, and `child` for a complete child
   statechart. `Machine.invoke({...})` preserves owner state and source channels
   across sibling lifecycle handlers. Inside `.handle(...)`, `self` and `parent`
   use the owning definition's exact public input and `parentEvents` protocols.
@@ -942,6 +943,38 @@ The source may also be a function of the owning state's entry context when it
 needs `state`, `containingState`, `ancestors`, or the entry `event`. Source construction
 errors, defects, and interruption are machine failures rather than a second
 phase in `onFailure`.
+
+Use a Stream invocation for repeated values that are not themselves machine
+events. `onElement` maps each value into an owner transition, while `onDone`
+handles normal Stream completion and `onFailure` handles the typed Stream error:
+
+```ts
+invoke: Machine.invoke({
+  id: "broadcast-channel",
+  stream: () => messages,
+  onElement: {
+    target: Machine.targetless,
+    resolve: ({ element }, enqueue) => {
+      enqueue.raise(Events.MessageReceived({ message: element }))
+    }
+  },
+  onDone: { target: Machine.targetless },
+  onFailure: Machine.transition({
+    target: (to) => to.full.Disconnected(),
+    resolve: ({ error, target }) => target.from({ error })
+  })
+})
+```
+
+Element delivery is owner-scoped and backpressured: the Stream pulls again only
+after the selected parent macrostep commits. Exiting or reentering the owner
+interrupts the Stream and runs its finalizers. A later entry starts a fresh
+Stream. Stream defects and self-interruption fail the owning machine.
+
+The direct `{ target: Machine.targetless, resolve }` shorthand is available
+when a transition only enqueues commands. It is non-reentering and the resolver
+must return `undefined`. Keep `Machine.transition(...)` for full state selection,
+conditional branches, or reentry.
 
 When a source function reads `state`, `containingState`, `ancestors`, or the entry `event`,
 `Machine.invoke` infers that owner context and the returned Effect's output,

--- a/examples/playground/src/examples/media-player/invocations.ts
+++ b/examples/playground/src/examples/media-player/invocations.ts
@@ -1,8 +1,6 @@
-import { Machine } from "@typeonce/effect-machine"
-import { Data, Effect, Stream } from "effect"
-import { MediaPlayerInternalEvents } from "./definition.ts"
-import { type LoudnessSample, type SoundSettings, toAudioSettings } from "./schemas.ts"
-import { MediaPlayer, MediaPlayerError } from "./service.ts"
+import { Effect, Stream } from "effect"
+import { type SoundSettings, toAudioSettings } from "./schemas.ts"
+import { MediaPlayer } from "./service.ts"
 
 export const loadAudio = (url: string) =>
   Effect.gen(function*() {
@@ -31,30 +29,6 @@ export const applyAudioSettings = (settings: SoundSettings, muted: boolean) =>
     yield* mediaPlayer.applySettings(toAudioSettings(settings, muted))
   })
 
-type LoudnessProcessState = Data.TaggedEnum<{
-  Waiting: {}
-  Measured: { readonly sample: LoudnessSample }
-  Failed: { readonly failure: MediaPlayerError }
-}>
-
-const LoudnessProcessState = Data.taggedEnum<LoudnessProcessState>()
-
-export const analyzeAudio = Machine.logic<LoudnessProcessState, never, void, never, MediaPlayer>({
-  initial: LoudnessProcessState.Waiting(),
-  run: ({ setState }) =>
-    Effect.gen(function*() {
-      const mediaPlayer = yield* MediaPlayer
-
-      yield* mediaPlayer.loudness.pipe(
-        Stream.runForEach((sample) => setState(LoudnessProcessState.Measured({ sample }))),
-        Effect.catch((failure) => setState(LoudnessProcessState.Failed({ failure })).pipe(Effect.andThen(Effect.never)))
-      )
-    })
-})
-
-export const loudnessEvent = (state: LoudnessProcessState) =>
-  LoudnessProcessState.$match(state, {
-    Waiting: () => undefined,
-    Measured: ({ sample }) => MediaPlayerInternalEvents.LoudnessMeasured(sample),
-    Failed: ({ failure }) => MediaPlayerInternalEvents.OperationFailed({ message: failure.message })
-  })
+export const analyzeAudio = Stream.unwrap(
+  Effect.map(MediaPlayer, (mediaPlayer) => mediaPlayer.loudness)
+)

--- a/examples/playground/src/examples/media-player/machine.ts
+++ b/examples/playground/src/examples/media-player/machine.ts
@@ -1,63 +1,9 @@
 import { Machine } from "@typeonce/effect-machine"
 import { Effect } from "effect"
 import { MediaPlayerDefinition, MediaPlayerInternalEvents } from "./definition.ts"
-import {
-  analyzeAudio,
-  applyAudioSettings,
-  loadAudio,
-  loudnessEvent,
-  pauseAudio,
-  playAudio,
-  restartAudio
-} from "./invocations.ts"
+import { analyzeAudio, applyAudioSettings, loadAudio, pauseAudio, playAudio, restartAudio } from "./invocations.ts"
 import { initialPlaybackData, updatePlaybackData } from "./schemas.ts"
 import { MediaPlayer } from "./service.ts"
-
-type Definition = typeof MediaPlayerDefinition
-type States = Machine.Machine.States<Definition>
-type Events = Machine.Machine.Events<Definition>
-type Emits = Machine.Machine.Emits<Definition>
-type InputEvents = Machine.Machine.InputEvents<Definition>
-type ParentEvents = Machine.Machine.ParentEvents<Definition>
-type PlayingStateId = "Player.transport.Ready.Playing"
-type AnalyzeDone = Machine.Machine.InvokeTransition<
-  States,
-  Events,
-  Emits,
-  PlayingStateId,
-  Machine.Machine.InvokeDoneContext<States, Events, Emits, PlayingStateId, void, InputEvents, ParentEvents>
->
-type AnalyzeSnapshot = Machine.Machine.InvokeTransition<
-  States,
-  Events,
-  Emits,
-  PlayingStateId,
-  Machine.Machine.InvokeSnapshotContext<
-    States,
-    Events,
-    Emits,
-    PlayingStateId,
-    Machine.Machine.LogicStateOf<typeof analyzeAudio>,
-    Machine.Machine.LogicErrorOf<typeof analyzeAudio>,
-    Machine.Machine.LogicOutputOf<typeof analyzeAudio>,
-    InputEvents,
-    ParentEvents
-  >
->
-
-const analyzeDone: AnalyzeDone = Machine.transition({
-  target: (to) => to.none(),
-  resolve: () => undefined
-})
-
-const analyzeSnapshot: AnalyzeSnapshot = Machine.transition({
-  target: (to) => to.none(),
-  resolve: ({ snapshot }, enqueue) => {
-    const event = loudnessEvent(snapshot.state)
-    if (event !== undefined) enqueue.raise(event)
-    return undefined
-  }
-})
 
 export const MediaPlayerMachine = MediaPlayerDefinition.handle({
   Player: {
@@ -164,10 +110,20 @@ export const MediaPlayerMachine = MediaPlayerDefinition.handle({
                   }),
                   MediaPlayerDefinition.invoke({
                     id: "analyze-audio",
-                    address: Machine.childAddress("analyze-audio"),
-                    logic: analyzeAudio,
-                    onDone: analyzeDone,
-                    onSnapshot: analyzeSnapshot
+                    stream: () => analyzeAudio,
+                    onElement: {
+                      target: Machine.targetless,
+                      resolve: ({ element }, enqueue) => {
+                        enqueue.raise(MediaPlayerInternalEvents.LoudnessMeasured(element))
+                      }
+                    },
+                    onDone: { target: Machine.targetless },
+                    onFailure: {
+                      target: Machine.targetless,
+                      resolve: ({ error }, enqueue) => {
+                        enqueue.raise(MediaPlayerInternalEvents.OperationFailed({ message: error.message }))
+                      }
+                    }
                   })
                 ],
                 on: {

--- a/scripts/invoke-autocomplete.test.mjs
+++ b/scripts/invoke-autocomplete.test.mjs
@@ -7,7 +7,7 @@ import ts from "typescript"
 const projectRoot = path.resolve(import.meta.dirname, "..")
 const virtualFile = path.join(projectRoot, "invoke-autocomplete.fixture.ts")
 const source = `
-import { Effect, Option } from "effect"
+import { Effect, Option, Stream } from "effect"
 import { Machine } from "./src/index.js"
 
 const States = Machine.states({ Loading: {}, Done: {}, Failed: {} })
@@ -39,6 +39,22 @@ definition.handle({
 definition.handle({
   Loading: {
     invoke: Machine.invoke({
+      id: "updates",
+      stream: () => Stream.make(1),
+      onElement: {
+        target: Machine.targetless,
+        resolve: ({ /*element-context*/ ...context }) => undefined
+      },
+      onDone: { target: Machine.targetless }
+    })
+  },
+  Done: {},
+  Failed: {}
+})
+
+definition.handle({
+  Loading: {
+    invoke: Machine.invoke({
       id: "incomplete",
       effect: () => Effect.fail("offline").pipe(Effect.as(1)),
       /*invoke-properties*/
@@ -58,10 +74,10 @@ definition.handle({
 
 definition.handle({
   Loading: {
-    always: Machine.transition({
-      target: (to) => to.none(),
+    always: {
+      target: Machine.targetless,
       resolve: ({ /*targetless-context*/ }) => undefined
-    })
+    }
   }
 })
 
@@ -159,6 +175,13 @@ test("contextually completes Effect invocation factories while authoring", () =>
   const properties = completions("invoke-properties")
   assert.equal(properties.has("onDone"), true)
   assert.equal(properties.has("onFailure"), true)
+})
+
+test("contextually completes Stream element handlers while authoring", () => {
+  const element = completions("element-context")
+  assert.equal(element.has("element"), true)
+  assert.equal(element.has("state"), true)
+  assert.equal(element.has("target"), false)
 })
 
 test("contextually completes transition definitions while authoring", () => {

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -1953,10 +1953,10 @@ export declare namespace Inspection {
     readonly sessionId: string
     readonly owner: Subject
     readonly ownerPath: string
-    readonly kind: "Effect" | "Timer"
+    readonly kind: "Effect" | "Stream" | "Timer"
   }
 
-  /** Announces an Effect or timer invocation starting. */
+  /** Announces an Effect, Stream, or timer invocation starting. */
   export interface ActivityStarted extends Base {
     readonly _tag: "ActivityStarted"
     readonly activity: Activity
@@ -3252,7 +3252,7 @@ export declare namespace Machine {
     | {
       readonly type: "invoke"
       readonly id: string
-      readonly outcome: "done" | "failure" | "snapshot"
+      readonly outcome: "element" | "done" | "failure" | "snapshot"
     }
 
   /** Static topology selected by a transition branch. */
@@ -4651,6 +4651,25 @@ export declare namespace Machine {
     readonly output: Output
   }
 
+  /** Context passed to a Stream invocation's element transition. */
+  export interface InvokeElementContext<
+    States extends StateSchemas,
+    Events extends ReadonlyArray<TaggedSchema>,
+    Emits extends ReadonlyArray<TaggedSchema>,
+    StateId extends StateIdentifier<States>,
+    Element,
+    InputEvents extends ReadonlyArray<TaggedSchema> = Events,
+    ParentEvents extends ReadonlyArray<TaggedSchema> = readonly []
+  > extends MachineReferences<InputEvents, ParentEvents> {
+    readonly id: string
+    readonly state: StateByIdentifier<States, StateId>
+    readonly containingState: ParentStateValue<States, StateId>
+    readonly ancestors: ParentStateValues<States, StateId>
+    readonly snapshot: Snapshot<States>
+    readonly target: TargetBuilder<States, StateId>
+    readonly element: Element
+  }
+
   /** Context passed to an invocation typed-failure transition. */
   export interface InvokeFailureContext<
     States extends StateSchemas,
@@ -5003,6 +5022,15 @@ export declare namespace Machine {
         Effect.Success<Fx>
       >
     : never
+    : Invoke extends { readonly stream: infer Source } ?
+      InvokeFactoryResult<Source> extends infer SourceStream extends Stream.Stream<any, any, any> ? Logic<
+          void,
+          never,
+          Stream.Error<SourceStream>,
+          Stream.Services<SourceStream>,
+          void
+        >
+      : never
     : Invoke extends { readonly after: unknown } ? Logic<void, never, never, never, void>
     : Invoke extends { readonly logic: infer Source } ? InvokeResolvedSource<Source>
     : Invoke extends { readonly child: infer Child } ? ChildMachineLogic<Child>
@@ -5074,6 +5102,7 @@ export declare namespace Machine {
   export type InvokeOutcomeReturn<Invoke> = Invoke extends unknown ?
       | (Invoke extends { readonly onDone?: infer Handler } ? EventTransitionReturn<NonNullable<Handler>> : never)
       | (Invoke extends { readonly onFailure?: infer Handler } ? EventTransitionReturn<NonNullable<Handler>> : never)
+      | (Invoke extends { readonly onElement?: infer Handler } ? EventTransitionReturn<NonNullable<Handler>> : never)
       | (Invoke extends { readonly onSnapshot?: infer Handler } ? EventTransitionReturn<NonNullable<Handler>> : never)
     : never
   /**
@@ -5176,10 +5205,30 @@ export declare namespace Machine {
     Context,
     Reenter extends boolean = false
   > =
-    & (TransitionTyped<States, Events, Emits, StateId, Context, Reenter> | TargetlessTransitionTyped)
+    & (
+      | TransitionTyped<States, Events, Emits, StateId, Context, Reenter>
+      | TargetlessTransitionTyped
+      | TargetlessTransitionInput<Events, Emits, Context>
+    )
     & {
       readonly reenter?: [Reenter] extends [true] ? boolean : never
     }
+
+  /** Direct shorthand for a non-reentering targetless transition. */
+  export type TargetlessTransitionInput<
+    Events extends ReadonlyArray<TaggedSchema>,
+    Emits extends ReadonlyArray<TaggedSchema>,
+    Context
+  > = {
+    readonly target: TargetlessSelector
+    readonly resolve?: (
+      context: Omit<Context, "target">,
+      enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
+    ) => undefined
+    readonly cases?: never
+    readonly otherwise?: never
+    readonly reenter?: never
+  }
 
   export type SelectionBuilder<Selection> = Selection extends TargetSelection<infer Builder, any, any> ? Builder : never
   export type SelectionKind<Selection> = Selection extends TargetSelection<any, any, infer Kind> ? Kind : never
@@ -5317,11 +5366,28 @@ export declare namespace Machine {
         readonly effect: (
           context: InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
         ) => Effect.Effect<any, any, any>
+        readonly stream?: never
         readonly after?: never
         readonly logic?: never
         readonly child?: never
         readonly address?: never
         readonly onDone?: unknown
+        readonly onFailure?: unknown
+        readonly onElement?: never
+        readonly onSnapshot?: never
+      }
+      | {
+        readonly id: string
+        readonly stream: (
+          context: InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+        ) => Stream.Stream<any, any, any>
+        readonly effect?: never
+        readonly after?: never
+        readonly logic?: never
+        readonly child?: never
+        readonly address?: never
+        readonly onElement?: unknown
+        readonly onDone: unknown
         readonly onFailure?: unknown
         readonly onSnapshot?: never
       }
@@ -5332,11 +5398,13 @@ export declare namespace Machine {
           InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
         >
         readonly effect?: never
+        readonly stream?: never
         readonly logic?: never
         readonly child?: never
         readonly address?: never
         readonly onDone: unknown
         readonly onFailure?: never
+        readonly onElement?: never
         readonly onSnapshot?: never
       }
       | {
@@ -5347,10 +5415,12 @@ export declare namespace Machine {
           InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
         >
         readonly effect?: never
+        readonly stream?: never
         readonly after?: never
         readonly child?: never
         readonly onDone?: unknown
         readonly onFailure?: unknown
+        readonly onElement?: never
         readonly onSnapshot?: unknown
       }
       | {
@@ -5362,10 +5432,12 @@ export declare namespace Machine {
         readonly id?: never
         readonly address?: never
         readonly effect?: never
+        readonly stream?: never
         readonly after?: never
         readonly logic?: never
         readonly onDone?: unknown
         readonly onFailure?: unknown
+        readonly onElement?: never
         readonly onSnapshot?: unknown
       }
     )
@@ -5400,6 +5472,11 @@ export declare namespace Machine {
     : { readonly onFailure?: never }
     : never
 
+  export type InvokeElementRequirement<Value, Handler> = InvokeHandlerRequirement<Value, Handler> extends
+    infer Requirement ? Requirement extends { readonly handler: infer Required } ? { readonly onElement: Required }
+    : { readonly onElement?: never }
+    : never
+
   export type TimerInvokeArgs<
     States extends StateSchemas,
     Events extends ReadonlyArray<TaggedSchema>,
@@ -5414,10 +5491,12 @@ export declare namespace Machine {
       InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
     >
     readonly effect?: never
+    readonly stream?: never
     readonly logic?: never
     readonly child?: never
     readonly address?: never
     readonly onFailure?: never
+    readonly onElement?: never
     readonly onSnapshot?: never
     readonly onDone: InvokeTransition<
       States,
@@ -5449,8 +5528,10 @@ export declare namespace Machine {
       readonly address: Address & ChildAddress.Compatibility<Address, ChildEvent>
       readonly logic: Source
       readonly effect?: never
+      readonly stream?: never
       readonly after?: never
       readonly child?: never
+      readonly onElement?: never
       readonly onSnapshot?: InvokeTransition<
         States,
         Events,
@@ -5512,8 +5593,10 @@ export declare namespace Machine {
       readonly id?: never
       readonly address?: never
       readonly effect?: never
+      readonly stream?: never
       readonly after?: never
       readonly logic?: never
+      readonly onElement?: never
       readonly onSnapshot?: InvokeTransition<
         States,
         Events,
@@ -5623,6 +5706,55 @@ export declare namespace Machine {
               Emits,
               StateId,
               InvokeFailureContext<States, Events, Emits, StateId, Effect.Error<Fx>, InputEvents, ParentEvents>
+            >
+          >
+          & { readonly onSnapshot?: never }
+      : never
+    : Raw extends { readonly stream: infer Source } ?
+      InvokeFactoryResult<Source> extends infer SourceStream extends Stream.Stream<any, any, any> ?
+          & InvokeElementRequirement<
+            Stream.Success<SourceStream>,
+            InvokeTransition<
+              States,
+              Events,
+              Emits,
+              StateId,
+              InvokeElementContext<
+                States,
+                Events,
+                Emits,
+                StateId,
+                Stream.Success<SourceStream>,
+                InputEvents,
+                ParentEvents
+              >
+            >
+          >
+          & {
+            readonly onDone: InvokeTransition<
+              States,
+              Events,
+              Emits,
+              StateId,
+              InvokeDoneContext<States, Events, Emits, StateId, void, InputEvents, ParentEvents>
+            >
+          }
+          & InvokeFailureRequirement<
+            Stream.Error<SourceStream>,
+            InvokeTransition<
+              States,
+              Events,
+              Emits,
+              StateId,
+              InvokeFailureContext<
+                States,
+                Events,
+                Emits,
+                StateId,
+                Stream.Error<SourceStream>,
+                InputEvents,
+                ParentEvents
+              >
             >
           >
           & { readonly onSnapshot?: never }
@@ -7516,10 +7648,12 @@ type EffectInvokeSource<
 > = {
   readonly id: InvokeLifecycleId
   readonly effect: Source
+  readonly stream?: never
   readonly after?: never
   readonly logic?: never
   readonly child?: never
   readonly address?: never
+  readonly onElement?: never
   readonly onSnapshot?: never
 }
 
@@ -7588,6 +7722,110 @@ type EffectInvokeResult<
     never
   >
 
+type StreamInvokeSource<
+  States extends Machine.StateSchemas,
+  Events extends ReadonlyArray<Machine.TaggedSchema>,
+  Emits extends ReadonlyArray<Machine.TaggedSchema>,
+  InputEvents extends ReadonlyArray<Machine.TaggedSchema>,
+  ParentEvents extends ReadonlyArray<Machine.TaggedSchema>,
+  StateId extends Machine.StateIdentifier<States>,
+  Source extends (...args: ReadonlyArray<any>) => unknown
+> = {
+  readonly id: InvokeLifecycleId
+  readonly stream:
+    & Source
+    & ((context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>) => unknown)
+  readonly effect?: never
+  readonly after?: never
+  readonly logic?: never
+  readonly child?: never
+  readonly address?: never
+  readonly onSnapshot?: never
+}
+
+type StreamSourceResult<Source extends (...args: ReadonlyArray<any>) => unknown> = ReturnType<Source> extends
+  infer Result extends Stream.Stream<any, any, any> ? Result : never
+
+type StreamElementHandler<
+  States extends Machine.StateSchemas,
+  Events extends ReadonlyArray<Machine.TaggedSchema>,
+  Emits extends ReadonlyArray<Machine.TaggedSchema>,
+  InputEvents extends ReadonlyArray<Machine.TaggedSchema>,
+  ParentEvents extends ReadonlyArray<Machine.TaggedSchema>,
+  StateId extends Machine.StateIdentifier<States>,
+  Source extends (...args: ReadonlyArray<any>) => unknown
+> = Machine.InvokeTransition<
+  States,
+  Events,
+  Emits,
+  StateId,
+  Machine.InvokeElementContext<
+    States,
+    Events,
+    Emits,
+    StateId,
+    Stream.Success<StreamSourceResult<NoInfer<Source>>>,
+    InputEvents,
+    ParentEvents
+  >
+>
+
+type StreamDoneHandler<
+  States extends Machine.StateSchemas,
+  Events extends ReadonlyArray<Machine.TaggedSchema>,
+  Emits extends ReadonlyArray<Machine.TaggedSchema>,
+  InputEvents extends ReadonlyArray<Machine.TaggedSchema>,
+  ParentEvents extends ReadonlyArray<Machine.TaggedSchema>,
+  StateId extends Machine.StateIdentifier<States>
+> = Machine.InvokeTransition<
+  States,
+  Events,
+  Emits,
+  StateId,
+  Machine.InvokeDoneContext<States, Events, Emits, StateId, void, InputEvents, ParentEvents>
+>
+
+type StreamFailureHandler<
+  States extends Machine.StateSchemas,
+  Events extends ReadonlyArray<Machine.TaggedSchema>,
+  Emits extends ReadonlyArray<Machine.TaggedSchema>,
+  InputEvents extends ReadonlyArray<Machine.TaggedSchema>,
+  ParentEvents extends ReadonlyArray<Machine.TaggedSchema>,
+  StateId extends Machine.StateIdentifier<States>,
+  Source extends (...args: ReadonlyArray<any>) => unknown
+> = Machine.InvokeTransition<
+  States,
+  Events,
+  Emits,
+  StateId,
+  Machine.InvokeFailureContext<
+    States,
+    Events,
+    Emits,
+    StateId,
+    Stream.Error<StreamSourceResult<NoInfer<Source>>>,
+    InputEvents,
+    ParentEvents
+  >
+>
+
+type StreamInvokeResult<
+  States extends Machine.StateSchemas,
+  Events extends ReadonlyArray<Machine.TaggedSchema>,
+  Emits extends ReadonlyArray<Machine.TaggedSchema>,
+  InputEvents extends ReadonlyArray<Machine.TaggedSchema>,
+  ParentEvents extends ReadonlyArray<Machine.TaggedSchema>,
+  StateId extends Machine.StateIdentifier<States>,
+  Source extends (...args: ReadonlyArray<any>) => unknown
+> =
+  & Machine.InvokeConfig<States, Events, Emits, StateId, InputEvents, ParentEvents>
+  & Machine.InvokeTyped<
+    void,
+    Stream.Error<StreamSourceResult<Source>>,
+    Stream.Services<StreamSourceResult<Source>>,
+    never
+  >
+
 type InvokeChannelIsNever<Value> = IsAny<Value> extends true ? false : [Value] extends [never] ? true : false
 
 type BoundEffectInvokeSource<
@@ -7603,10 +7841,12 @@ type BoundEffectInvokeSource<
 > = {
   readonly id: InvokeLifecycleId
   readonly effect: Source
+  readonly stream?: never
   readonly after?: never
   readonly logic?: never
   readonly child?: never
   readonly address?: never
+  readonly onElement?: never
   readonly onSnapshot?: never
 }
 
@@ -7832,6 +8072,47 @@ export const transition: TransitionConstructor = ((config: unknown) => {
 }) as TransitionConstructor
 
 /**
+ * Sentinel used by direct targetless transition shorthands.
+ *
+ * This is the concise form of `target: (to) => to.none()`.
+ *
+ * ```ts
+ * onElement: {
+ *   target: Machine.targetless,
+ *   resolve: ({ element }, enqueue) => {
+ *     enqueue.raise(new MeasurementReceived({ value: element }))
+ *   }
+ * }
+ *
+ * onDone: { target: Machine.targetless }
+ * ```
+ *
+ * @category constructors
+ * @since 0.16.0
+ */
+export interface TargetlessSelector {
+  readonly "~effect/Machine/TargetlessSelector": true
+  <
+    const States extends Machine.StateSchemas,
+    StateId extends Machine.StateNodeIdentifier<States>
+  >(to: Machine.TargetSelector<States, StateId>): ReturnType<Machine.TargetSelector<States, StateId>["none"]>
+}
+
+/**
+ * Selects no transition target while keeping enqueue operations explicit.
+ *
+ * Use as the `target` of a direct handler object when the handler should keep
+ * the current state configuration and only raise, emit, or send events.
+ *
+ * @category constructors
+ * @since 0.16.0
+ */
+export const targetless: TargetlessSelector = Object.assign(
+  (to: Machine.TargetSelector<any, any>) => to.none(),
+  { "~effect/Machine/TargetlessSelector": true as const }
+)
+
+/**
  * Machine-bound invocation constructor that preserves the owning machine's
  * public input and parent protocols in every invocation callback.
  *
@@ -7944,6 +8225,73 @@ export interface Invoker<
         readonly onFailure?: never
       }
   ): BoundEffectInvokeResult<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+  <
+    StateId extends Machine.StateIdentifier<States>,
+    const Source extends (
+      context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    ) => Stream.Stream<unknown, unknown, any>
+  >(
+    config:
+      & StreamInvokeSource<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+      & {
+        readonly onElement: StreamElementHandler<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+        readonly onDone: StreamDoneHandler<States, Events, Emits, InputEvents, ParentEvents, StateId>
+        readonly onFailure: StreamFailureHandler<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+      },
+    ..._validation: InvokeChannelIsNever<Stream.Success<ReturnType<Source>>> extends true ? [
+        "onElement must be omitted when the Stream element is never"
+      ]
+      : InvokeChannelIsNever<Stream.Error<ReturnType<Source>>> extends true ? [
+          "onFailure must be omitted when the Stream error is never"
+        ]
+      : []
+  ): StreamInvokeResult<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+  <
+    StateId extends Machine.StateIdentifier<States>,
+    const Source extends (
+      context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    ) => Stream.Stream<never, unknown, any>
+  >(
+    config:
+      & StreamInvokeSource<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+      & {
+        readonly onElement?: never
+        readonly onDone: StreamDoneHandler<States, Events, Emits, InputEvents, ParentEvents, StateId>
+        readonly onFailure: StreamFailureHandler<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+      },
+    ..._validation: InvokeChannelIsNever<Stream.Error<ReturnType<Source>>> extends true ? [
+        "onFailure must be omitted when the Stream error is never"
+      ]
+      : []
+  ): StreamInvokeResult<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+  <
+    StateId extends Machine.StateIdentifier<States>,
+    const Source extends (
+      context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    ) => Stream.Stream<never, never, any>
+  >(
+    config:
+      & StreamInvokeSource<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+      & {
+        readonly onElement?: never
+        readonly onDone: StreamDoneHandler<States, Events, Emits, InputEvents, ParentEvents, StateId>
+        readonly onFailure?: never
+      }
+  ): StreamInvokeResult<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+  <
+    StateId extends Machine.StateIdentifier<States>,
+    const Source extends (
+      context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    ) => Stream.Stream<unknown, never, any>
+  >(
+    config:
+      & StreamInvokeSource<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+      & {
+        readonly onElement: StreamElementHandler<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+        readonly onDone: StreamDoneHandler<States, Events, Emits, InputEvents, ParentEvents, StateId>
+        readonly onFailure?: never
+      }
+  ): StreamInvokeResult<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
   <StateId extends Machine.StateIdentifier<States>, const Config extends object>(
     config: Config & Machine.TimerInvokeArgs<States, Events, Emits, StateId, InputEvents, ParentEvents>
   ): Config & Machine.InvokeOwned<States, Events, Emits, StateId> & Machine.InvokeTyped<void, never, never, never>
@@ -8050,15 +8398,18 @@ export interface Invoker<
 /**
  * Preserves inference for a state-owned invocation configuration.
  *
- * Use `effect` for one-shot work, `after` for a cancellable timer, `logic` for
- * reusable process logic, or `child` for a complete child machine. `onDone` is
- * required whenever the source can complete with an output, while `onFailure`
- * is required only when the source has a typed failure channel.
+ * Use `effect` for one-shot work, `stream` for repeated values, `after` for a
+ * cancellable timer, `logic` for reusable process logic, or `child` for a
+ * complete child machine. Stream elements are handled by `onElement` before
+ * the next element is pulled. `onDone` is required whenever the source can
+ * complete, while `onFailure` is required only when the source has a typed
+ * failure channel.
  *
  * This constructor is an identity at runtime, but preserves lifecycle callback
- * inference through published declarations. Effect factories run when their
- * owning state is entered and infer the owner context, output, error, and
- * service channels together without a return annotation. Durations may be
+ * inference through published declarations. Effect and Stream factories run
+ * when their owning state is entered and infer the owner context, value,
+ * output, error, and service channels together without a return annotation.
+ * Durations may be
  * supplied directly or derived from the owning state's entry context. Logic
  * invocations require both a lifecycle `id` and a typed communication
  * `address`. Child descriptors already own their identity, so `id` and
@@ -8179,6 +8530,93 @@ export const invoke: {
         readonly onFailure?: never
       }
   ): EffectInvokeResult<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+  <
+    const States extends Machine.StateSchemas,
+    const Events extends ReadonlyArray<Machine.TaggedSchema>,
+    const Emits extends ReadonlyArray<Machine.TaggedSchema>,
+    StateId extends Machine.StateIdentifier<States>,
+    const Source extends (
+      context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    ) => Stream.Stream<unknown, unknown, any>,
+    const InputEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+    const ParentEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly []
+  >(
+    config:
+      & StreamInvokeSource<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+      & {
+        readonly onElement: StreamElementHandler<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+        readonly onDone: StreamDoneHandler<States, Events, Emits, InputEvents, ParentEvents, StateId>
+        readonly onFailure: StreamFailureHandler<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+      },
+    ..._validation: InvokeChannelIsNever<Stream.Success<ReturnType<Source>>> extends true ? [
+        "onElement must be omitted when the Stream element is never"
+      ]
+      : InvokeChannelIsNever<Stream.Error<ReturnType<Source>>> extends true ? [
+          "onFailure must be omitted when the Stream error is never"
+        ]
+      : []
+  ): StreamInvokeResult<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+  <
+    const States extends Machine.StateSchemas,
+    const Events extends ReadonlyArray<Machine.TaggedSchema>,
+    const Emits extends ReadonlyArray<Machine.TaggedSchema>,
+    StateId extends Machine.StateIdentifier<States>,
+    const Source extends (
+      context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    ) => Stream.Stream<never, unknown, any>,
+    const InputEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+    const ParentEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly []
+  >(
+    config:
+      & StreamInvokeSource<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+      & {
+        readonly onElement?: never
+        readonly onDone: StreamDoneHandler<States, Events, Emits, InputEvents, ParentEvents, StateId>
+        readonly onFailure: StreamFailureHandler<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+      },
+    ..._validation: InvokeChannelIsNever<Stream.Error<ReturnType<Source>>> extends true ? [
+        "onFailure must be omitted when the Stream error is never"
+      ]
+      : []
+  ): StreamInvokeResult<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+  <
+    const States extends Machine.StateSchemas,
+    const Events extends ReadonlyArray<Machine.TaggedSchema>,
+    const Emits extends ReadonlyArray<Machine.TaggedSchema>,
+    StateId extends Machine.StateIdentifier<States>,
+    const Source extends (
+      context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    ) => Stream.Stream<never, never, any>,
+    const InputEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+    const ParentEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly []
+  >(
+    config:
+      & StreamInvokeSource<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+      & {
+        readonly onElement?: never
+        readonly onDone: StreamDoneHandler<States, Events, Emits, InputEvents, ParentEvents, StateId>
+        readonly onFailure?: never
+      }
+  ): StreamInvokeResult<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+  <
+    const States extends Machine.StateSchemas,
+    const Events extends ReadonlyArray<Machine.TaggedSchema>,
+    const Emits extends ReadonlyArray<Machine.TaggedSchema>,
+    StateId extends Machine.StateIdentifier<States>,
+    const Source extends (
+      context: Machine.InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    ) => Stream.Stream<unknown, never, any>,
+    const InputEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly [],
+    const ParentEvents extends ReadonlyArray<Machine.TaggedSchema> = readonly []
+  >(
+    config:
+      & StreamInvokeSource<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+      & {
+        readonly onElement: StreamElementHandler<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
+        readonly onDone: StreamDoneHandler<States, Events, Emits, InputEvents, ParentEvents, StateId>
+        readonly onFailure?: never
+      }
+  ): StreamInvokeResult<States, Events, Emits, InputEvents, ParentEvents, StateId, Source>
   <
     const States extends Machine.StateSchemas,
     const Events extends ReadonlyArray<Machine.TaggedSchema>,

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -5215,16 +5215,26 @@ export declare namespace Machine {
     }
 
   /** Direct shorthand for a non-reentering targetless transition. */
+  // Keep the context generic so omitting `target` is deferred until a resolver
+  // is actually authored instead of expanding every TransitionConfig eagerly.
+  interface TargetlessTransitionResolver<
+    Events extends ReadonlyArray<TaggedSchema>,
+    Emits extends ReadonlyArray<TaggedSchema>,
+    Context
+  > {
+    <ResolvedContext extends Omit<Context, "target">>(
+      context: ResolvedContext,
+      enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
+    ): undefined
+  }
+
   export type TargetlessTransitionInput<
     Events extends ReadonlyArray<TaggedSchema>,
     Emits extends ReadonlyArray<TaggedSchema>,
     Context
   > = {
     readonly target: TargetlessSelector
-    readonly resolve?: (
-      context: Omit<Context, "target">,
-      enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-    ) => undefined
+    readonly resolve?: TargetlessTransitionResolver<Events, Emits, Context>
     readonly cases?: never
     readonly otherwise?: never
     readonly reenter?: never

--- a/src/internal/machine/activities.ts
+++ b/src/internal/machine/activities.ts
@@ -23,6 +23,9 @@ export type StaticActivityMetadata =
     readonly duration: string | "dynamic"
   }
   | {
+    readonly type: "stream"
+  }
+  | {
     readonly type: "machine"
     readonly child: {
       readonly id: string
@@ -92,6 +95,10 @@ const appendStaticDefinition = (
       type: "timer",
       duration: typeof after === "function" ? "dynamic" : Duration.format(Duration.fromInputUnsafe(after as any))
     })
+    return
+  }
+  if (Reflect.has(descriptor, "stream")) {
+    definitions.push({ source, id, type: "stream" })
     return
   }
   if (Reflect.has(descriptor, "logic")) {

--- a/src/internal/machine/invocation.ts
+++ b/src/internal/machine/invocation.ts
@@ -6,12 +6,13 @@
 
 import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
+import * as Stream from "effect/Stream"
 import type { ChildMachine, Inspection, Logic, Machine } from "../../Machine.js"
 import * as Configuration from "./configuration.js"
 import { InfiniteTransitionError, MachineSchemaDecodeError, StoppedError } from "./errors.js"
 import * as InvocationEvent from "./invocationEvent.js"
 import * as Planner from "./planner.js"
-import type * as Runtime from "./runtime.js"
+import * as Runtime from "./runtime.js"
 import { ChildMachineLogicTypeId } from "./symbols.js"
 
 /** @internal */
@@ -37,12 +38,35 @@ const oneShot = (effect: Effect.Effect<any, any, any>): Logic<void, never, any, 
   run: () => effect
 })
 
+const streamLogic = (
+  stream: Stream.Stream<any, any, any>,
+  path: string,
+  id: string
+): Runtime.ProcessLogic<void, never, any, any, void> => ({
+  initial: () => Effect.void,
+  run: ({ parent }) => {
+    const send = parent?.[Runtime.acknowledgedSend]
+    if (send === undefined) {
+      return Effect.die(new Error("Stream invocation requires an acknowledged parent machine"))
+    }
+    return Stream.runForEach(
+      stream,
+      (element) =>
+        send(InvocationEvent.element(path, id, element)).pipe(
+          Effect.asVoid,
+          Effect.catchCause(() => Effect.interrupt)
+        )
+    )
+  }
+})
+
 const resolveValue = (value: unknown, context: Machine.InvokeContext<any, any, any, any>): unknown =>
   typeof value === "function" ? value(context) : value
 
 const resolveOne = (
   raw: Record<PropertyKey, any>,
-  context: Machine.InvokeContext<any, any, any, any>
+  context: Machine.InvokeContext<any, any, any, any>,
+  path: string
 ): AnyConfig => {
   if ("effect" in raw) {
     return {
@@ -78,6 +102,17 @@ const resolveOne = (
       activityKind: "Timer"
     }
   }
+  if ("stream" in raw) {
+    const id = String(raw.id)
+    return {
+      id,
+      src: () =>
+        streamLogic(raw.stream(context), path, id) as unknown as Runtime.ProcessLogic<any, any, any, any, any, any>,
+      onDone: raw.onDone,
+      onFailure: raw.onFailure,
+      activityKind: "Stream"
+    }
+  }
   if ("logic" in raw) {
     return {
       id: String(raw.id),
@@ -103,7 +138,7 @@ const resolveOne = (
       onSnapshot: raw.onSnapshot
     }
   }
-  throw new Error("Machine invoke must define exactly one of effect, after, logic, or child")
+  throw new Error("Machine invoke must define exactly one of effect, stream, after, logic, or child")
 }
 
 /** @internal */
@@ -269,7 +304,7 @@ export const startAll = (
       return InvocationEvent.definitions(Configuration.getStateConfigByPath(machine, path)?.invoke).map((definition) =>
         "child" in definition && !("input" in definition)
           ? startStaticChild(scope, ownedChildren, path, definition)
-          : start(scope, ownedChildren, path, resolveOne(definition, context))
+          : start(scope, ownedChildren, path, resolveOne(definition, context, path))
       )
     })
   return effects.length === 0 ? undefined : runSequentialDiscard(effects)

--- a/src/internal/machine/invocationEvent.ts
+++ b/src/internal/machine/invocationEvent.ts
@@ -14,6 +14,13 @@ export type InvocationEvent =
     readonly [InvocationEventTypeId]: true
     readonly path: string
     readonly id: string
+    readonly type: "element"
+    readonly element: unknown
+  }
+  | {
+    readonly [InvocationEventTypeId]: true
+    readonly path: string
+    readonly id: string
     readonly type: "done"
     readonly output: unknown
   }
@@ -39,6 +46,15 @@ export const done = (path: string, id: string, output: unknown): InvocationEvent
   id,
   type: "done",
   output
+})
+
+/** @internal */
+export const element = (path: string, id: string, value: unknown): InvocationEvent => ({
+  [InvocationEventTypeId]: true,
+  path,
+  id,
+  type: "element",
+  element: value
 })
 
 /** @internal */

--- a/src/internal/machine/machine.ts
+++ b/src/internal/machine/machine.ts
@@ -465,7 +465,7 @@ const captureInvokeDefinition = (
   if (Array.isArray(invoke)) return invoke.map((item) => captureInvokeDefinition(item, stateNodes, path))
   if (typeof invoke !== "object" || invoke === null) return invoke
   const captured = { ...(invoke as Record<PropertyKey, unknown>) }
-  for (const key of ["onDone", "onFailure", "onSnapshot"] as const) {
+  for (const key of ["onElement", "onDone", "onFailure", "onSnapshot"] as const) {
     if (captured[key] !== undefined) {
       captured[key] = captureTransition(captured[key], stateNodes, path, key)
     }

--- a/src/internal/machine/planner.ts
+++ b/src/internal/machine/planner.ts
@@ -952,7 +952,9 @@ const selectInvocationTransition = <
     return String(id) === event.id
   })
   if (invoke === undefined) return []
-  const handler = event.type === "done"
+  const handler = event.type === "element"
+    ? invoke.onElement
+    : event.type === "done"
     ? invoke.onDone
     : event.type === "failure"
     ? invoke.onFailure
@@ -968,7 +970,9 @@ const selectInvocationTransition = <
     snapshot,
     target: getTargetBuilder(machine, event.path),
     id: event.id,
-    ...(event.type === "done"
+    ...(event.type === "element"
+      ? { element: event.element }
+      : event.type === "done"
       ? { output: event.output }
       : event.type === "failure"
       ? { error: event.error }

--- a/src/internal/machine/runtime.ts
+++ b/src/internal/machine/runtime.ts
@@ -355,6 +355,9 @@ interface ProcessAddress<in Event> {
     source: Inspection.Subject | undefined,
     causedBy: Inspection.Causation | undefined
   ) => Effect.Effect<void, StoppedError>
+  readonly [acknowledgedSend]?: (
+    event: Event
+  ) => Effect.Effect<AcknowledgedDelivery<unknown>, unknown | StoppedError>
 }
 
 const isMachineTarget = (value: unknown): value is MachineTarget<unknown> =>
@@ -886,7 +889,15 @@ class OwnedChildRuntimeImpl implements OwnedChildRuntime {
         ...this.self,
         send: (event) => options.sendParent(isCurrent, event),
         sendInspected: (event, source, causedBy) =>
-          isCurrent() ? sendMachineTarget(this.self, event, source, causedBy) : Effect.void
+          isCurrent() ? sendMachineTarget(this.self, event, source, causedBy) : Effect.void,
+        ...(this.self[acknowledgedSend] === undefined
+          ? undefined
+          : {
+            [acknowledgedSend]: (event: unknown) =>
+              isCurrent()
+                ? this.self[acknowledgedSend]!(event)
+                : Effect.interrupt
+          })
       }
       const startOptions: StartInternalOptions = {
         detached: true,
@@ -1376,6 +1387,23 @@ const startGenericInternal: <
         Effect.tap(() => Effect.sync(() => publishInspectedSent(inspector, subject!, message)))
       )
     })
+  const sendAcknowledged:
+    | ((event: Event) => Effect.Effect<AcknowledgedDelivery<State>, Error | StoppedError>)
+    | undefined = logic.execution?._tag !== "Compiled"
+      ? undefined
+      : (event) =>
+        Effect.uninterruptibleMask((restore) =>
+          Deferred.make<AcknowledgedDelivery<unknown>, unknown>().pipe(
+            Effect.flatMap((deferred) => {
+              const offered = inspector === undefined
+                ? offerDirect({ [AcknowledgedMessageTypeId]: true as const, event, deferred })
+                : offerInspected!(event, undefined, undefined, deferred)
+              return offered.pipe(Effect.andThen(restore(Deferred.await(deferred))))
+            }),
+            Effect.map((delivery) => delivery as AcknowledgedDelivery<State>)
+          )
+        ) as Effect.Effect<AcknowledgedDelivery<State>, Error | StoppedError>
+
   const self: ProcessAddress<Event> = {
     id,
     sessionId,
@@ -1394,24 +1422,9 @@ const startGenericInternal: <
       : (event) => offerInspected!(event, undefined, undefined),
     ...(inspector === undefined
       ? undefined
-      : { inspectionSubject: subject!, sendInspected: offerInspected! })
+      : { inspectionSubject: subject!, sendInspected: offerInspected! }),
+    ...(sendAcknowledged === undefined ? undefined : { [acknowledgedSend]: sendAcknowledged })
   }
-  const sendAcknowledged:
-    | ((event: Event) => Effect.Effect<AcknowledgedDelivery<State>, Error | StoppedError>)
-    | undefined = logic.execution?._tag !== "Compiled"
-      ? undefined
-      : (event) =>
-        Effect.uninterruptibleMask((restore) =>
-          Deferred.make<AcknowledgedDelivery<unknown>, unknown>().pipe(
-            Effect.flatMap((deferred) => {
-              const offered = inspector === undefined
-                ? offerDirect({ [AcknowledgedMessageTypeId]: true as const, event, deferred })
-                : offerInspected!(event, undefined, undefined, deferred)
-              return offered.pipe(Effect.andThen(restore(Deferred.await(deferred))))
-            }),
-            Effect.map((delivery) => delivery as AcknowledgedDelivery<State>)
-          )
-        ) as Effect.Effect<AcknowledgedDelivery<State>, Error | StoppedError>
 
   let {
     changes: childChanges,
@@ -2150,6 +2163,7 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
       sessionId,
       stop: Effect.suspend(() => this.stopFromProcess()),
       send: this.send,
+      [acknowledgedSend]: (event) => this.sendAcknowledgedEffect(event),
       ...(inspector === undefined
         ? undefined
         : {

--- a/src/internal/machine/runtime.ts
+++ b/src/internal/machine/runtime.ts
@@ -846,7 +846,10 @@ class OwnedChildRuntimeImpl implements OwnedChildRuntime {
     private readonly registry: ChildRegistry,
     private readonly self: ProcessAddress<any>,
     private readonly runtime: ProcessRuntime,
-    private readonly services?: Context.Context<any>
+    private readonly services?: Context.Context<any>,
+    private readonly sendAcknowledged?: (
+      event: unknown
+    ) => Effect.Effect<AcknowledgedDelivery<unknown>, unknown | StoppedError>
   ) {}
 
   private has(key: string): boolean {
@@ -890,12 +893,12 @@ class OwnedChildRuntimeImpl implements OwnedChildRuntime {
         send: (event) => options.sendParent(isCurrent, event),
         sendInspected: (event, source, causedBy) =>
           isCurrent() ? sendMachineTarget(this.self, event, source, causedBy) : Effect.void,
-        ...(this.self[acknowledgedSend] === undefined
+        ...(this.sendAcknowledged === undefined
           ? undefined
           : {
             [acknowledgedSend]: (event: unknown) =>
               isCurrent()
-                ? this.self[acknowledgedSend]!(event)
+                ? this.sendAcknowledged!(event)
                 : Effect.interrupt
           })
       }
@@ -1059,7 +1062,10 @@ const childlessRuntime: ChildRuntime = {
 const makeChildRuntimeSync = (
   self: ProcessAddress<any>,
   runtime: ProcessRuntime,
-  services?: Context.Context<any>
+  services?: Context.Context<any>,
+  sendAcknowledged?: (
+    event: unknown
+  ) => Effect.Effect<AcknowledgedDelivery<unknown>, unknown | StoppedError>
 ): ChildRuntime => {
   // Child-registry decisions are synchronous and every access below runs in
   // one Effect.sync / Effect.suspend step. Keep the unobserved representation
@@ -1301,15 +1307,18 @@ const makeChildRuntimeSync = (
     changes,
     sendTo,
     stop,
-    owned: new OwnedChildRuntimeImpl(registry, self, runtime, services)
+    owned: new OwnedChildRuntimeImpl(registry, self, runtime, services, sendAcknowledged)
   }
 }
 
 const makeChildRuntime = (
   self: ProcessAddress<any>,
   runtime: ProcessRuntime,
-  services?: Context.Context<any>
-): Effect.Effect<ChildRuntime> => Effect.sync(() => makeChildRuntimeSync(self, runtime, services))
+  services?: Context.Context<any>,
+  sendAcknowledged?: (
+    event: unknown
+  ) => Effect.Effect<AcknowledgedDelivery<unknown>, unknown | StoppedError>
+): Effect.Effect<ChildRuntime> => Effect.sync(() => makeChildRuntimeSync(self, runtime, services, sendAcknowledged))
 
 // `Machine.logic` permits an arbitrary Effect program, including programs that
 // suspend or supervise their own fibers. Keep its two-fiber worker/supervisor
@@ -1422,8 +1431,7 @@ const startGenericInternal: <
       : (event) => offerInspected!(event, undefined, undefined),
     ...(inspector === undefined
       ? undefined
-      : { inspectionSubject: subject!, sendInspected: offerInspected! }),
-    ...(sendAcknowledged === undefined ? undefined : { [acknowledgedSend]: sendAcknowledged })
+      : { inspectionSubject: subject!, sendInspected: offerInspected! })
   }
 
   let {
@@ -1444,7 +1452,12 @@ const startGenericInternal: <
       sendTo,
       spawn,
       stop: stopChild
-    } = yield* makeChildRuntime(self, runtime))
+    } = yield* makeChildRuntime(
+      self,
+      runtime,
+      undefined,
+      sendAcknowledged === undefined ? undefined : (event) => sendAcknowledged(event as Event)
+    ))
   }
   const cleanupStartupFailure = <A, E>(exit: Exit.Exit<A, E>): Effect.Effect<void> => {
     if (Exit.isSuccess(exit)) return Effect.void
@@ -2163,7 +2176,6 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
       sessionId,
       stop: Effect.suspend(() => this.stopFromProcess()),
       send: this.send,
-      [acknowledgedSend]: (event) => this.sendAcknowledgedEffect(event),
       ...(inspector === undefined
         ? undefined
         : {
@@ -2241,7 +2253,12 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
   initializeCompiledSync(): Effect.Effect<MachineRef<any, any, any, any>, unknown> {
     this.publishCreated()
     if (!this.execution.childless) {
-      this.childRuntime = makeChildRuntimeSync(this.address, this.options.runtime, this.services)
+      this.childRuntime = makeChildRuntimeSync(
+        this.address,
+        this.options.runtime,
+        this.services,
+        (event) => this.sendAcknowledgedEffect(event)
+      )
     }
     const parent = this.options.parent
     const sendParent = this.options.sendParent ?? (parent === undefined
@@ -2318,7 +2335,12 @@ class CompiledProcess implements MachineRef<any, any, any, any> {
     return Effect.gen(function*() {
       self.publishCreated()
       if (!self.execution.childless) {
-        self.childRuntime = yield* makeChildRuntime(self.address, self.options.runtime, self.services)
+        self.childRuntime = yield* makeChildRuntime(
+          self.address,
+          self.options.runtime,
+          self.services,
+          (event) => self.sendAcknowledgedEffect(event)
+        )
       }
       const parent = self.options.parent
       const sendParent = self.options.sendParent ?? (parent === undefined

--- a/src/internal/machine/topology.ts
+++ b/src/internal/machine/topology.ts
@@ -467,8 +467,10 @@ export const transitionDefinitions = (
       : [config.invoke]
     for (const invoke of invokes) {
       const id = "child" in invoke ? String(invoke.child.id) : String(invoke.id)
-      for (const outcome of ["done", "failure", "snapshot"] as const) {
-        const handler = outcome === "done"
+      for (const outcome of ["element", "done", "failure", "snapshot"] as const) {
+        const handler = outcome === "element"
+          ? invoke.onElement
+          : outcome === "done"
           ? invoke.onDone
           : outcome === "failure"
           ? invoke.onFailure

--- a/test/internal/machine/activities.test.ts
+++ b/test/internal/machine/activities.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Duration, Effect, Schema } from "effect"
+import { Duration, Effect, Schema, Stream } from "effect"
 import { FastCheck } from "effect/testing"
 import { Machine } from "../../../src/index.js"
 import { activityDefinitions } from "../../../src/internal/machine/activities.js"
@@ -64,6 +64,11 @@ const activityMachine = Machine.make({
           resolve: () => undefined
         })
       }),
+      Machine.invoke({
+        id: "updates",
+        stream: () => Stream.empty,
+        onDone: { target: Machine.targetless }
+      }),
       Machine.invoke({ child })
     ]
   },
@@ -107,7 +112,8 @@ const machine = {
           onFailure: () => undefined,
           type: "effect"
         },
-        { id: "load-timeout", after: "10 seconds" }
+        { id: "load-timeout", after: "10 seconds" },
+        { id: "updates", stream: () => Stream.empty }
       ]
     },
     "Parent.Active": {
@@ -140,6 +146,11 @@ describe("machine activity metadata", () => {
         id: "load-timeout",
         type: "timer",
         duration: "10s"
+      },
+      {
+        source: "Loading",
+        id: "updates",
+        type: "stream"
       },
       {
         source: "Loading",
@@ -223,6 +234,7 @@ describe("machine activity metadata", () => {
         type: "timer",
         duration: "10s"
       },
+      { source: "Loading", id: "updates", type: "stream" },
       {
         source: "Parent.Active",
         id: "child",
@@ -293,6 +305,7 @@ describe("machine activity metadata", () => {
         "│  ├─ ◆ process: poll-server",
         "│  ├─ ◆ effect: load-document [success: dynamic, failure: dynamic]",
         "│  ├─ ◆ timer: load-timeout [10s]",
+        "│  ├─ ◆ stream: updates",
         "│  └─ ◆ machine: child → document-worker",
         "└─ ○ Dynamic",
         "   └─ ◆ process: context-owned",
@@ -310,7 +323,7 @@ describe("machine activity metadata", () => {
 
     assert.include(
       rendered,
-      "state_0: process / poll-server · effect / load-document · timer / load-timeout (10s) · machine / child → document-worker"
+      "state_0: process / poll-server · effect / load-document · timer / load-timeout (10s) · stream / updates · machine / child → document-worker"
     )
     assert.notInclude(rendered, "success: dynamic")
     assert.notInclude(rendered, "note right of")

--- a/test/internal/machine/strategyDifferential.test.ts
+++ b/test/internal/machine/strategyDifferential.test.ts
@@ -417,6 +417,53 @@ describe("machine planner and runtime strategies", () => {
       }
     }) as Effect.Effect<void, unknown, any>)
 
+  it.effect("matches generic and compiled Stream invocation delivery and completion", () =>
+    Effect.gen(function*() {
+      class Streaming extends Schema.TaggedClass<Streaming>("StrategyStreaming")("Streaming", {}) {}
+      class StreamDone extends Schema.TaggedClass<StreamDone>("StrategyStreamDone")("StreamDone", {
+        values: Schema.Array(Schema.Number)
+      }) {}
+      const states = Machine.states({
+        Streaming,
+        StreamDone: { schema: StreamDone, type: "final", output: Schema.Array(Schema.Number) }
+      })
+      const seen: Array<number> = []
+      const definition = Machine.make({
+        states: states.states,
+        events: Machine.events(),
+        initial: {
+          target: (to) => to.Streaming(),
+          resolve: ({ target }) => target.from()
+        }
+      })
+      const machine = definition.handle({
+        Streaming: {
+          invoke: definition.invoke({
+            id: "values",
+            stream: () => Stream.fromIterable([1, 2, 3]),
+            onElement: {
+              target: Machine.targetless,
+              resolve: ({ element }) => {
+                seen.push(element)
+              }
+            },
+            onDone: Machine.transition({
+              target: (to) => to.full.StreamDone(),
+              resolve: ({ target }) => target(new StreamDone({ values: [...seen] }))
+            })
+          })
+        },
+        StreamDone: { output: ({ state }) => state.values }
+      })
+
+      for (const strategy of ["generic", "compiled"] as const) {
+        seen.length = 0
+        const ref = yield* openWithRuntimeStrategy(machine, strategy)
+        assert.deepStrictEqual(yield* ref.join, [1, 2, 3])
+        assert.deepStrictEqual(seen, [1, 2, 3])
+      }
+    }) as Effect.Effect<void, unknown, any>)
+
   it.effect("decodes deferred event constructions in generic and compiled managed runtimes", () =>
     Effect.gen(function*() {
       const Event = Schema.TaggedUnion({ Set: { value: Schema.NonEmptyString } })

--- a/test/machine/Invoke.test.ts
+++ b/test/machine/Invoke.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Effect, Schema } from "effect"
+import { Cause, Effect, Schema, Stream } from "effect"
 import { Machine } from "../../src/index.js"
 
 class Loading extends Schema.TaggedClass<Loading>("InvokeLoading")("Loading", {}) {}
@@ -11,10 +11,224 @@ class Failed extends Schema.TaggedClass<Failed>("InvokeFailed")("Failed", {
 }) {}
 class Idle extends Schema.TaggedClass<Idle>("InvokeIdle")("Idle", {}) {}
 class Start extends Schema.TaggedClass<Start>("InvokeStart")("Start", {}) {}
+class Collecting extends Schema.TaggedClass<Collecting>("InvokeCollecting")("Collecting", {
+  values: Schema.Array(Schema.Number)
+}) {}
+class Add extends Schema.TaggedClass<Add>("InvokeAdd")("Add", {
+  value: Schema.Number
+}) {}
+class FinishStream extends Schema.TaggedClass<FinishStream>("InvokeFinishStream")("FinishStream", {
+  value: Schema.Number
+}) {}
 
 const States = Machine.states({ Idle, Loading, Complete, Failed })
 
 describe("inline invoke", () => {
+  it.effect("handles Stream elements sequentially before completion", () =>
+    Effect.gen(function*() {
+      const states = Machine.states({ Collecting, Complete })
+      const definition = Machine.make({
+        states: states.states,
+        events: Machine.events(Add),
+        initial: {
+          target: (to) => to.Collecting(),
+          resolve: ({ target }) => target(new Collecting({ values: [] }))
+        }
+      })
+      const machine = definition.handle({
+        Collecting: {
+          invoke: Machine.invoke({
+            id: "numbers",
+            stream: () => Stream.fromIterable([1, 2, 3]),
+            onElement: {
+              target: Machine.targetless,
+              resolve: ({ element }, enqueue) => {
+                enqueue.raise(new Add({ value: element }))
+              }
+            },
+            onDone: Machine.transition({
+              target: (to) => to.full.Complete(),
+              resolve: ({ state, target }) => target(new Complete({ value: state.values.join(",") }))
+            })
+          }),
+          on: {
+            Add: Machine.transition({
+              target: (to) => to.full.Collecting(),
+              resolve: ({ event, state, target }) => target(new Collecting({ values: [...state.values, event.value] }))
+            })
+          }
+        },
+        Complete: {}
+      })
+
+      assert.deepStrictEqual(Machine.transitionDefinitions(machine), [
+        {
+          source: "Collecting",
+          trigger: { type: "event", event: "Add" },
+          reenter: false,
+          branches: [{
+            type: "direct",
+            target: "Collecting",
+            selection: { path: "Collecting", kind: "state", scope: "full" }
+          }]
+        },
+        {
+          source: "Collecting",
+          trigger: { type: "invoke", id: "numbers", outcome: "element" },
+          reenter: false,
+          branches: [{
+            type: "direct",
+            target: undefined,
+            selection: { path: undefined, kind: "none", scope: "local" }
+          }]
+        },
+        {
+          source: "Collecting",
+          trigger: { type: "invoke", id: "numbers", outcome: "done" },
+          reenter: false,
+          branches: [{
+            type: "direct",
+            target: "Complete",
+            selection: { path: "Complete", kind: "state", scope: "full" }
+          }]
+        }
+      ])
+
+      const ref = yield* Machine.start(machine)
+      yield* ref.changes.pipe(
+        Stream.filter((snapshot) => snapshot.state.path === "Complete"),
+        Stream.take(1),
+        Stream.runDrain
+      )
+      assert.deepStrictEqual(yield* ref.state, {
+        path: "Complete" as const,
+        value: new Complete({ value: "1,2,3" })
+      })
+    }))
+
+  it.effect("routes a Stream typed failure through onFailure", () =>
+    Effect.gen(function*() {
+      const definition = Machine.make({
+        states: States.states,
+        events: Machine.events(),
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target.from()
+        }
+      })
+      const machine = definition.handle({
+        Loading: {
+          invoke: definition.invoke({
+            id: "updates",
+            stream: () => Stream.fail("offline"),
+            onDone: { target: Machine.targetless },
+            onFailure: Machine.transition({
+              target: (to) => to.full.Failed(),
+              resolve: ({ error, target }) => target(new Failed({ message: error }))
+            })
+          })
+        },
+        Complete: {},
+        Failed: {}
+      })
+
+      const ref = yield* Machine.start(machine)
+      yield* ref.changes.pipe(
+        Stream.filter((snapshot) => snapshot.state.path === "Failed"),
+        Stream.take(1),
+        Stream.runDrain
+      )
+      assert.deepStrictEqual(yield* ref.state, {
+        path: "Failed" as const,
+        value: new Failed({ message: "offline" })
+      })
+    }))
+
+  it.effect("fails the owning machine when a Stream defects", () =>
+    Effect.gen(function*() {
+      const defect = new Error("stream defect")
+      const definition = Machine.make({
+        states: States.states,
+        events: Machine.events(),
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target.from()
+        }
+      })
+      const machine = definition.handle({
+        Loading: {
+          invoke: definition.invoke({
+            id: "updates",
+            stream: () => Stream.die(defect),
+            onDone: { target: Machine.targetless }
+          })
+        },
+        Complete: {},
+        Failed: {}
+      })
+
+      const ref = yield* Machine.start(machine)
+      yield* ref.changes.pipe(Stream.runDrain)
+      const snapshot = yield* ref.snapshot
+      assert.strictEqual(snapshot.status, "error")
+      if (snapshot.status !== "error") return assert.fail("expected an error snapshot")
+      assert.strictEqual(Cause.squash(snapshot.cause), defect)
+    }))
+
+  it.effect("interrupts a Stream before pulling another element after its owner exits", () =>
+    Effect.gen(function*() {
+      let pulls = 0
+      let finalized = false
+      const source = Stream.fromEffect(Effect.sync(() => ++pulls)).pipe(
+        Stream.forever,
+        Stream.ensuring(Effect.sync(() => {
+          finalized = true
+        }))
+      )
+      const definition = Machine.make({
+        states: States.states,
+        events: Machine.events(FinishStream),
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target.from()
+        }
+      })
+      const machine = definition.handle({
+        Loading: {
+          invoke: definition.invoke({
+            id: "updates",
+            stream: () => source,
+            onElement: {
+              target: Machine.targetless,
+              resolve: ({ element }, enqueue) => {
+                enqueue.raise(new FinishStream({ value: element }))
+              }
+            },
+            onDone: { target: Machine.targetless }
+          }),
+          on: {
+            FinishStream: Machine.transition({
+              target: (to) => to.full.Complete(),
+              resolve: ({ event, target }) => target(new Complete({ value: String(event.value) }))
+            })
+          }
+        },
+        Complete: {},
+        Failed: {}
+      })
+
+      const ref = yield* Machine.start(machine)
+      yield* ref.changes.pipe(
+        Stream.filter((snapshot) => snapshot.state.path === "Complete"),
+        Stream.take(1),
+        Stream.runDrain
+      )
+      yield* Effect.yieldNow
+      assert.strictEqual(pulls, 1)
+      assert.isTrue(finalized)
+      yield* ref.stop
+    }))
+
   it.effect("plans a successful Effect outcome directly", () =>
     Effect.gen(function*() {
       const machine = Machine.make({

--- a/test/machine/LiveInspection.test.ts
+++ b/test/machine/LiveInspection.test.ts
@@ -180,6 +180,45 @@ describe("Machine live inspection", () => {
       }
     })))
 
+  it.effect("represents Stream invokes as owned Stream activities", () =>
+    Effect.scoped(Effect.gen(function*() {
+      const active = Machine.make({
+        id: "stream-activity-root",
+        states: states.states,
+        events: Machine.events(),
+        initial: {
+          target: (to) => to.Idle(),
+          resolve: ({ target }) => target(new Idle({}))
+        }
+      }).handle({
+        Idle: {
+          invoke: Machine.invoke({
+            id: "updates",
+            stream: () => Stream.never,
+            onDone: { target: Machine.targetless }
+          })
+        }
+      })
+      const prepared = yield* Machine.prepare(active)
+      const collected = yield* prepared.inspection.pipe(
+        Stream.runCollect,
+        Effect.forkScoped({ startImmediately: true })
+      )
+      yield* Effect.yieldNow
+      const ref = yield* prepared.start
+      yield* Effect.yieldNow
+      yield* ref.stop
+
+      const records = Array.from(yield* Fiber.join(collected))
+      const started = records.find((record) => record._tag === "ActivityStarted")
+      assert.ok(started !== undefined && started._tag === "ActivityStarted")
+      if (started?._tag === "ActivityStarted") {
+        assert.strictEqual(started.activity.kind, "Stream")
+        assert.strictEqual(started.activity.id, "updates")
+        assert.strictEqual(started.activity.ownerPath, "Idle")
+      }
+    })))
+
   it.effect("correlates an explicit child-to-parent send with both local subjects", () =>
     Effect.scoped(Effect.gen(function*() {
       class ChildIdle extends Schema.TaggedClass<ChildIdle>("InspectionChildIdle")("ChildIdle", {}) {}

--- a/test/machine/visualization/mermaid.ts
+++ b/test/machine/visualization/mermaid.ts
@@ -68,6 +68,8 @@ const activityLabel = (definition: ActivityDefinition): string => {
       return `effect / ${definition.id}`
     case "timer":
       return `timer / ${definition.id} (${definition.duration})`
+    case "stream":
+      return `stream / ${definition.id}`
     case "machine": {
       const identity = definition.child.machineId === null ? definition.child.id : definition.child.machineId
       return `machine / ${definition.id} → ${identity}`

--- a/test/machine/visualization/model.ts
+++ b/test/machine/visualization/model.ts
@@ -38,7 +38,7 @@ export interface TransitionDefinition {
     | {
       readonly type: "invoke"
       readonly id: string
-      readonly outcome: "done" | "failure" | "snapshot"
+      readonly outcome: "element" | "done" | "failure" | "snapshot"
     }
   readonly reenter: boolean
   readonly branches: ReadonlyArray<
@@ -78,6 +78,11 @@ export type ActivityDefinition =
     readonly id: string
     readonly type: "timer"
     readonly duration: string | "dynamic"
+  }
+  | {
+    readonly source: string
+    readonly id: string
+    readonly type: "stream"
   }
   | {
     readonly source: string

--- a/test/machine/visualization/text.ts
+++ b/test/machine/visualization/text.ts
@@ -56,6 +56,8 @@ const activityLabel = (definition: ActivityDefinition): string => {
       return `◆ effect: ${definition.id} [success: ${definition.outcomes.success}, failure: ${definition.outcomes.failure}]`
     case "timer":
       return `◆ timer: ${definition.id} [${definition.duration}]`
+    case "stream":
+      return `◆ stream: ${definition.id}`
     case "machine": {
       const identity = definition.child.machineId === null ? definition.child.id : definition.child.machineId
       return `◆ machine: ${definition.id} → ${identity}`

--- a/typetest/machine/Activities.tst.ts
+++ b/typetest/machine/Activities.tst.ts
@@ -42,7 +42,7 @@ describe("Machine activity inspection", () => {
     const definition = Machine.activityDefinitions(machine)[0]!
 
     expect(definition.source).type.toBe<"Loading" | "Dynamic">()
-    expect(definition.type).type.toBe<"process" | "effect" | "timer" | "machine">()
+    expect(definition.type).type.toBe<"process" | "effect" | "stream" | "timer" | "machine">()
   })
 
   it("narrows kind-specific descriptive metadata", () => {
@@ -51,6 +51,9 @@ describe("Machine activity inspection", () => {
     if (definition.type === "timer") {
       expect(definition.id).type.toBe<string>()
       expect(definition.duration).type.toBe<string | "dynamic">()
+    }
+    if (definition.type === "stream") {
+      expect(definition.id).type.toBe<string>()
     }
   })
 })

--- a/typetest/machine/Machine.tst.ts
+++ b/typetest/machine/Machine.tst.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Option, Schema } from "effect"
+import { Context, Effect, Option, Schema, Stream } from "effect"
 import { describe, expect, it } from "tstyche"
 import { Machine } from "../../src/index.js"
 
@@ -610,6 +610,112 @@ describe("Machine", () => {
           })
         })
       }
+    })
+  })
+
+  it("infers Stream elements, failures, and services through the bound constructor", () => {
+    class StreamFailure {
+      readonly _tag = "StreamFailure"
+    }
+    const updates: Stream.Stream<1, StreamFailure, EntryRequirement> = Stream.fromEffect(
+      Effect.as(EntryRequirement, 1 as const)
+    ).pipe(Stream.concat(Stream.fail(new StreamFailure())))
+    const machine = Machine.make({
+      states: UpStates.states,
+      events: Machine.events(SignIn),
+      initial: {
+        target: (to) => to.down(),
+        resolve: ({ target }) => target(new Down({}))
+      }
+    })
+    const handled = machine.handle({
+      down: {
+        invoke: machine.invoke({
+          id: "updates",
+          stream: ({ state }) => {
+            expect(state).type.toBe<Down>()
+            return updates
+          },
+          onElement: {
+            target: Machine.targetless,
+            resolve: ({ element }) => {
+              expect(element).type.toBe<1>()
+            }
+          },
+          onDone: { target: Machine.targetless },
+          onFailure: {
+            target: Machine.targetless,
+            resolve: ({ error }) => {
+              expect(error).type.toBe<StreamFailure>()
+            }
+          }
+        })
+      }
+    })
+
+    expect<EntryRequirement>().type.toBeAssignableTo<Machine.Machine.Services<typeof handled>>()
+    expect<Machine.Machine.Error<typeof handled>>().type.not.toBe<any>()
+
+    const staticHandled = machine.handle({
+      down: {
+        invoke: Machine.invoke({
+          id: "static-updates",
+          stream: ({ state }) => {
+            expect(state).type.toBe<Down>()
+            return updates
+          },
+          onElement: {
+            target: Machine.targetless,
+            resolve: ({ element }) => {
+              expect(element).type.toBe<1>()
+            }
+          },
+          onDone: { target: Machine.targetless },
+          onFailure: {
+            target: Machine.targetless,
+            resolve: ({ error }) => {
+              expect(error).type.toBe<StreamFailure>()
+            }
+          }
+        })
+      }
+    })
+
+    expect<EntryRequirement>().type.toBeAssignableTo<Machine.Machine.Services<typeof staticHandled>>()
+    expect<Machine.Machine.Error<typeof staticHandled>>().type.not.toBe<any>()
+  })
+
+  it("requires only reachable Stream handlers", () => {
+    type Context = Machine.Machine.InvokeContext<
+      typeof UpStates.states,
+      readonly [typeof SignIn],
+      readonly [],
+      "down"
+    >
+    const values = (_: Context) => Stream.make(1)
+    const failure = (_: Context) => Stream.fail("unavailable" as const)
+
+    expect(Machine.invoke).type.not.toBeCallableWith({
+      id: "missing-element",
+      stream: values,
+      onDone: { target: Machine.targetless }
+    })
+    expect(Machine.invoke).type.not.toBeCallableWith({
+      id: "missing-done",
+      stream: values,
+      onElement: { target: Machine.targetless }
+    })
+    expect(Machine.invoke).type.not.toBeCallableWith({
+      id: "missing-failure",
+      stream: failure,
+      onDone: { target: Machine.targetless }
+    })
+    expect(Machine.invoke).type.not.toBeCallableWith({
+      id: "unreachable-element",
+      stream: failure,
+      onElement: { target: Machine.targetless },
+      onDone: { target: Machine.targetless },
+      onFailure: { target: Machine.targetless }
     })
   })
 
@@ -2598,14 +2704,30 @@ describe("Machine", () => {
       definition.handle({
         down: {
           on: {
-            SignIn: Machine.transition({
-              target: (to) => to.none(),
-              resolve: () => undefined
-            })
+            SignIn: {
+              target: Machine.targetless,
+              resolve: ({ event }, enqueue) => {
+                expect(event).type.toBe<SignIn>()
+                expect(enqueue.raise).type.toBeCallableWith(event)
+              }
+            }
           }
         }
       })
     ).type.not.toRaiseError()
+    expect(definition.handle).type.not.toBeCallableWith({
+      down: {
+        on: {
+          SignIn: {
+            target: Machine.targetless,
+            resolve: () => 1
+          }
+        }
+      }
+    })
+    expect(Machine.targetless).type.toBeCallableWith(
+      null as unknown as Machine.Machine.TargetSelector<typeof UpStates.states, "down">
+    )
   })
 
   it("rejects invalid compound initial keys", () => {


### PR DESCRIPTION
## Summary

- Add `stream` sources to `Machine.invoke` with typed `onElement`, `onDone`, and `onFailure` handlers, acknowledged parent-macrostep delivery, and owner-scoped interruption.
- Add the direct `{ target: Machine.targetless, resolve }` shorthand for explicit targetless enqueue-only transitions.
- Expose Stream invocation topology and inspection metadata, and simplify the media-player example to invoke its loudness Stream directly.
- Cover generic and compiled runtimes, channel inference, cancellation/finalization, failures, defects, autocomplete, topology, and inspection.

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required
