### PR TITLE
Add declinable transition dispatch

### DIFF
--- a/.changeset/soft-hounds-decline.md
+++ b/.changeset/soft-hounds-decline.md
@@ -1,0 +1,11 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Add opt-in declinable transitions for conditional statechart dispatch.
+
+Set `declinable: true` on `Machine.transition` to expose a typed `decline()` resolver capability. Declining selects no transition, discards operations enqueued by that resolver, and lets hierarchical event or eventless dispatch continue with the next eligible ancestor. `target.none()` remains handled and continues to consume the trigger.
+
+Declining a completion or invocation outcome ignores that lifecycle occurrence because those triggers do not dispatch to ancestor handlers.
+
+Static transition definitions now expose `acceptance: "required" | "declinable"` alongside their exact target branches. Choices and initial routing remain total and reject declinable transitions.

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ paths. `parent` always means the owning machine target.
 | `target.full`    | Replacing or selecting a complete root   | Nothing implicit for a newly selected root        |
 | `target.history` | Restoring a declared history node        | The remembered configuration or its typed default |
 
-Every installed transition handler returns either a concrete target or
+Every required transition handler returns either a concrete target or
 `target.none()`. An absent handler ignores the trigger; `target.none()` handles
 it and retains queued commands, raised events, and emitted events without
 selecting a destination. Declared `targets` constrain only concrete
@@ -391,6 +391,28 @@ destinations, so `target.none()` is always permitted. Builders describe the
 next logical configuration. Shared states exit and enter only when paths
 change; use `{ reenter: true, transition }` when the source must restart. With
 `target.none()`, reentry restarts the source while retaining its configuration.
+
+Use `declinable: true` when a resolver may decide that its transition is not
+enabled. Only that resolver receives `decline()`, and its return type expands to
+accept the opaque declined result:
+
+```ts
+Submit: Machine.transition({
+  declinable: true,
+  target: (to) => to.local.Saving(),
+  resolve: ({ event, target, decline }) => accepts(event) ? target.from({ draft: event.draft }) : decline()
+})
+```
+
+Declining discards work enqueued by that resolver. Event and eventless dispatch
+continues with the next eligible ancestor; if no candidate accepts, no
+transition is selected. This differs from `target.none()`, which consumes the
+trigger and prevents an ancestor from handling it. `transitionDefinitions`
+reports each handler's `acceptance` as `"required"` or `"declinable"` while
+preserving the exact declared target branches. Choices and initial routing must
+remain total and cannot use declinable transitions. Completion and invocation
+outcomes have no ancestor candidate: declining one ignores that lifecycle
+occurrence and leaves the current configuration active.
 
 ## Statechart capabilities
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -661,6 +661,34 @@ an optional `title` controls presentation and otherwise defaults to the key.
 Selecting a branch whose target is `to.none()` handles the transition without a
 destination while retaining queued commands, raised events, and emitted events.
 
+Set `declinable: true` only when the resolver may decide that its transition is
+not enabled. The flag adds a typed `decline()` capability to that resolver and
+permits its opaque result:
+
+```ts
+Submit: Machine.transition({
+  declinable: true,
+  branches: (to) => ({
+    accepted: { target: to.local.Saving() },
+    consumed: { target: to.none() }
+  }),
+  resolve: ({ event, select, decline }) => {
+    if (!belongsToThisState(event)) return decline()
+    return event.consume ? select.consumed() : select.accepted.from()
+  }
+})
+```
+
+Declining discards that resolver's enqueue buffer and resumes hierarchical
+event or eventless selection at the next eligible ancestor. If no candidate
+accepts, the trigger is unhandled. This is deliberately different from
+`to.none()`, which consumes the trigger. `decline()` is absent and its result is
+rejected unless the literal flag is present. Choice and initial routing remain
+total and cannot decline. Static inspection exposes the distinction through
+`TransitionDefinition.acceptance` without executing resolver code. Completion
+and invocation outcomes have no ancestor candidate; declining one ignores that
+lifecycle occurrence and leaves the current configuration active.
+
 The `branches` callback runs once when handlers are installed. Its record uses
 the deterministic ECMAScript property order for presentation and `branchIndex`;
 array-index and symbol keys are rejected. Treat the string key as semantic:
@@ -1313,9 +1341,10 @@ const step = yield * probe.sendAndAwait(event)
 ```
 
 Inspect `step.before`, `step.after`, `step.plan`, `step.handled`, and
-`step.configurationChanged`. An ignored event has `handled: false` and an
-empty microstep list, but still completes its acknowledgement. A targetless
-handler has `handled: true` even if its before and after snapshots are equal.
+`step.configurationChanged`. An ignored event, including one for which every
+eligible candidate declines, has `handled: false` and an empty microstep list,
+but still completes its acknowledgement. A targetless handler has
+`handled: true` even if its before and after snapshots are equal.
 
 Do not use a probe as a substitute for a domain completion event. The
 acknowledgement covers the submitted event's synchronous macrostep, state

--- a/examples/platformer/src/machine.test.ts
+++ b/examples/platformer/src/machine.test.ts
@@ -165,6 +165,7 @@ describe("platformer history integration", () => {
         source: "Character.locomotion.Playing.Airborne.airJump",
         trigger: { type: "event", event: "WallJump" },
         reenter: true,
+        acceptance: "required",
         branches: [{
           type: "direct",
           target: "Character.locomotion.Playing.Airborne.airJump.AirJumpWallLock",

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -3306,6 +3306,7 @@ export declare namespace Machine {
     readonly source: SourcePath
     readonly trigger: TransitionTrigger<EventTag>
     readonly reenter: boolean
+    readonly acceptance: TransitionAcceptance
     readonly branches: ReadonlyArray<TransitionBranch<TargetPath>>
   }
 
@@ -4183,6 +4184,24 @@ export declare namespace Machine {
   export interface NoTarget {
     readonly [Topology.NoTargetTypeId]: typeof Topology.NoTargetTypeId
   }
+
+  /**
+   * Opaque result returned when a declinable transition does not accept the
+   * current event or lifecycle outcome.
+   *
+   * Declining selects no transition and discards operations enqueued by that
+   * resolver. Hierarchical event and eventless dispatch continues with the
+   * next eligible ancestor candidate.
+   *
+   * @category models
+   * @since 0.17.0
+   */
+  export interface Declined {
+    readonly [Topology.DeclinedTypeId]: typeof Topology.DeclinedTypeId
+  }
+
+  /** Static acceptance contract of one transition definition. */
+  export type TransitionAcceptance = "required" | "declinable"
 
   /**
    * Transition instruction that restores a history pseudo-state's parent.
@@ -5172,17 +5191,20 @@ export declare namespace Machine {
     Emits extends ReadonlyArray<TaggedSchema>,
     StateId extends StateNodeIdentifier<States>,
     Context,
-    Reenter extends boolean
+    Reenter extends boolean,
+    Acceptance extends TransitionAcceptance = "required"
   > {
     readonly [TransitionTypeId]: {
       readonly owner: Types.Covariant<readonly [States, Events, Emits, StateId, Context]>
+      readonly acceptance: Types.Covariant<Acceptance>
     }
   }
 
   /** Type evidence for a targetless transition reusable in every owning context. */
-  export interface TargetlessTransitionTyped {
+  export interface TargetlessTransitionTyped<Acceptance extends TransitionAcceptance = "required"> {
     readonly [TransitionTypeId]: {
       readonly targetless: true
+      readonly acceptance: Types.Covariant<Acceptance>
     }
   }
 
@@ -5193,11 +5215,12 @@ export declare namespace Machine {
     Emits extends ReadonlyArray<TaggedSchema>,
     StateId extends StateNodeIdentifier<States>,
     Context,
-    Reenter extends boolean = false
+    Reenter extends boolean = false,
+    Acceptance extends TransitionAcceptance = "required"
   > =
     & (
-      | TransitionTyped<States, Events, Emits, StateId, Context, Reenter>
-      | TargetlessTransitionTyped
+      | TransitionTyped<States, Events, Emits, StateId, Context, Reenter, Acceptance>
+      | TargetlessTransitionTyped<Acceptance>
       | TargetlessTransitionInput<Events, Emits, Context>
     )
     & {
@@ -5227,6 +5250,7 @@ export declare namespace Machine {
     readonly resolve?: TargetlessTransitionResolver<Events, Emits, Context>
     readonly branches?: never
     readonly reenter?: never
+    readonly declinable?: false
   }
 
   export type SelectionBuilder<Selection> = Selection extends TargetSelection<infer Builder, any, any> ? Builder : never
@@ -5245,6 +5269,11 @@ export declare namespace Machine {
   > =
     & Omit<Context, "target">
     & (SelectionKind<Selection> extends "none" ? {} : { readonly target: SelectionBuilder<Selection> })
+
+  /** Context capability available only to explicitly declinable resolvers. */
+  export interface DeclineCapability {
+    readonly decline: () => Declined
+  }
 
   export type TransitionResolver<
     Events extends ReadonlyArray<TaggedSchema>,
@@ -5269,6 +5298,35 @@ export declare namespace Machine {
     readonly resolve?: TransitionResolver<Events, Emits, Context, Selection>
     readonly branches?: never
     readonly reenter?: Reenter
+    readonly declinable?: false
+  }
+
+  export type DeclinableTransitionResolver<
+    Events extends ReadonlyArray<TaggedSchema>,
+    Emits extends ReadonlyArray<TaggedSchema>,
+    Context,
+    Selection
+  > = (
+    context: TransitionResolveContext<Context, Selection> & DeclineCapability,
+    enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
+  ) =>
+    | (SelectionKind<Selection> extends "none" ? undefined : SelectedTargetResult<Selection> | undefined)
+    | Declined
+
+  export type DeclinableTransitionDirectInput<
+    States extends StateSchemas,
+    Events extends ReadonlyArray<TaggedSchema>,
+    Emits extends ReadonlyArray<TaggedSchema>,
+    StateId extends StateNodeIdentifier<States>,
+    Context,
+    Reenter extends boolean,
+    Selection extends TargetSelection<any, any, any>
+  > = {
+    readonly target: (to: TargetSelector<States, StateId>) => Selection
+    readonly resolve: DeclinableTransitionResolver<Events, Emits, Context, Selection>
+    readonly branches?: never
+    readonly reenter?: Reenter
+    readonly declinable: true
   }
 
   /** One named destination declared by a branching transition. */
@@ -5357,6 +5415,33 @@ export declare namespace Machine {
     readonly branches: (to: TargetSelector<States, StateId>) => Branches
     readonly resolve: TransitionBranchesResolver<Events, Emits, Context, Branches>
     readonly reenter?: Reenter
+    readonly declinable?: false
+  }
+
+  export type DeclinableTransitionBranchesResolver<
+    Events extends ReadonlyArray<TaggedSchema>,
+    Emits extends ReadonlyArray<TaggedSchema>,
+    Context,
+    Branches extends Readonly<Record<string, TransitionBranchInput>>
+  > = (
+    context: TransitionBranchesResolveContext<Context, Branches> & DeclineCapability,
+    enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
+  ) => BranchSelectionResult<Branches> | Declined
+
+  export type DeclinableTransitionBranchesInput<
+    States extends StateSchemas,
+    Events extends ReadonlyArray<TaggedSchema>,
+    Emits extends ReadonlyArray<TaggedSchema>,
+    StateId extends StateNodeIdentifier<States>,
+    Context,
+    Reenter extends boolean,
+    Branches extends Readonly<Record<string, TransitionBranchInput>>
+  > = {
+    readonly target?: never
+    readonly branches: (to: TargetSelector<States, StateId>) => Branches
+    readonly resolve: DeclinableTransitionBranchesResolver<Events, Emits, Context, Branches>
+    readonly reenter?: Reenter
+    readonly declinable: true
   }
 
   export type InvokeTransition<
@@ -5365,7 +5450,7 @@ export declare namespace Machine {
     Emits extends ReadonlyArray<TaggedSchema>,
     StateId extends StateNodeIdentifier<States>,
     Context
-  > = TransitionConfig<States, Events, Emits, StateId, Context, true>
+  > = TransitionConfig<States, Events, Emits, StateId, Context, true, TransitionAcceptance>
 
   export type InvokeSource<Value, Context> = Value | ((context: Context) => Value)
 
@@ -6011,14 +6096,18 @@ export declare namespace Machine {
       Events,
       Emits,
       StateId,
-      AlwaysContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+      AlwaysContext<States, Events, Emits, StateId, InputEvents, ParentEvents>,
+      false,
+      TransitionAcceptance
     >
     readonly onDone?: TransitionConfig<
       States,
       Events,
       Emits,
       StateId,
-      DoneContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
+      DoneContext<States, Events, Emits, StateId, InputEvents, ParentEvents>,
+      false,
+      TransitionAcceptance
     >
     readonly on?: {
       readonly [EventTag in TagOf<Events[number]>]?: TransitionConfig<
@@ -6027,7 +6116,8 @@ export declare namespace Machine {
         Emits,
         StateId,
         HandlerContext<States, Events, Emits, StateId, EventTag, E, R, InputEvents, ParentEvents>,
-        true
+        true,
+        TransitionAcceptance
       >
     }
     readonly initialize?: StateInitializeHandler<States, Events, Emits, StateId, InputEvents, ParentEvents>
@@ -7022,7 +7112,8 @@ export declare namespace Machine {
         Emits,
         StateId,
         HandlerContext<States, Events, Emits, StateId, EventTag, E, R>,
-        true
+        true,
+        TransitionAcceptance
       >
     >
   >
@@ -7056,14 +7147,18 @@ export declare namespace Machine {
       Events,
       Emits,
       StateId,
-      AlwaysContext<States, Events, Emits, StateId>
+      AlwaysContext<States, Events, Emits, StateId>,
+      false,
+      TransitionAcceptance
     >
     readonly onDone?: TransitionConfig<
       States,
       Events,
       Emits,
       StateId,
-      DoneContext<States, Events, Emits, StateId>
+      DoneContext<States, Events, Emits, StateId>,
+      false,
+      TransitionAcceptance
     >
     readonly output?:
       | ((context: FinalOutputContext<States, Events, StateId>) => unknown)
@@ -7964,10 +8059,32 @@ type BranchingTransitionResult<
   StateId extends Machine.StateNodeIdentifier<States>,
   Context,
   Reenter extends boolean,
-  Branches extends Readonly<Record<string, Machine.TransitionBranchInput>>
+  Branches extends Readonly<Record<string, Machine.TransitionBranchInput>>,
+  Acceptance extends Machine.TransitionAcceptance = "required"
 > =
-  & Machine.TransitionBranchesInput<States, Events, Emits, StateId, Context, Reenter, Branches>
-  & Machine.TransitionTyped<States, Events, Emits, StateId, Context, Reenter>
+  & (Acceptance extends "declinable" ? Machine.DeclinableTransitionBranchesInput<
+      States,
+      Events,
+      Emits,
+      StateId,
+      Context,
+      Reenter,
+      Branches
+    >
+    : Machine.TransitionBranchesInput<States, Events, Emits, StateId, Context, Reenter, Branches>)
+  & Machine.TransitionTyped<States, Events, Emits, StateId, Context, Reenter, Acceptance>
+
+type DirectTransitionEvidence<
+  States extends Machine.StateSchemas,
+  Events extends ReadonlyArray<Machine.TaggedSchema>,
+  Emits extends ReadonlyArray<Machine.TaggedSchema>,
+  StateId extends Machine.StateNodeIdentifier<States>,
+  Context,
+  Reenter extends boolean,
+  Selection,
+  Acceptance extends Machine.TransitionAcceptance
+> = Machine.SelectionKind<Selection> extends "none" ? Machine.TargetlessTransitionTyped<Acceptance>
+  : Machine.TransitionTyped<States, Events, Emits, StateId, Context, Reenter, Acceptance>
 
 type TransitionBranchRecordError<Message extends string, Key extends PropertyKey = never> = {
   readonly "~effect/Machine/TransitionBranchRecordError": Message
@@ -8000,11 +8117,53 @@ export interface TransitionConstructor {
     const Selection extends Machine.TargetSelection<any, any, any>,
     Reenter extends boolean = never
   >(
+    config: Machine.DeclinableTransitionDirectInput<States, Events, Emits, StateId, Context, Reenter, Selection>
+  ):
+    & Machine.DeclinableTransitionDirectInput<States, Events, Emits, StateId, Context, Reenter, Selection>
+    & DirectTransitionEvidence<States, Events, Emits, StateId, Context, Reenter, Selection, "declinable">
+  <
+    const States extends Machine.StateSchemas,
+    const Events extends ReadonlyArray<Machine.TaggedSchema>,
+    const Emits extends ReadonlyArray<Machine.TaggedSchema>,
+    StateId extends Machine.StateNodeIdentifier<States>,
+    Context,
+    const Selection extends Machine.TargetSelection<any, any, any>,
+    Reenter extends boolean = never
+  >(
     config: Machine.TransitionDirectInput<States, Events, Emits, StateId, Context, Reenter, Selection>
   ):
     & Machine.TransitionDirectInput<States, Events, Emits, StateId, Context, Reenter, Selection>
-    & (Machine.SelectionKind<Selection> extends "none" ? Machine.TargetlessTransitionTyped
-      : Machine.TransitionTyped<States, Events, Emits, StateId, Context, Reenter>)
+    & DirectTransitionEvidence<States, Events, Emits, StateId, Context, Reenter, Selection, "required">
+  <
+    const States extends Machine.StateSchemas,
+    const Events extends ReadonlyArray<Machine.TaggedSchema>,
+    const Emits extends ReadonlyArray<Machine.TaggedSchema>,
+    StateId extends Machine.StateNodeIdentifier<States>,
+    Context,
+    const Branches extends Readonly<Record<string, Machine.TransitionBranchInput>>,
+    Reenter extends boolean = never
+  >(
+    config:
+      & Machine.DeclinableTransitionBranchesInput<
+        States,
+        Events,
+        Emits,
+        StateId,
+        Context,
+        Reenter,
+        Branches
+      >
+      & ValidateTransitionBranchRecord<NoInfer<Branches>>
+  ): BranchingTransitionResult<
+    States,
+    Events,
+    Emits,
+    StateId,
+    Context,
+    Reenter,
+    Branches,
+    "declinable"
+  >
   <
     const States extends Machine.StateSchemas,
     const Events extends ReadonlyArray<Machine.TaggedSchema>,
@@ -8059,6 +8218,14 @@ export interface TransitionConstructor {
  *   resolve: ({ event, select }) => event.cached
  *     ? select.cached.from({ data: event.cached })
  *     : select.loading.from()
+ * })
+ *
+ * Machine.transition({
+ *   declinable: true,
+ *   target: (to) => to.full.Ready(),
+ *   resolve: ({ event, target, decline }) => event.accepted
+ *     ? target.from()
+ *     : decline()
  * })
  * ```
  *
@@ -8899,7 +9066,8 @@ export const initialDefinition: <M extends Machine.Any>(machine: M) => Machine.I
  * Event handlers retain their handler-key order within each source state and
  * are followed by eventless and completion handlers. This function does not
  * execute resolvers. Every direct, named, and targetless branch exposes the
- * destination selected by its required static `target` declaration.
+ * destination selected by its required static `target` declaration, while
+ * `acceptance` reports whether the resolver may decline the transition.
  *
  * @category getters
  * @since 0.4.0
@@ -8952,7 +9120,12 @@ export const configuration: <M extends Machine.Any>(
 > = internal.configuration
 
 /**
- * Returns the event tags handled by the current state snapshot.
+ * Returns event tags with at least one structurally eligible handler in the
+ * current state snapshot.
+ *
+ * A `declinable` handler may still reject a concrete event at planning time,
+ * so this is a static candidate query rather than a guarantee that every value
+ * with the returned tag will be handled.
  *
  * @category getters
  * @since 0.4.0

--- a/src/internal/machine/executionPlan.ts
+++ b/src/internal/machine/executionPlan.ts
@@ -47,7 +47,7 @@ import {
   validateDeclaredTransitionTarget
 } from "./planner.js"
 import { decodeEmitSync, decodeEventSync, decodeInputSync, decodeStateValueSync } from "./protocol.js"
-import { isDeclined, isInitialTarget, isNoTarget, isSnapshot, isTarget, TargetSnapshotTypeId } from "./topology.js"
+import { isInitialTarget, isNoTarget, isSnapshot, isTarget, TargetSnapshotTypeId } from "./topology.js"
 
 interface IndexedExecutionDescriptor {
   readonly flat: boolean
@@ -448,9 +448,6 @@ const collectIndexedTransition = (
   const evaluated = evaluate === undefined
     ? { result: transition(context, enqueue), branchIndex: 0, branchKey: undefined }
     : evaluate(context, enqueue)
-  if (isDeclined(evaluated.result)) {
-    throw new Error("Machine indexed transition returned decline without declaring declinable: true")
-  }
   return {
     state: isNoTarget(evaluated.result) ? undefined : evaluated.result,
     branchIndex: evaluated.branchIndex,

--- a/src/internal/machine/executionPlan.ts
+++ b/src/internal/machine/executionPlan.ts
@@ -47,7 +47,7 @@ import {
   validateDeclaredTransitionTarget
 } from "./planner.js"
 import { decodeEmitSync, decodeEventSync, decodeInputSync, decodeStateValueSync } from "./protocol.js"
-import { isInitialTarget, isNoTarget, isSnapshot, isTarget, TargetSnapshotTypeId } from "./topology.js"
+import { isDeclined, isInitialTarget, isNoTarget, isSnapshot, isTarget, TargetSnapshotTypeId } from "./topology.js"
 
 interface IndexedExecutionDescriptor {
   readonly flat: boolean
@@ -152,6 +152,7 @@ const compileIndexedExecutionDescriptor = (
     for (const tag of Reflect.ownKeys(config.on)) {
       const transition = normalizeTransition(config.on[tag] as Parameters<typeof normalizeTransition>[0])
       if (transition !== undefined) {
+        if (transition.declinable) return undefined
         byEvent.set(tag, transition)
       }
     }
@@ -447,6 +448,9 @@ const collectIndexedTransition = (
   const evaluated = evaluate === undefined
     ? { result: transition(context, enqueue), branchIndex: 0, branchKey: undefined }
     : evaluate(context, enqueue)
+  if (isDeclined(evaluated.result)) {
+    throw new Error("Machine indexed transition returned decline without declaring declinable: true")
+  }
   return {
     state: isNoTarget(evaluated.result) ? undefined : evaluated.result,
     branchIndex: evaluated.branchIndex,

--- a/src/internal/machine/machine.ts
+++ b/src/internal/machine/machine.ts
@@ -139,6 +139,7 @@ const makeWithHandlers = (
 type DefinitionBranch = {
   readonly target: (selector: unknown) => unknown
   readonly resolve?: (context: any, enqueue: unknown) => unknown
+  readonly declinable?: boolean
 }
 
 type CapturedBranch = DefinitionBranch & {
@@ -352,7 +353,14 @@ const runCapturedBranch = (
   const resolverContext = { ...context }
   if (branch.selection.kind === "none") delete resolverContext.target
   else resolverContext.target = selectedTarget
+  if (branch.declinable === true) resolverContext.decline = Topology.makeDeclined
   const resolved = branch.resolve(resolverContext, enqueue)
+  if (Topology.isDeclined(resolved)) {
+    if (branch.declinable !== true) {
+      throw new Error(`Machine transition for state "${source}" returned decline without declaring declinable: true`)
+    }
+    return resolved
+  }
   validateResolvedSelection(resolved, branch.selection, stateNodes)
   return resolved === undefined ? constructSelectedTarget(selectedTarget) : resolved
 }
@@ -485,6 +493,7 @@ const captureTransition = (
   const definition = transition as Record<PropertyKey, unknown>
   const selector = makeTargetSelector(stateNodes, path)
   const reenter = definition.reenter === true
+  const declinable = definition.declinable === true
   if (hasProperty(definition, "branches")) {
     const branching = definition as { readonly branches: unknown; readonly resolve?: unknown }
     if (typeof branching.branches !== "function" || typeof branching.resolve !== "function") {
@@ -499,7 +508,18 @@ const captureTransition = (
       const resolverContext = { ...context }
       delete resolverContext.target
       resolverContext.select = makeBranchSelectors(context, branches, owner, stateNodes, path)
+      if (declinable) resolverContext.decline = Topology.makeDeclined
       const selected = resolve(resolverContext, enqueue)
+      if (Topology.isDeclined(selected)) {
+        if (!declinable) {
+          throw new Error(
+            `Machine branching transition for state "${path}" on "${
+              String(trigger)
+            }" returned decline without declaring declinable: true`
+          )
+        }
+        return { result: selected, branchIndex: -1, branchKey: undefined }
+      }
       if (!Topology.isSelectedBranch(selected) || selected.owner !== owner) {
         throw new Error(
           `Machine branching transition for state "${path}" on "${String(trigger)}" must select one declared branch`
@@ -518,6 +538,7 @@ const captureTransition = (
     }
     return {
       reenter,
+      declinable,
       targets: [
         ...new Set(
           branches.flatMap((branch) => branch.selection.path === undefined ? [] : [branch.selection.path])
@@ -544,6 +565,7 @@ const captureTransition = (
   })
   return {
     reenter,
+    declinable,
     targets: branch.selection.path === undefined ? [] : [branch.selection.path],
     branches: [{
       type: "direct" as const,

--- a/src/internal/machine/planner.ts
+++ b/src/internal/machine/planner.ts
@@ -53,6 +53,7 @@ import {
   getNode,
   type InitialTarget as InitialTargetInstruction,
   isChoiceTarget,
+  isDeclined,
   isHistoryTarget,
   isInitialTarget,
   isNoTarget,
@@ -104,10 +105,10 @@ export type MacrostepPlan<State, Event, E, R, Output> =
 export type TransitionHandler<States extends Machine.StateSchemas, E, R, Context> = (
   context: Context,
   enqueue: Enqueue<any, any>
-) => Machine.HandlerResult<States, E, R>
+) => Machine.HandlerResult<States, E, R> | Machine.Declined
 
 type TransitionEvaluation<States extends Machine.StateSchemas, E, R> = {
-  readonly result: Machine.HandlerResult<States, E, R>
+  readonly result: Machine.HandlerResult<States, E, R> | Machine.Declined
   readonly branchIndex: number
   readonly branchKey: string | undefined
 }
@@ -153,6 +154,7 @@ type EventTransition<States extends Machine.StateSchemas, E, R, Context> =
   | TransitionHandler<States, E, R, Context>
   | {
     readonly reenter?: boolean
+    readonly declinable?: boolean
     readonly targets?: ReadonlyArray<string>
     readonly transition: TransitionHandler<States, E, R, Context>
     readonly evaluate?: TransitionEvaluator<States, E, R, Context>
@@ -160,6 +162,7 @@ type EventTransition<States extends Machine.StateSchemas, E, R, Context> =
 
 export type MicrostepTransition<States extends Machine.StateSchemas, E, R, Context> = {
   readonly reenter: boolean
+  readonly declinable: boolean
   readonly targets: ReadonlyArray<string> | undefined
   readonly transition: TransitionHandler<States, E, R, Context>
   readonly evaluate: TransitionEvaluator<States, E, R, Context> | undefined
@@ -172,9 +175,10 @@ export const normalizeTransition = <States extends Machine.StateSchemas, E, R, C
     return undefined
   }
   return typeof transition === "function"
-    ? { reenter: false, targets: undefined, transition, evaluate: undefined }
+    ? { reenter: false, declinable: false, targets: undefined, transition, evaluate: undefined }
     : {
       reenter: transition.reenter === true,
+      declinable: transition.declinable === true,
       targets: transition.targets,
       transition: transition.transition,
       evaluate: transition.evaluate
@@ -218,7 +222,11 @@ const collectTransition = <
   const evaluated = evaluate === undefined
     ? { result: transition(context, collected.enqueue), branchIndex: 0, branchKey: undefined }
     : evaluate(context, collected.enqueue)
+  if (isDeclined(evaluated.result)) {
+    return { declined: true as const }
+  }
   return {
+    declined: false as const,
     state: isNoTarget(evaluated.result) ? undefined : evaluated.result,
     branchIndex: evaluated.branchIndex,
     branchKey: evaluated.branchKey,
@@ -521,6 +529,29 @@ export type SelectedTransition<States extends Machine.StateSchemas, E, R, Contex
   readonly trigger: Machine.TransitionTrigger
   readonly transition: MicrostepTransition<States, E, R, Context>
   readonly context: Context
+  readonly collected?: {
+    readonly declined: false
+    readonly state: unknown
+    readonly branchIndex: number
+    readonly branchKey: string | undefined
+    readonly commands: ReadonlyArray<RuntimeCommand>
+    readonly raisedEvents: ReadonlyArray<unknown>
+    readonly emittedEvents: ReadonlyArray<unknown>
+  }
+}
+
+const resolveDeclinableCandidate = <States extends Machine.StateSchemas, E, R, Context>(
+  machine: Machine.Any,
+  selection: SelectedTransition<States, E, R, Context>
+): SelectedTransition<States, E, R, Context> | undefined => {
+  if (!selection.transition.declinable) return selection
+  const collected = collectTransition(
+    machine,
+    selection.transition.transition,
+    selection.context,
+    selection.transition.evaluate
+  )
+  return collected.declined ? undefined : { ...selection, collected }
 }
 
 export type EvaluatedTransition<States extends Machine.StateSchemas, Event, E, R, Context> = {
@@ -759,15 +790,16 @@ const selectAlwaysTransitions = <
     >
   > = []
   const selectedSources = new Set<string>()
+  const evaluatedSources = new Map<string, SelectedTransition<States, E, R, any> | undefined>()
   let snapshot: Machine.Snapshot<States> | undefined
   const capturedSnapshot = () => snapshot ??= snapshotFromConfiguration<States>(machine, configuration)
   for (const leaf of getActiveLeafPaths(machine, configuration)) {
     for (const path of getLeafCandidatePaths(machine, leaf)) {
       const always = normalizeTransition(machine.handlers[path]?.always)
       if (always !== undefined) {
-        if (!selectedSources.has(path)) {
-          selectedSources.add(path)
-          selected.push({
+        let candidate = evaluatedSources.get(path)
+        if (!evaluatedSources.has(path)) {
+          candidate = resolveDeclinableCandidate(machine, {
             sourcePath: path,
             leafPath: leaf,
             trigger: { type: "always" },
@@ -796,6 +828,12 @@ const selectAlwaysTransitions = <
               target: getTargetBuilder(machine, path)
             }
           })
+          evaluatedSources.set(path, candidate)
+        }
+        if (candidate === undefined) continue
+        if (!selectedSources.has(path)) {
+          selectedSources.add(path)
+          selected.push(candidate as (typeof selected)[number])
         }
         break
       }
@@ -838,7 +876,7 @@ const selectDoneTransitions = <
     const onDone = normalizeTransition(machine.handlers[completion.path]?.onDone)
     if (onDone !== undefined && !selectedSources.has(completion.path)) {
       selectedSources.add(completion.path)
-      selected.push({
+      const candidate = resolveDeclinableCandidate(machine, {
         sourcePath: completion.path,
         leafPath: getActiveLeafPathFrom(machine, configuration, completion.path),
         trigger: { type: "done" },
@@ -857,6 +895,7 @@ const selectDoneTransitions = <
           capturedSnapshot()
         )
       })
+      if (candidate !== undefined) selected.push(candidate)
     }
   }
   return selected
@@ -897,15 +936,16 @@ const selectEventTransitions = <
     >
   > = []
   const selectedSources = new Set<string>()
+  const evaluatedSources = new Map<string, SelectedTransition<States, E, R, any> | undefined>()
   let snapshot: Machine.Snapshot<States> | undefined
   const capturedSnapshot = () => snapshot ??= snapshotFromConfiguration<States>(machine, configuration)
   for (const leaf of getActiveLeafPaths(machine, configuration)) {
     for (const path of getLeafCandidatePaths(machine, leaf)) {
       const transition = normalizeTransition(machine.handlers[path]?.on?.[event._tag])
       if (transition !== undefined) {
-        if (!selectedSources.has(path)) {
-          selectedSources.add(path)
-          selected.push({
+        let candidate = evaluatedSources.get(path)
+        if (!evaluatedSources.has(path)) {
+          candidate = resolveDeclinableCandidate(machine, {
             sourcePath: path,
             leafPath: leaf,
             trigger: { type: "event", event: event._tag },
@@ -931,6 +971,12 @@ const selectEventTransitions = <
               Machine.TagOf<Events[number]>
             >(machine as any, configuration, path, event, capturedSnapshot())
           })
+          evaluatedSources.set(path, candidate)
+        }
+        if (candidate === undefined) continue
+        if (!selectedSources.has(path)) {
+          selectedSources.add(path)
+          selected.push(candidate as (typeof selected)[number])
         }
         break
       }
@@ -983,13 +1029,14 @@ const selectInvocationTransition = <
       ? { error: event.error }
       : { snapshot: event.snapshot })
   }
-  return [{
+  const candidate = resolveDeclinableCandidate(machine, {
     sourcePath: event.path,
     leafPath: getActiveLeafPathFrom(machine, configuration, event.path),
     trigger: { type: "invoke", id: event.id, outcome: event.type },
     transition: transition as unknown as MicrostepTransition<States, E, R, any>,
     context
-  }]
+  })
+  return candidate === undefined ? [] : [candidate]
 }
 
 export const getTargetNodePath = <const States extends Machine.StateSchemas>(
@@ -1275,12 +1322,15 @@ const collectEvaluatedTransition = <
   selection: SelectedTransition<States, E, R, Context>
 ) => {
   const stateIdentifier = selection.leafPath
-  const transitionResult = collectTransition<States, Event, E, R, Context>(
+  const transitionResult = selection.collected ?? collectTransition<States, Event, E, R, Context>(
     machine,
     selection.transition.transition,
     selection.context,
     selection.transition.evaluate
   )
+  if (transitionResult.declined) {
+    throw new Error("Machine transition returned decline without declaring declinable: true")
+  }
   const unresolvedTarget = transitionResult.state === undefined
     ? undefined
     : transitionResult.state as

--- a/src/internal/machine/topology.ts
+++ b/src/internal/machine/topology.ts
@@ -25,6 +25,8 @@ export const ChoiceTargetTypeId: unique symbol = Symbol("effect/Machine/ChoiceTa
 
 export const NoTargetTypeId: unique symbol = Symbol("effect/Machine/NoTarget")
 
+export const DeclinedTypeId: unique symbol = Symbol("effect/Machine/Declined")
+
 export const TargetSelectionTypeId: unique symbol = Symbol("effect/Machine/TargetSelection")
 
 export const SelectedBranchTypeId: unique symbol = Symbol("effect/Machine/SelectedBranch")
@@ -64,6 +66,11 @@ export interface ChoiceTarget {
 /** Internal marker returned by an explicitly targetless transition. */
 export interface NoTarget {
   readonly [NoTargetTypeId]: typeof NoTargetTypeId
+}
+
+/** Internal marker returned when a declinable transition is not enabled. */
+export interface Declined {
+  readonly [DeclinedTypeId]: typeof DeclinedTypeId
 }
 
 export type TargetSelectionKind = "state" | "initial" | "history" | "choice" | "none"
@@ -124,6 +131,14 @@ const noTarget = Object.freeze({
 export const makeNoTarget = (): Machine.NoTarget => noTarget
 
 export const isNoTarget = (u: unknown): u is Machine.NoTarget => hasProperty(u, NoTargetTypeId)
+
+const declined = Object.freeze({
+  [DeclinedTypeId]: DeclinedTypeId
+}) as Declined
+
+export const makeDeclined = (): Machine.Declined => declined
+
+export const isDeclined = (u: unknown): u is Machine.Declined => hasProperty(u, DeclinedTypeId)
 
 export const makeHistoryTarget = (path: string, parent: string): HistoryTarget => ({
   [HistoryTargetTypeId]: HistoryTargetTypeId,
@@ -441,6 +456,11 @@ const transitionBranches = (handler: unknown): ReadonlyArray<Machine.TransitionB
     ? Array.from(handler.branches as ReadonlyArray<Machine.TransitionBranch>)
     : []
 
+const transitionAcceptance = (handler: unknown): Machine.TransitionAcceptance =>
+  typeof handler === "object" && handler !== null && "declinable" in handler && handler.declinable === true
+    ? "declinable"
+    : "required"
+
 export const transitionDefinitions = (
   machine: Machine.Any
 ): ReadonlyArray<Machine.TransitionDefinition> => {
@@ -457,6 +477,7 @@ export const transitionDefinitions = (
           source: node.path,
           trigger: { type: "choice" },
           reenter: false,
+          acceptance: "required",
           branches: transitionBranches(choice)
         })
       }
@@ -468,6 +489,7 @@ export const transitionDefinitions = (
         source: node.path,
         trigger: { type: "event", event },
         reenter: hasProperty(handler, "reenter") && handler.reenter === true,
+        acceptance: transitionAcceptance(handler),
         branches: transitionBranches(handler)
       })
     }
@@ -476,6 +498,7 @@ export const transitionDefinitions = (
         source: node.path,
         trigger: { type: "always" },
         reenter: false,
+        acceptance: transitionAcceptance(config.always),
         branches: transitionBranches(config.always)
       })
     }
@@ -484,6 +507,7 @@ export const transitionDefinitions = (
         source: node.path,
         trigger: { type: "done" },
         reenter: false,
+        acceptance: transitionAcceptance(config.onDone),
         branches: transitionBranches(config.onDone)
       })
     }
@@ -507,6 +531,7 @@ export const transitionDefinitions = (
             source: node.path,
             trigger: { type: "invoke", id, outcome },
             reenter: typeof handler === "object" && handler !== null && handler.reenter === true,
+            acceptance: transitionAcceptance(handler),
             branches: transitionBranches(handler)
           })
         }

--- a/src/internal/testing/machine/transitionCoverage.ts
+++ b/src/internal/testing/machine/transitionCoverage.ts
@@ -66,6 +66,7 @@ export const makeTransitionCoverageCollector = <M extends AnyMachine>(
       source: definition.source,
       trigger: definition.trigger,
       reenter: definition.reenter,
+      acceptance: definition.acceptance,
       branches: definition.branches
     })
   )
@@ -85,6 +86,7 @@ export const makeTransitionCoverageCollector = <M extends AnyMachine>(
         source: definition.source,
         trigger: definition.trigger,
         reenter: definition.reenter,
+        acceptance: definition.acceptance,
         branch
       })
     })

--- a/src/testing/MachineTest.ts
+++ b/src/testing/MachineTest.ts
@@ -1703,6 +1703,7 @@ export interface TransitionDefinitionCoverageItem<
   readonly source: SourcePath
   readonly trigger: Machine.Machine.TransitionTrigger<EventTag>
   readonly reenter: boolean
+  readonly acceptance: Machine.Machine.TransitionAcceptance
   readonly branches: ReadonlyArray<Machine.Machine.TransitionBranch<TargetPath>>
 }
 
@@ -1725,6 +1726,7 @@ export interface TransitionBranchCoverageItem<
   readonly source: SourcePath
   readonly trigger: Machine.Machine.TransitionTrigger<EventTag>
   readonly reenter: boolean
+  readonly acceptance: Machine.Machine.TransitionAcceptance
   readonly branch: Machine.Machine.TransitionBranch<TargetPath>
 }
 

--- a/test/internal/machine/strategyDifferential.test.ts
+++ b/test/internal/machine/strategyDifferential.test.ts
@@ -113,6 +113,38 @@ describe("machine planner and runtime strategies", () => {
     })
   })
 
+  it.effect("fails closed to generic planning for declinable transitions", () => {
+    const states = Machine.states({ Count })
+    const machine = Machine.make({
+      states: states.states,
+      events: Machine.events(Select),
+      initial: {
+        target: (to) => to.Count(),
+        resolve: ({ target }) => target(new Count({ value: 0 }))
+      }
+    }).handle({
+      Count: {
+        on: {
+          Select: Machine.transition({
+            declinable: true,
+            target: (to) => to.full.Count(),
+            resolve: ({ event, state, target, decline }) =>
+              event.value < 0
+                ? decline()
+                : target(new Count({ value: state.value + event.value }))
+          })
+        }
+      }
+    })
+
+    return verifyPlannerStrategies({
+      machine,
+      events: [new Select({ value: -1 }), new Select({ value: 2 })],
+      expected: "generic",
+      label: "declinable transition"
+    })
+  })
+
   it.effect("reenters the source when an explicit targetless transition requests reentry", () =>
     Effect.gen(function*() {
       const machine = makeFlatMachine()

--- a/test/machine/Choice.test.ts
+++ b/test/machine/Choice.test.ts
@@ -626,6 +626,7 @@ describe("Machine choice pseudo-states", () => {
         source: "Flow.Routing",
         trigger: { type: "choice" },
         reenter: false,
+        acceptance: "required",
         branches: [
           {
             type: "branch",

--- a/test/machine/Invoke.test.ts
+++ b/test/machine/Invoke.test.ts
@@ -24,6 +24,38 @@ class FinishStream extends Schema.TaggedClass<FinishStream>("InvokeFinishStream"
 const States = Machine.states({ Idle, Loading, Complete, Failed })
 
 describe("inline invoke", () => {
+  it.effect("ignores an invocation outcome when its transition declines", () =>
+    Effect.gen(function*() {
+      const machine = Machine.make({
+        states: States.states,
+        events: Machine.events(),
+        initial: {
+          target: (to) => to.Loading(),
+          resolve: ({ target }) => target.from()
+        }
+      }).handle({
+        Loading: {
+          invoke: Machine.invoke({
+            id: "load",
+            effect: () => Effect.succeed("ignored"),
+            onDone: Machine.transition({
+              declinable: true,
+              target: (to) => to.full.Complete(),
+              resolve: ({ decline }) => decline()
+            })
+          })
+        },
+        Complete: {},
+        Failed: {},
+        Idle: {}
+      })
+
+      assert.strictEqual(Machine.transitionDefinitions(machine)[0]?.acceptance, "declinable")
+      const ref = yield* Machine.start(machine)
+      for (let index = 0; index < 5; index += 1) yield* Effect.yieldNow
+      assert.deepStrictEqual(yield* ref.state, { path: "Loading" as const, value: new Loading({}) })
+    }))
+
   it.effect("handles Stream elements sequentially before completion", () =>
     Effect.gen(function*() {
       const states = Machine.states({ Collecting, Complete })
@@ -66,6 +98,7 @@ describe("inline invoke", () => {
           source: "Collecting",
           trigger: { type: "event", event: "Add" },
           reenter: false,
+          acceptance: "required",
           branches: [{
             type: "direct",
             target: "Collecting",
@@ -76,6 +109,7 @@ describe("inline invoke", () => {
           source: "Collecting",
           trigger: { type: "invoke", id: "numbers", outcome: "element" },
           reenter: false,
+          acceptance: "required",
           branches: [{
             type: "direct",
             target: undefined,
@@ -86,6 +120,7 @@ describe("inline invoke", () => {
           source: "Collecting",
           trigger: { type: "invoke", id: "numbers", outcome: "done" },
           reenter: false,
+          acceptance: "required",
           branches: [{
             type: "direct",
             target: "Complete",
@@ -257,6 +292,7 @@ describe("inline invoke", () => {
         source: "Loading",
         trigger: { type: "invoke", id: "load", outcome: "done" },
         reenter: false,
+        acceptance: "required",
         branches: [{
           type: "direct",
           target: "Complete",

--- a/test/machine/LocalTargetWith.test.ts
+++ b/test/machine/LocalTargetWith.test.ts
@@ -58,6 +58,7 @@ describe("local compound target selection", () => {
         source: "search",
         trigger: { type: "event", event: "UpdateQuery" },
         reenter: true,
+        acceptance: "required",
         branches: [{
           type: "direct",
           target: "search",
@@ -67,6 +68,7 @@ describe("local compound target selection", () => {
         source: "search.Updated",
         trigger: { type: "event", event: "Reset" },
         reenter: false,
+        acceptance: "required",
         branches: [{
           type: "direct",
           target: "search.Idle",
@@ -143,6 +145,7 @@ describe("local compound target selection", () => {
         source: "search.Searching",
         trigger: { type: "invoke", id: "search", outcome: "done" },
         reenter: false,
+        acceptance: "required",
         branches: [{
           type: "direct",
           target: "search",

--- a/test/machine/Machine.test.ts
+++ b/test/machine/Machine.test.ts
@@ -160,6 +160,7 @@ describe("Machine", () => {
         source: "Stable",
         trigger: { type: "event", event: "Ping" },
         reenter: false,
+        acceptance: "required",
         branches: [{
           type: "direct",
           target: undefined,
@@ -221,6 +222,7 @@ describe("Machine", () => {
         source: "Stable",
         trigger: { type: "event", event: "Ping" },
         reenter: true,
+        acceptance: "required",
         branches: [{
           type: "branch",
           key: "unchanged",
@@ -2393,6 +2395,278 @@ describe("Machine", () => {
         path: "payment.authorized" as const,
         value: new AuthorizedPayment({ code: "auth-1" })
       })
+    }))
+
+  it.effect("lets declinable child handlers yield to ancestors without retaining queued work", () =>
+    Effect.gen(function*() {
+      class Notice extends Schema.TaggedClass<Notice>("DeclineNotice")("Notice", {}) {}
+      const payment = new Payment({ id: "payment-1" })
+      const entering = new EnteringPayment({ amount: 100 })
+      const machine = Machine.make({
+        states: {
+          payment: {
+            schema: Payment,
+            initial: "entering",
+            states: {
+              entering: EnteringPayment,
+              authorized: AuthorizedPayment
+            }
+          },
+          failed: Failed
+        },
+        events: Machine.events(Authorize),
+        emittedEvents: Machine.emittedEvents(Notice),
+        initial: {
+          target: (to) => to.payment.initial(),
+          resolve: () => ({
+            path: "payment" as const,
+            value: payment,
+            state: {
+              path: "payment.entering" as const,
+              value: entering
+            }
+          })
+        }
+      }).handle({
+        payment: {
+          on: {
+            Authorize: Machine.transition({
+              target: (to) => to.full.failed(),
+              resolve: ({ target }) => target(new Failed({ message: "parent" }))
+            })
+          },
+          states: {
+            entering: {
+              on: {
+                Authorize: Machine.transition({
+                  declinable: true,
+                  branches: (to) => ({
+                    authorize: { target: to.local.authorized() },
+                    consume: { target: to.none() }
+                  }),
+                  resolve: ({ event, select, decline }, enqueue) => {
+                    if (event.code === "child") {
+                      return select.authorize(new AuthorizedPayment({ code: event.code }))
+                    }
+                    if (event.code === "consume") return select.consume()
+                    enqueue.emit(new Notice({}))
+                    return decline()
+                  }
+                })
+              }
+            }
+          }
+        }
+      })
+
+      assert.strictEqual(
+        Machine.transitionDefinitions(machine).find(({ source }) => source === "payment.entering")?.acceptance,
+        "declinable"
+      )
+      const initial = yield* Machine.planInitial(machine)
+      const child = yield* Machine.plan(machine, initial.state, new Authorize({ code: "child" }))
+      assert.strictEqual(child.next.path, "payment")
+      if (child.next.path === "payment") assert.strictEqual(child.next.state.path, "payment.authorized")
+      assert.strictEqual(child.microsteps[0]?.transitions[0]?.source, "payment.entering")
+      assert.strictEqual(child.microsteps[0]?.transitions[0]?.branchKey, "authorize")
+
+      const consumed = yield* Machine.plan(machine, initial.state, new Authorize({ code: "consume" }))
+      assert.deepStrictEqual(consumed.next, initial.state)
+      assert.strictEqual(consumed.microsteps[0]?.transitions[0]?.source, "payment.entering")
+      assert.strictEqual(consumed.microsteps[0]?.transitions[0]?.branchKey, "consume")
+      assert.strictEqual(consumed.microsteps[0]?.transitions[0]?.target, undefined)
+
+      const declined = yield* Machine.plan(machine, initial.state, new Authorize({ code: "parent" }))
+      assert.strictEqual(declined.next.path, "failed")
+      assert.strictEqual(declined.microsteps[0]?.transitions[0]?.source, "payment")
+      assert.deepStrictEqual(declined.emittedEvents, [])
+    }))
+
+  it.effect("continues eventless selection at an ancestor when a child declines", () =>
+    Effect.gen(function*() {
+      class Workflow extends Schema.TaggedClass<Workflow>("DeclineWorkflow")("Workflow", {}) {}
+      class Waiting extends Schema.TaggedClass<Waiting>("DeclineWaiting")("Waiting", { ready: Schema.Boolean }) {}
+      class Finished extends Schema.TaggedClass<Finished>("DeclineFinished")("Finished", {}) {}
+      const states = Machine.states({
+        workflow: {
+          schema: Workflow,
+          initial: "waiting",
+          states: { waiting: Waiting }
+        },
+        finished: Finished
+      })
+      const machine = Machine.make({
+        states: states.states,
+        events: Machine.events(),
+        initial: {
+          target: (to) => to.workflow.initial(),
+          resolve: ({ target }) =>
+            target(new Workflow({}), (workflow) => workflow.waiting(new Waiting({ ready: false })))
+        }
+      }).handle({
+        workflow: {
+          always: Machine.transition({
+            target: (to) => to.full.finished(),
+            resolve: ({ target }) => target(new Finished({}))
+          }),
+          states: {
+            waiting: {
+              always: Machine.transition({
+                declinable: true,
+                target: (to) => to.none(),
+                resolve: ({ state, decline }) => state.ready ? undefined : decline()
+              })
+            }
+          }
+        }
+      })
+
+      const planned = yield* Machine.planInitial(machine)
+      assert.strictEqual(planned.state.path, "finished")
+      assert.strictEqual(planned.microsteps[0]?.transitions[0]?.source, "workflow")
+    }))
+
+  it.effect("treats an event as unhandled when every candidate declines", () =>
+    Effect.gen(function*() {
+      class Stable extends Schema.TaggedClass<Stable>("DeclineStable")("Stable", {}) {}
+      class Ping extends Schema.TaggedClass<Ping>("DeclinePing")("Ping", {}) {}
+      const states = Machine.states({ Stable })
+      const machine = Machine.make({
+        states: states.states,
+        events: Machine.events(Ping),
+        initial: {
+          target: (to) => to.Stable(),
+          resolve: ({ target }) => target(new Stable({}))
+        }
+      }).handle({
+        Stable: {
+          on: {
+            Ping: Machine.transition({
+              declinable: true,
+              target: (to) => to.none(),
+              resolve: ({ decline }) => decline()
+            })
+          }
+        }
+      })
+
+      const initial = yield* Machine.planInitial(machine)
+      assert.deepStrictEqual(Machine.enabled(machine, initial.state), ["Ping"])
+      const planned = yield* Machine.plan(machine, initial.state, new Ping({}))
+      assert.deepStrictEqual(planned.next, initial.state)
+      assert.deepStrictEqual(planned.microsteps, [])
+    }))
+
+  it.effect("leaves a completed compound state active when onDone declines", () =>
+    Effect.gen(function*() {
+      class Workflow extends Schema.TaggedClass<Workflow>("DeclineDoneWorkflow")("Workflow", {}) {}
+      class Complete extends Schema.TaggedClass<Complete>("DeclineDoneComplete")("Complete", {}) {}
+      class Finished extends Schema.TaggedClass<Finished>("DeclineDoneFinished")("Finished", {}) {}
+      const states = Machine.states({
+        workflow: {
+          schema: Workflow,
+          initial: "complete",
+          states: {
+            complete: { schema: Complete, type: "final", output: Schema.String }
+          }
+        },
+        finished: Finished
+      })
+      const machine = Machine.make({
+        states: states.states,
+        events: Machine.events(),
+        initial: {
+          target: (to) => to.workflow.initial(),
+          resolve: ({ target }) => target(new Workflow({}), (workflow) => workflow.complete(new Complete({})))
+        }
+      }).handle({
+        workflow: {
+          onDone: Machine.transition({
+            declinable: true,
+            target: (to) => to.full.finished(),
+            resolve: ({ decline }) => decline()
+          }),
+          states: {
+            complete: { output: () => "complete" }
+          }
+        }
+      })
+
+      const planned = yield* Machine.planInitial(machine)
+      assert.isFalse(planned.done)
+      assert.strictEqual(planned.state.path, "workflow")
+      if (planned.state.path === "workflow") assert.strictEqual(planned.state.state.path, "workflow.complete")
+    }))
+
+  it.effect("preserves descendant preemption when parallel candidates decline", () =>
+    Effect.gen(function*() {
+      class Root extends Schema.TaggedClass<Root>("DeclineParallelRoot")("Root", {}) {}
+      class Left extends Schema.TaggedClass<Left>("DeclineParallelLeft")("Left", {}) {}
+      class Right extends Schema.TaggedClass<Right>("DeclineParallelRight")("Right", {}) {}
+      class Finished extends Schema.TaggedClass<Finished>("DeclineParallelFinished")("Finished", {}) {}
+      class Ping extends Schema.TaggedClass<Ping>("DeclineParallelPing")("Ping", {
+        handleRight: Schema.Boolean
+      }) {}
+      const states = Machine.states({
+        root: {
+          schema: Root,
+          type: "parallel",
+          states: { left: Left, right: Right }
+        },
+        finished: Finished
+      })
+      let parentCalls = 0
+      const machine = Machine.make({
+        states: states.states,
+        events: Machine.events(Ping),
+        initial: {
+          target: (to) => to.root.initial(),
+          resolve: ({ target }) => target(new Root({}), (root) => root.left(new Left({})).right(new Right({})))
+        }
+      }).handle({
+        root: {
+          on: {
+            Ping: Machine.transition({
+              target: (to) => to.full.finished(),
+              resolve: ({ target }) => {
+                parentCalls++
+                return target(new Finished({}))
+              }
+            })
+          },
+          states: {
+            left: {
+              on: {
+                Ping: Machine.transition({
+                  declinable: true,
+                  target: (to) => to.none(),
+                  resolve: ({ decline }) => decline()
+                })
+              }
+            },
+            right: {
+              on: {
+                Ping: Machine.transition({
+                  declinable: true,
+                  target: (to) => to.none(),
+                  resolve: ({ event, decline }) => event.handleRight ? undefined : decline()
+                })
+              }
+            }
+          }
+        }
+      })
+
+      const initial = yield* Machine.planInitial(machine)
+      const descendant = yield* Machine.plan(machine, initial.state, new Ping({ handleRight: true }))
+      assert.strictEqual(descendant.next.path, "root")
+      assert.deepStrictEqual(descendant.microsteps[0]?.transitions.map(({ source }) => source), ["root.right"])
+      assert.strictEqual(parentCalls, 0)
+
+      const ancestor = yield* Machine.plan(machine, initial.state, new Ping({ handleRight: false }))
+      assert.strictEqual(ancestor.next.path, "finished")
+      assert.deepStrictEqual(ancestor.microsteps[0]?.transitions.map(({ source }) => source), ["root"])
+      assert.strictEqual(parentCalls, 1)
     }))
 
   it.effect("handles parent config and nested states in the same object", () =>

--- a/test/machine/MermaidVisualization.test.ts
+++ b/test/machine/MermaidVisualization.test.ts
@@ -42,15 +42,25 @@ const states: ReadonlyArray<StateNode> = [
 const inspection: InspectionApi<TestMachine, { readonly active: boolean }> = {
   stateNodes: () => states,
   initialDefinition: () => ({ target: "Root" }),
-  transitionDefinitions: () => [{
-    source: "Root.Route",
-    trigger: { type: "choice" },
-    reenter: false,
-    branches: [
-      { type: "branch", key: "approved", title: "approved %%\nnow", target: "Root.Done" },
-      { type: "branch", key: "unchanged", title: "unchanged", target: undefined }
-    ]
-  }],
+  transitionDefinitions: () => [
+    {
+      source: "Root.Route",
+      trigger: { type: "choice" },
+      reenter: false,
+      acceptance: "required",
+      branches: [
+        { type: "branch", key: "approved", title: "approved %%\nnow", target: "Root.Done" },
+        { type: "branch", key: "unchanged", title: "unchanged", target: undefined }
+      ]
+    },
+    {
+      source: "Root.Done",
+      trigger: { type: "event", event: "Retry" },
+      reenter: false,
+      acceptance: "declinable",
+      branches: [{ type: "direct", target: "Root.Route" }]
+    }
+  ],
   activityDefinitions: () => [{ source: "Root.Route", id: "worker %%\nend note", type: "process" }],
   configuration: () => states.slice(0, 2),
   enabled: () => ["Continue %%\nnow"]
@@ -68,6 +78,7 @@ describe("Mermaid visualization", () => {
     assert.include(rendered, "state \"● Choose route (Route)\" as state_1")
     assert.include(rendered, "state state_1 <<choice>>")
     assert.include(rendered, "state_1 --> state_2: choice [approved #37;#37; now]")
+    assert.include(rendered, "state_2 --> state_1: Retry [declinable]")
     assert.notMatch(rendered, /state_1 --> .*otherwise/)
     assert.include(rendered, "state_1: process / worker #37;#37; end note")
     assert.notInclude(rendered, "Candidate events")

--- a/test/machine/Visualization.test.ts
+++ b/test/machine/Visualization.test.ts
@@ -243,6 +243,7 @@ describe("Machine structural visualization", () => {
         source: "application.workflow.idle",
         trigger: { type: "event", event: "Start" },
         reenter: false,
+        acceptance: "required",
         branches: [{
           type: "direct",
           target: "application.workflow.running",
@@ -253,6 +254,7 @@ describe("Machine structural visualization", () => {
         source: "application.workflow.idle",
         trigger: { type: "event", event: "Refresh" },
         reenter: false,
+        acceptance: "required",
         branches: [{
           type: "direct",
           target: undefined,
@@ -263,6 +265,7 @@ describe("Machine structural visualization", () => {
         source: "application.connection.online",
         trigger: { type: "event", event: "Disconnect" },
         reenter: false,
+        acceptance: "required",
         branches: [{
           type: "direct",
           target: "application.connection.offline",
@@ -295,6 +298,7 @@ describe("Machine structural visualization", () => {
         source: "idle",
         trigger: { type: "event", event: "Refresh" },
         reenter: true,
+        acceptance: "required",
         branches: [{
           type: "direct",
           target: undefined,
@@ -305,6 +309,7 @@ describe("Machine structural visualization", () => {
         source: "idle",
         trigger: { type: "always" },
         reenter: false,
+        acceptance: "required",
         branches: [{
           type: "direct",
           target: undefined,
@@ -315,6 +320,7 @@ describe("Machine structural visualization", () => {
         source: "idle",
         trigger: { type: "done" },
         reenter: false,
+        acceptance: "required",
         branches: [{
           type: "direct",
           target: undefined,
@@ -336,6 +342,7 @@ describe("Machine structural visualization", () => {
           source: "idle",
           trigger: { type: "always" },
           reenter: false,
+          acceptance: "required",
           branches: [{
             type: "direct",
             target: "workflow",
@@ -346,6 +353,7 @@ describe("Machine structural visualization", () => {
           source: "workflow",
           trigger: { type: "done" },
           reenter: false,
+          acceptance: "required",
           branches: [{
             type: "direct",
             target: "disabled",

--- a/test/machine/visualization/mermaid.ts
+++ b/test/machine/visualization/mermaid.ts
@@ -45,7 +45,9 @@ const triggerLabel = (definition: TransitionDefinition): string => {
     definition.trigger.type === "invoke" ?
     `invoke ${definition.trigger.id} ${definition.trigger.outcome}` :
     definition.trigger.type
-  return `${trigger}${definition.reenter ? " [reenter]" : ""}`
+  return `${trigger}${definition.reenter ? " [reenter]" : ""}${
+    definition.acceptance === "declinable" ? " [declinable]" : ""
+  }`
 }
 
 const branchLabel = (

--- a/test/machine/visualization/model.ts
+++ b/test/machine/visualization/model.ts
@@ -41,6 +41,7 @@ export interface TransitionDefinition {
       readonly outcome: "element" | "done" | "failure" | "snapshot"
     }
   readonly reenter: boolean
+  readonly acceptance: "required" | "declinable"
   readonly branches: ReadonlyArray<
     | {
       readonly type: "direct"

--- a/test/machine/visualization/text.ts
+++ b/test/machine/visualization/text.ts
@@ -33,15 +33,16 @@ const triggerLabels = (definitions: ReadonlyArray<TransitionDefinition>): Readon
     if (branches.length === 0) return []
 
     const reenter = definition.reenter ? " [reenter]" : ""
+    const acceptance = definition.acceptance === "declinable" ? " [declinable]" : ""
     const trigger = definition.trigger.type === "event" ?
-      `◇ on: ${String(definition.trigger.event)}${reenter}`
+      `◇ on: ${String(definition.trigger.event)}${reenter}${acceptance}`
       : definition.trigger.type === "always" ?
-      `◇ always${reenter}`
+      `◇ always${reenter}${acceptance}`
       : definition.trigger.type === "done" ?
-      `◇ done${reenter}`
+      `◇ done${reenter}${acceptance}`
       : definition.trigger.type === "choice" ?
       "◇ choice"
-      : `◇ invoke ${definition.trigger.id} ${definition.trigger.outcome}${reenter}`
+      : `◇ invoke ${definition.trigger.id} ${definition.trigger.outcome}${reenter}${acceptance}`
 
     return [{ trigger, branches }]
   })

--- a/test/testing/Coverage.test.ts
+++ b/test/testing/Coverage.test.ts
@@ -28,6 +28,7 @@ const counterMachine = Machine.make({
   count: {
     on: {
       Add: Machine.transition({
+        declinable: true,
         target: (to) => to.full.count(),
         resolve: ({ event, state, target }) => target(new Count({ value: state.value + event.amount })),
         reenter: true
@@ -241,6 +242,8 @@ describe("MachineTest trace coverage", () => {
       const partial = MachineTest.coverage(counterMachine, addTrace)
       assert.strictEqual(partial.events.available, true)
       if (!partial.events.available) return
+      assert.strictEqual(partial.transitions.definitions.hits[0]?.acceptance, "declinable")
+      assert.strictEqual(partial.transitions.branches.hits[0]?.acceptance, "declinable")
       assert.deepStrictEqual(partial.states.activation.misses.map(({ path }) => path), ["done"])
       assert.deepStrictEqual(
         partial.transitions.definitions.misses.map(({ source, trigger }) => ({ source, trigger })),

--- a/test/testing/Probe.test.ts
+++ b/test/testing/Probe.test.ts
@@ -13,6 +13,7 @@ class Increment extends Schema.TaggedClass<Increment>("ProbeIncrement")("Increme
 
 class Noop extends Schema.TaggedClass<Noop>("ProbeNoop")("Noop", {}) {}
 class Ignored extends Schema.TaggedClass<Ignored>("ProbeIgnored")("Ignored", {}) {}
+class Decline extends Schema.TaggedClass<Decline>("ProbeDecline")("Decline", {}) {}
 class Burst extends Schema.TaggedClass<Burst>("ProbeBurst")("Burst", {}) {}
 class Reenter extends Schema.TaggedClass<Reenter>("ProbeReenter")("Reenter", {}) {}
 class RaisedIncrement extends Schema.TaggedClass<RaisedIncrement>("ProbeRaisedIncrement")("RaisedIncrement", {}) {}
@@ -21,7 +22,7 @@ const states = Machine.states({ Counter })
 
 const machine = Machine.make({
   states: states.states,
-  events: Machine.events(Increment, Noop, Ignored, Burst, Reenter),
+  events: Machine.events(Increment, Noop, Ignored, Decline, Burst, Reenter),
   internalEvents: Machine.internalEvents(RaisedIncrement),
   initial: {
     target: (to) => to.Counter(),
@@ -37,6 +38,11 @@ const machine = Machine.make({
       Noop: Machine.transition({
         target: (to) => to.none(),
         resolve: () => undefined
+      }),
+      Decline: Machine.transition({
+        declinable: true,
+        target: (to) => to.none(),
+        resolve: ({ decline }) => decline()
       }),
       Reenter: Machine.transition({
         target: (to) => to.full.Counter(),
@@ -92,6 +98,11 @@ describe("MachineTest probe", () => {
       assert.strictEqual(ignored.plan.microsteps.length, 0)
       assert.strictEqual(ignored.before.value.count, 0)
       assert.strictEqual(ignored.after.value.count, 0)
+
+      const declined = yield* probe.sendAndAwait(new Decline({}))
+      assert.strictEqual(declined.handled, false)
+      assert.strictEqual(declined.configurationChanged, false)
+      assert.strictEqual(declined.plan.microsteps.length, 0)
 
       const targetless = yield* probe.sendAndAwait(new Noop({}))
       assert.strictEqual(targetless.handled, true)

--- a/typetest/machine/Choice.tst.ts
+++ b/typetest/machine/Choice.tst.ts
@@ -157,5 +157,22 @@ describe("Machine choice pseudo-states", () => {
         }
       }
     })
+
+    const declinableChoice = null as unknown as Machine.Machine.TransitionConfig<
+      typeof States.states,
+      readonly [],
+      readonly [],
+      "Flow.Routing",
+      Machine.Machine.ChoiceContext<typeof States.states, readonly [], readonly [], "Flow.Routing">,
+      false,
+      "declinable"
+    >
+    expect(base.handle).type.not.toBeCallableWith({
+      Flow: {
+        states: {
+          Routing: { choice: declinableChoice }
+        }
+      }
+    })
   })
 })

--- a/typetest/machine/Inspection.tst.ts
+++ b/typetest/machine/Inspection.tst.ts
@@ -193,6 +193,7 @@ describe("Machine inspection", () => {
 
     const definition = Machine.transitionDefinitions(machine)[0]!
     expect(definition.source).type.toBe<"root" | "root.idle" | "root.recent">()
+    expect(definition.acceptance).type.toBe<Machine.Machine.TransitionAcceptance>()
     if (definition.trigger.type === "event") {
       expect(definition.trigger.event).type.toBe<"Reset">()
     }

--- a/typetest/machine/Machine.tst.ts
+++ b/typetest/machine/Machine.tst.ts
@@ -1337,6 +1337,51 @@ describe("Machine", () => {
       }
     })
 
+    machine.handle({
+      down: {
+        on: {
+          SignIn: Machine.transition({
+            declinable: true,
+            branches: (to) => ({
+              accepted: { target: to.full.down() },
+              consumed: { target: to.none() }
+            }),
+            resolve: (context) => {
+              expect(context.decline()).type.toBe<Machine.Machine.Declined>()
+              if (context.event.userId === "decline") return context.decline()
+              if (context.event.userId === "consume") return context.select.consumed()
+              return context.select.accepted(new Down({}))
+            }
+          })
+        }
+      }
+    })
+
+    machine.handle({
+      down: {
+        on: {
+          SignIn: Machine.transition({
+            target: (to) => to.none(),
+            resolve: (context) => {
+              expect(context).type.not.toHaveProperty("decline")
+              return undefined
+            }
+          })
+        }
+      }
+    })
+
+    const declined = null as unknown as Machine.Machine.Declined
+    expect(Machine.transition).type.not.toBeCallableWith({
+      target: (to: Machine.Machine.TargetSelector<typeof UpStates.states, "down">) => to.none(),
+      resolve: () => declined
+    })
+    expect(Machine.transition).type.not.toBeCallableWith({
+      declinable: true as boolean,
+      target: (to: Machine.Machine.TargetSelector<typeof UpStates.states, "down">) => to.none(),
+      resolve: () => declined
+    })
+
     const target = (to: Machine.Machine.TargetSelector<typeof UpStates.states, "down">) => to.none()
     type BranchesInput = Machine.Machine.TransitionBranchesInput<
       typeof UpStates.states,

--- a/typetest/testing/Coverage.tst.ts
+++ b/typetest/testing/Coverage.tst.ts
@@ -39,8 +39,10 @@ describe("MachineTest coverage and observed graph", () => {
     expect(result.states.activation.hits[0]!.path).type.toBe<"idle" | "done">()
     expect(result.transitions.definitions.hits[0]!.source).type.toBe<"idle" | "done">()
     expect(result.transitions.definitions.hits[0]!.trigger).type.toBe<Machine.Machine.TransitionTrigger<"Start">>()
+    expect(result.transitions.definitions.hits[0]!.acceptance).type.toBe<Machine.Machine.TransitionAcceptance>()
     expect(result.transitions.branches.hits[0]!.source).type.toBe<"idle" | "done">()
     expect(result.transitions.branches.hits[0]!.trigger).type.toBe<Machine.Machine.TransitionTrigger<"Start">>()
+    expect(result.transitions.branches.hits[0]!.acceptance).type.toBe<Machine.Machine.TransitionAcceptance>()
     expect(result.transitions.branches.hits[0]!.branch).type.toBe<
       Machine.Machine.TransitionBranch<"idle" | "done">
     >()


### PR DESCRIPTION
## Summary

- add opt-in `declinable: true` transitions with a resolver-scoped `decline()` capability
- continue hierarchical event and eventless dispatch at ancestors while keeping `target.none()` handled and consuming
- expose static acceptance metadata to inspection, visualizers, and `MachineTest`, with generic planner fallback and focused semantic/type coverage

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (not required; no examples changed)
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required
