### PR TITLE
Fix fluent transition changeset example

### DIFF
--- a/.changeset/fluent-transition-handlers.md
+++ b/.changeset/fluent-transition-handlers.md
@@ -5,16 +5,16 @@
 Replace `Machine.transition(...)` with fluent transition selectors supplied directly to inline handlers. Select a target and optionally attach its resolver, reentry, or named branches without an intermediate wrapper:
 
 ```ts
-Start: ;
-;((to) => to.full.Running().resolve(({ event, target }) => target.from({ count: event.count })))
+const handlers = {
+  Start: (to) => to.full.Running().resolve(({ event, target }) => target.from({ count: event.count })),
 
-Route: ;
-;((to) =>
-  to.branches({
-    running: { target: to.full.Running() },
-    done: { target: to.full.Done() },
-    unchanged: { target: to.none() }
-  }).resolve(({ event, select }) => event.cached ? select.done.from() : select.running.from()))
+  Route: (to) =>
+    to.branches({
+      running: { target: to.full.Running() },
+      done: { target: to.full.Done() },
+      unchanged: { target: to.none() }
+    }).resolve(({ event, select }) => event.cached ? select.done.from() : select.running.from())
+}
 ```
 
 Use `.reenter()` for resolver-free reentry, or pass literal `declinable: true` to `.resolve(...)` when the resolver must receive `decline()`. Bare targets are accepted only when their schemas support default construction.


### PR DESCRIPTION
## Summary

- wrap the fluent transition migration example in a complete object literal so Markdown formatting preserves valid, readable TypeScript

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required

Focused validation: `pnpm format:check` and `pnpm docs:site:check`.