### PR TITLE
Fix Mermaid composite activity labels

### DIFF
--- a/test/machine/MermaidVisualization.test.ts
+++ b/test/machine/MermaidVisualization.test.ts
@@ -61,7 +61,15 @@ const inspection: InspectionApi<TestMachine, { readonly active: boolean }> = {
       branches: [{ type: "direct", target: "Root.Route" }]
     }
   ],
-  activityDefinitions: () => [{ source: "Root.Route", id: "worker %%\nend note", type: "process" }],
+  activityDefinitions: () => [
+    {
+      source: "Root",
+      id: "search",
+      type: "machine",
+      child: { id: "search", machineId: null }
+    },
+    { source: "Root.Route", id: "worker %%\nend note", type: "process" }
+  ],
   configuration: () => states.slice(0, 2),
   enabled: () => ["Continue %%\nnow"]
 }
@@ -74,7 +82,11 @@ describe("Mermaid visualization", () => {
 
     assert.notInclude(rendered, "%%")
     assert.include(rendered, "accTitle: Unsafe #37;#37; Machine")
-    assert.include(rendered, "state \"● Quoted #quot;root#quot; #37;#37; (Root)\" as state_0")
+    assert.include(
+      rendered,
+      "state \"● Quoted #quot;root#quot; #37;#37; (Root) · machine / search → search\" as state_0"
+    )
+    assert.notInclude(rendered, "state_0: machine / search → search")
     assert.include(rendered, "state \"● Choose route (Route)\" as state_1")
     assert.include(rendered, "state state_1 <<choice>>")
     assert.include(rendered, "state_1 --> state_2: choice [approved #37;#37; now]")

--- a/test/machine/visualization/mermaid.ts
+++ b/test/machine/visualization/mermaid.ts
@@ -118,11 +118,17 @@ export const makeMermaidRenderer = <Machine extends MachineValue, Snapshot>(
     const id = ids.get(node.path)
     if (id === undefined) return
 
-    lines.push(`${indent(depth)}state "${stateLabel(node, active)}" as ${id}`)
     const ownedActivities = activities.get(node.path) ?? []
-    if (ownedActivities.length > 0) {
+    const descendants = children.get(node.path) ?? []
+    const renderedActivities = ownedActivities.map((activity) => escapeText(activityLabel(activity))).join(" · ")
+    const label = descendants.length > 0 && renderedActivities.length > 0
+      ? `${stateLabel(node, active)} · ${renderedActivities}`
+      : stateLabel(node, active)
+
+    lines.push(`${indent(depth)}state "${label}" as ${id}`)
+    if (descendants.length === 0 && renderedActivities.length > 0) {
       lines.push(
-        `${indent(depth)}${id}: ${ownedActivities.map((activity) => escapeText(activityLabel(activity))).join(" · ")}`
+        `${indent(depth)}${id}: ${renderedActivities}`
       )
     }
     if (node.type === "choice") {
@@ -130,7 +136,6 @@ export const makeMermaidRenderer = <Machine extends MachineValue, Snapshot>(
       return
     }
 
-    const descendants = children.get(node.path) ?? []
     if (descendants.length > 0) {
       lines.push(`${indent(depth)}state ${id} {`)
       if (node.type === "parallel") {


### PR DESCRIPTION
## Summary

- Keep activities owned by composite or parallel states in the state's single Mermaid group label.
- Preserve the existing description syntax for activities owned by leaf states.
- Cover composite child-machine activities with a focused regression assertion.

The renderer previously emitted both a labelled composite declaration and a second `state_id:` description. Mermaid rejects that representation with `Group nodes can only have label`.

## Changeset

- [ ] Added or updated for a library or package-metadata change
- [x] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (not applicable)
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required
