### PR TITLE
Add machine authoring API guide

### DIFF
--- a/.changeset/quiet-machines-document.md
+++ b/.changeset/quiet-machines-document.md
@@ -1,0 +1,7 @@
+---
+"@typeonce/effect-machine": patch
+---
+
+Document the nested configuration and callback APIs used by `Machine.states`, event protocols, `Machine.make`, `Definition.handle`, execution, transitions, and state invocation.
+
+The documentation site now presents those core authoring APIs on a standalone guide-reference page while keeping module pages focused on public exports. Parameters remain grouped under their point of use with searchable signatures, lifecycle contexts, target semantics, defaults, source links, focused examples, and a complete nested page outline. Redundant configuration headings are omitted, and each parameter is presented as a named API block with its signature, description, and attached source link. Long signatures stay contained within their documentation blocks across responsive layouts.

--- a/api-reference.config.json
+++ b/api-reference.config.json
@@ -25,6 +25,146 @@
       "export": "./Machine",
       "source": "src/Machine.ts",
       "barrel": ".",
+      "referenceSections": [
+        {
+          "title": "Define state topology",
+          "description": "Declare the complete state tree and its schema-backed values before constructing the machine.",
+          "entries": [
+            { "declaration": "states" },
+            { "declaration": "state" }
+          ]
+        },
+        {
+          "title": "Define event protocols",
+          "description": "Describe public input, machine-local events, outward notifications, and parent ownership.",
+          "entries": [
+            { "declaration": "events" },
+            { "declaration": "internalEvents" },
+            { "declaration": "emittedEvents" },
+            { "declaration": "parent" },
+            { "declaration": "optionalParent" }
+          ]
+        },
+        {
+          "title": "Create the definition",
+          "description": "Combine topology and protocols into a reusable machine definition with an explicit initial target.",
+          "entries": [
+            { "declaration": "make" }
+          ]
+        },
+        {
+          "title": "Implement state behavior",
+          "description": "Attach state-local actions, transitions, output, and invoked lifecycles to the definition.",
+          "entries": [
+            {
+              "reflection": "Definition.handle",
+              "label": "handle",
+              "kind": "method",
+              "owner": "Definition",
+              "ownerKind": "interface",
+              "usageSections": [
+                "State handler configuration",
+                "Transition declarations",
+                "Handler and resolver contexts",
+                "State invocation"
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Run and observe",
+          "description": "Start or resume an executable machine and subscribe to its state over time.",
+          "entries": [
+            { "declaration": "start" },
+            { "declaration": "resume" },
+            { "declaration": "watch" }
+          ]
+        }
+      ],
+      "usageSections": [
+        {
+          "owner": "states",
+          "title": "State node configuration",
+          "description": "Properties accepted while declaring the state tree passed to `Machine.states`.",
+          "roots": [
+            { "reflection": "Machine.AtomicStateNodeConfig", "label": "Atomic and final states" },
+            { "reflection": "Machine.CompoundStateNodeConfig", "label": "Compound states" },
+            { "reflection": "Machine.ParallelStateNodeConfig", "label": "Parallel states" },
+            { "reflection": "Machine.HistoryStateNodeConfig", "label": "History states" },
+            { "reflection": "Machine.ChoiceStateNodeConfig", "label": "Choice states" },
+            { "reflection": "Machine.StateNodeAnnotations", "label": "Annotations" }
+          ]
+        },
+        {
+          "owner": "make",
+          "title": "Machine definition configuration",
+          "description": "Parameters accepted by `Machine.make` and its initial-state declaration.",
+          "roots": [
+            { "declaration": "make", "parameter": "config", "label": "Configuration" },
+            { "reflection": "Machine.InitialTransitionTarget", "label": "Initial target resolution" }
+          ]
+        },
+        {
+          "owner": "Definition",
+          "ownerKind": "interface",
+          "title": "State handler configuration",
+          "description": "Properties accepted for each state inside `Definition.handle`.",
+          "roots": [
+            { "reflection": "Machine.ActiveStateConfig", "label": "Active states" },
+            { "reflection": "Machine.FinalStateConfig", "label": "Final states" },
+            { "reflection": "Machine.ChoiceStateConfig", "label": "Choice states", "members": ["choice"] },
+            { "reflection": "Machine.HandlerNode", "label": "Nested handler tree", "members": ["states", "history"] },
+            { "reflection": "Machine.OutputHandlerConfig", "label": "Output functions", "members": ["output"] },
+            { "reflection": "Machine.HistoryDefaultEntry", "label": "History defaults" }
+          ]
+        },
+        {
+          "owner": "Definition",
+          "ownerKind": "interface",
+          "title": "Transition declarations",
+          "description": "Target selection, resolution, branching, and commands available to state and invocation transitions.",
+          "roots": [
+            { "reflection": "Machine.TargetSelector", "label": "Target selection" },
+            { "reflection": "Machine.TargetBuilder", "label": "Resolver target construction" },
+            { "reflection": "Machine.TransitionSelector", "label": "Named branch selection", "nested": true },
+            { "reflection": "Machine.TransitionTarget", "label": "Selected target" },
+            { "reflection": "Machine.TransitionBranchInput", "label": "Named branches" },
+            { "reflection": "Machine.DeclineCapability", "label": "Declinable transitions" },
+            { "reflection": "Enqueue", "label": "Enqueued commands" }
+          ]
+        },
+        {
+          "owner": "Definition",
+          "ownerKind": "interface",
+          "title": "Handler and resolver contexts",
+          "description": "Values supplied to state actions, transitions, completion handlers, choices, and output functions.",
+          "roots": [
+            { "reflection": "MachineReferences", "label": "Machine references" },
+            { "reflection": "Machine.HandlerContext", "label": "Event handlers" },
+            { "reflection": "Machine.StateActionContext", "label": "Entry and exit actions" },
+            { "reflection": "Machine.AlwaysContext", "label": "Eventless transitions" },
+            { "reflection": "Machine.DoneContext", "label": "State completion" },
+            { "reflection": "Machine.ChoiceContext", "label": "Choice resolution" },
+            { "reflection": "Machine.FinalOutputContext", "label": "Final output" },
+            { "reflection": "Machine.ParallelOutputContext", "label": "Parallel output" }
+          ]
+        },
+        {
+          "owner": "Definition",
+          "ownerKind": "interface",
+          "title": "State invocation",
+          "description": "State-owned Effect, Stream, timer, logic, and child lifecycles declared through `invoke`.",
+          "roots": [
+            { "reflection": "Machine.InvokeSelector", "label": "Invocation sources" },
+            { "reflection": "Machine.InvokeBuilder", "label": "Lifecycle handlers" },
+            { "reflection": "Machine.InvokeContext", "label": "Source context" },
+            { "reflection": "Machine.InvokeDoneContext", "label": "Completion context" },
+            { "reflection": "Machine.InvokeFailureContext", "label": "Failure context" },
+            { "reflection": "Machine.InvokeElementContext", "label": "Stream element context" },
+            { "reflection": "Machine.InvokeSnapshotContext", "label": "Child snapshot context" }
+          ]
+        }
+      ],
       "examples": [
         "decodeSnapshot",
         "encodeSnapshot",

--- a/scripts/api-reference-site/api-reference-site.test.mjs
+++ b/scripts/api-reference-site/api-reference-site.test.mjs
@@ -10,6 +10,7 @@ import {
   parseChangelog,
   parseChangeset,
   renderChangelogPage,
+  renderGuidePage,
   renderIndexPage,
   renderLayout,
   renderMarkdown,
@@ -194,6 +195,156 @@ test("renders collapsible category navigation with declaration anchors", () => {
   assert.match(html, /<h3 id="make">make<\/h3>/)
 })
 
+test("renders declaration-owned usage sections and documented members in the guide", () => {
+  const declaration = {
+    name: "make",
+    kind: "variable",
+    description: "Creates a machine.",
+    examples: [],
+    see: [],
+    usageSections: [{
+      owner: "make",
+      title: "Machine configuration",
+      description: "Parameters accepted by make.",
+      roots: [{
+        label: "Configuration",
+        description: "Complete machine configuration.",
+        examples: [],
+        members: [{
+          name: "id",
+          signature: "readonly id?: string",
+          description: "Stable definition identifier.",
+          sourceUrl: "https://github.com/example/repo/blob/main/src/Machine.ts#L1",
+          examples: [],
+          parameters: [],
+          members: []
+        }]
+      }]
+    }]
+  }
+  const module = {
+    api: {
+      declarationCount: 1,
+      description: "State machine APIs",
+      referenceSections: [{
+        title: "Create the definition",
+        description: "Construct the machine.",
+        entries: [{ origin: { type: "declaration", name: "make", kind: "variable" }, api: declaration }]
+      }],
+      groups: [{ category: "constructors", declarations: [declaration] }]
+    },
+    export: "./Machine",
+    label: "Machine",
+    route: "Machine"
+  }
+  const html = renderGuidePage({ ...site, modules: [module], guideModule: module })
+  assert.doesNotMatch(html, />Machine configuration<\//)
+  assert.match(html, /href="#make-usage-machine-configuration-configuration">Configuration<\/a>/)
+  assert.match(html, /<h4 id="make-usage-machine-configuration-configuration">Configuration<\/h4>/)
+  assert.match(html, /id="make-usage-machine-configuration-configuration-id" aria-labelledby="make-usage-machine-configuration-configuration-id-title"/)
+  assert.match(html, /<h5 id="make-usage-machine-configuration-configuration-id-title">id<\/h5>/)
+  assert.match(html, /<span class="syntax-keyword">readonly<\/span> id/)
+  assert.match(html, /<span class="syntax-type">string<\/span>/)
+  assert.match(html, /Stable definition identifier\./)
+  assert.doesNotMatch(html, />Usage reference</)
+  assert.ok(html.indexOf("id-title") < html.indexOf("Copy id signature"))
+  assert.ok(html.indexOf("Copy id signature") < html.indexOf("Stable definition identifier."))
+  assert.ok(html.indexOf(">Source</") < html.indexOf("Copy id signature"))
+})
+
+test("renders the ordered workflow only in the standalone guide", () => {
+  const states = {
+    name: "states",
+    kind: "variable",
+    description: "Defines state topology.",
+    examples: [],
+    see: [],
+    usageSections: []
+  }
+  const make = {
+    name: "make",
+    kind: "variable",
+    description: "Creates a definition.",
+    examples: [],
+    see: [],
+    usageSections: []
+  }
+  const handlerUsage = {
+    owner: "Definition",
+    ownerKind: "interface",
+    title: "State handler configuration",
+    description: "State-local behavior.",
+    roots: []
+  }
+  const definition = {
+    name: "Definition",
+    kind: "interface",
+    description: "Reusable definition model.",
+    examples: [],
+    see: [],
+    usageSections: [handlerUsage]
+  }
+  const helper = {
+    name: "helper",
+    kind: "function",
+    description: "Supporting helper.",
+    examples: [],
+    see: [],
+    usageSections: []
+  }
+  const handle = {
+    name: "handle",
+    kind: "method",
+    description: "Adds typed state handlers.",
+    examples: [],
+    see: [],
+    usageSections: [handlerUsage]
+  }
+  const module = {
+    api: {
+      declarationCount: 4,
+      description: "State machine APIs",
+      referenceSections: [{
+        title: "Define state topology",
+        description: "Start with the states.",
+        entries: [{ origin: { type: "declaration", name: "states", kind: "variable" }, api: states }]
+      }, {
+        title: "Create the definition",
+        description: "Construct and implement the machine.",
+        entries: [
+          { origin: { type: "declaration", name: "make", kind: "variable" }, api: make },
+          { origin: { type: "reflection", reflection: "Definition.handle" }, api: handle }
+        ]
+      }],
+      groups: [
+        { category: "constructors", declarations: [helper, make, states] },
+        { category: "models", declarations: [definition] }
+      ]
+    },
+    export: "./Machine",
+    label: "Machine",
+    route: "Machine"
+  }
+
+  const guideSite = { ...site, modules: [module], guideModule: module }
+  const guideHtml = renderGuidePage(guideSite)
+  assert.ok(guideHtml.indexOf("Define state topology") < guideHtml.indexOf('id="states"'))
+  assert.ok(guideHtml.indexOf('id="states"') < guideHtml.indexOf("Create the definition"))
+  assert.match(guideHtml, /<h3 id="handle">handle<\/h3>/)
+  assert.doesNotMatch(guideHtml, /id="helper"/)
+  assert.match(guideHtml, /class="navigation-guide is-current"/)
+  assert.ok(guideHtml.indexOf("navigation-changelog") < guideHtml.indexOf("navigation-guide is-current"))
+
+  const moduleHtml = renderModulePage(guideSite, module)
+  assert.match(moduleHtml, /<h3 id="helper">helper<\/h3>/)
+  assert.match(moduleHtml, /<h3 id="make">make<\/h3>/)
+  assert.match(moduleHtml, /<h3 id="states">states<\/h3>/)
+  assert.match(moduleHtml, /<h3 id="definition">Definition<\/h3>/)
+  assert.doesNotMatch(moduleHtml, /Define state topology/)
+  assert.doesNotMatch(moduleHtml, /State handler configuration/)
+  assert.doesNotMatch(moduleHtml, /id="handle"/)
+})
+
 test("renders canonical and social metadata without exposing the internal channel", () => {
   const html = renderLayout(site, {
     content: '<section class="reference-hero"><div class="eyebrow">API reference</div></section>',
@@ -264,11 +415,13 @@ test("keeps the internal Effect channel out of the homepage label", () => {
 
 test("generates manifest, robots, and sitemap URLs from the deployment base", () => {
   const manifest = siteManifest(site)
+  const siteWithGuide = { ...site, guideModule: site.modules[0] }
   assert.equal(manifest.start_url, "/docs/")
   assert.equal(manifest.icons[2].purpose, "maskable")
   assert.match(renderRobots(site), /Sitemap: https:\/\/docs\.example\.com\/docs\/sitemap\.xml/)
   assert.match(renderSitemap(site), /<loc>https:\/\/docs\.example\.com\/docs\/Machine\/<\/loc>/)
   assert.match(renderSitemap(site), /<loc>https:\/\/docs\.example\.com\/docs\/changelog\/<\/loc>/)
+  assert.match(renderSitemap(siteWithGuide), /<loc>https:\/\/docs\.example\.com\/docs\/guide\/<\/loc>/)
 })
 
 test("accepts only pathless HTTPS production origins", () => {

--- a/scripts/api-reference-site/assets/styles.css
+++ b/scripts/api-reference-site/assets/styles.css
@@ -82,6 +82,8 @@
 }
 
 html {
+  max-width: 100%;
+  overflow-x: clip;
   scroll-behavior: smooth;
   scroll-padding-top: 6rem;
 }
@@ -90,6 +92,8 @@ body {
   background: var(--background);
   color: var(--text);
   margin: 0;
+  max-width: 100%;
+  overflow-x: clip;
 }
 
 a {
@@ -261,7 +265,9 @@ kbd {
   grid-template-columns: var(--width-navigation) minmax(0, 1fr) var(--width-toc);
   margin: 0 auto;
   max-width: 100rem;
+  min-width: 0;
   min-height: calc(100vh - 4rem);
+  width: 100%;
 }
 
 .module-navigation {
@@ -312,7 +318,8 @@ kbd {
   padding: 0.55rem 0.65rem;
 }
 
-.module-navigation .navigation-changelog {
+.module-navigation .navigation-changelog,
+.module-navigation .navigation-guide {
   margin-top: 0.15rem;
 }
 
@@ -352,9 +359,11 @@ kbd {
 
 .reference-hero,
 .module-reference,
+.guide-reference,
 .changelog {
   margin: 0 auto;
   max-width: 64rem;
+  min-width: 0;
 }
 
 .reference-hero {
@@ -387,6 +396,7 @@ h3 {
 
 .reference-hero h1,
 .module-header h1,
+.guide-header h1,
 .changelog-header h1 {
   font-size: clamp(2.35rem, 4.5vw, 4.2rem);
   line-height: 0.95;
@@ -395,6 +405,7 @@ h3 {
 
 .reference-hero > p,
 .module-header > p,
+.guide-header > p,
 .changelog-header > p {
   color: var(--text-soft);
   font-size: 1.06rem;
@@ -563,6 +574,49 @@ h3 {
   font-size: 0.62rem;
 }
 
+.guide-toc-section + .guide-toc-section {
+  margin-top: 1.1rem;
+}
+
+.page-toc .guide-toc-section__link {
+  color: var(--text);
+  font-weight: 700;
+}
+
+.guide-toc-section__entries,
+.guide-toc-root {
+  display: grid;
+  gap: 0.02rem;
+}
+
+.page-toc .guide-toc-entry__link {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  padding-left: 1.05rem;
+}
+
+.page-toc .guide-toc-root__link {
+  color: var(--text-soft);
+  font-size: 0.67rem;
+  font-weight: 650;
+  padding-left: 1.45rem;
+}
+
+.page-toc .guide-toc-member {
+  color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.63rem;
+  padding-block: 0.22rem;
+  padding-left: 1.85rem;
+}
+
+.page-toc .guide-toc-member--depth-1 {
+  padding-left: 2.25rem;
+}
+
+.page-toc .guide-toc-member--depth-2 {
+  padding-left: 2.65rem;
+}
+
 .breadcrumbs {
   color: var(--muted);
   display: flex;
@@ -664,6 +718,7 @@ h3 {
 
 .api-group {
   margin-top: 5rem;
+  min-width: 0;
 }
 
 .api-group__heading {
@@ -675,9 +730,49 @@ h3 {
   padding-bottom: 0.8rem;
 }
 
-.api-group__heading h2 {
+.api-group__heading h2,
+.api-group__heading h3 {
   font-size: 1.65rem;
   margin: 0;
+}
+
+.guide-header {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 3rem;
+}
+
+.workflow-section__header p {
+  color: var(--text-soft);
+  line-height: 1.7;
+  margin-bottom: 0;
+  max-width: 45rem;
+}
+
+.workflow-section {
+  min-width: 0;
+  padding-top: 6rem;
+}
+
+.workflow-section + .workflow-section {
+  border-top: 1px solid var(--border);
+  margin-top: 3rem;
+}
+
+.workflow-section__header {
+  margin-bottom: 1.25rem;
+}
+
+.workflow-section__header h2 {
+  font-size: clamp(1.8rem, 3vw, 2.35rem);
+  margin-bottom: 0.7rem;
+}
+
+.workflow-section__entries {
+  min-width: 0;
+}
+
+.declaration--core {
+  padding: 3.75rem 0 4.25rem;
 }
 
 .api-group__heading span {
@@ -687,6 +782,7 @@ h3 {
 
 .declaration {
   border-bottom: 1px solid var(--border);
+  min-width: 0;
   padding: 2.8rem 0 3.2rem;
 }
 
@@ -706,7 +802,8 @@ h3 {
   min-width: 0;
 }
 
-.declaration__title h3 {
+.declaration__title h3,
+.declaration__title h4 {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 1.25rem;
   margin: 0;
@@ -736,11 +833,14 @@ h3 {
   border: 1px solid var(--border);
   border-radius: 0.65rem;
   margin: 1rem 0 1.4rem;
+  max-width: 100%;
+  min-width: 0;
   overflow: hidden;
   position: relative;
 }
 
 .code-block pre {
+  max-width: 100%;
   margin: 0;
   overflow-x: auto;
   padding: 1.15rem 3.5rem 1.15rem 1.15rem;
@@ -846,6 +946,123 @@ h3 {
 
 .example__heading span {
   color: var(--muted);
+}
+
+.usage-section {
+  margin-top: 5.75rem;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.usage-root__description,
+.usage-member__description,
+.usage-parameters dd {
+  color: var(--text-soft);
+  font-size: 0.82rem;
+  line-height: 1.65;
+}
+
+.usage-root__description p,
+.usage-member__description p {
+  margin: 0;
+}
+
+.usage-roots {
+  display: grid;
+  gap: 7rem;
+  min-width: 0;
+}
+
+.usage-root {
+  max-width: 100%;
+  min-width: 0;
+}
+
+.usage-root__header,
+.usage-member__header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.usage-root__header h4,
+.usage-root__header h5,
+.usage-root__header h6 {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.usage-root__description {
+  margin-top: 0.6rem;
+}
+
+.usage-members {
+  display: grid;
+  gap: 5.5rem;
+  margin-top: 4.5rem;
+  min-width: 0;
+}
+
+.usage-members--nested {
+  gap: 4.5rem;
+  margin-left: 1rem;
+  margin-top: 4.5rem;
+  padding-left: 1rem;
+}
+
+.usage-member {
+  max-width: 100%;
+  min-width: 0;
+  padding: 0;
+}
+
+.usage-member__header h5,
+.usage-member__header h6 {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 1.02rem;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.usage-member__header .source-link {
+  font-size: 0.72rem;
+}
+
+.code-block--usage-signature {
+  margin: 1.15rem 0 1.2rem;
+}
+
+.code-block--usage-signature pre {
+  padding-block: 0.75rem;
+}
+
+.usage-member__default {
+  color: var(--muted);
+  font-size: 0.75rem;
+  margin-top: 0.45rem;
+}
+
+.usage-parameters {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0.75rem 0 0;
+}
+
+.usage-parameters > div {
+  display: grid;
+  gap: 0.3rem;
+  grid-template-columns: minmax(8rem, 0.45fr) minmax(0, 1fr);
+  min-width: 0;
+}
+
+.usage-parameters dt,
+.usage-parameters dd {
+  margin: 0;
+  min-width: 0;
+}
+
+.usage-parameters code {
+  overflow-wrap: anywhere;
 }
 
 .see-also {
@@ -1034,6 +1251,7 @@ h3 {
 
   .reference-hero h1,
   .module-header h1,
+  .guide-header h1,
   .changelog-header h1 {
     font-size: clamp(2.15rem, 11vw, 3.35rem);
   }
@@ -1057,6 +1275,36 @@ h3 {
   .declaration__title {
     align-items: start;
     flex-wrap: wrap;
+  }
+
+  .workflow-section {
+    padding-top: 3.5rem;
+  }
+
+  .workflow-section + .workflow-section {
+    margin-top: 1rem;
+  }
+
+  .usage-section {
+    margin-top: 4.5rem;
+  }
+
+  .usage-roots {
+    gap: 5.5rem;
+  }
+
+  .usage-members {
+    gap: 4.5rem;
+    margin-top: 3.5rem;
+  }
+
+  .usage-members--nested {
+    margin-left: 0.35rem;
+    padding-left: 0.75rem;
+  }
+
+  .usage-parameters > div {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .anchor {

--- a/scripts/api-reference-site/generate.mjs
+++ b/scripts/api-reference-site/generate.mjs
@@ -51,13 +51,17 @@ const readSiteModel = (inputDirectory, config) => {
   const packageManifestPath = safeResolve(inputDirectory, packageEntry.manifest)
   const packageDirectory = dirname(packageManifestPath)
   const packageManifest = readJson(packageManifestPath)
-  if (packageManifest.schemaVersion !== 4 || !Array.isArray(packageManifest.modules)) {
+  if (packageManifest.schemaVersion !== 6 || !Array.isArray(packageManifest.modules)) {
     throw new Error("Unsupported API reference package manifest")
   }
 
   const modules = packageManifest.modules.map((entry) => {
     const reflection = readJson(safeResolve(packageDirectory, entry.json))
-    const api = normalizeApiModule(reflection)
+    const api = normalizeApiModule(
+      reflection,
+      entry.usageSections ?? [],
+      entry.referenceSections ?? []
+    )
     const route = moduleRoute(entry.json)
     const segments = entry.export.replace(/^\.\//, "").split("/")
     return {
@@ -76,6 +80,7 @@ const readSiteModel = (inputDirectory, config) => {
     revision: dataset.revision,
     package: packageManifest,
     modules,
+    guideModule: modules.find((module) => (module.api.referenceSections ?? []).length > 0),
     navigation: groupNavigation(modules),
     changelog
   }
@@ -98,6 +103,9 @@ const groupNavigation = (modules) => {
 const writeSite = (outputDirectory, site) => {
   writePage(join(outputDirectory, "index.html"), renderIndexPage(site))
   writePage(join(outputDirectory, "changelog", "index.html"), renderChangelogPage(site))
+  if (site.guideModule !== undefined) {
+    writePage(join(outputDirectory, "guide", "index.html"), renderGuidePage(site))
+  }
   for (const module of site.modules) {
     writePage(join(outputDirectory, module.route, "index.html"), renderModulePage(site, module))
   }
@@ -203,9 +211,9 @@ export const renderModulePage = (site, module) => {
     <details class="page-toc__group">
       <summary>
         <span>${escapeHtml(titleCase(group.category))}</span>
-        <small>${group.declarations.length}</small>
-      </summary>
-      <nav aria-label="${escapeAttribute(titleCase(group.category))} APIs">
+      <small>${group.declarations.length}</small>
+    </summary>
+    <nav aria-label="${escapeAttribute(titleCase(group.category))} APIs">
         ${group.declarations.map((declaration) => `
           <a href="#${declarationIds.get(declaration)}">${escapeHtml(declaration.name)}</a>`).join("")}
       </nav>
@@ -217,7 +225,13 @@ export const renderModulePage = (site, module) => {
         <span>${group.declarations.length}</span>
       </div>
       ${group.declarations.map((declaration) =>
-    renderDeclaration(declaration, declarationIds.get(declaration))).join("")}
+    renderDeclaration(
+      {
+        ...declaration,
+        usageSections: []
+      },
+      declarationIds.get(declaration)
+    )).join("")}
     </section>`).join("")
   const content = `
     <article class="module-reference" data-pagefind-meta="module:${escapeAttribute(module.label)}">
@@ -253,27 +267,89 @@ export const renderModulePage = (site, module) => {
   })
 }
 
-const renderDeclaration = (declaration, id) => {
-  const examples = declaration.examples.map((example, index) => `
-    <section class="example">
-      <div class="example__heading">
-        <strong>${escapeHtml(example.title ?? `Example${declaration.examples.length > 1 ? ` ${index + 1}` : ""}`)}</strong>
-        <span>${escapeHtml(example.language)}</span>
+export const renderGuidePage = (site) => {
+  const module = site.guideModule
+  if (module === undefined) throw new Error("The guide reference requires a configured guide module")
+  const declarationIds = uniqueDeclarationIds(module.api.groups)
+  const entryIds = referenceIds(module.api.referenceSections, declarationIds)
+  const entryCount = module.api.referenceSections.reduce((count, section) => count + section.entries.length, 0)
+  const content = `
+    <article class="guide-reference" data-pagefind-meta="type:guide">
+      <header class="guide-header">
+        <div class="breadcrumbs">
+          <a href="${siteUrl(site, "")}">API</a>
+          <span aria-hidden="true">/</span>
+          <span>Guide reference</span>
+        </div>
+        <h1>Machine authoring guide</h1>
+        <p>The core APIs and nested parameters used to define, implement, and run a machine, organized in authoring order.</p>
+        <div class="module-meta">
+          <span>${module.api.referenceSections.length} sections</span>
+          <span>${entryCount} core APIs</span>
+          <code>${escapeHtml(module.export)}</code>
+        </div>
+      </header>
+      <div class="guide-sections">
+        ${module.api.referenceSections.map((section) => `
+          <section class="workflow-section" aria-labelledby="workflow-${slugify(section.title)}">
+            <header class="workflow-section__header">
+              <h2 id="workflow-${slugify(section.title)}">${escapeHtml(section.title)}</h2>
+              ${renderMarkdown(section.description)}
+            </header>
+            <div class="workflow-section__entries">
+              ${section.entries.map((entry) =>
+    renderDeclaration(entry.api, entryIds.get(entry), { core: true })).join("")}
+            </div>
+          </section>`).join("")}
       </div>
-      <div class="code-block">
-        <button class="copy-button" type="button" aria-label="Copy example code">Copy</button>
-        <pre><code>${highlightCode(example.source, example.language)}</code></pre>
-      </div>
-    </section>`).join("")
+    </article>`
+  return renderLayout(site, {
+    title: `Machine authoring guide · ${site.title}`,
+    description: "Core Effect Machine APIs and nested authoring parameters in usage order.",
+    content,
+    currentRoute: "guide",
+    pageKind: "guide",
+    toc: renderGuideToc(module.api.referenceSections, entryIds)
+  })
+}
+
+const referenceIds = (sections, declarationIds) => {
+  const ids = new Map()
+  const used = new Set(declarationIds.values())
+  for (const section of sections) {
+    for (const entry of section.entries) {
+      if (entry.origin.type === "declaration") {
+        ids.set(entry, declarationIds.get(entry.api))
+        continue
+      }
+      const base = slugify(entry.api.name)
+      let id = base
+      for (let suffix = 2; used.has(id); suffix++) id = `${base}-${suffix}`
+      used.add(id)
+      ids.set(entry, id)
+    }
+  }
+  return ids
+}
+
+const renderDeclaration = (
+  declaration,
+  id,
+  { core = false, headingLevel = 3, usageHeadingLevel = 4 } = {}
+) => {
+  const examples = renderExamples(declaration.examples)
+  const usageSections = (declaration.usageSections ?? [])
+    .map((section) => renderUsageSection(section, id, usageHeadingLevel))
+    .join("")
   const see = declaration.see.flatMap((entry) => entry.split("\n"))
     .map((entry) => entry.replace(/^\s*-\s*/, "").trim())
     .filter(Boolean)
   return `
-    <article class="declaration" aria-labelledby="${id}" data-pagefind-meta="kind:${escapeAttribute(declaration.kind)}">
+    <article class="declaration${core ? " declaration--core" : ""}" aria-labelledby="${id}" data-pagefind-meta="kind:${escapeAttribute(declaration.kind)}">
       <header class="declaration__header">
         <div class="declaration__title">
           <a class="anchor" href="#${id}" aria-label="Link to ${escapeAttribute(declaration.name)}">#</a>
-          <h3 id="${id}">${escapeHtml(declaration.name)}</h3>
+          <h${headingLevel} id="${id}">${escapeHtml(declaration.name)}</h${headingLevel}>
           <span class="kind kind--${slugify(declaration.kind)}">${escapeHtml(declaration.kind)}</span>
         </div>
         ${declaration.sourceUrl === undefined ? "" : sourceLink(declaration.sourceUrl, "Source")}
@@ -290,6 +366,7 @@ const renderDeclaration = (declaration, id) => {
           ${renderMarkdown(declaration.deprecated)}
         </aside>`}
       ${examples}
+      ${usageSections}
       ${see.length === 0 ? "" : `
         <div class="see-also">
           <strong>See also</strong>
@@ -298,6 +375,115 @@ const renderDeclaration = (declaration, id) => {
       ${declaration.since === undefined ? "" : `<div class="since">Since v${escapeHtml(declaration.since)}</div>`}
     </article>`
 }
+
+const renderExamples = (examples) => examples.map((example, index) => `
+    <section class="example">
+      <div class="example__heading">
+        <strong>${escapeHtml(example.title ?? `Example${examples.length > 1 ? ` ${index + 1}` : ""}`)}</strong>
+        <span>${escapeHtml(example.language)}</span>
+      </div>
+      <div class="code-block">
+        <button class="copy-button" type="button" aria-label="Copy example code">Copy</button>
+        <pre><code>${highlightCode(example.source, example.language)}</code></pre>
+      </div>
+    </section>`).join("")
+
+const usageSectionId = (declarationId, section) => `${declarationId}-usage-${slugify(section.title)}`
+const usageRootId = (sectionId, root) => `${sectionId}-${slugify(root.label)}`
+const usageMemberId = (parentId, member) => `${parentId}-${slugify(member.name)}`
+
+const renderUsageSection = (section, declarationId, headingLevel = 4) => {
+  const id = usageSectionId(declarationId, section)
+  return `
+    <div class="usage-section" id="${id}" data-pagefind-meta="type:configuration">
+      <div class="usage-roots">
+        ${section.roots.map((root) => renderUsageRoot(root, id, headingLevel)).join("")}
+      </div>
+    </div>`
+}
+
+const renderUsageRoot = (root, sectionId, headingLevel = 5) => {
+  const id = usageRootId(sectionId, root)
+  return `
+    <section class="usage-root" aria-labelledby="${id}">
+      <header class="usage-root__header">
+        <h${Math.min(headingLevel, 6)} id="${id}">${escapeHtml(root.label)}</h${Math.min(headingLevel, 6)}>
+        ${root.sourceUrl === undefined ? "" : sourceLink(root.sourceUrl, "Source")}
+      </header>
+      <div class="usage-root__description">${renderMarkdown(root.description)}</div>
+      ${renderExamples(root.examples ?? [])}
+      <div class="usage-members">
+        ${root.members.map((member) => renderUsageMember(member, 0, id, headingLevel + 1)).join("")}
+      </div>
+    </section>`
+}
+
+const renderUsageMember = (member, depth, parentId, headingLevel) => {
+  const hasSignature = member.signature !== undefined && member.signature.length > 0
+  const id = usageMemberId(parentId, member)
+  const titleId = `${id}-title`
+  const titleLevel = Math.min(headingLevel, 6)
+  return `
+  <article class="usage-member usage-member--depth-${Math.min(depth, 2)}" id="${id}" aria-labelledby="${titleId}" data-pagefind-meta="parameter:${escapeAttribute(member.name)}">
+    <header class="usage-member__header">
+      <h${titleLevel} id="${titleId}">${escapeHtml(member.name)}</h${titleLevel}>
+      ${member.sourceUrl === undefined ? "" : sourceLink(member.sourceUrl, "Source")}
+    </header>
+    ${hasSignature ? `
+      <div class="code-block code-block--usage-signature">
+        <button class="copy-button" type="button" aria-label="Copy ${escapeAttribute(member.name)} signature">Copy</button>
+        <pre><code>${highlightCode(member.signature, "typescript")}</code></pre>
+      </div>` : ""}
+    <div class="usage-member__description">${renderMarkdown(member.description)}</div>
+    ${member.defaultValue === undefined ? "" : `
+      <div class="usage-member__default"><strong>Default</strong> ${renderInlineMarkdown(member.defaultValue)}</div>`}
+    ${member.deprecated === undefined ? "" : `
+      <aside class="callout callout--deprecated"><strong>Deprecated</strong>${renderMarkdown(member.deprecated)}</aside>`}
+    ${renderExamples(member.examples ?? [])}
+    ${member.parameters.length === 0 ? "" : `
+      <dl class="usage-parameters">
+        ${member.parameters.map((parameter) => `
+          <div><dt><code>${escapeHtml(parameter.signature)}</code></dt><dd>${renderMarkdown(parameter.description)}</dd></div>`).join("")}
+      </dl>`}
+    ${member.members.length === 0 ? "" : `
+      <div class="usage-members usage-members--nested">
+        ${member.members.map((child) => renderUsageMember(child, depth + 1, id, titleLevel + 1)).join("")}
+      </div>`}
+    ${member.since === undefined ? "" : `<div class="since">Since v${escapeHtml(member.since)}</div>`}
+  </article>`
+}
+
+const renderGuideToc = (sections, entryIds) => sections.map((section) => `
+  <section class="guide-toc-section">
+    <a class="guide-toc-section__link" href="#workflow-${slugify(section.title)}">${escapeHtml(section.title)}</a>
+    <div class="guide-toc-section__entries">
+      ${section.entries.map((entry) => {
+  const declarationId = entryIds.get(entry)
+  return `
+        <div class="guide-toc-entry">
+          <a class="guide-toc-entry__link" href="#${declarationId}">${escapeHtml(entry.api.name)}</a>
+          ${(entry.api.usageSections ?? []).map((usageSection) => {
+    const sectionId = usageSectionId(declarationId, usageSection)
+    return usageSection.roots.map((root) => {
+      const rootId = usageRootId(sectionId, root)
+      return `
+                <div class="guide-toc-root">
+                  <a class="guide-toc-root__link" href="#${rootId}">${escapeHtml(root.label)}</a>
+                  ${renderGuideMemberLinks(root.members, rootId, 0)}
+                </div>`
+    }).join("")
+  }).join("")}
+        </div>`
+}).join("")}
+    </div>
+  </section>`).join("")
+
+const renderGuideMemberLinks = (members, parentId, depth) => members.map((member) => {
+  const id = usageMemberId(parentId, member)
+  return `
+    <a class="guide-toc-member guide-toc-member--depth-${Math.min(depth, 2)}" href="#${id}">${escapeHtml(member.name)}</a>
+    ${renderGuideMemberLinks(member.members, id, depth + 1)}`
+}).join("")
 
 export const renderLayout = (site, { content, currentRoute, description, pageKind, title, toc = "" }) => {
   const pageDescription = description ?? site.description
@@ -410,6 +596,8 @@ const renderNavigation = (site, currentRoute) => `
     </div>
     <a class="navigation-overview${currentRoute === "" ? " is-current" : ""}" href="${siteUrl(site, "")}">Overview</a>
     <a class="navigation-changelog${currentRoute === "changelog" ? " is-current" : ""}" href="${siteUrl(site, "changelog")}">Changelog</a>
+    ${site.guideModule === undefined ? "" : `
+      <a class="navigation-guide${currentRoute === "guide" ? " is-current" : ""}" href="${siteUrl(site, "guide")}">Guide reference</a>`}
     ${site.navigation.map((group) => `
       <section>
         <h2>${escapeHtml(group.label)}</h2>
@@ -728,7 +916,7 @@ Sitemap: ${absoluteSiteUrl(site, "sitemap.xml")}
 
 export const renderSitemap = (site) => `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${["", "changelog/", ...site.modules.map((module) => `${module.route}/`)]
+${["", "changelog/", ...(site.guideModule === undefined ? [] : ["guide/"]), ...site.modules.map((module) => `${module.route}/`)]
     .map((route) => `  <url><loc>${escapeXml(absoluteSiteUrl(site, route))}</loc></url>`)
     .join("\n")}
 </urlset>
@@ -830,6 +1018,7 @@ const validateSite = (outputDirectory, site) => {
   for (const path of [
     "index.html",
     "changelog/index.html",
+    ...(site.guideModule === undefined ? [] : ["guide/index.html"]),
     "assets/styles.css",
     "assets/client.js",
     "apple-touch-icon.png",

--- a/scripts/api-reference/api-reference.test.mjs
+++ b/scripts/api-reference/api-reference.test.mjs
@@ -109,3 +109,176 @@ test("normalizes categories, signatures, examples, tags, and source links", () =
     /make: missing example/
   )
 })
+
+test("normalizes documented parameters into declaration-owned usage sections", () => {
+  const reflection = {
+    schemaVersion: "2.0",
+    id: 1,
+    name: "sample",
+    variant: "project",
+    kind: ReflectionKind.Project,
+    flags: {},
+    children: [{
+      id: 2,
+      name: "sample/Machine",
+      variant: "declaration",
+      kind: ReflectionKind.Module,
+      flags: {},
+      children: [{
+        id: 3,
+        name: "make",
+        variant: "declaration",
+        kind: ReflectionKind.Variable,
+        flags: {},
+        comment: {
+          summary: [{ kind: "text", text: "Creates a machine." }],
+          blockTags: [
+            { tag: "@category", content: [{ kind: "text", text: "constructors" }] },
+            { tag: "@since", content: [{ kind: "text", text: "1.0.0" }] }
+          ]
+        },
+        type: {
+          type: "reflection",
+          declaration: {
+            id: 4,
+            name: "__type",
+            variant: "declaration",
+            kind: ReflectionKind.TypeLiteral,
+            flags: {},
+            signatures: [{
+              id: 5,
+              name: "__call",
+              variant: "signature",
+              kind: ReflectionKind.CallSignature,
+              flags: {},
+              parameters: [{
+                id: 6,
+                name: "config",
+                variant: "param",
+                kind: ReflectionKind.Parameter,
+                flags: {},
+                comment: { summary: [{ kind: "text", text: "Complete machine configuration." }] },
+                type: {
+                  type: "reflection",
+                  declaration: {
+                    id: 7,
+                    name: "__type",
+                    variant: "declaration",
+                    kind: ReflectionKind.TypeLiteral,
+                    flags: {},
+                    children: [{
+                      id: 8,
+                      name: "id",
+                      variant: "declaration",
+                      kind: ReflectionKind.Property,
+                      flags: { isOptional: true, isReadonly: true },
+                      comment: { summary: [{ kind: "text", text: "Stable definition identifier." }] },
+                      type: { type: "intrinsic", name: "string" }
+                    }]
+                  }
+                }
+              }],
+              type: { type: "intrinsic", name: "unknown" }
+            }]
+          }
+        }
+      }]
+    }]
+  }
+  const normalized = normalizeApiModule(reflection, [{
+    owner: "make",
+    title: "Machine configuration",
+    roots: [{ declaration: "make", parameter: "config", label: "Configuration" }]
+  }])
+  const declaration = normalized.groups[0].declarations[0]
+  assert.equal(declaration.usageSections[0].title, "Machine configuration")
+  assert.equal(declaration.usageSections[0].roots[0].description, "Complete machine configuration.")
+  assert.deepEqual(declaration.usageSections[0].roots[0].members.map((member) => member.name), ["id"])
+  assert.equal(declaration.usageSections[0].roots[0].members[0].description, "Stable definition identifier.")
+})
+
+test("projects a nested API reflection into an ordered core workflow", () => {
+  const reflection = {
+    schemaVersion: "2.0",
+    id: 1,
+    name: "sample",
+    variant: "project",
+    kind: ReflectionKind.Project,
+    flags: {},
+    children: [{
+      id: 2,
+      name: "sample/Machine",
+      variant: "declaration",
+      kind: ReflectionKind.Module,
+      flags: {},
+      children: [{
+        id: 3,
+        name: "Definition",
+        variant: "declaration",
+        kind: ReflectionKind.Interface,
+        flags: {},
+        children: [{
+          id: 4,
+          name: "handle",
+          variant: "declaration",
+          kind: ReflectionKind.Property,
+          flags: { isReadonly: true },
+          comment: {
+            summary: [{ kind: "text", text: "Adds typed state handlers." }],
+            blockTags: [{ tag: "@since", content: [{ kind: "text", text: "1.0.0" }] }]
+          },
+          type: { type: "intrinsic", name: "unknown" }
+        }]
+      }, {
+        id: 5,
+        name: "Machine",
+        variant: "declaration",
+        kind: ReflectionKind.Namespace,
+        flags: {},
+        children: [{
+          id: 6,
+          name: "HandlerConfig",
+          variant: "declaration",
+          kind: ReflectionKind.Interface,
+          flags: {},
+          comment: { summary: [{ kind: "text", text: "State handler configuration." }] },
+          children: [{
+            id: 7,
+            name: "entry",
+            variant: "declaration",
+            kind: ReflectionKind.Property,
+            flags: { isOptional: true, isReadonly: true },
+            comment: { summary: [{ kind: "text", text: "Runs when the state is entered." }] },
+            type: { type: "intrinsic", name: "unknown" }
+          }]
+        }]
+      }]
+    }]
+  }
+  const usageSections = [{
+    owner: "Definition",
+    ownerKind: "interface",
+    title: "State handler configuration",
+    roots: [{ reflection: "Machine.HandlerConfig", label: "Active states" }]
+  }]
+  const referenceSections = [{
+    title: "Implement state behavior",
+    entries: [{
+      reflection: "Definition.handle",
+      label: "handle",
+      kind: "method",
+      owner: "Definition",
+      ownerKind: "interface",
+      usageSections: ["State handler configuration"]
+    }]
+  }]
+
+  const normalized = normalizeApiModule(reflection, usageSections, referenceSections)
+  const entry = normalized.referenceSections[0].entries[0]
+  assert.deepEqual(entry.origin, { type: "reflection", reflection: "Definition.handle" })
+  assert.equal(entry.api.name, "handle")
+  assert.equal(entry.api.kind, "method")
+  assert.equal(entry.api.signature, "readonly handle: unknown")
+  assert.equal(entry.api.usageSections[0].title, "State handler configuration")
+  assert.equal(entry.api.usageSections[0].roots[0].members[0].name, "entry")
+})

--- a/scripts/api-reference/generate.mjs
+++ b/scripts/api-reference/generate.mjs
@@ -115,7 +115,7 @@ const generateDataset = async (config, outputDirectory) => {
     await application.generateJson(project, jsonPath)
 
     const reflection = readJson(jsonPath)
-    const normalized = normalizeApiModule(reflection)
+    const normalized = normalizeApiModule(reflection, module.usageSections, module.referenceSections)
     validateApiDocumentation(module.export, normalized, module.examples)
     if (
       normalized.name.length === 0 ||
@@ -130,6 +130,8 @@ const generateDataset = async (config, outputDirectory) => {
       source: relativePosix(packageDirectory, module.source),
       json: relativePosix(packageOutputDirectory, jsonPath),
       sha256: hashFile(jsonPath),
+      ...(module.usageSections.length === 0 ? {} : { usageSections: module.usageSections }),
+      ...(module.referenceSections.length === 0 ? {} : { referenceSections: module.referenceSections }),
       ...(module.barrel === undefined ? {} : { barrel: module.barrel })
     })
   }
@@ -139,7 +141,7 @@ const generateDataset = async (config, outputDirectory) => {
   const packageSourceUrl = `${repositoryUrl}/tree/${revision}${packageSourcePath === "" ? "" : `/${packageSourcePath}`}`
   const packageManifestOutput = join(packageOutputDirectory, "manifest.json")
   writeJson(packageManifestOutput, {
-    schemaVersion: 4,
+    schemaVersion: 6,
     channel: config.channel,
     name: packageManifest.name,
     version: packageManifest.version,
@@ -178,7 +180,7 @@ export const validateDataset = (outputDirectory) => {
     const packageManifestPath = safeResolve(outputDirectory, packageEntry.manifest)
     const packageManifest = readJson(packageManifestPath)
     if (
-      packageManifest.schemaVersion !== 4 ||
+      packageManifest.schemaVersion !== 6 ||
       packageManifest.channel !== dataset.channel ||
       packageManifest.revision !== dataset.revision ||
       packageManifest.name !== packageEntry.name ||
@@ -197,7 +199,10 @@ export const validateDataset = (outputDirectory) => {
       if (reflection.schemaVersion !== "2.0" || reflection.variant !== "project") {
         throw new Error(`Invalid TypeDoc reflection: ${reflectionPath}`)
       }
-      validateApiDocumentation(module.export, normalizeApiModule(reflection))
+      validateApiDocumentation(
+        module.export,
+        normalizeApiModule(reflection, module.usageSections ?? [], module.referenceSections ?? [])
+      )
     }
   }
   return dataset
@@ -215,7 +220,73 @@ const readConfig = (path) => {
   if (config.modules.some((module) => module.examples !== undefined && !Array.isArray(module.examples))) {
     throw new Error("API reference module examples must be an array")
   }
+  for (const module of config.modules) {
+    validateUsageSections(module)
+    validateReferenceSections(module)
+  }
   return config
+}
+
+const validateReferenceSections = (module) => {
+  if (module.referenceSections === undefined) return
+  if (!Array.isArray(module.referenceSections)) {
+    throw new Error(`Module ${module.export} referenceSections must be an array`)
+  }
+  for (const section of module.referenceSections) {
+    if (
+      typeof section.title !== "string" || section.title.length === 0 ||
+      (section.description !== undefined && typeof section.description !== "string") ||
+      !Array.isArray(section.entries) || section.entries.length === 0
+    ) {
+      throw new Error(`Module ${module.export} has an invalid reference section`)
+    }
+    for (const entry of section.entries) {
+      const declaration = typeof entry.declaration === "string" && entry.declaration.length > 0
+      const reflection = typeof entry.reflection === "string" && entry.reflection.length > 0
+      if (
+        declaration === reflection ||
+        (entry.label !== undefined && typeof entry.label !== "string") ||
+        (entry.kind !== undefined && typeof entry.kind !== "string") ||
+        (entry.owner !== undefined && typeof entry.owner !== "string") ||
+        (entry.ownerKind !== undefined && typeof entry.ownerKind !== "string") ||
+        (entry.usageSections !== undefined && (
+          !Array.isArray(entry.usageSections) ||
+          entry.usageSections.some((title) => typeof title !== "string" || title.length === 0) ||
+          typeof entry.owner !== "string"
+        ))
+      ) {
+        throw new Error(`Module ${module.export} has an invalid reference entry in ${section.title}`)
+      }
+    }
+  }
+}
+
+const validateUsageSections = (module) => {
+  if (module.usageSections === undefined) return
+  if (!Array.isArray(module.usageSections)) throw new Error(`Module ${module.export} usageSections must be an array`)
+  for (const section of module.usageSections) {
+    if (
+      typeof section.owner !== "string" || section.owner.length === 0 ||
+      typeof section.title !== "string" || section.title.length === 0 ||
+      (section.ownerKind !== undefined && typeof section.ownerKind !== "string") ||
+      !Array.isArray(section.roots) || section.roots.length === 0
+    ) {
+      throw new Error(`Module ${module.export} has an invalid usage section`)
+    }
+    for (const root of section.roots) {
+      const reflection = typeof root.reflection === "string" && root.reflection.length > 0
+      const parameter = typeof root.declaration === "string" && root.declaration.length > 0 &&
+        typeof root.parameter === "string" && root.parameter.length > 0
+      if (
+        reflection === parameter ||
+        (root.label !== undefined && typeof root.label !== "string") ||
+        (root.members !== undefined && (!Array.isArray(root.members) || root.members.some((name) => typeof name !== "string"))) ||
+        (root.nested !== undefined && typeof root.nested !== "boolean")
+      ) {
+        throw new Error(`Module ${module.export} has an invalid usage root in ${section.title}`)
+      }
+    }
+  }
 }
 
 const resolveEntry = (packageDirectory, entry) => {
@@ -225,7 +296,9 @@ const resolveEntry = (packageDirectory, entry) => {
     ...entry,
     source,
     outputPath: exportPathToOutputPath(entry.export),
-    examples: entry.examples ?? []
+    examples: entry.examples ?? [],
+    usageSections: entry.usageSections ?? [],
+    referenceSections: entry.referenceSections ?? []
   }
 }
 

--- a/scripts/api-reference/normalize.mjs
+++ b/scripts/api-reference/normalize.mjs
@@ -5,9 +5,26 @@ import { ReflectionKind } from "typedoc"
  * Raw TypeDoc JSON remains the generated artifact; this adapter isolates a
  * future site from TypeDoc's complete reflection schema.
  */
-export const normalizeApiModule = (reflection) => {
+export const normalizeApiModule = (
+  reflection,
+  configuredUsageSections = [],
+  configuredReferenceSections = []
+) => {
   const moduleReflection = reflection.children?.find((child) => child.children !== undefined)
-  const declarations = (moduleReflection?.children ?? []).map(normalizeDeclaration)
+  const usageSections = normalizeUsageSections(moduleReflection, configuredUsageSections)
+  const declarations = (moduleReflection?.children ?? []).map((declaration) => ({
+    ...normalizeDeclaration(declaration),
+    usageSections: usageSections.filter((section) =>
+      section.owner === declaration.name &&
+      (section.ownerKind === undefined || section.ownerKind === reflectionKindName(declaration.kind))
+    )
+  }))
+  const referenceSections = normalizeReferenceSections(
+    moduleReflection,
+    configuredReferenceSections,
+    declarations,
+    usageSections
+  )
   const groups = groupBy(declarations, (declaration) => declaration.category)
   const versions = declarations.flatMap((declaration) => declaration.since === undefined ? [] : [declaration.since])
 
@@ -17,6 +34,7 @@ export const normalizeApiModule = (reflection) => {
     since: versions.toSorted(compareVersions)[0],
     sourceUrl: declarations.find((declaration) => declaration.sourceUrl !== undefined)?.sourceUrl,
     declarationCount: declarations.length,
+    referenceSections,
     groups: [...groups]
       .map(([category, groupedDeclarations]) => ({
         category,
@@ -45,6 +63,29 @@ export const validateApiDocumentation = (moduleExport, api, requiredExamples = [
     } else if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(declaration.since)) {
       violations.push(`${declaration.name}: invalid @since ${JSON.stringify(declaration.since)}`)
     }
+    for (const section of declaration.usageSections ?? []) {
+      for (const root of section.roots) {
+        if (root.description === undefined) {
+          violations.push(`${declaration.name}.${section.title}.${root.label}: missing summary`)
+        }
+        if (root.members.length === 0) {
+          violations.push(`${declaration.name}.${section.title}.${root.label}: no documented members`)
+        }
+        visitUsageMembers(root.members, (member, path) => {
+          if (member.description === undefined) {
+            violations.push(`${declaration.name}.${section.title}.${root.label}.${path}: missing summary`)
+          }
+        })
+      }
+    }
+  }
+
+  for (const section of api.referenceSections ?? []) {
+    for (const entry of section.entries) {
+      if (entry.api.description === undefined) {
+        violations.push(`${section.title}.${entry.api.name}: missing summary`)
+      }
+    }
   }
 
   const declarationsByName = new Map(declarations.map((declaration) => [declaration.name, declaration]))
@@ -61,6 +102,286 @@ export const validateApiDocumentation = (moduleExport, api, requiredExamples = [
     throw new Error(`Incomplete API documentation for ${moduleExport}:\n- ${violations.join("\n- ")}`)
   }
 }
+
+const normalizeReferenceSections = (moduleReflection, configuredSections, declarations, usageSections) => {
+  if (configuredSections.length === 0) return []
+  const index = reflectionIndex(moduleReflection)
+  return configuredSections.map((section) => ({
+    title: section.title,
+    description: section.description,
+    entries: section.entries.map((entry) => {
+      if (entry.declaration !== undefined) {
+        const matches = declarations.filter((declaration) =>
+          declaration.name === entry.declaration &&
+          (entry.kind === undefined || declaration.kind === entry.kind)
+        )
+        if (matches.length !== 1) {
+          throw new Error(
+            `Could not uniquely resolve core API declaration: ${entry.declaration}${
+              entry.kind === undefined ? "" : ` (${entry.kind})`
+            }`
+          )
+        }
+        return {
+          origin: { type: "declaration", name: matches[0].name, kind: matches[0].kind },
+          api: matches[0]
+        }
+      }
+
+      const reflection = index.get(entry.reflection)
+      if (reflection === undefined) {
+        throw new Error(`Could not resolve core API reflection: ${entry.reflection}`)
+      }
+      const selectedUsageSections = usageSections.filter((usageSection) =>
+        usageSection.owner === entry.owner &&
+        (entry.ownerKind === undefined || usageSection.ownerKind === entry.ownerKind) &&
+        (entry.usageSections === undefined || entry.usageSections.includes(usageSection.title))
+      )
+      if (
+        entry.usageSections !== undefined &&
+        selectedUsageSections.length !== entry.usageSections.length
+      ) {
+        throw new Error(`Could not resolve every usage section configured for ${entry.reflection}`)
+      }
+      return {
+        origin: { type: "reflection", reflection: entry.reflection },
+        api: normalizeReferenceReflection(reflection, entry, selectedUsageSections)
+      }
+    })
+  }))
+}
+
+const normalizeReferenceReflection = (reflection, entry, usageSections) => {
+  const comment = declarationComment(reflection)
+  return {
+    name: entry.label ?? reflection.name,
+    kind: entry.kind ?? reflectionKindName(reflection.kind),
+    category: "Core API",
+    signature: usageMemberSignature(reflection),
+    description: commentMarkdown(comment),
+    since: blockTagText(comment?.blockTags, "@since"),
+    deprecated: blockTagText(comment?.blockTags, "@deprecated"),
+    see: blockTagTexts(comment?.blockTags, "@see"),
+    examples: codeExamples(reflection),
+    sourceUrl: firstSourceUrl(reflection.sources),
+    usageSections
+  }
+}
+
+const visitUsageMembers = (members, visit, prefix = "") => {
+  for (const member of members) {
+    const path = prefix.length === 0 ? member.name : `${prefix}.${member.name}`
+    visit(member, path)
+    visitUsageMembers(member.members, visit, path)
+  }
+}
+
+const normalizeUsageSections = (moduleReflection, configuredSections) => {
+  if (configuredSections.length === 0) return []
+  const index = reflectionIndex(moduleReflection)
+  const topLevel = new Map((moduleReflection?.children ?? []).map((reflection) => [reflection.name, reflection]))
+  return configuredSections.map((section) => ({
+    owner: section.owner,
+    ownerKind: section.ownerKind,
+    title: section.title,
+    description: section.description,
+    roots: section.roots.map((root) => {
+      const reflection = root.reflection === undefined
+        ? findParameter(topLevel.get(root.declaration), root.parameter)
+        : index.get(root.reflection)
+      if (reflection === undefined) {
+        const locator = root.reflection ?? `${root.declaration} parameter ${root.parameter}`
+        throw new Error(`Could not resolve API usage root: ${locator}`)
+      }
+      return normalizeUsageRoot(reflection, root.label ?? reflection.name, root)
+    })
+  }))
+}
+
+const reflectionIndex = (moduleReflection) => {
+  const index = new Map()
+  const visit = (reflection, path) => {
+    for (const child of reflection?.children ?? []) {
+      const childPath = child.name === "__type" ? path : [...path, child.name]
+      if (child.name !== "__type") index.set(childPath.join("."), child)
+      visit(child, childPath)
+      for (const signature of child.signatures ?? []) visitSignature(signature, childPath)
+      visitType(child.type, childPath)
+    }
+  }
+  const visitSignature = (signature, path) => {
+    for (const parameter of signature.parameters ?? []) {
+      visitType(parameter.type, [...path, parameter.name])
+    }
+    visitType(signature.type, path)
+  }
+  const visitType = (type, path) => {
+    if (type === undefined) return
+    if (type.type === "reflection") {
+      visit(type.declaration, path)
+      for (const signature of type.declaration.signatures ?? []) visitSignature(signature, path)
+      return
+    }
+    for (const childType of childTypes(type)) visitType(childType, path)
+  }
+  visit(moduleReflection, [])
+  return index
+}
+
+const findParameter = (reflection, name) => {
+  let found
+  const visit = (value) => {
+    if (found !== undefined || value === undefined) return
+    for (const parameter of value.parameters ?? []) {
+      if (parameter.name === name) {
+        found = parameter
+        return
+      }
+      visitType(parameter.type)
+    }
+    for (const signature of value.signatures ?? []) visit(signature)
+    for (const child of value.children ?? []) visit(child)
+    visitType(value.type)
+  }
+  const visitType = (type) => {
+    if (found !== undefined || type === undefined) return
+    if (type.type === "reflection") visit(type.declaration)
+    for (const childType of childTypes(type)) visitType(childType)
+  }
+  visit(reflection)
+  return found
+}
+
+const normalizeUsageRoot = (reflection, label, options) => ({
+  label,
+  name: reflection.name,
+  kind: reflectionKindName(reflection.kind),
+  description: commentMarkdown(declarationComment(reflection)),
+  examples: codeExamples(reflection),
+  members: normalizeUsageMembers(reflection, 0, options.nested === true ? 1 : 0)
+    .filter((member) => options.members === undefined || options.members.includes(member.name)),
+  sourceUrl: firstSourceUrl(reflection.sources)
+})
+
+const normalizeUsageMembers = (reflection, depth, maxDepth) => {
+  if (depth > maxDepth) return []
+  const members = memberReflections(reflection)
+    .filter(isDocumentableUsageMember)
+    .map((member) => normalizeUsageMember(member, depth, maxDepth))
+  return mergeUsageMembers(members)
+}
+
+const normalizeUsageMember = (member, depth, maxDepth) => {
+  const comment = declarationComment(member)
+  return {
+    name: member.name,
+    signature: usageMemberSignature(member),
+    description: commentMarkdown(comment),
+    since: blockTagText(comment?.blockTags, "@since"),
+    deprecated: blockTagText(comment?.blockTags, "@deprecated"),
+    defaultValue: blockTagText(comment?.blockTags, "@defaultValue") ?? blockTagText(comment?.blockTags, "@default"),
+    examples: codeExamples(member),
+    parameters: normalizeUsageParameters(member),
+    members: normalizeUsageMembersFromMember(member, depth + 1, maxDepth),
+    sourceUrl: firstSourceUrl(member.sources)
+  }
+}
+
+const normalizeUsageParameters = (member) => {
+  const parameters = (member.signatures ?? []).flatMap((signature) => signature.parameters ?? [])
+  return mergeBy(parameters.map((parameter) => ({
+    name: parameter.name,
+    signature: formatParameter(parameter),
+    description: commentMarkdown(parameter.comment),
+    sourceUrl: firstSourceUrl(parameter.sources)
+  })), (parameter) => parameter.name)
+}
+
+const normalizeUsageMembersFromMember = (member, depth, maxDepth) => {
+  if (depth > maxDepth) return []
+  const nested = []
+  collectTypeMembers(member.type, nested, true)
+  for (const signature of member.signatures ?? []) collectTypeMembers(signature.type, nested, true)
+  return mergeUsageMembers(
+    nested.filter(isDocumentableUsageMember).map((child) => normalizeUsageMember(child, depth, maxDepth))
+  )
+}
+
+const memberReflections = (reflection) => {
+  const members = [...reflection.children ?? []]
+  collectTypeMembers(reflection.type, members, false)
+  return members
+}
+
+const collectTypeMembers = (type, members, includeReturnTypes) => {
+  if (type === undefined) return
+  if (type.type === "reflection") {
+    members.push(...type.declaration.children ?? [])
+    if (includeReturnTypes) {
+      for (const signature of type.declaration.signatures ?? []) collectTypeMembers(signature.type, members, true)
+    }
+    return
+  }
+  for (const childType of childTypes(type)) collectTypeMembers(childType, members, includeReturnTypes)
+}
+
+const childTypes = (type) => {
+  switch (type.type) {
+    case "array":
+      return [type.elementType]
+    case "conditional":
+      return [type.trueType, type.falseType]
+    case "indexedAccess":
+      return [type.objectType, type.indexType]
+    case "intersection":
+    case "union":
+      return type.types ?? []
+    case "mapped":
+    case "optional":
+    case "rest":
+    case "typeOperator":
+      return [type.elementType ?? type.target ?? type.parameterType]
+    case "reference":
+    case "tuple":
+      return type.typeArguments ?? type.elements ?? []
+    default:
+      return []
+  }
+}
+
+const isDocumentableUsageMember = (member) =>
+  member.name !== "__type" &&
+  !member.name.startsWith("[") &&
+  !member.name.startsWith("~effect/") &&
+  blockTagText(member.comment?.blockTags, "@internal") === undefined &&
+  member.comment?.modifierTags?.includes("@internal") !== true &&
+  !isNeverMember(member)
+
+const isNeverMember = (member) => member.type?.type === "intrinsic" && member.type.name === "never"
+
+const usageMemberSignature = (member) => {
+  const signatures = formatMember(member, 0)
+    .map((signature) => signature.replace(/;$/, ""))
+  return signatures.length === 0 ? undefined : signatures.join("\n")
+}
+
+const mergeUsageMembers = (members) => {
+  const groups = groupBy(members, (member) => member.name)
+  return [...groups].map(([, variants]) => {
+    const first = variants.find((variant) => variant.description !== undefined) ?? variants[0]
+    return {
+      ...first,
+      signature: unique(variants.flatMap((variant) => variant.signature === undefined ? [] : [variant.signature])).join("\n"),
+      parameters: mergeBy(variants.flatMap((variant) => variant.parameters), (parameter) => parameter.name),
+      members: mergeUsageMembers(variants.flatMap((variant) => variant.members)),
+      sourceUrl: variants.find((variant) => variant.sourceUrl !== undefined)?.sourceUrl
+    }
+  }).toSorted((left, right) => left.name.localeCompare(right.name))
+}
+
+const mergeBy = (values, keyOf) => [...new Map(values.map((value) => [keyOf(value), value])).values()]
+
+const unique = (values) => [...new Set(values.filter(Boolean))]
 
 const groupBy = (values, keyOf) => {
   const groups = new Map()

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -278,6 +278,20 @@ export interface Definition<
    * captured by value, so later mutation of the supplied objects cannot alter
    * the resulting machine.
    *
+   * **Example**
+   *
+   * ```ts
+   * const counter = definition.handle({
+   *   Count: {
+   *     on: {
+   *       Increment: (to) =>
+   *         to.full.Count().resolve(({ event, state, target }) =>
+   *           target(new Count({ value: state.value + event.by })))
+   *     }
+   *   }
+   * })
+   * ```
+   *
    * @since 0.4.0
    */
   readonly handle: Machine.Handler<
@@ -523,8 +537,10 @@ export type MachineReferences<
 
 /**
  * Synchronous commands available while a machine transition is being
- * selected. Enqueuing only records statechart and machine operations; it never
- * executes an Effect.
+ * selected.
+ *
+ * Enqueuing records statechart and machine operations for the selected
+ * transition. It never executes an Effect while the transition is evaluated.
  *
  * @category models
  * @since 0.4.0
@@ -2915,8 +2931,11 @@ export declare namespace Machine {
    * @since 0.4.0
    */
   export interface StateNodeAnnotations extends Schema.Annotations.Annotations {
+    /** Human-readable label used by visualization and documentation tooling. */
     readonly title?: string | undefined
+    /** Short explanation of the state node's domain meaning. */
     readonly description?: string | undefined
+    /** Longer documentation text associated with the state node. */
     readonly documentation?: string | undefined
   }
 
@@ -2930,22 +2949,29 @@ export declare namespace Machine {
   export type PseudoStateAnnotations = SchemaLessStateAnnotations
 
   /**
-   * Configuration accepted for an atomic object state node. Omit `schema` when
-   * the state owns no value; a schema-less final may still declare `output`.
+   * Configuration accepted for an atomic object state node.
+   *
+   * Omit `schema` when the state owns no value. A schema-less final may still
+   * declare `output`.
    *
    * @category models
    * @since 0.4.0
    */
   export type AtomicStateNodeConfig =
     | {
+      /** Tagged schema that owns the state's decoded value. */
       readonly schema: TaggedSchema
+      /** Declares an ordinary active state. Omitted values default to `"active"`. */
       readonly type?: "active"
+      /** Atomic active states cannot declare terminal output. */
       readonly output?: never
+      /** Schema-backed states take their annotations from the schema. */
       readonly annotations?: never
     }
     | {
       readonly schema: TaggedSchema
       readonly type: "final"
+      /** Optional schema describing the terminal value produced by this final state. */
       readonly output?: Schema.Top
       readonly annotations?: never
     }
@@ -2953,12 +2979,15 @@ export declare namespace Machine {
       readonly schema?: never
       readonly type?: "active"
       readonly output?: never
+      /** Descriptive metadata for a schema-less state. */
       readonly annotations?: SchemaLessStateAnnotations
     }
     | {
       readonly schema?: never
       readonly type: "final"
+      /** Optional schema describing the terminal value produced by this final state. */
       readonly output?: Schema.Top
+      /** Descriptive metadata for a schema-less state. */
       readonly annotations?: SchemaLessStateAnnotations
     }
 
@@ -2971,10 +3000,15 @@ export declare namespace Machine {
    */
   export type CompoundStateNodeConfig =
     | {
+      /** Tagged schema that owns the compound state's decoded value. */
       readonly schema: TaggedSchema
+      /** Compound states are ordinary active states. */
       readonly type?: "active"
+      /** Direct child selected when the compound state is entered initially. */
       readonly initial: string
+      /** Nested state nodes owned by this compound state. */
       readonly states: StateTree
+      /** Schema-backed states take their annotations from the schema. */
       readonly annotations?: never
     }
     | {
@@ -2982,6 +3016,7 @@ export declare namespace Machine {
       readonly type?: "active"
       readonly initial: string
       readonly states: StateTree
+      /** Descriptive metadata for a schema-less state. */
       readonly annotations?: SchemaLessStateAnnotations
     }
 
@@ -2994,10 +3029,15 @@ export declare namespace Machine {
    */
   export type ParallelStateNodeConfig =
     | {
+      /** Tagged schema that owns the parallel state's decoded value. */
       readonly schema: TaggedSchema
+      /** Selects parallel-region semantics for the node. */
       readonly type: "parallel"
+      /** Optional schema describing the value produced after every region completes. */
       readonly output?: Schema.Top
+      /** Child regions that are entered and remain active simultaneously. */
       readonly states: StateTree
+      /** Schema-backed states take their annotations from the schema. */
       readonly annotations?: never
     }
     | {
@@ -3005,6 +3045,7 @@ export declare namespace Machine {
       readonly type: "parallel"
       readonly output?: Schema.Top
       readonly states: StateTree
+      /** Descriptive metadata for a schema-less state. */
       readonly annotations?: SchemaLessStateAnnotations
     }
 
@@ -3021,9 +3062,16 @@ export declare namespace Machine {
    * @since 0.4.0
    */
   export interface HistoryStateNodeConfig {
+    /** Selects history pseudo-state semantics. */
     readonly type: "history"
-    /** Defaults to shallow history. */
+    /**
+     * Restores only the direct child for shallow history or the complete
+     * descendant configuration for deep history.
+     *
+     * @defaultValue `"shallow"`
+     */
     readonly history?: "shallow" | "deep"
+    /** Descriptive metadata used by visualization and documentation tooling. */
     readonly annotations?: SchemaLessStateAnnotations
   }
 
@@ -3038,7 +3086,9 @@ export declare namespace Machine {
    * @since 0.4.0
    */
   export interface ChoiceStateNodeConfig {
+    /** Selects transient choice pseudo-state semantics. */
     readonly type: "choice"
+    /** Descriptive metadata used by visualization and documentation tooling. */
     readonly annotations?: SchemaLessStateAnnotations
   }
 
@@ -4642,18 +4692,26 @@ export declare namespace Machine {
 
   /**
    * Definition-time topology selector available to an ordinary transition.
+   *
    * Topology-only instructions (`none`, declared `initial` and history
-   * selections, and `local.with`) are values. State and choice destinations
-   * remain callable selection methods.
+   * selections, and `local.with`) are values.
+   *
+   * State and choice destinations remain callable selection methods so their
+   * target-specific resolver APIs retain exact inference.
    */
   export interface TargetSelector<
     States extends StateSchemas,
     Source extends StateNodeIdentifier<States>
   > {
+    /** Handles the trigger without selecting a destination. */
     readonly none: SelectionValue<TargetBuilder<States, Source>["none"], never, "none">
+    /** Selects a destination inside the nearest active compound scope. */
     readonly local: LocalTargetSelector<States, Source>
+    /** Selects a destination elsewhere under the currently active root. */
     readonly branch: BranchTargetSelector<States, Source>
+    /** Selects a complete destination under any top-level state. */
     readonly full: FullTargetSelector<States>
+    /** Restores a shallow or deep history pseudo-state. */
     readonly history: HistorySelectionTree<States, States, "", HistoryTargetBuilder<States>>
   }
 
@@ -4683,11 +4741,15 @@ export declare namespace Machine {
     InputEvents extends ReadonlyArray<TaggedSchema> = Events,
     ParentEvents extends ReadonlyArray<TaggedSchema> = readonly []
   > = MachineReferences<InputEvents, ParentEvents> & {
+    /** Value owned by the state whose handler is running. */
     readonly state: StateByIdentifier<States, StateId>
+    /** Value owned by the nearest schema-backed ancestor, when one exists. */
     readonly containingState: ParentStateValue<States, StateId>
+    /** Schema-backed ancestor values keyed by their complete state paths. */
     readonly ancestors: ParentStateValues<States, StateId>
     /** Complete logical configuration captured at the start of this microstep. */
     readonly snapshot: Snapshot<States>
+    /** Event that selected this handler, narrowed by its `_tag`. */
     readonly event: EventByTag<Events, EventTag>
 
     /**
@@ -4713,9 +4775,13 @@ export declare namespace Machine {
     InputEvents extends ReadonlyArray<TaggedSchema> = Events,
     ParentEvents extends ReadonlyArray<TaggedSchema> = readonly []
   > = MachineReferences<InputEvents, ParentEvents> & {
+    /** Value owned by the state entering or exiting. */
     readonly state: StateByIdentifier<States, StateId>
+    /** Value owned by the nearest schema-backed ancestor, when one exists. */
     readonly containingState: ParentStateValue<States, StateId>
+    /** Schema-backed ancestor values keyed by their complete state paths. */
     readonly ancestors: ParentStateValues<States, StateId>
+    /** Event or initial-entry marker responsible for the lifecycle action. */
     readonly event: LifecycleEvent<Events>
   }
 
@@ -4733,9 +4799,13 @@ export declare namespace Machine {
     InputEvents extends ReadonlyArray<TaggedSchema> = Events,
     ParentEvents extends ReadonlyArray<TaggedSchema> = readonly []
   > = MachineReferences<InputEvents, ParentEvents> & {
+    /** Value owned by the state that owns this invocation. */
     readonly state: StateByIdentifier<States, StateId>
+    /** Value owned by the nearest schema-backed ancestor, when one exists. */
     readonly containingState: ParentStateValue<States, StateId>
+    /** Schema-backed ancestor values keyed by their complete state paths. */
     readonly ancestors: ParentStateValues<States, StateId>
+    /** Event or initial-entry marker responsible for starting the invocation. */
     readonly event: LifecycleEvent<Events>
   }
 
@@ -4756,11 +4826,17 @@ export declare namespace Machine {
     InputEvents extends ReadonlyArray<TaggedSchema> = Events,
     ParentEvents extends ReadonlyArray<TaggedSchema> = readonly []
   > = MachineReferences<InputEvents, ParentEvents> & {
+    /** Parent-local invocation identifier. */
     readonly id: string
+    /** Current value of the state that owns the invocation. */
     readonly state: StateByIdentifier<States, StateId>
+    /** Value owned by the nearest schema-backed ancestor, when one exists. */
     readonly containingState: ParentStateValue<States, StateId>
+    /** Schema-backed ancestor values keyed by their complete state paths. */
     readonly ancestors: ParentStateValues<States, StateId>
+    /** Builders for selecting the owning machine's next state. */
     readonly target: TargetBuilder<States, StateId>
+    /** Latest active lifecycle snapshot published by the invoked logic or child. */
     readonly snapshot: Extract<RuntimeSnapshot<State, Error, Output>, { readonly status: "active" }>
   }
 
@@ -4779,12 +4855,19 @@ export declare namespace Machine {
     InputEvents extends ReadonlyArray<TaggedSchema> = Events,
     ParentEvents extends ReadonlyArray<TaggedSchema> = readonly []
   > = MachineReferences<InputEvents, ParentEvents> & {
+    /** Parent-local invocation identifier. */
     readonly id: string
+    /** Current value of the state that owns the invocation. */
     readonly state: StateByIdentifier<States, StateId>
+    /** Value owned by the nearest schema-backed ancestor, when one exists. */
     readonly containingState: ParentStateValue<States, StateId>
+    /** Schema-backed ancestor values keyed by their complete state paths. */
     readonly ancestors: ParentStateValues<States, StateId>
+    /** Complete owning-machine configuration captured for this transition. */
     readonly snapshot: Snapshot<States>
+    /** Builders for selecting the owning machine's next state. */
     readonly target: TargetBuilder<States, StateId>
+    /** Successful output produced by the invocation. */
     readonly output: Output
   }
 
@@ -4798,12 +4881,19 @@ export declare namespace Machine {
     InputEvents extends ReadonlyArray<TaggedSchema> = Events,
     ParentEvents extends ReadonlyArray<TaggedSchema> = readonly []
   > = MachineReferences<InputEvents, ParentEvents> & {
+    /** Parent-local invocation identifier. */
     readonly id: string
+    /** Current value of the state that owns the Stream invocation. */
     readonly state: StateByIdentifier<States, StateId>
+    /** Value owned by the nearest schema-backed ancestor, when one exists. */
     readonly containingState: ParentStateValue<States, StateId>
+    /** Schema-backed ancestor values keyed by their complete state paths. */
     readonly ancestors: ParentStateValues<States, StateId>
+    /** Complete owning-machine configuration captured for this transition. */
     readonly snapshot: Snapshot<States>
+    /** Builders for selecting the owning machine's next state. */
     readonly target: TargetBuilder<States, StateId>
+    /** Next element emitted by the invoked Stream. */
     readonly element: Element
   }
 
@@ -4817,12 +4907,19 @@ export declare namespace Machine {
     InputEvents extends ReadonlyArray<TaggedSchema> = Events,
     ParentEvents extends ReadonlyArray<TaggedSchema> = readonly []
   > = MachineReferences<InputEvents, ParentEvents> & {
+    /** Parent-local invocation identifier. */
     readonly id: string
+    /** Current value of the state that owns the invocation. */
     readonly state: StateByIdentifier<States, StateId>
+    /** Value owned by the nearest schema-backed ancestor, when one exists. */
     readonly containingState: ParentStateValue<States, StateId>
+    /** Schema-backed ancestor values keyed by their complete state paths. */
     readonly ancestors: ParentStateValues<States, StateId>
+    /** Complete owning-machine configuration captured for this transition. */
     readonly snapshot: Snapshot<States>
+    /** Builders for selecting the owning machine's next state. */
     readonly target: TargetBuilder<States, StateId>
+    /** Typed failure produced by the invocation. */
     readonly error: Error
   }
 
@@ -4840,11 +4937,15 @@ export declare namespace Machine {
     InputEvents extends ReadonlyArray<TaggedSchema> = Events,
     ParentEvents extends ReadonlyArray<TaggedSchema> = readonly []
   > = MachineReferences<InputEvents, ParentEvents> & {
+    /** Current value of the state evaluating the eventless transition. */
     readonly state: StateByIdentifier<States, StateId>
+    /** Value owned by the nearest schema-backed ancestor, when one exists. */
     readonly containingState: ParentStateValue<States, StateId>
+    /** Schema-backed ancestor values keyed by their complete state paths. */
     readonly ancestors: ParentStateValues<States, StateId>
     /** Complete logical configuration captured at the start of this microstep. */
     readonly snapshot: Snapshot<States>
+    /** Lifecycle event retained while the eventless transition is evaluated. */
     readonly event: LifecycleEvent<Events>
 
     /**
@@ -4871,12 +4972,17 @@ export declare namespace Machine {
     InputEvents extends ReadonlyArray<TaggedSchema> = Events,
     ParentEvents extends ReadonlyArray<TaggedSchema> = readonly []
   > = MachineReferences<InputEvents, ParentEvents> & {
+    /** Current value of the state whose child configuration completed. */
     readonly state: StateByIdentifier<States, StateId>
+    /** Value owned by the nearest schema-backed ancestor, when one exists. */
     readonly containingState: ParentStateValue<States, StateId>
+    /** Schema-backed ancestor values keyed by their complete state paths. */
     readonly ancestors: ParentStateValues<States, StateId>
     /** Complete logical configuration captured at the start of this microstep. */
     readonly snapshot: Snapshot<States>
+    /** Lifecycle event retained while state completion is processed. */
     readonly event: LifecycleEvent<Events>
+    /** Output produced by the completed final child or parallel regions. */
     readonly output: CompletionOutputByIdentifier<States, StateId>
 
     /**
@@ -4898,17 +5004,21 @@ export declare namespace Machine {
     InputEvents extends ReadonlyArray<TaggedSchema> = Events,
     ParentEvents extends ReadonlyArray<TaggedSchema> = readonly []
   > = MachineReferences<InputEvents, ParentEvents> & {
+    /** Value owned by the choice node's immediate schema-backed parent. */
     readonly containingState: StateByIdentifier<
       States,
       Extract<ImmediateParentStateIdentifier<ChoiceId>, StateIdentifier<States>>
     >
+    /** Schema-backed ancestor values keyed by their complete state paths. */
     readonly ancestors: {
       readonly [Parent in Extract<ParentStateIdentifier<ChoiceId>, ValuedStateIdentifier<States>>]: StateByIdentifier<
         States,
         Parent
       >
     }
+    /** Lifecycle event that led to the transient choice. */
     readonly event: LifecycleEvent<Events>
+    /** Builders for selecting the concrete destination of this choice. */
     readonly target: TargetBuilder<States, ChoiceId>
   }
 
@@ -4923,9 +5033,13 @@ export declare namespace Machine {
     Events extends ReadonlyArray<TaggedSchema>,
     StateId extends StateIdentifier<States>
   > {
+    /** Decoded value owned by the final state. */
     readonly state: StateByIdentifier<States, StateId>
+    /** Value owned by the nearest schema-backed ancestor, when one exists. */
     readonly containingState: ParentStateValue<States, StateId>
+    /** Schema-backed ancestor values keyed by their complete state paths. */
     readonly ancestors: ParentStateValues<States, StateId>
+    /** Lifecycle event responsible for entering the final state. */
     readonly event: LifecycleEvent<Events>
   }
 
@@ -4958,10 +5072,15 @@ export declare namespace Machine {
     Events extends ReadonlyArray<TaggedSchema>,
     StateId extends StateIdentifier<States>
   > {
+    /** Decoded value owned by the completed parallel state. */
     readonly state: StateByIdentifier<States, StateId>
+    /** Value owned by the nearest schema-backed ancestor, when one exists. */
     readonly containingState: ParentStateValue<States, StateId>
+    /** Schema-backed ancestor values keyed by their complete state paths. */
     readonly ancestors: ParentStateValues<States, StateId>
+    /** Lifecycle event retained while parallel completion is processed. */
     readonly event: LifecycleEvent<Events>
+    /** Completion output from every direct parallel region. */
     readonly outputs: ParallelOutputRegions<States, StateId>
   }
 
@@ -5366,6 +5485,7 @@ export declare namespace Machine {
 
   /** Context capability available only to explicitly declinable resolvers. */
   export interface DeclineCapability {
+    /** Declines this candidate and continues hierarchical transition selection. */
     readonly decline: () => Declined
   }
 
@@ -5395,7 +5515,9 @@ export declare namespace Machine {
   export interface TransitionBranchInput<
     Selection extends TargetSelection<any, any, any> = TargetSelection<any, any, any>
   > {
+    /** Exact topology destination available to the branching resolver. */
     readonly target: Selection
+    /** Optional human-readable branch label used by visualization tooling. */
     readonly title?: string
   }
 
@@ -5475,16 +5597,25 @@ export declare namespace Machine {
     }
   }
 
-  type TransitionReenterOption<Reenter extends boolean> = [Reenter] extends [true] ? { readonly reenter?: boolean }
+  type TransitionReenterOption<Reenter extends boolean> = [Reenter] extends [true] ? {
+      /** Forces the source state to exit and enter even when active paths remain unchanged. */
+      readonly reenter?: boolean
+    }
     : { readonly reenter?: never }
 
   type TransitionRequiredOptions<Reenter extends boolean> =
     & TransitionReenterOption<Reenter>
-    & { readonly declinable?: false }
+    & {
+      /** Keeps the transition required. The resolver cannot return `decline()`. */
+      readonly declinable?: false
+    }
 
   type TransitionDeclinableOptions<Reenter extends boolean> =
     & TransitionReenterOption<Reenter>
-    & { readonly declinable: true }
+    & {
+      /** Adds `decline()` to the resolver context and permits declining this candidate. */
+      readonly declinable: true
+    }
 
   type BuiltTransition<
     States extends StateSchemas,
@@ -5548,7 +5679,23 @@ export declare namespace Machine {
     >
   }
 
-  /** A selected transition target with target-specific resolver operations. */
+  /**
+   * A selected transition target with target-specific resolver operations.
+   *
+   * **Example** (Updating state while reentering)
+   *
+   * ```ts
+   * Reset: (to) =>
+   *   to.full.Ready().resolve(
+   *     ({ target }) => target.from(),
+   *     { reenter: true }
+   *   )
+   * ```
+   *
+   * @inlineType TransitionRequiredOptions
+   * @inlineType TransitionDeclinableOptions
+   * @inlineType TransitionReenterOption
+   */
   export type TransitionTarget<
     States extends StateSchemas,
     Events extends ReadonlyArray<TaggedSchema>,
@@ -5572,6 +5719,10 @@ export declare namespace Machine {
       >
       : {})
     & {
+      /**
+       * Evaluates state construction and queued commands only after this
+       * transition has been selected.
+       */
       readonly resolve:
         & TransitionResolveRequired<States, Events, Emits, StateId, Context, Reenter, Selection>
         & ("declinable" extends Acceptance ? TransitionResolveDeclinable<
@@ -5586,6 +5737,7 @@ export declare namespace Machine {
           : {})
     }
     & ([Reenter] extends [true] ? SelectionSupportsDefaultConstruction<Selection> extends true ? {
+          /** Reenters the source using the selected target's default construction. */
           readonly reenter: () => BuiltTransition<
             States,
             Events,
@@ -5610,9 +5762,12 @@ export declare namespace Machine {
     & Selection
     & (SelectionSupportsDefaultConstruction<Selection> extends true ? InitialBuilderEvidence<Selection> : {})
     & {
+      /** Lazily constructs the selected initial state from decoded machine input. */
       readonly resolve: (
         resolve: (context: {
+          /** Decoded value supplied when the machine is started. */
           readonly input: Input
+          /** Builder specialized to the selected initial destination. */
           readonly target: SelectionBuilder<Selection>
         }) => SelectedTargetResult<Selection>
       ) => InitialBuilderEvidence<Selection>
@@ -5766,9 +5921,11 @@ export declare namespace Machine {
       TargetSelector<States, StateId>
     >
     & {
+      /** Declares a closed set of named destinations for one resolver. */
       readonly branches: <const Branches extends Readonly<Record<string, TransitionBranchInput>>>(
         branches: Branches & ValidateTransitionBranchRecord<NoInfer<Branches>>
       ) => {
+        /** Resolves exactly one declared branch after this transition is selected. */
         readonly resolve:
           & TransitionBranchesResolveRequired<States, Events, Emits, StateId, Context, Reenter, Branches>
           & ("declinable" extends Acceptance ? TransitionBranchesResolveDeclinable<
@@ -5988,6 +6145,7 @@ export declare namespace Machine {
     & InvokeTyped<Output, Error, Requirements, InitialError, ChildEmits, ChildParentEvent, Outcomes>
     & { readonly [InvokeBuilderTypeId]: true }
 
+  /** Lifecycle handlers exposed according to the selected invocation source. */
   type InvokeBuilder<
     States extends StateSchemas,
     Events extends ReadonlyArray<TaggedSchema>,
@@ -6023,6 +6181,7 @@ export declare namespace Machine {
       >
       : {})
     & ("done" extends Pending ? {
+        /** Handles successful completion and exposes the invocation output. */
         readonly onDone: <
           const Handler extends InvokeTransition<
             States,
@@ -6062,6 +6221,7 @@ export declare namespace Machine {
       }
       : {})
     & ("failure" extends Pending ? {
+        /** Handles typed failure and exposes the invocation error. */
         readonly onFailure: <
           const Handler extends InvokeTransition<
             States,
@@ -6101,6 +6261,7 @@ export declare namespace Machine {
       }
       : {})
     & ("element" extends Pending ? {
+        /** Handles each backpressured element emitted by an invoked Stream. */
         readonly onElement: <
           const Handler extends InvokeTransition<
             States,
@@ -6140,6 +6301,7 @@ export declare namespace Machine {
       }
       : {})
     & ([SnapshotHandler] extends [never] ? {} : {
+      /** Handles each active snapshot published by invoked logic or a child machine. */
       readonly onSnapshot: <const Handler extends SnapshotHandler>(handler: Handler & SnapshotHandler) => InvokeBuilder<
         States,
         Events,
@@ -6309,6 +6471,23 @@ export declare namespace Machine {
    * chain becomes returnable from `invoke` only after every reachable required
    * channel has been handled.
    *
+   * **Example** (Invoking an Effect)
+   *
+   * ```ts
+   * invoke: (from) =>
+   *   from.effect("load-user", () => loadUser).onDone((to) =>
+   *     to.full.Ready().resolve(({ output, target }) => target.from({ user: output }))
+   *   ).onFailure((to) =>
+   *     to.full.Failed().resolve(({ error, target }) => target.from({ error }))
+   *   )
+   * ```
+   *
+   * @inlineType EffectInvokeBuilder
+   * @inlineType StreamInvokeBuilder
+   * @inlineType LogicInvokeBuilder
+   * @inlineType ChildInvokeBuilder
+   * @inlineType InvokeBuilder
+   *
    * @category models
    * @since 0.18.0
    */
@@ -6320,7 +6499,12 @@ export declare namespace Machine {
     InputEvents extends ReadonlyArray<TaggedSchema> = Events,
     ParentEvents extends ReadonlyArray<TaggedSchema> = readonly []
   > {
-    /** Starts a fresh Effect each time the owning state is entered. */
+    /**
+     * Starts a fresh Effect each time the owning state is entered.
+     *
+     * @param id Parent-local lifecycle identifier.
+     * @param source Lazy Effect factory evaluated on every entry.
+     */
     readonly effect: <
       const Source extends (
         context: InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
@@ -6330,7 +6514,12 @@ export declare namespace Machine {
       source: Source
     ) => EffectInvokeBuilder<States, Events, Emits, StateId, InputEvents, ParentEvents, Source>
 
-    /** Starts a fresh, backpressured Stream each time the owning state is entered. */
+    /**
+     * Starts a fresh, backpressured Stream each time the owning state is entered.
+     *
+     * @param id Parent-local lifecycle identifier.
+     * @param source Lazy Stream factory evaluated on every entry.
+     */
     readonly stream: <
       const Source extends (
         context: InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
@@ -6340,7 +6529,12 @@ export declare namespace Machine {
       source: Source
     ) => StreamInvokeBuilder<States, Events, Emits, StateId, InputEvents, ParentEvents, Source>
 
-    /** Starts a cancellable state-scoped timer. */
+    /**
+     * Starts a cancellable state-scoped timer.
+     *
+     * @param id Parent-local lifecycle identifier.
+     * @param duration Duration input or context-dependent duration factory.
+     */
     readonly timer: (
       id: InvokeLifecycleId,
       duration: InvokeSource<
@@ -6365,7 +6559,12 @@ export declare namespace Machine {
       never
     >
 
-    /** Starts reusable process logic at a typed parent-local address. */
+    /**
+     * Starts reusable process logic at a typed parent-local address.
+     *
+     * @param id Parent-local lifecycle identifier.
+     * @param options Address and reusable logic value or factory.
+     */
     readonly logic: {
       <
         const Source extends (
@@ -6375,9 +6574,11 @@ export declare namespace Machine {
       >(
         id: InvokeLifecycleId,
         options: {
+          /** Typed parent-local address used to send events to this logic. */
           readonly address:
             & Address
             & ChildAddress.Compatibility<Address, LogicEventOf<ReturnType<NoInfer<Source>>>>
+          /** Context-dependent factory that returns reusable process logic. */
           readonly logic: Source
         },
         ..._validation: ReturnType<Source> extends { readonly initial: unknown; readonly run: unknown } ? [] : [
@@ -6395,7 +6596,9 @@ export declare namespace Machine {
       <const Source, Address extends ChildAddress<never>>(
         id: InvokeLifecycleId,
         options: {
+          /** Typed parent-local address used to send events to this logic. */
           readonly address: Address & ChildAddress.Compatibility<Address, LogicEventOf<NoInfer<Source>>>
+          /** Reusable process logic started when the owning state enters. */
           readonly logic: Source
         },
         ..._validation: Source extends { readonly initial: unknown; readonly run: unknown } ? [] : [
@@ -6412,7 +6615,12 @@ export declare namespace Machine {
       >
     }
 
-    /** Starts a complete child statechart represented by a reusable descriptor. */
+    /**
+     * Starts a complete child statechart represented by a reusable descriptor.
+     *
+     * @param child Reusable descriptor created with `Machine.child`.
+     * @param options Input construction for a child with a non-void input schema.
+     */
     readonly child: <const Child extends ChildMachine.Any>(
       child:
         & Child
@@ -6424,6 +6632,7 @@ export declare namespace Machine {
           : never),
       ...options: InputSchema<Child["machine"]> extends typeof Schema.Void ? [options?: { readonly input?: never }]
         : [options: {
+          /** Child input value or factory evaluated from the owning state context. */
           readonly input: InvokeSource<
             Input<Child["machine"]>,
             InvokeContext<States, Events, Emits, StateId, InputEvents, ParentEvents>
@@ -6461,12 +6670,14 @@ export declare namespace Machine {
       }
     >
 
+  /** Output construction available to final and output-producing parallel states. */
   type OutputHandlerConfig<
     States extends StateSchemas,
     Events extends ReadonlyArray<TaggedSchema>,
     StateId extends StateIdentifier<States>,
     Context
   > = NodeByIdentifier<States, StateId> extends { readonly output: Schema.Top } ? {
+      /** Constructs the decoded output declared by the state's `output` schema. */
       readonly output: (context: Context) => OutputByIdentifier<States, StateId>
     }
     : {
@@ -6490,6 +6701,22 @@ export declare namespace Machine {
   /**
    * Configuration accepted for a non-final state.
    *
+   * **Example** (State actions, events, and invocation)
+   *
+   * ```ts
+   * machine.handle({
+   *   Loading: {
+   *     entry: (_, enqueue) => enqueue.emit({ _tag: "Started" }),
+   *     invoke: (from) =>
+   *       from.effect("load", () => load).onDone((to) => to.full.Ready()),
+   *     on: { Cancel: (to) => to.full.Idle() }
+   *   }
+   * })
+   * ```
+   *
+   * @inlineType ActiveOutputHandlerConfig
+   * @inlineType OutputHandlerConfig
+   *
    * @category models
    * @since 0.4.0
    */
@@ -6503,15 +6730,19 @@ export declare namespace Machine {
     InputEvents extends ReadonlyArray<TaggedSchema> = Events,
     ParentEvents extends ReadonlyArray<TaggedSchema> = readonly []
   > = {
+    /** Runs synchronously when the state is entered and may enqueue commands. */
     readonly entry?: (
       context: StateActionContext<States, Events, Emits, StateId, InputEvents, ParentEvents>,
       enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
     ) => StateActionResult<any, any>
+    /** Runs synchronously before the state is exited and may enqueue commands. */
     readonly exit?: (
       context: StateActionContext<States, Events, Emits, StateId, InputEvents, ParentEvents>,
       enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
     ) => StateActionResult<any, any>
+    /** Starts state-owned Effect, Stream, timer, logic, or child lifecycles. */
     readonly invoke?: InvokeBuilderInput<States, Events, Emits, StateId, InputEvents, ParentEvents>
+    /** Eventless transition evaluated after the state becomes stable. */
     readonly always?: TransitionConfig<
       States,
       Events,
@@ -6521,6 +6752,7 @@ export declare namespace Machine {
       false,
       TransitionAcceptance
     >
+    /** Transition evaluated after this compound or parallel state completes. */
     readonly onDone?: TransitionConfig<
       States,
       Events,
@@ -6530,6 +6762,7 @@ export declare namespace Machine {
       false,
       TransitionAcceptance
     >
+    /** Event handlers keyed by the `_tag` of the machine's public or internal events. */
     readonly on?: {
       readonly [EventTag in TagOf<Events[number]>]?: TransitionConfig<
         States,
@@ -6541,6 +6774,7 @@ export declare namespace Machine {
         TransitionAcceptance
       >
     }
+    /** Supplies missing direct initial-child values required by implicit entry and shallow history. */
     readonly initialize?: StateInitializeHandler<States, Events, Emits, StateId, InputEvents, ParentEvents>
   } & ActiveOutputHandlerConfig<States, Events, StateId>
 
@@ -6665,8 +6899,11 @@ export declare namespace Machine {
     Emits extends ReadonlyArray<TaggedSchema>,
     ParentId extends StateIdentifier<States>
   > {
+    /** Lifecycle event that attempted to restore this history node. */
     readonly event: LifecycleEvent<Events>
+    /** Complete target builder rooted at the history owner. */
     readonly target: HistoryDefaultTargetBuilder<States, ParentId>
+    /** State path whose child configuration is restored by this history node. */
     readonly owner: ParentId
   }
 
@@ -6689,7 +6926,26 @@ export declare namespace Machine {
     | CompleteSnapshotContaining<States, ParentId>
     | StateConstruction<CompleteSnapshotContaining<States, ParentId>>
 
-  /** Default implementations keyed by direct history child. */
+  /**
+   * Fallback implementation for one direct history pseudo-state.
+   *
+   * @inline
+   */
+  interface HistoryDefaultEntry<
+    States extends StateSchemas,
+    Events extends ReadonlyArray<TaggedSchema>,
+    Emits extends ReadonlyArray<TaggedSchema>,
+    ParentId extends StateIdentifier<States>
+  > {
+    /** Builds the complete fallback configuration used before history is first captured. */
+    readonly default: HistoryDefaultHandler<States, Events, Emits, ParentId>
+  }
+
+  /**
+   * Default implementations keyed by direct history child.
+   *
+   * @inlineType HistoryDefaultEntry
+   */
   export type HistoryDefaultConfig<
     States extends StateSchemas,
     Events extends ReadonlyArray<TaggedSchema>,
@@ -6697,9 +6953,7 @@ export declare namespace Machine {
     ParentId extends StateIdentifier<States>,
     Children extends StateSchemas
   > = {
-    readonly [Key in HistoryStateKey<Children>]?: {
-      readonly default: HistoryDefaultHandler<States, Events, Emits, ParentId>
-    }
+    readonly [Key in HistoryStateKey<Children>]?: HistoryDefaultEntry<States, Events, Emits, ParentId>
   }
 
   /** Required implementation for a choice pseudo-state. */
@@ -6711,6 +6965,7 @@ export declare namespace Machine {
     InputEvents extends ReadonlyArray<TaggedSchema> = Events,
     ParentEvents extends ReadonlyArray<TaggedSchema> = readonly []
   > {
+    /** Required transition that resolves this transient choice to a concrete destination. */
     readonly choice: TransitionConfig<
       States,
       Events,
@@ -6731,6 +6986,8 @@ export declare namespace Machine {
   /**
    * Configuration accepted for a final state.
    *
+   * @inlineType OutputHandlerConfig
+   *
    * @category models
    * @since 0.4.0
    */
@@ -6742,6 +6999,7 @@ export declare namespace Machine {
     InputEvents extends ReadonlyArray<TaggedSchema> = Events,
     ParentEvents extends ReadonlyArray<TaggedSchema> = readonly []
   > = {
+    /** Runs synchronously when the final state is entered and may enqueue commands. */
     readonly entry?: (
       context: StateActionContext<States, Events, Emits, StateId, InputEvents, ParentEvents>,
       enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
@@ -6824,6 +7082,7 @@ export declare namespace Machine {
     }
     : { readonly [Key in Path]?: Validation }
 
+  /** Nested handler-tree structure shared by active and final state configs. */
   type HandlerNode<
     AllStates extends StateSchemas,
     Node,
@@ -6845,6 +7104,7 @@ export declare namespace Machine {
             readonly history?: never
           }
         : {
+          /** Child-state handlers nested according to the declared state topology. */
           readonly states?: HandlerTree<
             AllStates,
             Children,
@@ -6856,6 +7116,7 @@ export declare namespace Machine {
             ParentEvents,
             Extract<StateId, StateIdentifier<AllStates>>
           >
+          /** First-use defaults keyed by direct history pseudo-state. */
           readonly history?: HistoryDefaultConfig<
             AllStates,
             Events,
@@ -7739,20 +8000,28 @@ type MakeConfig<
   InternalEvents extends ReadonlyArray<Machine.TaggedSchema>,
   ParentDeclaration extends Parent.Any | undefined
 > = {
+  /** Stable definition identifier used by inspection and visualization. */
   readonly id?: string
+  /** State topology and value schemas, normally supplied by `Machine.states`. */
   readonly states: States & DefineStateTreeInput<NoInfer<States>>
+  /** Public events accepted by independently running machine references. */
   readonly events:
     & Machine.EventProtocol<"public", InputEvents>
     & ValidateInputEventProtocol<NoInfer<InputEvents>>
+  /** Machine-local events used by raised events and other internal deliveries. */
   readonly internalEvents?:
     & Machine.EventProtocol<"internal", InternalEvents>
     & ValidateInternalEventProtocol<
       NoInfer<InputEvents>,
       NoInfer<InternalEvents>
     >
+  /** Ephemeral notifications that handlers may publish to observers. */
   readonly emittedEvents?: Machine.EventProtocol<"emitted", Emits>
+  /** Required or optional owning-machine protocol for this definition. */
   readonly parent?: ParentDeclaration
+  /** Schema used to decode input before initial-state construction. */
   readonly input?: Input
+  /** Target-first declaration that constructs the initial active configuration. */
   readonly initial: unknown
 }
 
@@ -7778,7 +8047,9 @@ type MakeResult<
   Machine.ParentEventsOf<ParentDeclaration>
 >
 
+/** @inline */
 interface Make {
+  /** @param config Complete schema-first machine definition. */
   <
     const States extends Machine.StateSchemas,
     const InputEvents extends ReadonlyArray<Machine.TaggedSchema>,
@@ -7797,6 +8068,7 @@ interface Make {
       & { readonly initial: Machine.InitialBuilderInput<States, Input["Type"]> },
     ..._validation: ValidateDefinedStates<NoInfer<States>>
   ): MakeResult<States, InputEvents, Emits, Input, InitialE, InitialR, InternalEvents, ParentDeclaration>
+  /** @param config Invalid state tree retained only to report its validation error at the call site. */
   <
     const States extends Machine.StateSchemas,
     const InputEvents extends ReadonlyArray<Machine.TaggedSchema>,
@@ -7874,6 +8146,7 @@ interface Make {
  * ```
  *
  * @see {@link states} for typed state-tree helpers.
+ * @inlineType MakeConfig
  * @category constructors
  * @since 0.4.0
  */


### PR DESCRIPTION
## Summary

- Generate a standalone machine authoring guide from TypeDoc reflections, including nested configuration, transition, handler-context, and invocation APIs.
- Keep module reference pages focused on public exports while giving the guide a complete, flattened page outline and readable parameter blocks with attached source links.
- Add missing JSDoc descriptions and focused examples for the reflected APIs, plus generator and site coverage for the new model.

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

## Validation

- [x] `pnpm check`
- [x] Relevant example checks, when examples changed (not required; no example package changed)
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required

Local `pnpm perf:types` and `pnpm perf:runtime` smoke checks also completed successfully. The CI base-versus-PR reports remain authoritative.
