### PR TITLE
Add combined retained owner updates

### DIFF
--- a/.changeset/clear-state-construction.md
+++ b/.changeset/clear-state-construction.md
@@ -1,0 +1,21 @@
+---
+"@typeonce/effect-machine": minor
+---
+
+Make state construction modes explicit and allow one topology target to replace a retained valued owner atomically.
+
+Valued builders are no longer callable. Replace `target(value)` and nested `builder(value, ...)` calls with `.decoded(value, ...)`; keep `.from(input, ...)` for schema make input. Plain state-update resolvers now expose the decoded owner as `current` and its construction builder as `owner`, replacing the previous `ancestors` plus `target` pattern.
+
+Declare a combined transition with `.updating(ownerSelector)`. The resolver must finish destination construction with `.update(...)`, so the owner replacement cannot be omitted:
+
+```ts
+to.local.SavingPlan()
+  .updating(to.branch.Ready)
+  .resolve(({ current, owner, target }) =>
+    target.from({ request }).update(
+      owner.decoded(new Ready({ ...current, notice: null }))
+    )
+  )
+```
+
+Transition inspection and retained microsteps now include an `updates` array naming replaced owners.

--- a/README.md
+++ b/README.md
@@ -149,16 +149,26 @@ parallel root.
 
 ### Construct state through builders
 
-Use `.from(...)` when constructing a new state from fields:
+Use `.from(...)` when constructing a new state from schema make input:
 
 ```ts
 target.from({ draft: event.draft })
 ```
 
 The machine runs these inputs through the state schema while planning. Schema
-defaults, refinements, and tagged-class identity are therefore preserved, and
-decode failures remain typed machine failures. Pass a value directly only when
-it is already decoded.
+defaults, transformations, refinements, and tagged-class identity are
+therefore preserved, and decode failures remain typed machine failures. This
+is the default construction path.
+
+Use `.decoded(...)` when the value is already a `Schema.Type`:
+
+```ts
+target.decoded(new Ready({ notice: null }))
+```
+
+The machine still validates the value against the schema's type side. It does
+not run encoded-input transformations again. State builders are not callable;
+the method name always makes the construction mode visible.
 
 When sibling states share fields, remove the source discriminator and pass the
 remaining fields through the target schema:
@@ -190,7 +200,7 @@ const States = Machine.states({
 const definition = Machine.make({
   states: States.states,
   events: Machine.events(),
-  initial: (to) => to.Form.initial.resolve(({ target }) => target((form) => form.Editing.from()))
+  initial: (to) => to.Form.initial.resolve(({ target }) => target.from((form) => form.Editing.from()))
 })
 ```
 
@@ -428,9 +438,9 @@ compound scope without rebuilding its active child. Use
 handler source:
 
 ```ts
-Increment: ;
-;((to) =>
-  to.branch.root.session.update(({ ancestors, target }) => target.from({ count: ancestors["root.session"].count + 1 })))
+const handlers = {
+  Increment: (to) => to.branch.root.session.update(({ current, owner }) => owner.from({ count: current.count + 1 }))
+}
 ```
 
 The update keeps the exact active descendants, their values, history records,
@@ -438,8 +448,8 @@ completion outputs, and unrelated parallel regions. It runs no exit or entry
 actions and does not restart state-owned work. Eventless stabilization still
 runs, so an `always` transition can react to the new value.
 
-`update` is callable when used directly and is also a static selection for a
-named branch:
+The plain update method remains useful when topology does not change. It is
+also a static selection for a named branch:
 
 ```ts
 to.branches({
@@ -452,10 +462,69 @@ to.branches({
 )
 ```
 
-The resolver must return `target(value)` or `target.from(input)`. It may return
-`decline()` only with `{ declinable: true }`. Pass `{ reenter: true }` on event
-or invocation transitions when the handler source should exit and enter again.
-Reentry applies to that source, not to the ancestor whose value changed.
+### Change topology and a retained owner together
+
+When a transition enters another child and also replaces a valued ancestor
+that stays active, declare both operations on the same target:
+
+```ts
+const handlers = {
+  CreatePlan: (to) =>
+    to.local.SavingPlan()
+      .updating(to.branch.Ready)
+      .resolve(({ current, event, owner, target }) =>
+        target.from({
+          request: { _tag: "Create", input: event.input }
+        }).update(
+          owner.decoded(new Ready({ ...current, notice: null }))
+        )
+      )
+}
+```
+
+`to.local.SavingPlan()` selects topology. `.updating(to.branch.Ready)` names
+the retained valued owner and makes its replacement mandatory: the resolver
+does not type-check unless destination construction finishes with
+`.update(...)`. `current` is that owner's decoded value from the
+pre-transition snapshot. `target` constructs the destination; `owner`
+constructs the complete replacement owner value.
+
+The topology change and owner replacement apply atomically in one microstep.
+The owner does not exit or reenter, its work is not restarted, and destination
+entry actions observe the new owner value. Eventless stabilization follows.
+Only one retained owner may be replaced by a combined target. A `full` target,
+or any target that exits the selected owner, does not expose `.updating`.
+Combined updates use a direct resolver in this release; named branches continue
+to support value-only updates.
+
+For a schema-less destination, construction remains explicit:
+
+```ts
+to.local.Idle()
+  .updating(to.branch.Ready)
+  .resolve(({ current, output, owner, target }) =>
+    target.from().update(
+      owner.decoded(
+        new Ready({
+          ...current,
+          day: output,
+          notice: "Plan changed."
+        })
+      )
+    )
+  )
+```
+
+Both values derive from the same pre-transition snapshot and are validated
+before lifecycle actions run. Competing transitions that write the same owner
+conflict; document order and hierarchy select one writer rather than applying
+last-write-wins behavior.
+
+The resolver must return `target.decoded(value)` or `target.from(input)`. It
+may return `decline()` only with `{ declinable: true }`. Pass `{ reenter: true }`
+on event or invocation transitions when the handler source should exit and
+enter again. Reentry applies to that source, not to the ancestor whose value
+changed.
 
 The selector omits `update` for schema-less scopes, atomic and final states,
 inactive branches, parallel sibling regions, and choice resolvers. Updating a

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -67,9 +67,12 @@ Each step has one job:
 Chain `.handle` from `Machine.make`. Do not store the intermediate definition
 when the module exports one machine implementation.
 
-State builders construct the next snapshot. Use `.from(...)` when a state owns
-data. The machine validates that input through the state schema while it plans
-the transition.
+State builders construct the next snapshot. Use `.from(...)` for schema make
+input; defaults, transformations, and refinements run while the machine plans
+the transition. Use `.decoded(...)` only for an existing `Schema.Type`. It is
+validated against the type side without rerunning encoded transformations.
+Valued state builders are not callable, so the construction mode is always
+visible. Schema-less state construction uses `.from()`.
 
 The examples below show one modeling decision at a time. They omit unchanged
 state and event declarations already shown above.
@@ -393,8 +396,8 @@ update selection instead of reconstructing its active descendants:
 
 ```ts
 Changed: (to) =>
-  to.local.update(({ ancestors, target }) =>
-    target.from({ revision: ancestors.document.revision + 1 })
+  to.local.update(({ current, owner }) =>
+    owner.from({ revision: current.revision + 1 })
   )
 ```
 
@@ -404,6 +407,34 @@ the handler source. Both preserve the complete active descendant
 configuration. Neither runs lifecycle actions or restarts state-owned work by
 default. Use an event handled inside a parallel sibling when that sibling owns
 the value that must change.
+
+When topology changes and one valued ancestor remains active but needs a new
+value, declare the owner on the destination:
+
+```ts
+CreatePlan: (to) =>
+  to.local.SavingPlan()
+    .updating(to.branch.Ready)
+    .resolve(({ current, event, owner, target }) =>
+      target.from({ request: event.input }).update(
+        owner.decoded(new Ready({ ...current, notice: null }))
+      )
+    )
+```
+
+`.updating(...)` accepts the retained state selector itself. It makes the
+owner replacement mandatory at compile time: the resolver must finish a
+destination construction with `.update(...)`. `current` is the owner's
+decoded pre-transition value. `target` constructs the destination and `owner`
+constructs the complete replacement value.
+
+Both instructions are validated and applied atomically. The retained owner is
+not reentered, destination entry sees its new value, and eventless
+stabilization runs afterward. Only local and branch targets that retain the
+owner expose `.updating`; full targets do not. Combined targets support one
+owner. Keep separate domain changes explicit by constructing the complete
+owner value instead of relying on a partial merge helper. Combined updates use
+a direct resolver; named branches support value-only updates.
 
 ## Test paths and invariants
 

--- a/perf/runtime/counter.mjs
+++ b/perf/runtime/counter.mjs
@@ -52,7 +52,7 @@ export const counterMachine = Machine.make({
   events: benchmarkApi.events(CounterEvent.cases.Increment, CounterEvent.cases.Finish),
   initial: benchmarkApi.initial({
     target: (to) => to.Count(),
-    resolve: ({ target }) => target(CounterState.cases.Count.make({ value: 0 }))
+    resolve: ({ target }) => target.from(CounterState.cases.Count.make({ value: 0 }))
   }, () => CounterStates.initial.Count.from({ value: 0 }))
 }).handle({
   Count: {

--- a/perf/types/adapter-readiness-control.ts
+++ b/perf/types/adapter-readiness-control.ts
@@ -29,18 +29,18 @@ export const machine = Machine.make({
   id: "perf-readiness",
   states: States.states,
   events: Machine.events(),
-  initial: (to) => to.Ready().resolve(({ target }) => target(Ready.make({})))
+  initial: (to) => to.Ready().resolve(({ target }) => target.from(Ready.make({})))
 }).handle({
   Flow: {
     history: {
       recent: {
-        default: ({ target }) => target.Flow(Flow.make({}), (flow) => flow.Idle(Idle.make({})))
+        default: ({ target }) => target.Flow.from(Flow.make({}), (flow) => flow.Idle.from(Idle.make({})))
       }
     },
     states: {
       Idle: {},
       Route: {
-        choice: (to) => to.full.Ready().resolve(({ target }) => target(Ready.make({})))
+        choice: (to) => to.full.Ready().resolve(({ target }) => target.from(Ready.make({})))
       }
     }
   },

--- a/perf/types/composition-control.ts
+++ b/perf/types/composition-control.ts
@@ -67,13 +67,13 @@ export const machine = Machine.make({
   events: Machine.events(),
   initial: (to) =>
     to.App.initial.resolve(({ target }) =>
-      target(App.make({}), (app) =>
-        app.Workspace(
+      target.from(App.make({}), (app) =>
+        app.Workspace.from(
           Workspace.make({}),
           (workspace) =>
             workspace
-              .Editor(Editor.make({}), (editor) => editor.Editing(Editing.make({})))
-              .Sync(Sync.make({}), (sync) => sync.Idle(SyncIdle.make({})))
+              .Editor.from(Editor.make({}), (editor) => editor.Editing.from(Editing.make({})))
+              .Sync.from(Sync.make({}), (sync) => sync.Idle.from(SyncIdle.make({})))
         ))
     )
 })

--- a/perf/types/composition.ts
+++ b/perf/types/composition.ts
@@ -31,13 +31,13 @@ const handled = machine.handle({
         history: {
           recent: {
             default: ({ target }) =>
-              target.App(App.make({}), (app) =>
-                app.Workspace(
+              target.App.from(App.make({}), (app) =>
+                app.Workspace.from(
                   Workspace.make({}),
                   (workspace) =>
                     workspace
-                      .Editor(Editor.make({}), (editor) => editor.Editing(Editing.make({})))
-                      .Sync(Sync.make({}), (sync) => sync.Idle(SyncIdle.make({})))
+                      .Editor.from(Editor.make({}), (editor) => editor.Editing.from(Editing.make({})))
+                      .Sync.from(Sync.make({}), (sync) => sync.Idle.from(SyncIdle.make({})))
                 ))
           }
         },
@@ -69,13 +69,13 @@ const handled = machine.handle({
       Route: {
         choice: (to) =>
           to.full.App().resolve(({ target }) =>
-            target(App.make({}), (app) =>
-              app.Workspace(
+            target.from(App.make({}), (app) =>
+              app.Workspace.from(
                 Workspace.make({}),
                 (workspace) =>
                   workspace
-                    .Editor(Editor.make({}), (editor) => editor.Editing(Editing.make({})))
-                    .Sync(Sync.make({}), (sync) => sync.Idle(SyncIdle.make({})))
+                    .Editor.from(Editor.make({}), (editor) => editor.Editing.from(Editing.make({})))
+                    .Sync.from(Sync.make({}), (sync) => sync.Idle.from(SyncIdle.make({})))
               ))
           )
       }

--- a/perf/types/definition-variants-control.ts
+++ b/perf/types/definition-variants-control.ts
@@ -34,5 +34,6 @@ export const States = Machine.states({
 export const machine = Machine.make({
   states: States.states,
   events: Machine.events(Start, Finish),
-  initial: (to) => to.Flow.initial.resolve(({ target }) => target(Flow.make({}), (flow) => flow.Idle(Idle.make({}))))
+  initial: (to) =>
+    to.Flow.initial.resolve(({ target }) => target.from(Flow.make({}), (flow) => flow.Idle.from(Idle.make({}))))
 })

--- a/perf/types/definition-variants.ts
+++ b/perf/types/definition-variants.ts
@@ -11,21 +11,21 @@ const complete = machine.handle({
   Flow: {
     history: {
       recent: {
-        default: ({ target }) => target.Flow(Flow.make({}), (flow) => flow.Idle(Idle.make({})))
+        default: ({ target }) => target.Flow.from(Flow.make({}), (flow) => flow.Idle.from(Idle.make({})))
       }
     },
     states: {
       Route: {
-        choice: (to) => to.local.Idle().resolve(({ target }) => target(Idle.make({})))
+        choice: (to) => to.local.Idle().resolve(({ target }) => target.from(Idle.make({})))
       },
       Idle: {
         on: {
-          Start: (to) => to.local.Running().resolve(({ target }) => target(Running.make({})))
+          Start: (to) => to.local.Running().resolve(({ target }) => target.from(Running.make({})))
         }
       },
       Running: {
         on: {
-          Finish: (to) => to.local.Done().resolve(({ event, target }) => target(Done.make({ value: event.value })))
+          Finish: (to) => to.local.Done().resolve(({ event, target }) => target.from(Done.make({ value: event.value })))
         }
       },
       Done: {
@@ -40,7 +40,7 @@ const idleOnly = machine.handle({
     states: {
       Idle: {
         on: {
-          Start: (to) => to.local.Running().resolve(({ target }) => target(Running.make({})))
+          Start: (to) => to.local.Running().resolve(({ target }) => target.from(Running.make({})))
         }
       }
     }
@@ -52,7 +52,7 @@ const runningOnly = machine.handle({
     states: {
       Running: {
         on: {
-          Finish: (to) => to.local.Done().resolve(({ event, target }) => target(Done.make({ value: event.value })))
+          Finish: (to) => to.local.Done().resolve(({ event, target }) => target.from(Done.make({ value: event.value })))
         }
       }
     }

--- a/perf/types/dynamic-invoke-control.ts
+++ b/perf/types/dynamic-invoke-control.ts
@@ -14,5 +14,5 @@ export const loadUser = (userId: string) => Effect.fail(new LoadError()).pipe(Ef
 export const machine = Machine.make({
   states: States.states,
   events: Machine.events(),
-  initial: (to) => to.Loading().resolve(({ target }) => target(Loading.make({ userId: "user-1" })))
+  initial: (to) => to.Loading().resolve(({ target }) => target.from(Loading.make({ userId: "user-1" })))
 })

--- a/perf/types/exact-channels-control.ts
+++ b/perf/types/exact-channels-control.ts
@@ -23,5 +23,5 @@ export const machine = Machine.make({
   internalEvents: Machine.internalEvents(Loaded),
   emittedEvents: Machine.emittedEvents(Notice),
   input: Input,
-  initial: (to) => to.Idle().resolve(({ input, target }) => target(Idle.make({ value: input.seed })))
+  initial: (to) => to.Idle().resolve(({ input, target }) => target.from(Idle.make({ value: input.seed })))
 })

--- a/perf/types/exact-channels.ts
+++ b/perf/types/exact-channels.ts
@@ -15,9 +15,9 @@ const complete = machine.handle({
       Start: (to) =>
         to.full.Done().resolve(({ event, target }, enqueue) => {
           enqueue.emit(Notice.make({ value: event.value }))
-          return target(Done.make({ value: event.value }))
+          return target.from(Done.make({ value: event.value }))
         }),
-      Loaded: (to) => to.full.Done().resolve(({ event, target }) => target(Done.make({ value: event.value })))
+      Loaded: (to) => to.full.Done().resolve(({ event, target }) => target.from(Done.make({ value: event.value })))
     }
   },
   Done: {

--- a/perf/types/handle.ts
+++ b/perf/types/handle.ts
@@ -17,17 +17,17 @@ const States = Machine.states(State.cases)
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(Event.cases.Start, Event.cases.Finish),
-  initial: (to) => to.Idle().resolve(({ target }) => target(State.cases.Idle.make({})))
+  initial: (to) => to.Idle().resolve(({ target }) => target.from(State.cases.Idle.make({})))
 }).handle({
   Idle: {
     on: {
-      Start: (to) => to.full.Running().resolve(({ target }) => target(State.cases.Running.make({})))
+      Start: (to) => to.full.Running().resolve(({ target }) => target.from(State.cases.Running.make({})))
     }
   },
   Running: {
     on: {
       Finish: (to) =>
-        to.full.Done().resolve(({ event, target }) => target(State.cases.Done.make({ value: event.value })))
+        to.full.Done().resolve(({ event, target }) => target.from(State.cases.Done.make({ value: event.value })))
     }
   },
   Done: {}

--- a/perf/types/make.ts
+++ b/perf/types/make.ts
@@ -17,7 +17,7 @@ const States = Machine.states(State.cases)
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(Event.cases.Start, Event.cases.Finish),
-  initial: (to) => to.Idle().resolve(({ target }) => target(State.cases.Idle.make({})))
+  initial: (to) => to.Idle().resolve(({ target }) => target.from(State.cases.Idle.make({})))
 })
 
 void machine

--- a/perf/types/named-branches-control.ts
+++ b/perf/types/named-branches-control.ts
@@ -13,5 +13,5 @@ export const States = Machine.states(State.cases)
 export const machine = Machine.make({
   states: States.states,
   events: Machine.events(Route),
-  initial: (to) => to.Idle().resolve(({ target }) => target(State.cases.Idle.make({})))
+  initial: (to) => to.Idle().resolve(({ target }) => target.from(State.cases.Idle.make({})))
 })

--- a/perf/types/named-branches.ts
+++ b/perf/types/named-branches.ts
@@ -21,25 +21,25 @@ const handled = machine.handle({
           const value = event.value
           switch (value.length) {
             case 1:
-              return select.length1(State.cases.Text.make({ value }))
+              return select.length1.from(State.cases.Text.make({ value }))
             case 2:
-              return select.length2(State.cases.Count.make({ value: value.length }))
+              return select.length2.from(State.cases.Count.make({ value: value.length }))
             case 3:
-              return select.length3(State.cases.Text.make({ value }))
+              return select.length3.from(State.cases.Text.make({ value }))
             case 4:
-              return select.length4(State.cases.Count.make({ value: value.length }))
+              return select.length4.from(State.cases.Count.make({ value: value.length }))
             case 5:
-              return select.length5(State.cases.Text.make({ value }))
+              return select.length5.from(State.cases.Text.make({ value }))
             case 6:
               return select.length6()
             case 7:
-              return select.length7(State.cases.Count.make({ value: value.length }))
+              return select.length7.from(State.cases.Count.make({ value: value.length }))
             case 8:
-              return select.length8(State.cases.Text.make({ value: value.toUpperCase() }))
+              return select.length8.from(State.cases.Text.make({ value: value.toUpperCase() }))
             case 9:
-              return select.length9(State.cases.Count.make({ value: value.length }))
+              return select.length9.from(State.cases.Count.make({ value: value.length }))
             case 10:
-              return select.length10(State.cases.Idle.make({}))
+              return select.length10.from(State.cases.Idle.make({}))
             default:
               return select.unchanged()
           }

--- a/scripts/fixtures/consumer/consumer.ts
+++ b/scripts/fixtures/consumer/consumer.ts
@@ -27,7 +27,7 @@ const machine = Machine.make({
   states: States.states,
   events: PublicEvents,
   internalEvents: InternalEvents,
-  initial: (to) => to.Idle().resolve(({ target }) => target(State.cases.Idle.make({})))
+  initial: (to) => to.Idle().resolve(({ target }) => target.decoded(State.cases.Idle.make({})))
 }).handle({
   Idle: {
     on: {
@@ -37,7 +37,7 @@ const machine = Machine.make({
           measured: { target: to.none },
           named: { target: to.full.Done() },
           confirmed: { target: to.full.Idle() }
-        }).resolve(({ select }) => select.cached(State.cases.Loading.make({})))
+        }).resolve(({ select }) => select.cached.decoded(State.cases.Loading.make({})))
     }
   },
   Loading: {
@@ -47,7 +47,7 @@ const machine = Machine.make({
     ],
     on: {
       Loaded: (to) =>
-        to.full.Done().resolve(({ event, target }) => target(State.cases.Done.make({ value: event.value })))
+        to.full.Done().resolve(({ event, target }) => target.decoded(State.cases.Done.make({ value: event.value })))
     }
   },
   Done: {}

--- a/scripts/fixtures/consumer/deep-bound.ts
+++ b/scripts/fixtures/consumer/deep-bound.ts
@@ -49,7 +49,8 @@ const childMachine = Machine.make({
   events: Machine.events(),
   parent: Machine.parent(ChildParentEvents),
   input: Schema.Struct({ value: Schema.String }),
-  initial: (to) => to.Done().resolve(({ input, target }) => target(ChildState.cases.Done.make({ value: input.value })))
+  initial: (to) =>
+    to.Done().resolve(({ input, target }) => target.decoded(ChildState.cases.Done.make({ value: input.value })))
 }).handle({
   Done: {
     entry: ({ parent, state }, enqueue) => {
@@ -90,7 +91,7 @@ const definition = Machine.make({
   internalEvents: Machine.internalEvents(Internal.cases.Loaded, Internal.cases.ChildCompleted),
   emittedEvents: Emissions,
   input: Schema.Struct({ seed: Schema.String }),
-  initial: (to) => to.Idle().resolve(({ input: { seed: _seed }, target }) => target(State.cases.Idle.make({})))
+  initial: (to) => to.Idle().resolve(({ input: { seed: _seed }, target }) => target.decoded(State.cases.Idle.make({})))
 })
 const machine = definition.handle({
   Idle: {
@@ -98,12 +99,12 @@ const machine = definition.handle({
     on: {
       Begin: (to) =>
         to.full.Ready().resolve(({ target }) =>
-          target(
+          target.decoded(
             State.cases.Ready.make({}),
             (ready) =>
-              ready.Editor(
+              ready.Editor.decoded(
                 State.cases.Editor.make({}),
-                (editor) => editor.Editing(State.cases.Editing.make({ value: "ready" }))
+                (editor) => editor.Editing.decoded(State.cases.Editing.make({ value: "ready" }))
               )
           )
         )
@@ -117,7 +118,7 @@ const machine = definition.handle({
             on: {
               Save: (to) =>
                 to.local.Saving().resolve(({ event, target }) =>
-                  target(State.cases.Saving.make({ value: event.value }))
+                  target.decoded(State.cases.Saving.make({ value: event.value }))
                 ),
               Loaded: (to) => to.none
             }
@@ -129,10 +130,12 @@ const machine = definition.handle({
               ChildNotice: (to) =>
                 to.local.Saving().resolve(({ event, target }, enqueue) => {
                   enqueue.emit(Emissions.Notice({ value: event.value }))
-                  return target(State.cases.Saving.make({ value: event.value }))
+                  return target.decoded(State.cases.Saving.make({ value: event.value }))
                 }),
               ChildCompleted: (to) =>
-                to.full.Done().resolve(({ event, target }) => target(State.cases.Done.make({ value: event.value })))
+                to.full.Done().resolve(({ event, target }) =>
+                  target.decoded(State.cases.Done.make({ value: event.value }))
+                )
             }
           }
         }

--- a/src/Machine.ts
+++ b/src/Machine.ts
@@ -286,7 +286,7 @@ export interface Definition<
    *     on: {
    *       Increment: (to) =>
    *         to.full.Count().resolve(({ event, state, target }) =>
-   *           target(new Count({ value: state.value + event.by })))
+   *           target.decoded(new Count({ value: state.value + event.by })))
    *     }
    *   }
    * })
@@ -972,6 +972,16 @@ type FromMethod<Arguments extends ReadonlyArray<unknown>, Result> = {
   readonly from: FromCallable<Arguments, Machine.StateConstruction<Result>>
 }
 
+type DecodedMethod<Arguments extends ReadonlyArray<unknown>, Result> = {
+  /**
+   * Constructs the selected state from an already-decoded schema value. The
+   * machine validates the value against the schema's type side while planning.
+   *
+   * @since 0.22.0
+   */
+  readonly decoded: (...args: Arguments) => Result
+}
+
 type ConstructionResult<Result> = Result | Machine.StateConstruction<Result>
 
 type UnwrapConstruction<Result> = Result extends Machine.StateConstruction<infer Value> ? Value : Result
@@ -997,9 +1007,7 @@ type NodeBuilderMethod<
 > = Machine.NodeSchema<Node> extends never ? {
     readonly from: FromCallable<FromArguments, FromResult>
   }
-  :
-    & ((...args: Arguments) => Result)
-    & { readonly from: FromCallable<FromArguments, FromResult> }
+  : DecodedMethod<Arguments, Result> & { readonly from: FromCallable<FromArguments, FromResult> }
 
 type NodeMethod<
   Node,
@@ -1007,7 +1015,7 @@ type NodeMethod<
   Result,
   FromArguments extends ReadonlyArray<unknown>
 > = Machine.NodeSchema<Node> extends never ? FromMethod<FromArguments, Result>
-  : ((...args: Arguments) => Result) & FromMethod<FromArguments, Result>
+  : DecodedMethod<Arguments, Result> & FromMethod<FromArguments, Result>
 
 type NodeMethodWithInitial<
   Node,
@@ -1020,7 +1028,7 @@ type NodeMethodWithInitial<
     readonly initial: InitialTargetFactory<Node, Path>
   }
   :
-    & ((...args: Arguments) => Result)
+    & DecodedMethod<Arguments, Result>
     & {
       readonly from: FromCallable<FromArguments, Machine.StateConstruction<Result>>
       readonly initial: InitialTargetFactory<Node, Path>
@@ -1038,11 +1046,11 @@ interface InitialTargetFactory<
   Node,
   Path extends string
 > {
-  (...args: WithNodeValue<Node, readonly []>): Machine.InitialTarget<Path>
   readonly from: FromCallable<
     WithNodeInput<Node, readonly []>,
     Machine.StateConstruction<Machine.InitialTarget<Path>>
   >
+  readonly decoded: (...args: WithNodeValue<Node, readonly []>) => Machine.InitialTarget<Path>
 }
 
 type NodeConstructionSelectorFromCallable<Node, Builder, Result> = Machine.NodeSchema<Node> extends never ? {
@@ -1056,15 +1064,14 @@ type NestedTargetMethod<Node, Builder, Result, Path extends string> = Machine.No
     readonly from: NodeConstructionSelectorFromCallable<Node, Builder, Result>
     readonly initial: InitialTargetFactory<Node, Path>
   }
-  :
-    & (<Selected extends ConstructionResult<Result>>(
+  : {
+    readonly decoded: <Selected extends ConstructionResult<Result>>(
       value: NodeValue<Node>,
       state: (builder: Builder) => Selected
-    ) => Selected)
-    & {
-      readonly from: NodeConstructionSelectorFromCallable<Node, Builder, Result>
-      readonly initial: InitialTargetFactory<Node, Path>
-    }
+    ) => Selected
+    readonly from: NodeConstructionSelectorFromCallable<Node, Builder, Result>
+    readonly initial: InitialTargetFactory<Node, Path>
+  }
 
 type ConstructionSelectorFromCallable<Input, Builder, Result> = {} extends Input ? {
     <Selected extends ConstructionResult<Result>>(
@@ -1100,9 +1107,10 @@ type InitialSnapshotMethod<
     InitialSnapshotResult<States, StateId, Prefix>
   >
   :
-    & ((
-      ...args: InitialSnapshotArguments<States, StateId, Prefix>
-    ) => InitialSnapshotResult<States, StateId, Prefix>)
+    & DecodedMethod<
+      InitialSnapshotArguments<States, StateId, Prefix>,
+      InitialSnapshotResult<States, StateId, Prefix>
+    >
     & FromMethod<
       InitialSnapshotFromArguments<States, StateId, Prefix>,
       InitialSnapshotResult<States, StateId, Prefix>
@@ -1242,9 +1250,10 @@ type FullSnapshotMethod<
     FullSnapshotResult<States, StateId, Prefix>
   >
   :
-    & ((
-      ...args: FullSnapshotArguments<States, StateId, Prefix>
-    ) => FullSnapshotResult<States, StateId, Prefix>)
+    & DecodedMethod<
+      FullSnapshotArguments<States, StateId, Prefix>,
+      FullSnapshotResult<States, StateId, Prefix>
+    >
     & FromMethod<
       FullSnapshotFromArguments<States, StateId, Prefix>,
       FullSnapshotResult<States, StateId, Prefix>
@@ -1416,9 +1425,10 @@ type HistorySnapshotMethod<
     HistorySnapshotResult<States, StateId, Prefix, Owner>
   >
   :
-    & ((
-      ...args: HistorySnapshotArguments<States, StateId, Prefix, Owner>
-    ) => HistorySnapshotResult<States, StateId, Prefix, Owner>)
+    & DecodedMethod<
+      HistorySnapshotArguments<States, StateId, Prefix, Owner>,
+      HistorySnapshotResult<States, StateId, Prefix, Owner>
+    >
     & FromMethod<
       HistorySnapshotFromArguments<States, StateId, Prefix, Owner>,
       HistorySnapshotResult<States, StateId, Prefix, Owner>
@@ -1645,20 +1655,19 @@ type LocalTargetBuilderForScope<
          *
          * @since 0.4.0
          */
-        readonly with:
-          & (<Result extends ConstructionResult<LocalTargetResultWithPrefix<States, Children, Scope>>>(
+        readonly with: {
+          readonly decoded: <Result extends ConstructionResult<LocalTargetResultWithPrefix<States, Children, Scope>>>(
             value: Machine.StateByIdentifier<States, Scope>,
             state: (
               builder: LocalTargetBuilderWithPrefix<States, Children, Scope, Source>
             ) => Result
-          ) => Result)
-          & {
-            readonly from: ConstructionSelectorFromCallable<
-              Machine.SchemaByIdentifier<States, Scope>["~type.make.in"],
-              LocalTargetBuilderWithPrefix<States, Children, Scope, Source>,
-              LocalTargetResultWithPrefix<States, Children, Scope>
-            >
-          }
+          ) => Result
+          readonly from: ConstructionSelectorFromCallable<
+            Machine.SchemaByIdentifier<States, Scope>["~type.make.in"],
+            LocalTargetBuilderWithPrefix<States, Children, Scope, Source>,
+            LocalTargetResultWithPrefix<States, Children, Scope>
+          >
+        }
       } :
       {})
   : {}
@@ -3557,6 +3566,7 @@ export declare namespace Machine {
       readonly type: "direct"
       readonly target: Path | undefined
       readonly selection: TransitionTargetSelection<Path | undefined>
+      readonly updates: ReadonlyArray<string>
     }
     | {
       readonly type: "branch"
@@ -3564,6 +3574,7 @@ export declare namespace Machine {
       readonly title: string
       readonly target: Path | undefined
       readonly selection: TransitionTargetSelection<Path | undefined>
+      readonly updates: ReadonlyArray<string>
     }
 
   /** The statically selected root entry for machine startup. */
@@ -3635,6 +3646,8 @@ export declare namespace Machine {
      * Choice microsteps retain each intermediate pseudo-state edge separately.
      */
     readonly resolvedTarget: TargetPath | undefined
+    /** Retained valued owners replaced by this transition. */
+    readonly updates: ReadonlyArray<string>
   }
 
   /**
@@ -4473,21 +4486,42 @@ export declare namespace Machine {
     States extends StateSchemas,
     StateId extends ValuedStateIdentifier<States>
   > {
-    readonly [Topology.StateUpdateTypeId]: typeof Topology.StateUpdateTypeId
-    readonly path: StateId
-    readonly value: StateByIdentifier<States, StateId>
+    readonly [Topology.StateUpdateTypeId]: {
+      readonly states: Types.Covariant<States>
+      readonly owner: Types.Covariant<StateId>
+    }
+  }
+
+  /**
+   * Opaque result that combines one topology target with one retained owner
+   * value replacement in the same microstep.
+   *
+   * @category models
+   * @since 0.22.0
+   */
+  export interface CombinedTarget<
+    Result,
+    States extends StateSchemas,
+    Owner extends ValuedStateIdentifier<States>
+  > {
+    readonly [Topology.CombinedTargetTypeId]: {
+      readonly result: Types.Covariant<Result>
+      readonly states: Types.Covariant<States>
+      readonly owner: Types.Covariant<Owner>
+    }
   }
 
   /** @internal */
   type StateUpdateBuilder<
     States extends StateSchemas,
     StateId extends ValuedStateIdentifier<States>
-  > =
-    & ((value: StateByIdentifier<States, StateId>) => StateUpdate<States, StateId>)
-    & FromMethod<
+  > = {
+    readonly decoded: (value: StateByIdentifier<States, StateId>) => StateUpdate<States, StateId>
+    readonly from: FromCallable<
       readonly [input: SchemaByIdentifier<States, StateId>["~type.make.in"]],
       StateUpdate<States, StateId>
     >
+  }
 
   /**
    * Opaque result returned by an explicitly targetless transition.
@@ -4720,23 +4754,36 @@ export declare namespace Machine {
   export interface TargetSelection<
     out Result,
     out Path extends string | undefined = string | undefined,
-    out Kind extends Topology.TargetSelectionKind = Topology.TargetSelectionKind
+    out Kind extends Topology.TargetSelectionKind = Topology.TargetSelectionKind,
+    out Scope extends Topology.TargetSelectionScope | undefined = Topology.TargetSelectionScope | undefined
   > {
     readonly [Topology.TargetSelectionTypeId]: typeof Topology.TargetSelectionTypeId
     readonly kind: Kind
-    readonly scope: Topology.TargetSelectionScope | undefined
+    readonly scope: Scope
     readonly path: Path
     readonly "~effect/Machine/TargetSelectionResult"?: Types.Covariant<Result>
   }
 
-  type SelectionValue<Builder, Path extends string, Kind extends Topology.TargetSelectionKind = "state"> =
-    TargetSelection<Builder, Path, Kind>
+  type SelectionValue<
+    Builder,
+    Path extends string,
+    Kind extends Topology.TargetSelectionKind = "state",
+    Scope extends Topology.TargetSelectionScope | undefined = Topology.TargetSelectionScope | undefined
+  > = TargetSelection<Builder, Path, Kind, Scope>
 
-  type SelectionMethod<Builder, Path extends string, Kind extends Topology.TargetSelectionKind = "state"> = () =>
-    SelectionValue<Builder, Path, Kind>
+  type SelectionMethod<
+    Builder,
+    Path extends string,
+    Kind extends Topology.TargetSelectionKind = "state",
+    Scope extends Topology.TargetSelectionScope | undefined = Topology.TargetSelectionScope | undefined
+  > = () => SelectionValue<Builder, Path, Kind, Scope>
 
-  type InitialSelectionMethod<Builder, Path extends string> = Builder extends { readonly initial: infer Initial } ? {
-      readonly initial: SelectionValue<Initial, Path, "initial">
+  type InitialSelectionMethod<
+    Builder,
+    Path extends string,
+    Scope extends Topology.TargetSelectionScope
+  > = Builder extends { readonly initial: infer Initial } ? {
+      readonly initial: SelectionValue<Initial, Path, "initial", Scope>
     }
     : {}
 
@@ -4765,25 +4812,28 @@ export declare namespace Machine {
   > = Node extends ChoiceStateNodeConfig ? SelectionMethod<
       Builder,
       Path,
-      "choice"
+      "choice",
+      Scope
     >
     : Node extends { readonly states: infer Children extends StateSchemas } ?
-        & SelectionMethod<Builder, Path>
-        & InitialSelectionMethod<Builder, Path>
+        & SelectionMethod<Builder, Path, "state", Scope>
+        & InitialSelectionMethod<Builder, Path, Scope>
         & SelectionTreeWithPrefix<AllStates, Children, Path, Scope, Builder>
-    : SelectionMethod<Builder, Path>
+    : SelectionMethod<Builder, Path, "state", Scope>
 
   /** @internal */
   type StateUpdateSelectionForNode<
     AllStates extends StateSchemas,
     Node,
-    Path extends string
+    Path extends string,
+    Scope extends "local" | "branch"
   > = Node extends { readonly states: StateSchemas } ? NodeSchema<Node> extends never ? {}
     : {
       readonly update: SelectionValue<
         StateUpdateBuilder<AllStates, Extract<Path, ValuedStateIdentifier<AllStates>>>,
         Path,
-        "update"
+        "update",
+        Scope
       >
     }
     : {}
@@ -4793,21 +4843,28 @@ export declare namespace Machine {
     AllStates extends StateSchemas,
     Node,
     Path extends string,
-    Rest extends string
+    Rest extends string,
+    Scope extends "local" | "branch" = "branch"
   > =
-    & StateUpdateSelectionForNode<AllStates, Node, Path>
+    & StateUpdateSelectionForNode<AllStates, Node, Path, Scope>
     & (Node extends { readonly states: infer Children extends StateSchemas } ?
       Rest extends `${infer Head}.${infer Tail}` ? Head extends keyof Children ? {
             readonly [Key in Head]: BranchUpdateSelectionPath<
               AllStates,
               Children[Head],
               JoinPath<Path, Head>,
-              Tail
+              Tail,
+              Scope
             >
           }
         : {}
       : Rest extends keyof Children ? {
-          readonly [Key in Rest]: StateUpdateSelectionForNode<AllStates, Children[Rest], JoinPath<Path, Rest>>
+          readonly [Key in Rest]: StateUpdateSelectionForNode<
+            AllStates,
+            Children[Rest],
+            JoinPath<Path, Rest>,
+            Scope
+          >
         }
       : {}
       : {})
@@ -4818,9 +4875,9 @@ export declare namespace Machine {
     Path extends StateIdentifier<AllStates>,
     Builder
   > = Node extends { readonly states: StateSchemas } ?
-      & SelectionMethod<Builder, Path>
-      & InitialSelectionMethod<Builder, Path>
-    : SelectionMethod<Builder, Path>
+      & SelectionMethod<Builder, Path, "state", "full">
+      & InitialSelectionMethod<Builder, Path, "full">
+    : SelectionMethod<Builder, Path, "state", "full">
 
   type FullTargetSelector<States extends StateSchemas> = {
     readonly [Key in Extract<ActiveStateKey<States>, keyof FullTargetBuilder<States>>]: FullSelectionNode<
@@ -4846,7 +4903,7 @@ export declare namespace Machine {
           >
           & (Source extends ChoiceIdentifier<States> ? {}
             : Source extends `${Key}.${infer Rest}` ? BranchUpdateSelectionPath<States, States[Key], Key, Rest>
-            : StateUpdateSelectionForNode<States, States[Key], Key>)
+            : StateUpdateSelectionForNode<States, States[Key], Key, "branch">)
       }
     : {}
     : {}
@@ -4860,12 +4917,12 @@ export declare namespace Machine {
         LocalTargetBuilder<States, Source> extends infer Builder ?
             & SelectionTreeWithPrefix<States, Children, Scope, "local", Builder>
             & ("with" extends keyof Builder ? {
-                readonly with: SelectionValue<Builder["with"], Scope>
+                readonly with: SelectionValue<Builder["with"], Scope, "state", "local">
               }
               : {})
             & (Source extends ChoiceIdentifier<States> ? {}
               : Scope extends ValuedStateIdentifier<States> ? {
-                  readonly update: SelectionValue<StateUpdateBuilder<States, Scope>, Scope, "update">
+                  readonly update: SelectionValue<StateUpdateBuilder<States, Scope>, Scope, "update", "local">
                 }
               : {})
         : {}
@@ -4883,7 +4940,8 @@ export declare namespace Machine {
       SelectionValue<
         Builder[Key],
         JoinPath<Prefix, Key>,
-        "history"
+        "history",
+        "full"
       >
       : States[Key] extends { readonly states: infer Children extends StateSchemas } ? HistorySelectionTree<
           AllStates,
@@ -4908,7 +4966,7 @@ export declare namespace Machine {
     Source extends StateNodeIdentifier<States>
   > {
     /** Handles the trigger without selecting a destination. */
-    readonly none: SelectionValue<TargetBuilder<States, Source>["none"], never, "none">
+    readonly none: SelectionValue<TargetBuilder<States, Source>["none"], never, "none", "local">
     /** Selects a destination or updates the nearest active compound scope. */
     readonly local: LocalTargetSelector<States, Source>
     /** Selects a destination or updates a valued active ancestor under the current root. */
@@ -4923,9 +4981,9 @@ export declare namespace Machine {
   type InitialTargetSelector<States extends StateSchemas> = {
     readonly [Key in Extract<ActiveStateKey<States>, keyof InitialBuilder<States>>]: States[Key] extends
       { readonly states: StateSchemas } ? {
-        readonly initial: SelectionValue<InitialBuilder<States>[Key], Key, "initial">
+        readonly initial: SelectionValue<InitialBuilder<States>[Key], Key, "initial", "initial">
       }
-      : SelectionMethod<InitialBuilder<States>[Key], Key>
+      : SelectionMethod<InitialBuilder<States>[Key], Key, "state", "initial">
   }
 
   /**
@@ -5334,6 +5392,11 @@ export declare namespace Machine {
     | HistoryTarget<States, HistoryIdentifier<States>>
     | ChoiceTarget<States, ChoiceIdentifier<States>>
     | StateUpdate<States, ValuedStateIdentifier<States>>
+    | CombinedTarget<
+      Target<States, StateIdentifier<States>> | Snapshot<States>,
+      States,
+      ValuedStateIdentifier<States>
+    >
     | StateConstruction<
       | Snapshot<States>
       | Target<States, StateIdentifier<States>>
@@ -5667,20 +5730,74 @@ export declare namespace Machine {
     Acceptance extends TransitionAcceptance = "required"
   > = TransitionBuilderInput<States, Events, Emits, StateId, Context, Reenter, Acceptance>
 
-  export type SelectionBuilder<Selection> = Selection extends TargetSelection<infer Builder, any, any> ? Builder : never
-  export type SelectionKind<Selection> = Selection extends TargetSelection<any, any, infer Kind> ? Kind : never
-  export type SelectionPath<Selection> = Selection extends TargetSelection<any, infer Path, any> ? Path : never
+  export type SelectionBuilder<Selection> = Selection extends TargetSelection<infer Builder, any, any, any> ? Builder
+    : never
+  export type SelectionKind<Selection> = Selection extends TargetSelection<any, any, infer Kind, any> ? Kind : never
+  export type SelectionPath<Selection> = Selection extends TargetSelection<any, infer Path, any, any> ? Path : never
+  type SelectionScope<Selection> = Selection extends TargetSelection<any, any, any, infer Scope> ? Scope : never
   export type TargetBuilderResult<Builder> =
     | (Builder extends (...args: any) => infer Result ? Result : never)
+    | (Builder extends { readonly decoded: (...args: any) => infer Result } ? Result : never)
     | (Builder extends { readonly from: (...args: any) => infer Result } ? Result : never)
   export type SelectedTargetResult<Selection> = SelectionBuilder<Selection> extends infer Builder ?
     TargetBuilderResult<Builder>
     : never
 
+  type RetainedUpdateOwner<
+    States extends StateSchemas,
+    Source extends StateNodeIdentifier<States>,
+    Selection
+  > = Extract<
+    ParentStateIdentifier<Source>,
+    ParentStateIdentifier<Extract<SelectionPath<Selection>, string>> & ValuedStateIdentifier<States>
+  >
+
+  type RetainedOwnerSelector<Owner extends string> = () => TargetSelection<any, Owner, "state", "branch">
+
+  /**
+   * Destination construction returned when a transition declares one retained
+   * valued owner with `.updating(...)`.
+   *
+   * @category models
+   * @since 0.22.0
+   */
+  export interface UpdatingStateConstruction<
+    Result,
+    States extends StateSchemas,
+    Owner extends ValuedStateIdentifier<States>
+  > {
+    /** Combines the selected topology with the required owner replacement. */
+    readonly update: (
+      update: StateUpdate<States, Owner>
+    ) => CombinedTarget<UnwrapConstruction<Result>, States, Owner>
+  }
+
+  type UpdatingCallable<
+    Callable,
+    States extends StateSchemas,
+    Owner extends ValuedStateIdentifier<States>
+  > = Callable extends {
+    (...args: infer Arguments1): infer Result1
+    (...args: infer Arguments2): infer Result2
+  } ? {
+      (...args: Arguments1): UpdatingStateConstruction<Result1, States, Owner>
+      (...args: Arguments2): UpdatingStateConstruction<Result2, States, Owner>
+    }
+    : Callable extends (...args: infer Arguments) => infer Result ?
+      (...args: Arguments) => UpdatingStateConstruction<Result, States, Owner>
+    : never
+
+  type UpdatingTargetBuilder<
+    Builder,
+    States extends StateSchemas,
+    Owner extends ValuedStateIdentifier<States>
+  > = {
+    readonly [Key in keyof Builder]: Key extends "from" | "decoded" ? UpdatingCallable<Builder[Key], States, Owner>
+      : Builder[Key]
+  }
+
   type SelectionSupportsDefaultConstruction<Selection> = SelectionKind<Selection> extends "none" ? true
     : SelectionBuilder<Selection> extends { readonly from: (...args: infer Args) => any } ? [] extends Args ? true
-      : false
-    : SelectionBuilder<Selection> extends (...args: infer Args) => any ? [] extends Args ? true
       : false
     : false
 
@@ -5690,6 +5807,31 @@ export declare namespace Machine {
   > =
     & Omit<Context, "target">
     & (SelectionKind<Selection> extends "none" ? {} : { readonly target: SelectionBuilder<Selection> })
+
+  type StateUpdateResolveContext<
+    States extends StateSchemas,
+    Context,
+    Owner extends ValuedStateIdentifier<States>
+  > = Omit<Context, "target"> & {
+    /** Decoded owner value from the pre-transition snapshot. */
+    readonly current: StateByIdentifier<States, Owner>
+    /** Constructs the complete replacement for the selected owner. */
+    readonly owner: StateUpdateBuilder<States, Owner>
+  }
+
+  type UpdatingTransitionResolveContext<
+    States extends StateSchemas,
+    Context,
+    Selection,
+    Owner extends ValuedStateIdentifier<States>
+  > = Omit<Context, "target"> & {
+    /** Decoded owner value from the pre-transition snapshot. */
+    readonly current: StateByIdentifier<States, Owner>
+    /** Constructs the selected topology and requires `.update(...)`. */
+    readonly target: UpdatingTargetBuilder<SelectionBuilder<Selection>, States, Owner>
+    /** Constructs the complete replacement for the retained owner. */
+    readonly owner: StateUpdateBuilder<States, Owner>
+  }
 
   /** Context capability available only to explicitly declinable resolvers. */
   export interface DeclineCapability {
@@ -5721,25 +5863,27 @@ export declare namespace Machine {
 
   /** @internal */
   type StateUpdateResolver<
+    States extends StateSchemas,
     Events extends ReadonlyArray<TaggedSchema>,
     Emits extends ReadonlyArray<TaggedSchema>,
     Context,
-    Selection
+    Owner extends ValuedStateIdentifier<States>
   > = (
-    context: TransitionResolveContext<Context, Selection>,
+    context: StateUpdateResolveContext<States, Context, Owner>,
     enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-  ) => SelectedTargetResult<Selection>
+  ) => StateUpdate<States, Owner>
 
   /** @internal */
   type DeclinableStateUpdateResolver<
+    States extends StateSchemas,
     Events extends ReadonlyArray<TaggedSchema>,
     Emits extends ReadonlyArray<TaggedSchema>,
     Context,
-    Selection
+    Owner extends ValuedStateIdentifier<States>
   > = (
-    context: TransitionResolveContext<Context, Selection> & DeclineCapability,
+    context: StateUpdateResolveContext<States, Context, Owner> & DeclineCapability,
     enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
-  ) => SelectedTargetResult<Selection> | Declined
+  ) => StateUpdate<States, Owner> | Declined
 
   /** One named destination declared by a branching transition. */
   export interface TransitionBranchInput<
@@ -5949,10 +6093,7 @@ export declare namespace Machine {
       >
       : {})
     & {
-      /**
-       * Evaluates state construction and queued commands only after this
-       * transition has been selected.
-       */
+      /** Evaluates state construction after this transition is selected. */
       readonly resolve:
         & TransitionResolveRequired<States, Events, Emits, StateId, Context, Reenter, Selection>
         & ("declinable" extends Acceptance ? TransitionResolveDeclinable<
@@ -5981,6 +6122,79 @@ export declare namespace Machine {
         }
       : {}
       : {})
+    & (SelectionKind<Selection> extends "state" ?
+      SelectionScope<Selection> extends "local" | "branch" ?
+        RetainedUpdateOwner<States, StateId, Selection> extends infer Owner extends ValuedStateIdentifier<States> ?
+          [Owner] extends [never] ? {}
+          : {
+            /** Declares one valued owner retained by the selected topology. */
+            readonly updating: <SelectedOwner extends Owner>(
+              owner: RetainedOwnerSelector<SelectedOwner>
+            ) => UpdatingTransitionTarget<
+              States,
+              Events,
+              Emits,
+              StateId,
+              Context,
+              Reenter,
+              Acceptance,
+              Selection,
+              SelectedOwner
+            >
+          }
+        : {}
+      : {}
+      : {})
+
+  /** A topology selection that requires one retained owner replacement. */
+  export type UpdatingTransitionTarget<
+    States extends StateSchemas,
+    Events extends ReadonlyArray<TaggedSchema>,
+    Emits extends ReadonlyArray<TaggedSchema>,
+    StateId extends StateNodeIdentifier<States>,
+    Context,
+    Reenter extends boolean,
+    Acceptance extends TransitionAcceptance,
+    Selection extends TargetSelection<any, any, "state">,
+    Owner extends ValuedStateIdentifier<States>
+  > = Selection & {
+    /** @internal */
+    readonly "~effect/Machine/UpdatingTransitionTarget": Owner
+    readonly resolve:
+      & ((
+        resolve: (
+          context: UpdatingTransitionResolveContext<States, Context, Selection, Owner>,
+          enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
+        ) => CombinedTarget<UnwrapConstruction<SelectedTargetResult<Selection>>, States, Owner>,
+        options?: TransitionRequiredOptions<Reenter>
+      ) => BuiltTransition<
+        States,
+        Events,
+        Emits,
+        StateId,
+        Context,
+        Reenter,
+        CombinedTarget<UnwrapConstruction<SelectedTargetResult<Selection>>, States, Owner>,
+        "required"
+      >)
+      & ("declinable" extends Acceptance ? (
+          resolve: (
+            context: UpdatingTransitionResolveContext<States, Context, Selection, Owner> & DeclineCapability,
+            enqueue: Enqueue<EventOf<Events>, EmitOf<Emits>>
+          ) => CombinedTarget<UnwrapConstruction<SelectedTargetResult<Selection>>, States, Owner> | Declined,
+          options: TransitionDeclinableOptions<Reenter>
+        ) => BuiltTransition<
+          States,
+          Events,
+          Emits,
+          StateId,
+          Context,
+          Reenter,
+          CombinedTarget<UnwrapConstruction<SelectedTargetResult<Selection>>, States, Owner> | Declined,
+          "declinable"
+        >
+        : {})
+  }
 
   /** @internal */
   interface StateUpdateTransitionRequired<
@@ -5993,7 +6207,13 @@ export declare namespace Machine {
     Selection extends TargetSelection<any, any, "update">
   > {
     (
-      resolve: StateUpdateResolver<Events, Emits, Context, Selection>,
+      resolve: StateUpdateResolver<
+        States,
+        Events,
+        Emits,
+        Context,
+        Extract<SelectionPath<Selection>, ValuedStateIdentifier<States>>
+      >,
       options?: TransitionRequiredOptions<Reenter>
     ): BuiltTransition<
       States,
@@ -6018,7 +6238,13 @@ export declare namespace Machine {
     Selection extends TargetSelection<any, any, "update">
   > {
     (
-      resolve: DeclinableStateUpdateResolver<Events, Emits, Context, Selection>,
+      resolve: DeclinableStateUpdateResolver<
+        States,
+        Events,
+        Emits,
+        Context,
+        Extract<SelectionPath<Selection>, ValuedStateIdentifier<States>>
+      >,
       options: TransitionDeclinableOptions<Reenter>
     ): BuiltTransition<
       States,
@@ -8447,13 +8673,13 @@ interface Make {
  * const counter = Machine.make({
  *   states: States.states,
  *   events: Events,
- *   initial: (to) => to.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+ *   initial: (to) => to.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
  * }).handle({
  *   Count: {
  *     on: {
  *       Increment: (to) =>
  *         to.full.Count().resolve(({ event, state, target }) =>
- *           target(new Count({ value: state.value + event.by })))
+ *           target.decoded(new Count({ value: state.value + event.by })))
  *     }
  *   }
  * })
@@ -8780,9 +9006,21 @@ type TransitionBranchRecordError<Message extends string, Key extends PropertyKey
 
 type InvalidStaticTransitionBranchKey<Branches> = Extract<keyof Branches, "" | number | symbol>
 
+type InvalidUpdatingTransitionBranchKey<Branches> = {
+  readonly [Key in keyof Branches]: Branches[Key] extends {
+    readonly target: { readonly "~effect/Machine/UpdatingTransitionTarget": string }
+  } ? Key
+    : never
+}[keyof Branches]
+
 type ValidateTransitionBranchRecord<Branches> = [keyof Branches] extends [never] ?
   TransitionBranchRecordError<"Branch records must contain at least one branch">
-  : [InvalidStaticTransitionBranchKey<Branches>] extends [never] ? unknown
+  : [InvalidStaticTransitionBranchKey<Branches>] extends [never] ?
+    [InvalidUpdatingTransitionBranchKey<Branches>] extends [never] ? unknown
+    : TransitionBranchRecordError<
+      "Updating targets require a direct resolver",
+      InvalidUpdatingTransitionBranchKey<Branches>
+    >
   : TransitionBranchRecordError<
     "Branch keys must be non-empty, non-index strings",
     InvalidStaticTransitionBranchKey<Branches>

--- a/src/internal/machine/executionPlan.ts
+++ b/src/internal/machine/executionPlan.ts
@@ -47,7 +47,15 @@ import {
   validateDeclaredTransitionTarget
 } from "./planner.js"
 import { decodeEmitSync, decodeEventSync, decodeInputSync, decodeStateValueSync } from "./protocol.js"
-import { isInitialTarget, isNoTarget, isSnapshot, isStateUpdate, isTarget, TargetSnapshotTypeId } from "./topology.js"
+import {
+  isCombinedTarget,
+  isInitialTarget,
+  isNoTarget,
+  isSnapshot,
+  isStateUpdate,
+  isTarget,
+  TargetSnapshotTypeId
+} from "./topology.js"
 
 interface IndexedExecutionDescriptor {
   readonly flat: boolean
@@ -548,25 +556,28 @@ const collectIndexedEvaluatedTransition = (
     selection.context,
     selection.transition.evaluate
   )
-  const update = isStateUpdate(transitionResult.state)
+  const combined = isCombinedTarget(transitionResult.state) ? transitionResult.state : undefined
+  const transitionState = combined?.target ?? transitionResult.state
+  const stateUpdate = combined?.update ?? (isStateUpdate(transitionState) ? transitionState : undefined)
+  const update = stateUpdate !== undefined
     ? (() => {
-      const index = descriptor.indexByPath.get(transitionResult.state.path)
+      const index = descriptor.indexByPath.get(stateUpdate.path)
       const node = index === undefined ? undefined : descriptor.nodes[index]
       if (
         index === undefined || node === undefined || state.active[index] !== 1 || node.schema === undefined ||
         (node.type !== "compound" && node.type !== "parallel")
       ) {
         throw new Error(
-          `Machine state update owner "${transitionResult.state.path}" must be an active valued compound or parallel state`
+          `Machine state update owner "${stateUpdate.path}" must be an active valued compound or parallel state`
         )
       }
       return {
         path: node.path,
-        value: decodeStateValueSync(machine, node, transitionResult.state.value)
+        value: decodeStateValueSync(machine, node, stateUpdate.value)
       }
     })()
     : undefined
-  const unresolvedTarget = update === undefined ? transitionResult.state : undefined
+  const unresolvedTarget = transitionState === undefined || isStateUpdate(transitionState) ? undefined : transitionState
   validateDeclaredTransitionTarget(
     selection.sourcePath,
     selection.trigger,
@@ -585,13 +596,22 @@ const collectIndexedEvaluatedTransition = (
   if (target !== undefined && !isTarget(target) && !isSnapshot(target)) {
     throw new Error("Machine expected indexed transition target to be a snapshot or target builder result")
   }
-  const next = target === undefined
+  let next = target === undefined
     ? update === undefined ? state : (() => {
       const next = copyOwnedIndexedState(state)
       next.values[descriptor.indexByPath.get(update.path)!] = update.value
       return next
     })()
     : normalizeIndexedTargetStateSync(machine, descriptor, state, target as any, selection.leafIndex)
+  if (combined !== undefined && update !== undefined) {
+    const ownerIndex = descriptor.indexByPath.get(update.path)!
+    if (next.active[ownerIndex] !== 1) {
+      throw new Error(`Machine combined target exited its updating owner "${update.path}"`)
+    }
+    const values = next.values.slice()
+    values[ownerIndex] = update.value
+    next = { ...next, values }
+  }
   const changed = selection.transition.reenter || !hasSameIndexedActive(state, next)
   const stabilize = changed || update !== undefined
   if (!changed) {
@@ -656,7 +676,8 @@ const indexedMicrostep = (
     branchIndex: transition.branchIndex,
     branchKey: transition.branchKey,
     target: transition.unresolvedTarget === undefined ? undefined : getTargetNodePath(transition.unresolvedTarget),
-    resolvedTarget: transition.target === undefined ? undefined : getTargetNodePath(transition.target)
+    resolvedTarget: transition.target === undefined ? undefined : getTargetNodePath(transition.target),
+    updates: transition.update === undefined ? [] : [transition.update.path]
   })
   if (selections.length === 1) {
     const transition = collectIndexedEvaluatedTransition(machine, descriptor, state, selections[0]!)
@@ -849,7 +870,8 @@ const planIndexedFlatState = (
               branchIndex: transitionResult.branchIndex,
               branchKey: transitionResult.branchKey,
               target: target === undefined ? undefined : getTargetNodePath(target as any),
-              resolvedTarget: target === undefined ? undefined : getTargetNodePath(target as any)
+              resolvedTarget: target === undefined ? undefined : getTargetNodePath(target as any),
+              updates: []
             }]
           }
           : undefined),

--- a/src/internal/machine/initialization.ts
+++ b/src/internal/machine/initialization.ts
@@ -14,11 +14,19 @@ const getNode = (machine: Machine.Any, path: string): Machine.StateNode => {
 }
 
 const withFrom = <Method extends (value: unknown) => unknown>(method: Method) => {
-  Object.defineProperty(method, "from", {
+  const builder = {}
+  Object.defineProperty(builder, "decoded", {
+    value: method,
+    enumerable: false
+  })
+  Object.defineProperty(builder, "from", {
     value: (...args: ReadonlyArray<unknown>) => method(Topology.makeStateInput(args.length === 0 ? {} : args[0])),
     enumerable: false
   })
-  return method as Method & { readonly from: (...args: ReadonlyArray<unknown>) => unknown }
+  return builder as {
+    readonly decoded: Method
+    readonly from: (...args: ReadonlyArray<unknown>) => unknown
+  }
 }
 
 const makeCompletion = (values: Readonly<Record<string, unknown>>): object => {

--- a/src/internal/machine/machine.ts
+++ b/src/internal/machine/machine.ts
@@ -191,7 +191,7 @@ type InitialBuilderDescriptor = {
 const plainTargetSelection = (selection: Topology.TargetSelection): Topology.TargetSelection =>
   selection.kind === "none"
     ? Topology.noneTargetSelection
-    : Topology.makeTargetSelection(selection.kind, selection.path, selection.scope)
+    : Topology.makeTargetSelection(selection.kind, selection.path, selection.scope, selection.updatePath)
 
 const transitionOptions = (options: unknown): { readonly reenter: boolean; readonly declinable: boolean } => {
   const configuration = typeof options === "object" && options !== null
@@ -224,7 +224,22 @@ const decorateTransitionSelection = (selection: Topology.TargetSelection): Topol
     ...selection,
     resolve: (resolve: (context: any, enqueue: unknown) => unknown, options?: unknown) =>
       makeDirectTransitionDescriptor(selection, resolve, options),
-    reenter: () => makeDirectTransitionDescriptor(selection, undefined, { reenter: true })
+    reenter: () => makeDirectTransitionDescriptor(selection, undefined, { reenter: true }),
+    updating: (owner: unknown) => {
+      if (typeof owner !== "function") {
+        throw new Error("Machine updating owner must be a state selector")
+      }
+      const ownerSelection = owner()
+      if (
+        !Topology.isTargetSelection(ownerSelection) || ownerSelection.kind !== "state" ||
+        ownerSelection.scope !== "branch"
+      ) {
+        throw new Error("Machine updating owner must be addressed by one branch state selector")
+      }
+      return decorateTransitionSelection(
+        Topology.makeTargetSelection(selection.kind, selection.path, selection.scope, ownerSelection.path)
+      )
+    }
   })
 
 const decorateStateUpdateSelection = (selection: Topology.TargetSelection): Topology.TargetSelection => {
@@ -360,6 +375,11 @@ const transitionTargetSelection = (
     scope: selection.scope
   })
 
+const selectionUpdates = (selection: Topology.TargetSelection): ReadonlyArray<string> =>
+  selection.updatePath === undefined ?
+    selection.kind === "update" && selection.path !== undefined ? [selection.path] : []
+    : [selection.updatePath]
+
 const makeSelectionMethod = (
   kind: Topology.TargetSelectionKind,
   path: string | undefined,
@@ -476,6 +496,7 @@ const makeTargetSelector = (
 const captureDefinitionBranch = (
   branch: unknown,
   selector: unknown,
+  stateNodes: Machine.StateNodes,
   path: string,
   trigger: PropertyKey
 ): CapturedBranch => {
@@ -489,7 +510,56 @@ const captureDefinitionBranch = (
   if (!Topology.isTargetSelection(selection)) {
     throw new Error(`Machine transition for state "${path}" on "${String(trigger)}" must select exactly one target`)
   }
+  if (selection.updatePath !== undefined) {
+    const owner = stateNodes.byPath.get(selection.updatePath)
+    if (
+      selection.kind !== "state" || (selection.scope !== "local" && selection.scope !== "branch") ||
+      selection.path === undefined || owner === undefined || owner.schema === undefined ||
+      (owner.type !== "compound" && owner.type !== "parallel") ||
+      !Configuration.isDescendantOf(path, owner.path) ||
+      !Configuration.isDescendantOf(selection.path, owner.path)
+    ) {
+      throw new Error(
+        `Machine updating owner "${selection.updatePath}" must be a valued ancestor retained by source "${path}" and target "${selection.path}"`
+      )
+    }
+  }
   return { ...(branch as DefinitionBranch), selection }
+}
+
+const makeUpdatingConstruction = (
+  target: unknown,
+  ownerPath: string
+): { readonly update: (update: unknown) => Topology.CombinedTarget } =>
+  Object.freeze({
+    update: (update: unknown) => {
+      if (!Topology.isStateUpdate(update) || update.path !== ownerPath) {
+        throw new Error(`Machine combined target must update its declared owner "${ownerPath}"`)
+      }
+      return Topology.makeCombinedTarget(target, update)
+    }
+  })
+
+const makeUpdatingTargetBuilder = (
+  builder: unknown,
+  ownerPath: string
+): unknown => {
+  if (typeof builder !== "object" || builder === null) {
+    throw new Error("Machine combined target requires a state construction builder")
+  }
+  const updating: Record<PropertyKey, unknown> = {}
+  for (const property of Reflect.ownKeys(builder)) {
+    const descriptor = Object.getOwnPropertyDescriptor(builder, property)
+    if (descriptor === undefined) continue
+    if (
+      (property === "from" || property === "decoded") && "value" in descriptor && typeof descriptor.value === "function"
+    ) {
+      const construct = descriptor.value
+      descriptor.value = (...args: ReadonlyArray<unknown>) => makeUpdatingConstruction(construct(...args), ownerPath)
+    }
+    Object.defineProperty(updating, property, descriptor)
+  }
+  return Object.freeze(updating)
 }
 
 const getSelectionBuilder = (
@@ -534,7 +604,7 @@ const getSelectionBuilder = (
   ) {
     throw new Error(`Machine could not construct selected transition target "${selection.path}"`)
   }
-  return builder
+  return selection.updatePath === undefined ? builder : makeUpdatingTargetBuilder(builder, selection.updatePath)
 }
 
 const constructSelectedTarget = (builder: any): unknown =>
@@ -557,10 +627,18 @@ const validateResolvedSelection = (
     }
     return
   }
+  if (selection.updatePath !== undefined) {
+    if (!Topology.isCombinedTarget(result) || result.update.path !== selection.updatePath) {
+      throw new Error(`Machine target updating "${selection.updatePath}" must return target construction .update(...)`)
+    }
+  } else if (Topology.isCombinedTarget(result)) {
+    throw new Error("Machine combined target requires an updating owner declaration")
+  }
   if (result === undefined) return
-  const resultPath = typeof result === "object" && result !== null && hasProperty(result, "path") &&
-      typeof result.path === "string"
-    ? result.path
+  const target = Topology.isCombinedTarget(result) ? result.target : result
+  const resultPath = typeof target === "object" && target !== null && hasProperty(target, "path") &&
+      typeof target.path === "string"
+    ? target.path
     : undefined
   const selectedNode = selection.path === undefined ? undefined : stateNodes.byPath.get(selection.path)
   const acceptsDescendant = (selection.scope === "local" || selection.scope === "branch") &&
@@ -587,6 +665,26 @@ const runCapturedBranch = (
   const resolverContext = { ...context }
   if (branch.selection.kind === "none") delete resolverContext.target
   else resolverContext.target = selectedTarget
+  if (branch.selection.kind === "update") {
+    const ownerPath = branch.selection.path!
+    delete resolverContext.target
+    resolverContext.current = context.ancestors[ownerPath] ?? context.state
+    resolverContext.owner = getSelectionBuilder(
+      context.target,
+      makeStateUpdateSelection(ownerPath, branch.selection.scope === "local" ? "local" : "branch"),
+      stateNodes,
+      source
+    )
+  } else if (branch.selection.updatePath !== undefined) {
+    const ownerPath = branch.selection.updatePath
+    resolverContext.current = context.ancestors[ownerPath]
+    resolverContext.owner = getSelectionBuilder(
+      context.target,
+      makeStateUpdateSelection(ownerPath, "branch"),
+      stateNodes,
+      source
+    )
+  }
   if (branch.declinable === true) resolverContext.decline = Topology.makeDeclined
   const resolved = branch.resolve(resolverContext, enqueue)
   if (Topology.isDeclined(resolved)) {
@@ -635,6 +733,9 @@ const captureNamedBranches = (
     const { target, title } = declaration as BranchDeclaration
     if (!Topology.isTargetSelection(target)) {
       throw new Error(`Machine transition branch "${key}" must select exactly one target`)
+    }
+    if (target.updatePath !== undefined) {
+      throw new Error(`Machine transition branch "${key}" cannot declare an updating target`)
     }
     if (title !== undefined && (typeof title !== "string" || title.length === 0)) {
       throw new Error(`Machine transition branch "${key}" title must be a non-empty string`)
@@ -795,14 +896,15 @@ const captureTransition = (
           key: branch.key,
           title: branch.title,
           target: topologyTargetPath(branch.selection),
-          selection: transitionTargetSelection(branch.selection)
+          selection: transitionTargetSelection(branch.selection),
+          updates: selectionUpdates(branch.selection)
         })
       ),
       evaluate,
       transition: (context: Record<string, any>, enqueue: unknown) => evaluate(context, enqueue).result
     }
   }
-  const branch = captureDefinitionBranch(transition, selector, path, trigger)
+  const branch = captureDefinitionBranch(transition, selector, stateNodes, path, trigger)
   const evaluate = (context: Record<string, any>, enqueue: unknown) => ({
     result: runCapturedBranch(branch, context, enqueue, stateNodes, path),
     branchIndex: 0,
@@ -815,7 +917,8 @@ const captureTransition = (
     branches: [{
       type: "direct" as const,
       target: topologyTargetPath(branch.selection),
-      selection: transitionTargetSelection(branch.selection)
+      selection: transitionTargetSelection(branch.selection),
+      updates: selectionUpdates(branch.selection)
     }],
     evaluate,
     transition: (context: Record<string, any>, enqueue: unknown) => evaluate(context, enqueue).result
@@ -1022,8 +1125,18 @@ const withFrom = <Method extends (value: unknown, ...args: ReadonlyArray<any>) =
   method: Method,
   kind: FromMethodKind,
   valued: boolean
-): Method & { readonly from: (...args: ReadonlyArray<any>) => unknown } => {
-  Object.defineProperty(method, "from", {
+): {
+  readonly decoded?: Method
+  readonly from: (...args: ReadonlyArray<any>) => unknown
+} => {
+  const builder: Record<string, unknown> = {}
+  if (valued) {
+    Object.defineProperty(builder, "decoded", {
+      value: method,
+      enumerable: false
+    })
+  }
+  Object.defineProperty(builder, "from", {
     value: (...args: ReadonlyArray<any>) => {
       if (!valued) {
         return method(undefined, ...args)
@@ -1035,7 +1148,10 @@ const withFrom = <Method extends (value: unknown, ...args: ReadonlyArray<any>) =
     },
     enumerable: false
   })
-  return method as Method & { readonly from: (...args: ReadonlyArray<any>) => unknown }
+  return builder as {
+    readonly decoded?: Method
+    readonly from: (...args: ReadonlyArray<any>) => unknown
+  }
 }
 
 const withInitial = <Builder extends object>(
@@ -1518,13 +1634,13 @@ const makeInitialSelector = (stateNodes: Machine.StateNodes): unknown => {
 const getInitialSelectionBuilder = (
   initialBuilder: Record<string, any>,
   selection: Topology.TargetSelection
-): (...args: ReadonlyArray<any>) => unknown => {
+): Record<string, any> => {
   const path = selection.path
   if (path === undefined || path.includes(".")) {
     throw new Error("Machine initial target must select one top-level state")
   }
   const builder = initialBuilder[path]
-  if (typeof builder !== "function") {
+  if (typeof builder !== "object" || builder === null || typeof builder.from !== "function") {
     throw new Error(`Machine could not construct selected initial state "${path}"`)
   }
   return builder
@@ -1537,7 +1653,7 @@ const captureInitialBranch = (
 ): {
   readonly selection: Topology.TargetSelection
   readonly resolve?: (context: any) => unknown
-  readonly builder: (...args: ReadonlyArray<any>) => unknown
+  readonly builder: Record<string, any>
 } => {
   if (typeof definition !== "function") {
     throw new Error("Machine initial definition must be a target-first callback")

--- a/src/internal/machine/planner.ts
+++ b/src/internal/machine/planner.ts
@@ -47,6 +47,7 @@ import {
   getNode,
   type InitialTarget as InitialTargetInstruction,
   isChoiceTarget,
+  isCombinedTarget,
   isDeclined,
   isHistoryTarget,
   isInitialTarget,
@@ -70,6 +71,7 @@ export type MicrostepPlan<State, Event, E, R> = {
     readonly branchKey: string | undefined
     readonly target: string | undefined
     readonly resolvedTarget: string | undefined
+    readonly updates: ReadonlyArray<string>
   }>
   readonly commands: ReadonlyArray<RuntimeCommand>
   readonly raisedEvents: ReadonlyArray<Event>
@@ -605,6 +607,7 @@ export type EvaluatedTransition<States extends Machine.StateSchemas, Event, E, R
     readonly branchKey: string | undefined
     readonly target: string
     readonly resolvedTarget: string
+    readonly updates: ReadonlyArray<string>
   }>
 }
 
@@ -1234,6 +1237,7 @@ interface ResolvedChoiceTransition {
   readonly branchKey: string | undefined
   readonly target: string
   readonly resolvedTarget: string
+  readonly updates: ReadonlyArray<string>
 }
 
 function resolveChoiceTarget(
@@ -1312,7 +1316,8 @@ function resolveChoiceTarget(
         branchIndex: collected.branchIndex,
         branchKey: collected.branchKey,
         target: returnedPath,
-        resolvedTarget: nested?.target.path ?? returnedPath
+        resolvedTarget: nested?.target.path ?? returnedPath,
+        updates: []
       })
       commands.push(...collected.commands)
       raisedEvents.push(...collected.raisedEvents)
@@ -1356,10 +1361,12 @@ const collectEvaluatedTransition = <
   if (transitionResult.declined) {
     throw new Error("Machine transition returned decline without declaring declinable: true")
   }
-  const unresolvedTarget = transitionResult.state === undefined
-      || isStateUpdate(transitionResult.state)
+  const combined = isCombinedTarget(transitionResult.state) ? transitionResult.state : undefined
+  const transitionState = combined?.target ?? transitionResult.state
+  const unresolvedTarget = transitionState === undefined
+      || isStateUpdate(transitionState)
     ? undefined
-    : transitionResult.state as
+    : transitionState as
       | Machine.Snapshot<States>
       | Machine.Target<States, Machine.StateIdentifier<States>>
       | Machine.HistoryTarget<States, Machine.HistoryIdentifier<States>>
@@ -1370,9 +1377,10 @@ const collectEvaluatedTransition = <
     selection.transition.targets,
     unresolvedTarget
   )
-  const update = isStateUpdate(transitionResult.state)
+  const stateUpdate = combined?.update ?? (isStateUpdate(transitionState) ? transitionState : undefined)
+  const update = stateUpdate !== undefined
     ? (() => {
-      const node = getNode(machine, transitionResult.state.path)
+      const node = getNode(machine, stateUpdate.path)
       if (
         !state.active.has(node.path) || node.schema === undefined ||
         (node.type !== "compound" && node.type !== "parallel")
@@ -1381,7 +1389,7 @@ const collectEvaluatedTransition = <
       }
       return {
         path: node.path,
-        value: decodeStateValueSync(machine, node, transitionResult.state.value)
+        value: decodeStateValueSync(machine, node, stateUpdate.value)
       }
     })()
     : undefined
@@ -1496,6 +1504,15 @@ const collectEvaluatedTransition = <
       stateAfterTransition,
       additionalTarget
     )
+  }
+  if (combined !== undefined && update !== undefined && !stateAfterTransition.active.has(update.path)) {
+    throw new Error(`Machine combined target exited its updating owner "${update.path}"`)
+  }
+  if (update !== undefined) {
+    stateAfterTransition = {
+      ...stateAfterTransition,
+      values: new Map(stateAfterTransition.values).set(update.path, update.value)
+    }
   }
   const changed = selection.transition.reenter || !hasSameActivePaths(state, stateAfterTransition)
   const stabilize = changed || update !== undefined
@@ -1915,7 +1932,8 @@ const microstep = <
       branchIndex: transition.branchIndex,
       branchKey: transition.branchKey,
       target: transition.unresolvedTarget === undefined ? undefined : getTargetNodePath(transition.unresolvedTarget),
-      resolvedTarget: transition.target === undefined ? undefined : getTargetNodePath(transition.target)
+      resolvedTarget: transition.target === undefined ? undefined : getTargetNodePath(transition.target),
+      updates: transition.update === undefined ? [] : [transition.update.path]
     },
     ...transition.choiceTransitions
   ])

--- a/src/internal/machine/topology.ts
+++ b/src/internal/machine/topology.ts
@@ -31,6 +31,8 @@ export const TargetSelectionTypeId: unique symbol = Symbol("effect/Machine/Targe
 
 export const StateUpdateTypeId: unique symbol = Symbol("effect/Machine/StateUpdate")
 
+export const CombinedTargetTypeId: unique symbol = Symbol("effect/Machine/CombinedTarget")
+
 export const SelectedBranchTypeId: unique symbol = Symbol("effect/Machine/SelectedBranch")
 
 interface StateInput {
@@ -85,6 +87,7 @@ export interface TargetSelection {
   readonly kind: TargetSelectionKind
   readonly scope: TargetSelectionScope | undefined
   readonly path: string | undefined
+  readonly updatePath?: string
 }
 
 /** One branch selection returned by a compiled branching transition. */
@@ -99,13 +102,15 @@ export interface SelectedBranch {
 export const makeTargetSelection = (
   kind: TargetSelectionKind,
   path?: string,
-  scope?: TargetSelectionScope
+  scope?: TargetSelectionScope,
+  updatePath?: string
 ): TargetSelection =>
   Object.freeze({
     [TargetSelectionTypeId]: TargetSelectionTypeId as typeof TargetSelectionTypeId,
     kind,
     scope,
-    path
+    path,
+    ...(updatePath === undefined ? {} : { updatePath })
   })
 
 /** Source-independent definition-time selection for an explicitly targetless transition. */
@@ -127,6 +132,21 @@ export const makeStateUpdate = (path: string, value: unknown): StateUpdate =>
   })
 
 export const isStateUpdate = (u: unknown): u is StateUpdate => hasProperty(u, StateUpdateTypeId)
+
+export interface CombinedTarget {
+  readonly [CombinedTargetTypeId]: typeof CombinedTargetTypeId
+  readonly target: unknown
+  readonly update: StateUpdate
+}
+
+export const makeCombinedTarget = (target: unknown, update: StateUpdate): CombinedTarget =>
+  Object.freeze({
+    [CombinedTargetTypeId]: CombinedTargetTypeId,
+    target,
+    update
+  })
+
+export const isCombinedTarget = (u: unknown): u is CombinedTarget => hasProperty(u, CombinedTargetTypeId)
 
 export const makeSelectedBranch = (
   owner: object,

--- a/src/internal/testing/machine/finiteModel.ts
+++ b/src/internal/testing/machine/finiteModel.ts
@@ -1234,7 +1234,10 @@ const selectSnapshot = (
   if (state.node._tag === "Choice") {
     return (builder[state.node.key] as () => unknown)()
   }
-  const method = builder[state.node.key] as (value: unknown, selector?: (builder: any) => unknown) => unknown
+  const method = builder[state.node.key].decoded as (
+    value: unknown,
+    selector?: (builder: any) => unknown
+  ) => unknown
   const value = stateValue(state, path === requestedParts?.join(".") ? requestedValue : undefined)
   if (state.node._tag === "Atomic" || state.node._tag === "Final") return method(value)
 
@@ -1473,14 +1476,15 @@ const makeHandlers = (
           ...(Object.keys(history).length === 0 ? {} : { history }),
           ...(node._tag === "Compound"
             ? {
-              initialize: ({ builder }: any) => builder(stateValue(byPath.get(`${path}.${node.initial}`)!))
+              initialize: ({ builder }: any) => builder.decoded(stateValue(byPath.get(`${path}.${node.initial}`)!))
             }
             : {
               initialize: ({ builder }: any) =>
                 node.states
                   .filter((child) => child._tag !== "History" && child._tag !== "Choice")
                   .reduce(
-                    (current: any, child) => current[child.key](stateValue(byPath.get(`${path}.${child.key}`)!)),
+                    (current: any, child) =>
+                      current[child.key].decoded(stateValue(byPath.get(`${path}.${child.key}`)!)),
                     builder
                   )
             }),

--- a/src/internal/testing/machine/verification.ts
+++ b/src/internal/testing/machine/verification.ts
@@ -564,7 +564,6 @@ export const coverage = <M extends AnyMachine>(
   const exitHits = new Set<number>()
 
   const transitionCoverage = makeTransitionCoverageCollector(machine)
-  const transitionDefinitions = Machine.transitionDefinitions(machine)
 
   const declaredEvents = publicEventTags(machine)
   const declaredEventTags = declaredEvents.tags
@@ -632,13 +631,8 @@ export const coverage = <M extends AnyMachine>(
     hitPaths(microstep.exitPaths, exitHits)
     observeSnapshot(microstep.next)
     for (const retained of microstep.transitions) {
-      const definition = transitionDefinitions.find((candidate) =>
-        candidate.source === retained.source && candidate.reenter === retained.reenter &&
-        sameTransitionTrigger(candidate.trigger, retained.trigger)
-      )
-      const branch = definition?.branches[retained.branchIndex]
-      if (branch?.selection.kind === "update") stateUpdates += 1
-      else if (retained.target === undefined) targetlessTransitions += 1
+      stateUpdates += retained.updates.length
+      if (retained.target === undefined && retained.updates.length === 0) targetlessTransitions += 1
       if (retained.trigger.type === "event") eventTriggered += 1
       else if (retained.trigger.type === "always") alwaysTriggered += 1
       else if (retained.trigger.type === "done") doneTriggered += 1
@@ -1549,6 +1543,18 @@ export const verify = <M extends AnyMachine>(
         transition.target === undefined ? transition.source : String(transition.target)
       )
     }
+    if (
+      transition.updates.length !== branch.updates.length ||
+      transition.updates.some((path, index) => path !== branch.updates[index])
+    ) {
+      add(
+        "definitions.selection",
+        location,
+        `transition branch ${transition.branchIndex} from "${transition.source}" reported retained owner updates ` +
+          `${JSON.stringify(transition.updates)} instead of ${JSON.stringify(branch.updates)}`,
+        transition.source
+      )
+    }
     return branch
   }
 
@@ -1607,8 +1613,10 @@ export const verify = <M extends AnyMachine>(
       const resolvedTarget = transition.resolvedTarget === undefined ? undefined : String(transition.resolvedTarget)
       const targetNode = target === undefined ? undefined : byPath.get(target)
       let expected = target
-      let explanation = branches[index]?.selection.kind === "update"
-        ? `update owner "${String(branches[index]?.selection.path)}"`
+      let explanation = transition.updates.length > 0
+        ? target === undefined
+          ? `update owner "${transition.updates.join("\", \"")}"`
+          : `target "${target}" and update owner "${transition.updates.join("\", \"")}"`
         : target === undefined
         ? "an unresolved targetless transition"
         : `target "${target}"`

--- a/src/testing/MachineTest.ts
+++ b/src/testing/MachineTest.ts
@@ -1109,7 +1109,7 @@ export const Invariant: {
  *   events: Machine.events(),
  *   initial: {
  *     target: (to) => to.Count(),
- *     resolve: ({ target }) => target(new Count({ value: 0 }))
+ *     resolve: ({ target }) => target.decoded(new Count({ value: 0 }))
  *   }
  * }).handle({ Count: {} })
  *
@@ -1444,14 +1444,14 @@ export type ExploreOptions<M extends AnyMachine, Key extends ExplorationKey = Ex
  *   events: Machine.events(Increment),
  *   initial: {
  *     target: (to) => to.Count(),
- *     resolve: ({ target }) => target(new Count({ value: 0 }))
+ *     resolve: ({ target }) => target.decoded(new Count({ value: 0 }))
  *   }
  * }).handle({
  *   Count: {
  *     on: {
  *       Increment: (to) =>
  *         to.full.Count().resolve(({ state, target }) =>
- *           target(new Count({ value: state.value + 1 })))
+ *           target.decoded(new Count({ value: state.value + 1 })))
  *     }
  *   }
  * })

--- a/src/unstable/reactivity/AtomMachine.ts
+++ b/src/unstable/reactivity/AtomMachine.ts
@@ -374,7 +374,7 @@ type ChildState<Child extends Machine.ChildMachine.Any> = RefState<Machine.Child
  *   events: Machine.events(),
  *   initial: {
  *     target: (to) => to.Count(),
- *     resolve: ({ target }) => target(new Count({ value: 0 }))
+ *     resolve: ({ target }) => target.decoded(new Count({ value: 0 }))
  *   }
  * }).handle({ Count: {} })
  * const machineAtom = AtomMachine.make(machine)

--- a/test/internal/machine/activities.test.ts
+++ b/test/internal/machine/activities.test.ts
@@ -18,7 +18,7 @@ const childMachine = Machine.make({
   id: "document-worker",
   states: childStates.states,
   events: Machine.events(),
-  initial: (to) => to.ChildIdle().resolve(({ target }) => target(new ChildIdle({})))
+  initial: (to) => to.ChildIdle().resolve(({ target }) => target.decoded(new ChildIdle({})))
 })
 const child = Machine.child("child", childMachine)
 
@@ -29,7 +29,7 @@ const activityMachine = Machine.make({
   id: "activity-inspection",
   states: activityStates.states,
   events: Machine.events(WorkSucceeded, WorkFailed, LoadTimedOut),
-  initial: (to) => to.Loading().resolve(({ target }) => target(new Loading({})))
+  initial: (to) => to.Loading().resolve(({ target }) => target.decoded(new Loading({})))
 }).handle({
   Loading: {
     invoke: (
@@ -168,7 +168,7 @@ describe("machine activity metadata", () => {
         const generated = Machine.make({
           states: activityStates.states,
           events: Machine.events(LoadTimedOut),
-          initial: (to) => to.Loading().resolve(({ target }) => target(new Loading({})))
+          initial: (to) => to.Loading().resolve(({ target }) => target.decoded(new Loading({})))
         }).handle({
           Loading: {
             invoke: (from) => from.timer(id, durationMillis).onDone((to) => to.none)

--- a/test/internal/machine/protocol.test.ts
+++ b/test/internal/machine/protocol.test.ts
@@ -41,7 +41,7 @@ describe("machine protocols", () => {
         states: states.states,
         events: Machine.events(PublicEvent),
         internalEvents: Machine.internalEvents(InternalEvent),
-        initial: (to) => to.ProtocolIdle().resolve(({ target }) => target(new ProtocolIdle({})))
+        initial: (to) => to.ProtocolIdle().resolve(({ target }) => target.decoded(new ProtocolIdle({})))
       }).handle({})
 
       assert.strictEqual(Object.hasOwn(machine, "eventSchemas"), false)

--- a/test/internal/machine/strategyDifferential.test.ts
+++ b/test/internal/machine/strategyDifferential.test.ts
@@ -35,15 +35,15 @@ const makeFlatMachine = () => {
   return Machine.make({
     states: states.states,
     events: Machine.events(Noop, Increment, Reenter, Finish),
-    initial: (to) => to.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+    initial: (to) => to.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
   }).handle({
     Count: {
       on: {
         Noop: (to) => to.none,
         Increment: (to) =>
-          to.full.Count().resolve(({ state, target }) => target(new Count({ value: state.value + 1 }))),
+          to.full.Count().resolve(({ state, target }) => target.decoded(new Count({ value: state.value + 1 }))),
         Reenter: (to) => to.none.resolve(() => undefined, { reenter: true }),
-        Finish: (to) => to.full.Done().resolve(({ state, target }) => target(new Done({ value: state.value })))
+        Finish: (to) => to.full.Done().resolve(({ state, target }) => target.decoded(new Done({ value: state.value })))
       }
     },
     Done: { output: ({ state }) => state.value }
@@ -64,7 +64,7 @@ describe("machine planner and runtime strategies", () => {
     const machine = Machine.make({
       states: states.states,
       events: Machine.events(Select),
-      initial: (to) => to.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+      initial: (to) => to.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
     }).handle({
       Count: {
         on: {
@@ -106,7 +106,7 @@ describe("machine planner and runtime strategies", () => {
     const machine = Machine.make({
       states: states.states,
       events: Machine.events(Select),
-      initial: (to) => to.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+      initial: (to) => to.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
     }).handle({
       Count: {
         on: {
@@ -114,7 +114,7 @@ describe("machine planner and runtime strategies", () => {
             to.full.Count().resolve(({ event, state, target, decline }) =>
               event.value < 0
                 ? decline()
-                : target(new Count({ value: state.value + event.value })), { declinable: true })
+                : target.decoded(new Count({ value: state.value + event.value })), { declinable: true })
         }
       }
     })
@@ -179,12 +179,12 @@ describe("machine planner and runtime strategies", () => {
       events: Machine.events(UpdateRegions, Compete, ExitRoot, ReenterUpdate),
       initial: (to) =>
         to.Root.initial.resolve(({ target }) =>
-          target(
+          target.decoded(
             new Root({ revision: 0 }),
             (root) =>
-              root.Work(new Work({}), (work) =>
-                work.Left(new Left({ value: 0 }), (left) => left.Leaf(new Leaf({})))
-                  .Right(new Right({ value: 0 }), (right) => right.Leaf(new Leaf({}))))
+              root.Work.decoded(new Work({}), (work) =>
+                work.Left.decoded(new Left({ value: 0 }), (left) => left.Leaf.decoded(new Leaf({})))
+                  .Right.decoded(new Right({ value: 0 }), (right) => right.Leaf.decoded(new Leaf({}))))
           )
         )
     }).handle({
@@ -197,14 +197,12 @@ describe("machine planner and runtime strategies", () => {
                   Leaf: {
                     on: {
                       UpdateRegions: (to) =>
-                        to.local.update(({ ancestors, target }) =>
-                          target(new Left({ value: ancestors["Root.Work.Left"].value + 1 }))
-                        ),
-                      Compete: (to) => to.branch.Root.update(({ target }) => target(new Root({ revision: 1 }))),
-                      ExitRoot: (to) => to.branch.Root.update(({ target }) => target(new Root({ revision: 3 }))),
+                        to.local.update(({ current, owner }) => owner.decoded(new Left({ value: current.value + 1 }))),
+                      Compete: (to) => to.branch.Root.update(({ owner }) => owner.decoded(new Root({ revision: 1 }))),
+                      ExitRoot: (to) => to.branch.Root.update(({ owner }) => owner.decoded(new Root({ revision: 3 }))),
                       ReenterUpdate: (to) =>
                         to.local.update(
-                          ({ ancestors, target }) => target(new Left({ value: ancestors["Root.Work.Left"].value + 1 })),
+                          ({ current, owner }) => owner.decoded(new Left({ value: current.value + 1 })),
                           { reenter: true }
                         )
                     }
@@ -216,11 +214,9 @@ describe("machine planner and runtime strategies", () => {
                   Leaf: {
                     on: {
                       UpdateRegions: (to) =>
-                        to.local.update(({ ancestors, target }) =>
-                          target(new Right({ value: ancestors["Root.Work.Right"].value + 2 }))
-                        ),
-                      Compete: (to) => to.branch.Root.update(({ target }) => target(new Root({ revision: 2 }))),
-                      ExitRoot: (to) => to.full.Outside().resolve(({ target }) => target(new Outside({})))
+                        to.local.update(({ current, owner }) => owner.decoded(new Right({ value: current.value + 2 }))),
+                      Compete: (to) => to.branch.Root.update(({ owner }) => owner.decoded(new Root({ revision: 2 }))),
+                      ExitRoot: (to) => to.full.Outside().resolve(({ target }) => target.decoded(new Outside({})))
                     }
                   }
                 }
@@ -255,6 +251,59 @@ describe("machine planner and runtime strategies", () => {
 
       const exited = yield* Machine.plan(machine, competed.next, new ExitRoot({}))
       assert.strictEqual(exited.next.path, "Outside")
+    })
+  })
+
+  it.effect("matches generic and indexed planning for a topology target with a retained owner update", () => {
+    class Ready extends Schema.TaggedClass<Ready>("StrategyCombinedReady")("Ready", {
+      revision: Schema.Number
+    }) {}
+    class Idle extends Schema.TaggedClass<Idle>("StrategyCombinedIdle")("Idle", {}) {}
+    class Saving extends Schema.TaggedClass<Saving>("StrategyCombinedSaving")("Saving", {
+      request: Schema.String
+    }) {}
+    class Save extends Schema.TaggedClass<Save>("StrategyCombinedSave")("Save", {
+      request: Schema.String
+    }) {}
+    const states = Machine.states({
+      Ready: {
+        schema: Ready,
+        initial: "Idle",
+        states: { Idle, Saving }
+      }
+    })
+    const machine = Machine.make({
+      states: states.states,
+      events: Machine.events(Save),
+      initial: (to) =>
+        to.Ready.initial.resolve(({ target }) =>
+          target.decoded(new Ready({ revision: 0 }), (ready) => ready.Idle.decoded(new Idle({})))
+        )
+    }).handle({
+      Ready: {
+        states: {
+          Idle: {
+            on: {
+              Save: (to) =>
+                to.local.Saving()
+                  .updating(to.branch.Ready)
+                  .resolve(({ current, event, owner, target }) =>
+                    target.decoded(new Saving({ request: event.request })).update(
+                      owner.decoded(new Ready({ revision: current.revision + 1 }))
+                    )
+                  )
+            }
+          },
+          Saving: {}
+        }
+      }
+    })
+
+    return verifyPlannerStrategies({
+      machine,
+      events: [new Save({ request: "plan" })],
+      expected: "indexed-hierarchical",
+      label: "combined retained owner update"
     })
   })
 
@@ -295,9 +344,9 @@ describe("machine planner and runtime strategies", () => {
         events: Machine.events(Advance),
         initial: (to) =>
           to.Root.initial.resolve(({ target }) =>
-            target(
+            target.decoded(
               new Root({}),
-              (root) => root.Left(new Left({ value: 0 })).Right(new Right({ value: 0 }))
+              (root) => root.Left.decoded(new Left({ value: 0 })).Right.decoded(new Right({ value: 0 }))
             )
           )
       }).handle({
@@ -306,13 +355,17 @@ describe("machine planner and runtime strategies", () => {
             Left: {
               on: {
                 Advance: (to) =>
-                  to.branch.Root.Left().resolve(({ state, target }) => target(new Left({ value: state.value + 1 })))
+                  to.branch.Root.Left().resolve(({ state, target }) =>
+                    target.decoded(new Left({ value: state.value + 1 }))
+                  )
               }
             },
             Right: {
               on: {
                 Advance: (to) =>
-                  to.branch.Root.Right().resolve(({ state, target }) => target(new Right({ value: state.value + 10 })))
+                  to.branch.Root.Right().resolve(({ state, target }) =>
+                    target.decoded(new Right({ value: state.value + 10 }))
+                  )
               }
             }
           }
@@ -344,11 +397,11 @@ describe("machine planner and runtime strategies", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Enter),
-        initial: (to) => to.Outside().resolve(({ target }) => target(new Outside({})))
+        initial: (to) => to.Outside().resolve(({ target }) => target.decoded(new Outside({})))
       }).handle({
         Outside: {
           on: {
-            Enter: (to) => to.full.Opened.initial.resolve(({ target }) => target(new Opened({})))
+            Enter: (to) => to.full.Opened.initial.resolve(({ target }) => target.decoded(new Opened({})))
           }
         },
         Opened: {
@@ -424,10 +477,10 @@ describe("machine planner and runtime strategies", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
       }).handle({
         Idle: {
-          always: (to) => to.full.Ready().resolve(({ target }) => target(new Ready({})))
+          always: (to) => to.full.Ready().resolve(({ target }) => target.decoded(new Ready({})))
         },
         Ready: {}
       })
@@ -481,7 +534,7 @@ describe("machine planner and runtime strategies", () => {
         events: Machine.events(),
         input: Input,
         initial: (to) =>
-          to.Complete().resolve(({ input: input, target }) => target(new Complete({ value: input.value })))
+          to.Complete().resolve(({ input: input, target }) => target.decoded(new Complete({ value: input.value })))
       }).handle({
         Complete: { output: ({ state }) => state.value }
       })
@@ -549,7 +602,7 @@ describe("machine planner and runtime strategies", () => {
                 seen.push(element)
               })
             ).onDone((to) =>
-              to.full.StreamDone().resolve(({ target }) => target(new StreamDone({ values: [...seen] })))
+              to.full.StreamDone().resolve(({ target }) => target.decoded(new StreamDone({ values: [...seen] })))
             )
         },
         StreamDone: { output: ({ state }) => state.values }
@@ -570,14 +623,14 @@ describe("machine planner and runtime strategies", () => {
       const definition = Machine.make({
         states: states.states,
         events: Machine.events(Event),
-        initial: (to) => to.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+        initial: (to) => to.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
       })
       const events = definition.events
       const machine = definition.handle({
         Count: {
           on: {
             Set: (to) =>
-              to.full.Count().resolve(({ event, target }) => target(new Count({ value: event.value.length })))
+              to.full.Count().resolve(({ event, target }) => target.decoded(new Count({ value: event.value.length })))
           }
         }
       })
@@ -621,7 +674,7 @@ describe("machine planner and runtime strategies", () => {
         states: states.states,
         events: Events,
         emittedEvents: Emissions,
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
       }).handle({
         Idle: {
           on: {
@@ -667,7 +720,7 @@ describe("machine planner and runtime strategies", () => {
         states: states.states,
         events: Machine.events(),
         emittedEvents: Emissions,
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
       }).handle({
         Idle: {
           entry: (_, enqueue) => {
@@ -793,17 +846,17 @@ describe("machine planner and runtime strategies", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Load, Loaded),
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
       }).handle({
         Idle: {
           on: {
-            Load: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({})))
+            Load: (to) => to.full.Loading().resolve(({ target }) => target.decoded(new Loading({})))
           }
         },
         Loading: {
           invoke: (from) =>
             from.effect("load", () => Effect.succeed(new Loaded({ value: "complete" }))).onDone((to) =>
-              to.full.Success().resolve(({ output, target }) => target(new Success({ value: output.value })))
+              to.full.Success().resolve(({ output, target }) => target.decoded(new Success({ value: output.value })))
             )
         },
         Success: { output: ({ state }) => state.value }
@@ -839,12 +892,12 @@ describe("machine planner and runtime strategies", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: (to) => to.Loading().resolve(({ target }) => target(new Loading({})))
+        initial: (to) => to.Loading().resolve(({ target }) => target.decoded(new Loading({})))
       }).handle({
         Loading: {
           invoke: (from) =>
             from.effect("load", () => Effect.fail("unavailable")).onFailure((to) =>
-              to.full.Failed().resolve(({ error, target }) => target(new Failed({ error })))
+              to.full.Failed().resolve(({ error, target }) => target.decoded(new Failed({ error })))
             )
         },
         Failed: { output: ({ state }) => state.error }
@@ -879,7 +932,7 @@ describe("machine planner and runtime strategies", () => {
         states: childStates.states,
         events: Machine.events(),
         parent: Machine.parent(ParentEvents),
-        initial: (to) => to.ChildIdle().resolve(({ target }) => target(new ChildIdle({})))
+        initial: (to) => to.ChildIdle().resolve(({ target }) => target.decoded(new ChildIdle({})))
       }).handle({
         ChildIdle: {
           invoke: (from) =>
@@ -895,12 +948,12 @@ describe("machine planner and runtime strategies", () => {
       const parentMachine = Machine.make({
         states: parentStates.states,
         events: ParentEvents,
-        initial: (to) => to.ParentWaiting().resolve(({ target }) => target(new ParentWaiting({})))
+        initial: (to) => to.ParentWaiting().resolve(({ target }) => target.decoded(new ParentWaiting({})))
       }).handle({
         ParentWaiting: {
           invoke: (from) => from.child(Child).onFailure((to) => to.none),
           on: {
-            ChildReady: (to) => to.full.ParentDone().resolve(({ target }) => target(new ParentDone({})))
+            ChildReady: (to) => to.full.ParentDone().resolve(({ target }) => target.decoded(new ParentDone({})))
           }
         },
         ParentDone: { output: () => "received" }
@@ -930,7 +983,7 @@ describe("machine planner and runtime strategies", () => {
         const definition = Machine.make({
           states: states.states,
           events: Machine.events(Reenter, Stale),
-          initial: (to) => to.Loading().resolve(({ target }) => target(new Loading({ epoch: 0 })))
+          initial: (to) => to.Loading().resolve(({ target }) => target.decoded(new Loading({ epoch: 0 })))
         })
         const machine = definition.handle({
           Loading: {
@@ -961,16 +1014,19 @@ describe("machine planner and runtime strategies", () => {
                   unchanged: { target: to.none }
                 }).resolve(({ snapshot, select }) =>
                   snapshot.state === "stale"
-                    ? select.stale(new Failed({}))
+                    ? select.stale.decoded(new Failed({}))
                     : select.unchanged()
                 )
               ),
             on: {
               Reenter: (to) =>
-                to.full.Loading().resolve(({ state, target }) => target(new Loading({ epoch: state.epoch + 1 })), {
-                  reenter: true
-                }),
-              Stale: (to) => to.full.Failed().resolve(({ target }) => target(new Failed({})))
+                to.full.Loading().resolve(
+                  ({ state, target }) => target.decoded(new Loading({ epoch: state.epoch + 1 })),
+                  {
+                    reenter: true
+                  }
+                ),
+              Stale: (to) => to.full.Failed().resolve(({ target }) => target.decoded(new Failed({})))
             }
           },
           Failed: {}
@@ -1007,7 +1063,7 @@ describe("machine planner and runtime strategies", () => {
       const childMachine = Machine.make({
         states: { ChildIdle },
         events: Machine.events(),
-        initial: (to) => to.ChildIdle().resolve(({ target }) => target(new ChildIdle({})))
+        initial: (to) => to.ChildIdle().resolve(({ target }) => target.decoded(new ChildIdle({})))
       }).handle({ ChildIdle: {} })
       const Child = Machine.childFamily(childMachine)
       class Commissioning extends Schema.TaggedClass<Commissioning>("StrategyDynamicCommissioning")(
@@ -1018,7 +1074,7 @@ describe("machine planner and runtime strategies", () => {
       const machine = Machine.make({
         states: { Commissioning, Operating },
         events: Machine.events(),
-        initial: (to) => to.Commissioning().resolve(({ target }) => target(new Commissioning({})))
+        initial: (to) => to.Commissioning().resolve(({ target }) => target.decoded(new Commissioning({})))
       }).handle({
         Commissioning: {
           invoke: (from) =>

--- a/test/machine/ActivityLifecycleModel.test.ts
+++ b/test/machine/ActivityLifecycleModel.test.ts
@@ -73,11 +73,11 @@ describe("machine activity lifecycle model", () => {
             const machine = Machine.make({
               states: states.states,
               events: Machine.events(Enter, Leave, Restart),
-              initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+              initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
             }).handle({
               Idle: {
                 on: {
-                  Enter: (to) => to.full.Active().resolve(({ target }) => target(new Active({})))
+                  Enter: (to) => to.full.Active().resolve(({ target }) => target.decoded(new Active({})))
                 }
               },
               Active: {
@@ -87,8 +87,9 @@ describe("machine activity lifecycle model", () => {
                     logic: probe.logic("active", { _tag: "Blocked" })
                   }).onDone((to) => to.none).onFailure((to) => to.none),
                 on: {
-                  Leave: (to) => to.full.Idle().resolve(({ target }) => target(new Idle({}))),
-                  Restart: (to) => to.full.Active().resolve(({ target }) => target(new Active({})), { reenter: true })
+                  Leave: (to) => to.full.Idle().resolve(({ target }) => target.decoded(new Idle({}))),
+                  Restart: (to) =>
+                    to.full.Active().resolve(({ target }) => target.decoded(new Active({})), { reenter: true })
                 }
               }
             })
@@ -143,14 +144,16 @@ describe("machine activity lifecycle model", () => {
         states: states.states,
         events: Machine.events(),
         internalEvents: Machine.internalEvents(Completed),
-        initial: (to) => to.Active().resolve(({ target }) => target(new Active({})))
+        initial: (to) => to.Active().resolve(({ target }) => target.decoded(new Active({})))
       }).handle({
         Active: {
           invoke: (from) =>
             from.logic("immediate", {
               address: Machine.childAddress("immediate"),
               logic: probe.immediate("immediate", (epoch) => new Completed({ epoch }))
-            }).onDone((to) => to.full.Done().resolve(({ output, target }) => target(new Done({ epoch: output.epoch }))))
+            }).onDone((to) =>
+              to.full.Done().resolve(({ output, target }) => target.decoded(new Done({ epoch: output.epoch })))
+            )
               .onFailure((to) => to.none)
         },
         Done: {
@@ -178,7 +181,7 @@ describe("machine activity lifecycle model", () => {
         states: states.states,
         events: Machine.events(Restart, QueueBarrier),
         internalEvents: Machine.internalEvents(Completed),
-        initial: (to) => to.Active().resolve(({ target }) => target(new EpochActive({ acknowledged: 0 })))
+        initial: (to) => to.Active().resolve(({ target }) => target.decoded(new EpochActive({ acknowledged: 0 })))
       }).handle({
         Active: {
           invoke: (from) =>
@@ -192,14 +195,15 @@ describe("machine activity lifecycle model", () => {
           on: {
             Restart: (to) =>
               to.full.Active().resolve(
-                ({ state, target }) => target(new EpochActive({ acknowledged: state.acknowledged })),
+                ({ state, target }) => target.decoded(new EpochActive({ acknowledged: state.acknowledged })),
                 { reenter: true }
               ),
             QueueBarrier: (to) =>
               to.full.Active().resolve(({ state, target }) =>
-                target(new EpochActive({ acknowledged: state.acknowledged + 1 }))
+                target.decoded(new EpochActive({ acknowledged: state.acknowledged + 1 }))
               ),
-            Completed: (to) => to.full.Done().resolve(({ event, target }) => target(new Done({ epoch: event.epoch })))
+            Completed: (to) =>
+              to.full.Done().resolve(({ event, target }) => target.decoded(new Done({ epoch: event.epoch })))
           }
         },
         Done: {}
@@ -304,7 +308,7 @@ describe("machine activity lifecycle model", () => {
                       logic: probe.logic("left", { _tag: "Blocked" })
                     }).onDone((to) => to.none).onFailure((to) => to.none),
                   on: {
-                    LeaveLeft: (to) => to.local.idle().resolve(({ target }) => target(new LeftIdle({})))
+                    LeaveLeft: (to) => to.local.idle().resolve(({ target }) => target.decoded(new LeftIdle({})))
                   }
                 }
               }
@@ -355,7 +359,7 @@ describe("machine activity lifecycle model", () => {
         states: states.states,
         events: Machine.events(Leave),
         internalEvents: Machine.internalEvents(TimerFired),
-        initial: (to) => to.Active().resolve(({ target }) => target(new Active({})))
+        initial: (to) => to.Active().resolve(({ target }) => target.decoded(new Active({})))
       }).handle({
         Idle: {},
         Active: {
@@ -367,11 +371,11 @@ describe("machine activity lifecycle model", () => {
               logic: probe.logic("timed", { _tag: "Blocked" })
             }).onDone((to) => to.none).onFailure((to) => to.none),
             from.timer("deadline", "1 hour").onDone((to) =>
-              to.full.Done().resolve(({ target }) => target(new Done({ epoch: -1 })))
+              to.full.Done().resolve(({ target }) => target.decoded(new Done({ epoch: -1 })))
             )
           ],
           on: {
-            Leave: (to) => to.full.Idle().resolve(({ target }) => target(new Idle({})))
+            Leave: (to) => to.full.Idle().resolve(({ target }) => target.decoded(new Idle({})))
           }
         },
         Done: {}
@@ -398,7 +402,7 @@ describe("machine activity lifecycle model", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: (to) => to.Active().resolve(({ target }) => target(new Active({})))
+        initial: (to) => to.Active().resolve(({ target }) => target.decoded(new Active({})))
       }).handle({
         Active: {
           invoke: (
@@ -444,7 +448,7 @@ describe("machine activity lifecycle model", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: (to) => to.Active().resolve(({ target }) => target(new Active({})))
+        initial: (to) => to.Active().resolve(({ target }) => target.decoded(new Active({})))
       }).handle({
         Active: {
           invoke: (

--- a/test/machine/Annotations.test.ts
+++ b/test/machine/Annotations.test.ts
@@ -48,7 +48,9 @@ const machine = Machine.make({
   states: States.states,
   events: Machine.events(),
   initial: (to) =>
-    to.Workflow.initial.resolve(({ target }) => target(new Workflow({}), (workflow) => workflow.Idle(new Idle({}))))
+    to.Workflow.initial.resolve(({ target }) =>
+      target.decoded(new Workflow({}), (workflow) => workflow.Idle.decoded(new Idle({})))
+    )
 })
 
 describe("Machine state annotations", () => {

--- a/test/machine/AnnotationsVisualization.test.ts
+++ b/test/machine/AnnotationsVisualization.test.ts
@@ -35,7 +35,9 @@ const machine = Machine.make({
   states: States.states,
   events: Machine.events(),
   initial: (to) =>
-    to.Workflow.initial.resolve(({ target }) => target(new Workflow({}), (workflow) => workflow.Idle(new Idle({}))))
+    to.Workflow.initial.resolve(({ target }) =>
+      target.decoded(new Workflow({}), (workflow) => workflow.Idle.decoded(new Idle({})))
+    )
 })
 
 const renderMachine = makeTextRenderer<

--- a/test/machine/Choice.test.ts
+++ b/test/machine/Choice.test.ts
@@ -25,7 +25,8 @@ let branchFactoryCalls = 0
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(Recheck),
-  initial: (to) => to.Flow.initial.resolve(({ target }) => target(new Flow({ score: 80 }), (flow) => flow.Routing()))
+  initial: (to) =>
+    to.Flow.initial.resolve(({ target }) => target.decoded(new Flow({ score: 80 }), (flow) => flow.Routing()))
 }).handle({
   Flow: {
     states: {
@@ -41,21 +42,21 @@ const machine = Machine.make({
           }).resolve(({ containingState, select }) => {
             const score = containingState.score
             return score === 100
-              ? select.perfect(new Approved({}))
+              ? select.perfect.decoded(new Approved({}))
               : score < 0
-              ? select.negative(new Rejected({}))
+              ? select.negative.decoded(new Rejected({}))
               : score === 0
-              ? select.zero(new Rejected({}))
+              ? select.zero.decoded(new Rejected({}))
               : score >= 70
-              ? select.passing(new Approved({}))
-              : select.failing(new Rejected({}))
+              ? select.passing.decoded(new Approved({}))
+              : select.failing.decoded(new Rejected({}))
           })
         }
       },
       Approved: {
         on: {
           Recheck: (to) =>
-            to.branch.Flow.initial.resolve(({ event, target }) => target(new Flow({ score: event.score })))
+            to.branch.Flow.initial.resolve(({ event, target }) => target.decoded(new Flow({ score: event.score })))
         }
       }
     }
@@ -84,35 +85,40 @@ describe("Machine choice pseudo-states", () => {
           key: "perfect",
           title: "Score is perfect",
           target: "Flow.Approved",
-          selection: { path: "Flow.Approved", kind: "state", scope: "local" }
+          selection: { path: "Flow.Approved", kind: "state", scope: "local" },
+          updates: []
         },
         {
           type: "branch",
           key: "negative",
           title: "Score is negative",
           target: "Flow.Rejected",
-          selection: { path: "Flow.Rejected", kind: "state", scope: "local" }
+          selection: { path: "Flow.Rejected", kind: "state", scope: "local" },
+          updates: []
         },
         {
           type: "branch",
           key: "zero",
           title: "Score is zero",
           target: "Flow.Rejected",
-          selection: { path: "Flow.Rejected", kind: "state", scope: "local" }
+          selection: { path: "Flow.Rejected", kind: "state", scope: "local" },
+          updates: []
         },
         {
           type: "branch",
           key: "passing",
           title: "Score is at least 70",
           target: "Flow.Approved",
-          selection: { path: "Flow.Approved", kind: "state", scope: "local" }
+          selection: { path: "Flow.Approved", kind: "state", scope: "local" },
+          updates: []
         },
         {
           type: "branch",
           key: "failing",
           title: "failing",
           target: "Flow.Rejected",
-          selection: { path: "Flow.Rejected", kind: "state", scope: "local" }
+          selection: { path: "Flow.Rejected", kind: "state", scope: "local" },
+          updates: []
         }
       ])
       assert.deepStrictEqual(Machine.stateNodes(machine).map(({ path, type }) => ({ path, type })), [
@@ -152,7 +158,7 @@ describe("Machine choice pseudo-states", () => {
         states: states.states,
         events: Machine.events(),
         initial: (to) =>
-          to.Flow.initial.resolve(({ target }) => target(new Flow({ score: 80 }), (flow) => flow.First()))
+          to.Flow.initial.resolve(({ target }) => target.decoded(new Flow({ score: 80 }), (flow) => flow.First()))
       }).handle({
         Flow: {
           states: {
@@ -160,7 +166,7 @@ describe("Machine choice pseudo-states", () => {
               choice: (to) => to.local.Second().resolve(({ target }) => target())
             },
             Second: {
-              choice: (to) => to.local.Approved().resolve(({ target }) => target(new Approved({})))
+              choice: (to) => to.local.Approved().resolve(({ target }) => target.decoded(new Approved({})))
             }
           }
         }
@@ -200,7 +206,7 @@ describe("Machine choice pseudo-states", () => {
         states: states.states,
         events: Machine.events(),
         initial: (to) =>
-          to.Flow.initial.resolve(({ target }) => target(new Flow({ score: 80 }), (flow) => flow.First()))
+          to.Flow.initial.resolve(({ target }) => target.decoded(new Flow({ score: 80 }), (flow) => flow.First()))
       }).handle({
         Flow: {
           states: {
@@ -238,9 +244,9 @@ describe("Machine choice pseudo-states", () => {
         events: Machine.events(),
         initial: (to) =>
           to.Flow.initial.resolve(({ target }) =>
-            target(
+            target.decoded(
               new Flow({ score: 10 }),
-              (flow) => flow.Approved(new Approved({}))
+              (flow) => flow.Approved.decoded(new Approved({}))
             )
           )
       }).handle({
@@ -250,7 +256,7 @@ describe("Machine choice pseudo-states", () => {
               always: (to) => to.local.Routing().resolve(({ target }) => target())
             },
             Routing: {
-              choice: (to) => to.local.Rejected().resolve(({ target }) => target(new Rejected({})))
+              choice: (to) => to.local.Rejected().resolve(({ target }) => target.decoded(new Rejected({})))
             }
           }
         }
@@ -294,13 +300,16 @@ describe("Machine choice pseudo-states", () => {
         states: states.states,
         events: Machine.events(),
         initial: (to) =>
-          to.Flow.initial.resolve(({ target }) => target(new Flow({ score: 0 }), (flow) => flow.Done(new Done({}))))
+          to.Flow.initial.resolve(({ target }) =>
+            target.decoded(new Flow({ score: 0 }), (flow) => flow.Done.decoded(new Done({})))
+          )
       }).handle({
         Flow: {
-          onDone: (to) => to.full.Flow().resolve(({ state, target }) => target(state, (flow) => flow.Routing())),
+          onDone: (to) =>
+            to.full.Flow().resolve(({ state, target }) => target.decoded(state, (flow) => flow.Routing())),
           states: {
             Routing: {
-              choice: (to) => to.local.Rejected().resolve(({ target }) => target(new Rejected({})))
+              choice: (to) => to.local.Rejected().resolve(({ target }) => target.decoded(new Rejected({})))
             }
           }
         }
@@ -353,12 +362,12 @@ describe("Machine choice pseudo-states", () => {
         events: Machine.events(),
         initial: (to) =>
           to.Board.initial.resolve(({ target }) =>
-            target(
+            target.decoded(
               new Board({}),
               (board) =>
                 board
-                  .Left(new Left({}), (left) => left.Routing())
-                  .Right(new Right({}), (right) => right.Routing())
+                  .Left.decoded(new Left({}), (left) => left.Routing())
+                  .Right.decoded(new Right({}), (right) => right.Routing())
             )
           )
       }).handle({
@@ -367,14 +376,14 @@ describe("Machine choice pseudo-states", () => {
             Left: {
               states: {
                 Routing: {
-                  choice: (to) => to.local.Ready().resolve(({ target }) => target(new Ready({})))
+                  choice: (to) => to.local.Ready().resolve(({ target }) => target.decoded(new Ready({})))
                 }
               }
             },
             Right: {
               states: {
                 Routing: {
-                  choice: (to) => to.local.Ready().resolve(({ target }) => target(new RightReady({})))
+                  choice: (to) => to.local.Ready().resolve(({ target }) => target.decoded(new RightReady({})))
                 }
               }
             }
@@ -414,18 +423,21 @@ describe("Machine choice pseudo-states", () => {
         states: states.states,
         events: Machine.events(Leave, Resume),
         initial: (to) =>
-          to.Flow.initial.resolve(({ target }) => target(new Flow({ score: 1 }), (flow) => flow.Active(new Active({}))))
+          to.Flow.initial.resolve(({ target }) =>
+            target.decoded(new Flow({ score: 1 }), (flow) => flow.Active.decoded(new Active({})))
+          )
       }).handle({
         Flow: {
           history: {
             Recent: {
-              default: ({ target }) => target.Flow(new Flow({ score: 0 }), (flow) => flow.Active(new Active({})))
+              default: ({ target }) =>
+                target.Flow.decoded(new Flow({ score: 0 }), (flow) => flow.Active.decoded(new Active({})))
             }
           },
           states: {
             Active: {
               on: {
-                Leave: (to) => to.full.Outside().resolve(({ target }) => target(new Outside({})))
+                Leave: (to) => to.full.Outside().resolve(({ target }) => target.decoded(new Outside({})))
               }
             },
             Routing: {
@@ -436,7 +448,7 @@ describe("Machine choice pseudo-states", () => {
         Outside: {
           on: {
             Resume: (to) =>
-              to.full.Flow().resolve(({ target }) => target(new Flow({ score: 2 }), (flow) => flow.Routing()))
+              to.full.Flow().resolve(({ target }) => target.decoded(new Flow({ score: 2 }), (flow) => flow.Routing()))
           }
         }
       })
@@ -469,7 +481,7 @@ describe("Machine choice pseudo-states", () => {
         states: states.states,
         events: Machine.events(),
         initial: (to) =>
-          to.Flow.initial.resolve(({ target }) => target(new Flow({ score: 1 }), (flow) => flow.Routing()))
+          to.Flow.initial.resolve(({ target }) => target.decoded(new Flow({ score: 1 }), (flow) => flow.Routing()))
       }).handle({
         Flow: {
           history: {
@@ -515,17 +527,17 @@ describe("Machine choice pseudo-states", () => {
       const historyChoice = Machine.make({
         states: states.states,
         events: Machine.events(Resume),
-        initial: (to) => to.Outside().resolve(({ target }) => target(new Outside({})))
+        initial: (to) => to.Outside().resolve(({ target }) => target.decoded(new Outside({})))
       }).handle({
         Flow: {
           history: {
             Recent: {
-              default: ({ target }) => target.Flow(new Flow({ score: 1 }), (flow) => flow.Routing())
+              default: ({ target }) => target.Flow.decoded(new Flow({ score: 1 }), (flow) => flow.Routing())
             }
           },
           states: {
             Routing: {
-              choice: (to) => to.local.Active().resolve(({ target }) => target(new Active({})))
+              choice: (to) => to.local.Active().resolve(({ target }) => target.decoded(new Active({})))
             }
           }
         },
@@ -572,35 +584,40 @@ describe("Machine choice pseudo-states", () => {
             key: "perfect",
             title: "Score is perfect",
             target: "Flow.Approved",
-            selection: { path: "Flow.Approved", kind: "state", scope: "local" }
+            selection: { path: "Flow.Approved", kind: "state", scope: "local" },
+            updates: []
           },
           {
             type: "branch",
             key: "negative",
             title: "Score is negative",
             target: "Flow.Rejected",
-            selection: { path: "Flow.Rejected", kind: "state", scope: "local" }
+            selection: { path: "Flow.Rejected", kind: "state", scope: "local" },
+            updates: []
           },
           {
             type: "branch",
             key: "zero",
             title: "Score is zero",
             target: "Flow.Rejected",
-            selection: { path: "Flow.Rejected", kind: "state", scope: "local" }
+            selection: { path: "Flow.Rejected", kind: "state", scope: "local" },
+            updates: []
           },
           {
             type: "branch",
             key: "passing",
             title: "Score is at least 70",
             target: "Flow.Approved",
-            selection: { path: "Flow.Approved", kind: "state", scope: "local" }
+            selection: { path: "Flow.Approved", kind: "state", scope: "local" },
+            updates: []
           },
           {
             type: "branch",
             key: "failing",
             title: "failing",
             target: "Flow.Rejected",
-            selection: { path: "Flow.Rejected", kind: "state", scope: "local" }
+            selection: { path: "Flow.Rejected", kind: "state", scope: "local" },
+            updates: []
           }
         ]
       }

--- a/test/machine/DeepHandlers.test.ts
+++ b/test/machine/DeepHandlers.test.ts
@@ -135,7 +135,7 @@ const machine = Machine.make({
                                                     on: {
                                                       Advance: (to) =>
                                                         to.local.done().resolve(({ event, target }) =>
-                                                          target(new DeepDone({ value: event.value }))
+                                                          target.decoded(new DeepDone({ value: event.value }))
                                                         )
                                                     }
                                                   },

--- a/test/machine/DynamicChildren.test.ts
+++ b/test/machine/DynamicChildren.test.ts
@@ -37,14 +37,14 @@ describe("dynamic child machines", () => {
         parent: Machine.parent(PlantOwnerEvents),
         initial: (to) =>
           to.PlantActive().resolve(({ input, target }) =>
-            target(new PlantActive({ id: input.id, produced: input.production }))
+            target.decoded(new PlantActive({ id: input.id, produced: input.production }))
           )
       }).handle({
         PlantActive: {
           on: {
             Produce: (to) =>
               to.full.PlantActive().resolve(({ event, state, target }) =>
-                target(new PlantActive({ ...state, produced: state.produced + event.amount }))
+                target.decoded(new PlantActive({ ...state, produced: state.produced + event.amount }))
               ),
             Report: (to) =>
               to.none.resolve(({ parent, state }, enqueue) => {
@@ -73,7 +73,8 @@ describe("dynamic child machines", () => {
         states: parentStates.states,
         events: Machine.events(PlantOwnerEvents, Grow, Decommission),
         input: Schema.Array(PlantInput),
-        initial: (to) => to.Commissioning().resolve(({ input, target }) => target(new Commissioning({ plants: input })))
+        initial: (to) =>
+          to.Commissioning().resolve(({ input, target }) => target.decoded(new Commissioning({ plants: input })))
       }).handle({
         Commissioning: {
           invoke: (from) =>
@@ -82,16 +83,20 @@ describe("dynamic child machines", () => {
                 state.plants,
                 (input) => children.spawn(Plant(input.id), { input }),
                 { discard: true }
-              )).onDone((to) => to.full.Operating().resolve(({ target }) => target(new Operating({ reports: 0 }))))
+              )).onDone((to) =>
+                to.full.Operating().resolve(({ target }) => target.decoded(new Operating({ reports: 0 })))
+              )
               .onFailure((to) => to.none)
         },
         Operating: {
           on: {
             PlantReported: (to) =>
-              to.full.Operating().resolve(({ state, target }) => target(new Operating({ reports: state.reports + 1 }))),
+              to.full.Operating().resolve(({ state, target }) =>
+                target.decoded(new Operating({ reports: state.reports + 1 }))
+              ),
             Grow: (to) =>
               to.full.Commissioning().resolve(({ event, target }) =>
-                target(new Commissioning({ plants: event.plants }))
+                target.decoded(new Commissioning({ plants: event.plants }))
               ),
             Decommission: (to) =>
               to.none.resolve(({ event }, enqueue) => {
@@ -198,7 +203,7 @@ describe("dynamic child machines", () => {
       const childMachine = Machine.make({
         states: { ChildIdle },
         events: Machine.events(),
-        initial: (to) => to.ChildIdle().resolve(({ target }) => target(new ChildIdle({})))
+        initial: (to) => to.ChildIdle().resolve(({ target }) => target.decoded(new ChildIdle({})))
       }).handle({ ChildIdle: {} })
       const Child = Machine.childFamily(childMachine)
       class Starting extends Schema.TaggedClass<Starting>("DynamicDuplicateStarting")("Starting", {}) {}
@@ -209,7 +214,7 @@ describe("dynamic child machines", () => {
       const parentMachine = Machine.make({
         states: { Starting, DuplicateRejected },
         events: Machine.events(),
-        initial: (to) => to.Starting().resolve(({ target }) => target(new Starting({})))
+        initial: (to) => to.Starting().resolve(({ target }) => target.decoded(new Starting({})))
       }).handle({
         Starting: {
           invoke: (from) =>
@@ -238,7 +243,8 @@ describe("dynamic child machines", () => {
         states: { WorkerIdle },
         events: Machine.events(),
         input: Input,
-        initial: (to) => to.WorkerIdle().resolve(({ input, target }) => target(new WorkerIdle({ id: input.id })))
+        initial: (to) =>
+          to.WorkerIdle().resolve(({ input, target }) => target.decoded(new WorkerIdle({ id: input.id })))
       }).handle({ WorkerIdle: {} })
       const Worker = Machine.childFamily(workerMachine)
       let scoped: Machine.ChildMachine.Ref<ReturnType<typeof Worker>> | undefined
@@ -264,7 +270,7 @@ describe("dynamic child machines", () => {
       const parentMachine = Machine.make({
         states: { Running },
         events: Machine.events(),
-        initial: (to) => to.Running().resolve(({ target }) => target(new Running({})))
+        initial: (to) => to.Running().resolve(({ target }) => target.decoded(new Running({})))
       }).handle({
         Running: {
           invoke: (from) => from.logic("supervisor", { address: Supervisor, logic: supervisorLogic })
@@ -297,12 +303,14 @@ describe("dynamic child machines", () => {
       const unitMachine = Machine.make({
         states: { UnitActive },
         events: Machine.events(Increment),
-        initial: (to) => to.UnitActive().resolve(({ target }) => target(new UnitActive({ count: 0 })))
+        initial: (to) => to.UnitActive().resolve(({ target }) => target.decoded(new UnitActive({ count: 0 })))
       }).handle({
         UnitActive: {
           on: {
             Increment: (to) =>
-              to.full.UnitActive().resolve(({ state, target }) => target(new UnitActive({ count: state.count + 1 })))
+              to.full.UnitActive().resolve(({ state, target }) =>
+                target.decoded(new UnitActive({ count: state.count + 1 }))
+              )
           }
         }
       })
@@ -312,7 +320,7 @@ describe("dynamic child machines", () => {
       const parentMachine = Machine.make({
         states: { Managing, Ready },
         events: Machine.events(),
-        initial: (to) => to.Managing().resolve(({ target }) => target(new Managing({})))
+        initial: (to) => to.Managing().resolve(({ target }) => target.decoded(new Managing({})))
       }).handle({
         Managing: {
           invoke: (from) =>

--- a/test/machine/History.test.ts
+++ b/test/machine/History.test.ts
@@ -127,9 +127,9 @@ const makeCheckoutMachine = (
     initial: ((to: any) =>
       initial.path === "checkout"
         ? to.checkout.initial.resolve(({ target }: any) =>
-          target(
+          target.decoded(
             new Checkout({ orderId: "initial" }),
-            (checkout: any) => checkout.shipping(new Shipping({ address: "initial" }))
+            (checkout: any) => checkout.shipping.decoded(new Shipping({ address: "initial" }))
           )
         )
         : to.support().resolve(() => initial)) as any
@@ -156,9 +156,9 @@ const makeCheckoutMachine = (
         }
       },
       on: {
-        Leave: (to) => to.full.support().resolve(({ target }) => target(new Support({ ticket: "ticket-1" }))),
+        Leave: (to) => to.full.support().resolve(({ target }) => target.decoded(new Support({ ticket: "ticket-1" }))),
         GoShipping: (to) =>
-          to.local.shipping().resolve(({ event, target }) => target(new Shipping({ address: event.address }))),
+          to.local.shipping().resolve(({ event, target }) => target.decoded(new Shipping({ address: event.address }))),
         ReenterHistory: (to) => to.history.checkout.exact.resolve(({ target }) => target(), { reenter: true })
       },
       states: {
@@ -166,9 +166,9 @@ const makeCheckoutMachine = (
           on: {
             EnterVerifying: (to) =>
               to.local.payment().resolve(({ target }) =>
-                target(
+                target.decoded(
                   new Payment({ attempt: 2 }),
-                  (payment) => payment.verifying(new Verifying({ challengeId: "challenge-7" }))
+                  (payment) => payment.verifying.decoded(new Verifying({ challengeId: "challenge-7" }))
                 )
               )
           }
@@ -182,7 +182,7 @@ const makeCheckoutMachine = (
           },
           initialize: ({ state, builder }) => {
             onInitialize?.()
-            return builder(new CardEntry({ cardNumber: `fresh-${state.attempt}` }))
+            return builder.decoded(new CardEntry({ cardNumber: `fresh-${state.attempt}` }))
           },
           states: {
             verifying: {
@@ -303,61 +303,67 @@ const makeWorkspaceMachine = (initialized: Array<string>) =>
     events: Machine.events(LeaveWorkspace, ResumeWorkspaceShallow, ResumeWorkspaceDeep),
     initial: (to) =>
       to.workspace.initial.resolve(({ target }) =>
-        target(new Workspace({ id: "initial" }), (workspace) =>
+        target.decoded(new Workspace({ id: "initial" }), (workspace) =>
           workspace
-            .editor(new Editor({ documentId: "initial" }), (editor) => editor.writing(new Writing({ draft: "" })))
-            .sidebar(new Sidebar({ width: 0 }), (sidebar) => sidebar.files(new Files({ directory: "/" }))))
+            .editor.decoded(
+              new Editor({ documentId: "initial" }),
+              (editor) => editor.writing.decoded(new Writing({ draft: "" }))
+            )
+            .sidebar.decoded(
+              new Sidebar({ width: 0 }),
+              (sidebar) => sidebar.files.decoded(new Files({ directory: "/" }))
+            ))
       )
   }).handle({
     workspace: {
       history: {
         recent: {
           default: ({ target }) =>
-            target.workspace(
+            target.workspace.decoded(
               new Workspace({ id: "fallback" }),
               (workspace) =>
                 workspace
-                  .editor(
+                  .editor.decoded(
                     new Editor({ documentId: "fallback" }),
-                    (editor) => editor.writing(new Writing({ draft: "" }))
+                    (editor) => editor.writing.decoded(new Writing({ draft: "" }))
                   )
-                  .sidebar(
+                  .sidebar.decoded(
                     new Sidebar({ width: 200 }),
-                    (sidebar) => sidebar.files(new Files({ directory: "/" }))
+                    (sidebar) => sidebar.files.decoded(new Files({ directory: "/" }))
                   )
             )
         },
         exact: {
           default: ({ target }) =>
-            target.workspace(
+            target.workspace.decoded(
               new Workspace({ id: "fallback" }),
               (workspace) =>
                 workspace
-                  .editor(
+                  .editor.decoded(
                     new Editor({ documentId: "fallback" }),
-                    (editor) => editor.writing(new Writing({ draft: "" }))
+                    (editor) => editor.writing.decoded(new Writing({ draft: "" }))
                   )
-                  .sidebar(
+                  .sidebar.decoded(
                     new Sidebar({ width: 200 }),
-                    (sidebar) => sidebar.files(new Files({ directory: "/" }))
+                    (sidebar) => sidebar.files.decoded(new Files({ directory: "/" }))
                   )
             )
         }
       },
       on: {
-        LeaveWorkspace: (to) => to.full.away().resolve(({ target }) => target(new Away({})))
+        LeaveWorkspace: (to) => to.full.away().resolve(({ target }) => target.decoded(new Away({})))
       },
       states: {
         editor: {
           initialize: ({ state, builder }) => {
             initialized.push("editor")
-            return builder(new Writing({ draft: `fresh:${state.documentId}` }))
+            return builder.decoded(new Writing({ draft: `fresh:${state.documentId}` }))
           }
         },
         sidebar: {
           initialize: ({ state, builder }) => {
             initialized.push("sidebar")
-            return builder(new Files({ directory: `/fresh/${state.width}` }))
+            return builder.decoded(new Files({ directory: `/fresh/${state.width}` }))
           }
         }
       }
@@ -416,15 +422,15 @@ const nestedHistoryMachine = Machine.make({
   events: Machine.events(RestoreEditor, DefaultEditor),
   initial: (to) =>
     to.workspace.initial.resolve(({ target }) =>
-      target(
+      target.decoded(
         new Workspace({ id: "workspace-1" }),
         (workspace) =>
           workspace
-            .editor(
+            .editor.decoded(
               new Editor({ documentId: "document-1" }),
-              (editor) => editor.writing(new Writing({ draft: "" }))
+              (editor) => editor.writing.decoded(new Writing({ draft: "" }))
             )
-            .sidebar(new Search({ query: "untouched" }))
+            .sidebar.decoded(new Search({ query: "untouched" }))
       )
     )
 }).handle({
@@ -434,15 +440,15 @@ const nestedHistoryMachine = Machine.make({
         history: {
           exact: {
             default: ({ target }) =>
-              target.workspace(
+              target.workspace.decoded(
                 new Workspace({ id: "fallback-workspace" }),
                 (workspace) =>
                   workspace
-                    .editor(
+                    .editor.decoded(
                       new Editor({ documentId: "fallback" }),
-                      (editor) => editor.writing(new Writing({ draft: "" }))
+                      (editor) => editor.writing.decoded(new Writing({ draft: "" }))
                     )
-                    .sidebar(new Search({ query: "fallback" }))
+                    .sidebar.decoded(new Search({ query: "fallback" }))
               )
           }
         },

--- a/test/machine/InitialEntry.test.ts
+++ b/test/machine/InitialEntry.test.ts
@@ -41,7 +41,7 @@ const makeMachine = () =>
   Machine.make({
     states: States.states,
     events: Machine.events(Open, OpenInvalid),
-    initial: (to) => to.closed().resolve(({ target }) => target(new Closed({})))
+    initial: (to) => to.closed().resolve(({ target }) => target.decoded(new Closed({})))
   }).handle({
     closed: {
       on: {
@@ -74,11 +74,11 @@ const makeParallelMachine = () =>
   Machine.make({
     states: ParallelStates.states,
     events: Machine.events(EnterDashboard),
-    initial: (to) => to.outside().resolve(({ target }) => target(new Outside({})))
+    initial: (to) => to.outside().resolve(({ target }) => target.decoded(new Outside({})))
   }).handle({
     outside: {
       on: {
-        EnterDashboard: (to) => to.full.dashboard.initial.resolve(({ target }) => target(new Dashboard({})))
+        EnterDashboard: (to) => to.full.dashboard.initial.resolve(({ target }) => target.decoded(new Dashboard({})))
       }
     },
     dashboard: {
@@ -107,17 +107,17 @@ const makeChoiceMachine = () =>
   Machine.make({
     states: ChoiceStates.states,
     events: Machine.events(EnterFlow),
-    initial: (to) => to.outside().resolve(({ target }) => target(new Outside({})))
+    initial: (to) => to.outside().resolve(({ target }) => target.decoded(new Outside({})))
   }).handle({
     outside: {
       on: {
-        EnterFlow: (to) => to.full.flow.initial.resolve(({ target }) => target(new Flow({})))
+        EnterFlow: (to) => to.full.flow.initial.resolve(({ target }) => target.decoded(new Flow({})))
       }
     },
     flow: {
       states: {
         routing: {
-          choice: (to) => to.local.approved().resolve(({ target }) => target(new Approved({})))
+          choice: (to) => to.local.approved().resolve(({ target }) => target.decoded(new Approved({})))
         }
       }
     }
@@ -135,7 +135,7 @@ const makeStructuralMachine = () =>
   Machine.make({
     states: StructuralStates.states,
     events: Machine.events(EnterFlow),
-    initial: (to) => to.outside().resolve(({ target }) => target(new Outside({})))
+    initial: (to) => to.outside().resolve(({ target }) => target.decoded(new Outside({})))
   }).handle({
     outside: {
       on: {
@@ -162,7 +162,7 @@ const makeNestedMachine = () =>
   Machine.make({
     states: NestedStates.states,
     events: Machine.events(OpenLocal, OpenBranch),
-    initial: (to) => to.root.initial.resolve(({ target }) => target.from((root) => root.closed(new Closed({}))))
+    initial: (to) => to.root.initial.resolve(({ target }) => target.from((root) => root.closed.decoded(new Closed({}))))
   }).handle({
     root: {
       states: {
@@ -292,7 +292,8 @@ describe("declared initial entry", () => {
         branchIndex: 0,
         branchKey: undefined,
         target: "flow",
-        resolvedTarget: "flow"
+        resolvedTarget: "flow",
+        updates: []
       }, {
         source: "flow.routing",
         trigger: { type: "choice" },
@@ -300,7 +301,8 @@ describe("declared initial entry", () => {
         branchIndex: 0,
         branchKey: undefined,
         target: "flow.approved",
-        resolvedTarget: "flow.approved"
+        resolvedTarget: "flow.approved",
+        updates: []
       }])
     }))
 

--- a/test/machine/Inspection.test.ts
+++ b/test/machine/Inspection.test.ts
@@ -39,10 +39,10 @@ const machine = Machine.make({
   events: Machine.events(),
   initial: (to) =>
     to.root.initial.resolve(({ target }) =>
-      target(new Root({}), (root) =>
+      target.decoded(new Root({}), (root) =>
         root
-          .flow(new Flow({}), (flow) => flow.idle(new Idle({})))
-          .side(new Side({})))
+          .flow.decoded(new Flow({}), (flow) => flow.idle.decoded(new Idle({})))
+          .side.decoded(new Side({})))
     )
 })
 
@@ -60,12 +60,12 @@ const ChoiceStates = Machine.states({
 const choiceMachine = Machine.make({
   states: ChoiceStates.states,
   events: Machine.events(),
-  initial: (to) => to.Flow.initial.resolve(({ target }) => target(new ChoiceFlow({}), (flow) => flow.Routing()))
+  initial: (to) => to.Flow.initial.resolve(({ target }) => target.decoded(new ChoiceFlow({}), (flow) => flow.Routing()))
 }).handle({
   Flow: {
     states: {
       Routing: {
-        choice: (to) => to.local.Ready().resolve(({ target }) => target(new Ready({})))
+        choice: (to) => to.local.Ready().resolve(({ target }) => target.decoded(new Ready({})))
       }
     }
   }

--- a/test/machine/Invoke.test.ts
+++ b/test/machine/Invoke.test.ts
@@ -80,7 +80,7 @@ describe("inline invoke", () => {
       const definition = Machine.make({
         states: states.states,
         events: Machine.events(Add),
-        initial: (to) => to.Collecting().resolve(({ target }) => target(new Collecting({ values: [] })))
+        initial: (to) => to.Collecting().resolve(({ target }) => target.decoded(new Collecting({ values: [] })))
       })
       const machine = definition.handle({
         Collecting: {
@@ -90,12 +90,14 @@ describe("inline invoke", () => {
                 enqueue.raise(new Add({ value: element }))
               })
             ).onDone((to) =>
-              to.full.Complete().resolve(({ state, target }) => target(new Complete({ value: state.values.join(",") })))
+              to.full.Complete().resolve(({ state, target }) =>
+                target.decoded(new Complete({ value: state.values.join(",") }))
+              )
             ),
           on: {
             Add: (to) =>
               to.full.Collecting().resolve(({ event, state, target }) =>
-                target(new Collecting({ values: [...state.values, event.value] }))
+                target.decoded(new Collecting({ values: [...state.values, event.value] }))
               )
           }
         },
@@ -111,7 +113,8 @@ describe("inline invoke", () => {
           branches: [{
             type: "direct",
             target: "Collecting",
-            selection: { path: "Collecting", kind: "state", scope: "full" }
+            selection: { path: "Collecting", kind: "state", scope: "full" },
+            updates: []
           }]
         },
         {
@@ -122,7 +125,8 @@ describe("inline invoke", () => {
           branches: [{
             type: "direct",
             target: undefined,
-            selection: { path: undefined, kind: "none", scope: "local" }
+            selection: { path: undefined, kind: "none", scope: "local" },
+            updates: []
           }]
         },
         {
@@ -133,7 +137,8 @@ describe("inline invoke", () => {
           branches: [{
             type: "direct",
             target: "Complete",
-            selection: { path: "Complete", kind: "state", scope: "full" }
+            selection: { path: "Complete", kind: "state", scope: "full" },
+            updates: []
           }]
         }
       ])
@@ -161,7 +166,7 @@ describe("inline invoke", () => {
         Loading: {
           invoke: (from) =>
             from.stream("updates", () => Stream.fail("offline")).onDone((to) => to.none).onFailure((to) =>
-              to.full.Failed().resolve(({ error, target }) => target(new Failed({ message: error })))
+              to.full.Failed().resolve(({ error, target }) => target.decoded(new Failed({ message: error })))
             )
         },
         Complete: {},
@@ -229,7 +234,9 @@ describe("inline invoke", () => {
             ).onDone((to) => to.none),
           on: {
             FinishStream: (to) =>
-              to.full.Complete().resolve(({ event, target }) => target(new Complete({ value: String(event.value) })))
+              to.full.Complete().resolve(({ event, target }) =>
+                target.decoded(new Complete({ value: String(event.value) }))
+              )
           }
         },
         Complete: {},
@@ -258,7 +265,7 @@ describe("inline invoke", () => {
         Loading: {
           invoke: (from) =>
             from.effect("load", () => Effect.succeed("ready")).onDone((to) =>
-              to.full.Complete().resolve(({ output, target }) => target(new Complete({ value: output })))
+              to.full.Complete().resolve(({ output, target }) => target.decoded(new Complete({ value: output })))
             )
         },
         Complete: {},
@@ -273,7 +280,8 @@ describe("inline invoke", () => {
         branches: [{
           type: "direct",
           target: "Complete",
-          selection: { path: "Complete", kind: "state", scope: "full" }
+          selection: { path: "Complete", kind: "state", scope: "full" },
+          updates: []
         }]
       }])
 
@@ -292,7 +300,7 @@ describe("inline invoke", () => {
         Loading: {
           invoke: (from) =>
             from.effect("load", () => Effect.fail("offline")).onFailure((to) =>
-              to.full.Failed().resolve(({ error, target }) => target(new Failed({ message: error })))
+              to.full.Failed().resolve(({ error, target }) => target.decoded(new Failed({ message: error })))
             )
         },
         Complete: {},

--- a/test/machine/LiveInspection.test.ts
+++ b/test/machine/LiveInspection.test.ts
@@ -19,14 +19,14 @@ const machine = Machine.make({
   states: states.states,
   events: Events,
   emittedEvents: Emissions,
-  initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+  initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
 }).handle({
   Idle: {
     on: {
       Increment: (to) =>
         to.full.Idle().resolve(({ event, target }, enqueue) => {
           enqueue.emit(Emissions.Notice({ value: event.by }))
-          return target(new Idle({}))
+          return target.decoded(new Idle({}))
         })
     }
   }
@@ -85,7 +85,8 @@ describe("Machine live inspection", () => {
           branchIndex: 0,
           branchKey: undefined,
           target: "Idle",
-          resolvedTarget: "Idle"
+          resolvedTarget: "Idle",
+          updates: []
         }])
       }
 
@@ -128,7 +129,7 @@ describe("Machine live inspection", () => {
         id: "activity-root",
         states: states.states,
         events: Machine.events(),
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
       }).handle({
         Idle: {
           invoke: (from) => from.effect("worker", () => Effect.never)
@@ -177,7 +178,7 @@ describe("Machine live inspection", () => {
         id: "stream-activity-root",
         states: states.states,
         events: Machine.events(),
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
       }).handle({
         Idle: {
           invoke: (from) => from.stream("updates", () => Stream.never).onDone((to) => to.none)
@@ -219,7 +220,7 @@ describe("Machine live inspection", () => {
         states: childStates.states,
         events: ChildEvents,
         parent: Machine.parent(ParentEvents),
-        initial: (to) => to.ChildIdle().resolve(({ target }) => target(new ChildIdle({})))
+        initial: (to) => to.ChildIdle().resolve(({ target }) => target.decoded(new ChildIdle({})))
       }).handle({
         ChildIdle: {
           on: {
@@ -240,12 +241,12 @@ describe("Machine live inspection", () => {
         id: "parent-machine",
         states: parentStates.states,
         events: Machine.events(ParentEvents),
-        initial: (to) => to.ParentIdle().resolve(({ target }) => target(new ParentIdle({})))
+        initial: (to) => to.ParentIdle().resolve(({ target }) => target.decoded(new ParentIdle({})))
       }).handle({
         ParentIdle: {
           invoke: (from) => from.child(Child),
           on: {
-            ChildReady: (to) => to.full.ParentDone().resolve(({ target }) => target(new ParentDone({})))
+            ChildReady: (to) => to.full.ParentDone().resolve(({ target }) => target.decoded(new ParentDone({})))
           }
         },
         ParentDone: {}

--- a/test/machine/LocalTargetWith.test.ts
+++ b/test/machine/LocalTargetWith.test.ts
@@ -57,7 +57,8 @@ describe("local compound target selection", () => {
         branches: [{
           type: "direct",
           target: "search",
-          selection: { path: "search", kind: "state", scope: "local" }
+          selection: { path: "search", kind: "state", scope: "local" },
+          updates: []
         }]
       }, {
         source: "search.Updated",
@@ -67,7 +68,8 @@ describe("local compound target selection", () => {
         branches: [{
           type: "direct",
           target: "search.Idle",
-          selection: { path: "search.Idle", kind: "state", scope: "local" }
+          selection: { path: "search.Idle", kind: "state", scope: "local" },
+          updates: []
         }]
       }])
 
@@ -142,7 +144,8 @@ describe("local compound target selection", () => {
         branches: [{
           type: "direct",
           target: "search",
-          selection: { path: "search", kind: "state", scope: "local" }
+          selection: { path: "search", kind: "state", scope: "local" },
+          updates: []
         }]
       }])
 

--- a/test/machine/Machine.test.ts
+++ b/test/machine/Machine.test.ts
@@ -108,7 +108,7 @@ describe("Machine", () => {
     const definition = Machine.make({
       states: states.states,
       events: Machine.events(Ping),
-      initial: (to) => to.Stable().resolve(({ target }) => target(new Stable({})))
+      initial: (to) => to.Stable().resolve(({ target }) => target.decoded(new Stable({})))
     })
     const handlingPing = definition.handle({ Stable: { on: { Ping: (to) => to.none } } })
     const ignoringPing = definition.handle({ Stable: {} })
@@ -132,7 +132,7 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Ping),
-        initial: (to) => to.Stable().resolve(({ target }) => target(new Stable({})))
+        initial: (to) => to.Stable().resolve(({ target }) => target.decoded(new Stable({})))
       }).handle({
         Stable: {
           on: {
@@ -157,7 +157,8 @@ describe("Machine", () => {
         branches: [{
           type: "direct",
           target: undefined,
-          selection: { path: undefined, kind: "none", scope: "local" }
+          selection: { path: undefined, kind: "none", scope: "local" },
+          updates: []
         }]
       }])
 
@@ -224,7 +225,7 @@ describe("Machine", () => {
       const definition = Machine.make({
         states: states.states,
         events: Machine.events(Ping),
-        initial: (to) => to.Stable().resolve(({ target }) => target(new Stable({})))
+        initial: (to) => to.Stable().resolve(({ target }) => target.decoded(new Stable({})))
       })
       const machine = definition.handle({
         Stable: {
@@ -238,7 +239,7 @@ describe("Machine", () => {
               declarations = captured
               return to.branches(captured).resolve(({ event, select }) =>
                 event.route
-                  ? select.refresh(new Stable({}))
+                  ? select.refresh.decoded(new Stable({}))
                   : select.unchanged(), { reenter: true })
             }
           }
@@ -258,13 +259,15 @@ describe("Machine", () => {
           key: "unchanged",
           title: "unchanged",
           target: undefined,
-          selection: { path: undefined, kind: "none", scope: "local" }
+          selection: { path: undefined, kind: "none", scope: "local" },
+          updates: []
         }, {
           type: "branch",
           key: "refresh",
           title: "Refresh stable state",
           target: "Stable",
-          selection: { path: "Stable", kind: "state", scope: "full" }
+          selection: { path: "Stable", kind: "state", scope: "full" },
+          updates: []
         }]
       }])
 
@@ -285,7 +288,7 @@ describe("Machine", () => {
       Machine.make({
         states: { Stable },
         events: Machine.events(Ping),
-        initial: (to) => to.Stable().resolve(({ target }) => target(new Stable({})))
+        initial: (to) => to.Stable().resolve(({ target }) => target.decoded(new Stable({})))
       })
     const handle = (branches: (to: any) => object) => () =>
       makeDefinition().handle({
@@ -317,7 +320,7 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: { Stable },
         events: Machine.events(Capture, Reuse),
-        initial: (to) => to.Stable().resolve(({ target }) => target(new Stable({})))
+        initial: (to) => to.Stable().resolve(({ target }) => target.decoded(new Stable({})))
       }).handle({
         Stable: {
           on: {
@@ -502,7 +505,8 @@ describe("Machine", () => {
         states: states.states,
         events: Machine.events(Submit),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       })
 
       const planned = yield* Machine.planInitial(machine, { userId: "user-1" })
@@ -516,7 +520,7 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: states.states,
       events: Machine.events(),
-      initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({ userId: "user-1" })))
+      initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-1" })))
     })
 
     assert.strictEqual(Machine.isMachine(machine), true)
@@ -530,7 +534,7 @@ describe("Machine", () => {
       const definition = Machine.make({
         states: states.states,
         events: Machine.events(Convert),
-        initial: (to) => to.Submit().resolve(({ target }) => target(new Submit({ value: "loaded" })))
+        initial: (to) => to.Submit().resolve(({ target }) => target.decoded(new Submit({ value: "loaded" })))
       })
       const machine = definition.handle({
         Submit: {
@@ -560,13 +564,14 @@ describe("Machine", () => {
       states: states.states,
       events: Machine.events(Submit),
       input: Input,
-      initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+      initial: (to) =>
+        to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
     }).handle({
       Idle: {
         on: {
           Submit: (to) =>
             to.full.Loading().resolve(({ target }) => {
-              return target(new Loading({ requestId: "request-1" }))
+              return target.decoded(new Loading({ requestId: "request-1" }))
             })
         }
       }
@@ -587,7 +592,7 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: defined.states,
         events: Machine.events(Submit),
-        initial: (to) => to.idle().resolve(({ target }) => target(new Idle({ userId: "user-1" })))
+        initial: (to) => to.idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-1" })))
       })
 
       const planned = yield* Machine.planInitial(machine)
@@ -711,9 +716,9 @@ describe("Machine", () => {
         events: Machine.events(Authorize),
         initial: (to) =>
           to.payment.initial.resolve(({ target }) =>
-            target(
+            target.decoded(
               payment,
-              (payment) => payment.entering(entering)
+              (payment) => payment.entering.decoded(entering)
             )
           )
       })
@@ -762,17 +767,17 @@ describe("Machine", () => {
         events: Machine.events(ReserveInventory),
         initial: (to) =>
           to.fulfillment.initial.resolve(({ target }) =>
-            target(
+            target.decoded(
               fulfillment,
               (fulfillment) =>
                 fulfillment
-                  .inventory(
+                  .inventory.decoded(
                     inventory,
-                    (inventory) => inventory.checking(checking)
+                    (inventory) => inventory.checking.decoded(checking)
                   )
-                  .shipping(
+                  .shipping.decoded(
                     shipping,
-                    (shipping) => shipping.quoting(quoting)
+                    (shipping) => shipping.quoting.decoded(quoting)
                   )
             )
           )
@@ -1510,7 +1515,9 @@ describe("Machine", () => {
           events: Machine.events(NonEmptySubmit),
           input: NonEmptyInput,
           initial: (to) =>
-            to.NonEmptyIdle().resolve(({ input: input, target }) => target(new NonEmptyIdle({ userId: input.userId })))
+            to.NonEmptyIdle().resolve(({ input: input, target }) =>
+              target.decoded(new NonEmptyIdle({ userId: input.userId }))
+            )
         })
 
         const error = yield* Effect.flip(Machine.planInitial(machine, { userId: "" as any }))
@@ -1525,7 +1532,9 @@ describe("Machine", () => {
           states: states.states,
           events: Machine.events(NonEmptySubmit),
           initial: (to) =>
-            to.NonEmptyIdle().resolve(({ target }) => target(unsafeTagged({ _tag: "NonEmptyIdle", userId: "" })))
+            to.NonEmptyIdle().resolve(({ target }) =>
+              target.decoded(unsafeTagged({ _tag: "NonEmptyIdle", userId: "" }))
+            )
         })
 
         const error = yield* Effect.flip(Machine.planInitial(machine))
@@ -1539,11 +1548,12 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(NonEmptySubmit),
-          initial: (to) => to.NonEmptyIdle().resolve(({ target }) => target(new NonEmptyIdle({ userId: "user-1" })))
+          initial: (to) =>
+            to.NonEmptyIdle().resolve(({ target }) => target.decoded(new NonEmptyIdle({ userId: "user-1" })))
         }).handle({
           NonEmptyIdle: {
             on: {
-              NonEmptySubmit: (to) => to.full.NonEmptyIdle().resolve(({ state, target }) => target(state))
+              NonEmptySubmit: (to) => to.full.NonEmptyIdle().resolve(({ state, target }) => target.decoded(state))
             }
           }
         })
@@ -1565,11 +1575,12 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(NonEmptySubmit),
-          initial: (to) => to.NonEmptyIdle().resolve(({ target }) => target(new NonEmptyIdle({ userId: "user-1" })))
+          initial: (to) =>
+            to.NonEmptyIdle().resolve(({ target }) => target.decoded(new NonEmptyIdle({ userId: "user-1" })))
         }).handle({
           NonEmptyIdle: {
             on: {
-              NonEmptySubmit: (to) => to.full.NonEmptyIdle().resolve(({ state, target }) => target(state))
+              NonEmptySubmit: (to) => to.full.NonEmptyIdle().resolve(({ state, target }) => target.decoded(state))
             }
           }
         })
@@ -1600,13 +1611,14 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(NonEmptySubmit),
-          initial: (to) => to.NonEmptyIdle().resolve(({ target }) => target(new NonEmptyIdle({ userId: "user-1" })))
+          initial: (to) =>
+            to.NonEmptyIdle().resolve(({ target }) => target.decoded(new NonEmptyIdle({ userId: "user-1" })))
         }).handle({
           NonEmptyIdle: {
             on: {
               NonEmptySubmit: (to) =>
                 to.full.NonEmptyLoading().resolve(({ target }) =>
-                  target(unsafeTagged({ _tag: "NonEmptyLoading", requestId: "" }))
+                  target.decoded(unsafeTagged({ _tag: "NonEmptyLoading", requestId: "" }))
                 )
             }
           }
@@ -1629,13 +1641,14 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(NonEmptySubmit),
-          initial: (to) => to.NonEmptyIdle().resolve(({ target }) => target(new NonEmptyIdle({ userId: "user-1" })))
+          initial: (to) =>
+            to.NonEmptyIdle().resolve(({ target }) => target.decoded(new NonEmptyIdle({ userId: "user-1" })))
         }).handle({
           NonEmptyIdle: {
             on: {
               NonEmptySubmit: (to) =>
                 to.full.NonEmptyIdle().resolve(({ target }) =>
-                  target(unsafeTagged({ _tag: "NonEmptyIdle", userId: "" }))
+                  target.decoded(unsafeTagged({ _tag: "NonEmptyIdle", userId: "" }))
                 )
             }
           }
@@ -1666,12 +1679,15 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(NonEmptySubmit),
-          initial: (to) => to.NonEmptyIdle().resolve(({ target }) => target(new NonEmptyIdle({ userId: "user-1" })))
+          initial: (to) =>
+            to.NonEmptyIdle().resolve(({ target }) => target.decoded(new NonEmptyIdle({ userId: "user-1" })))
         }).handle({
           NonEmptyIdle: {
             on: {
               NonEmptySubmit: (to) =>
-                to.full.done().resolve(({ event, target }) => target(new NonEmptyDone({ requestId: event.value })))
+                to.full.done().resolve(({ event, target }) =>
+                  target.decoded(new NonEmptyDone({ requestId: event.value }))
+                )
             }
           },
           done: {
@@ -1714,12 +1730,12 @@ describe("Machine", () => {
           events: Machine.events(),
           initial: (to) =>
             to.all.initial.resolve(({ target }) =>
-              target(
+              target.decoded(
                 new ParallelRoot({ id: "all" }),
                 (all) =>
                   all
-                    .left(new ParallelLeftDone({ id: "left" }))
-                    .right(new ParallelRightDone({ id: "right" }))
+                    .left.decoded(new ParallelLeftDone({ id: "left" }))
+                    .right.decoded(new ParallelRightDone({ id: "right" }))
               )
             )
         }).handle({
@@ -1739,7 +1755,8 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(NonEmptySubmit),
-          initial: (to) => to.NonEmptyIdle().resolve(({ target }) => target(new NonEmptyIdle({ userId: "user-1" })))
+          initial: (to) =>
+            to.NonEmptyIdle().resolve(({ target }) => target.decoded(new NonEmptyIdle({ userId: "user-1" })))
         })
 
         const error = yield* Effect.flip(
@@ -1763,7 +1780,7 @@ describe("Machine", () => {
           id: "Counter",
           states: states.states,
           events: Machine.events(),
-          initial: (to) => to.count().resolve(({ target }) => target(new EncodedCount({ count: 1 })))
+          initial: (to) => to.count().resolve(({ target }) => target.decoded(new EncodedCount({ count: 1 })))
         })
         const planned = yield* Machine.planInitial(machine)
 
@@ -1812,17 +1829,17 @@ describe("Machine", () => {
           events: Machine.events(),
           initial: (to) =>
             to.fulfillment.initial.resolve(({ target }) =>
-              target(
+              target.decoded(
                 new Fulfillment({ id: "fulfillment-1" }),
                 (fulfillment) =>
                   fulfillment
-                    .inventory(
+                    .inventory.decoded(
                       new Inventory({ warehouse: "warehouse-1" }),
-                      (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
+                      (inventory) => inventory.checking.decoded(new CheckingInventory({ sku: "sku-1" }))
                     )
-                    .shipping(
+                    .shipping.decoded(
                       new Shipping({ address: "Main Street" }),
-                      (shipping) => shipping.quoting(new QuotingShipping({ postalCode: "12345" }))
+                      (shipping) => shipping.quoting.decoded(new QuotingShipping({ postalCode: "12345" }))
                     )
               )
             )
@@ -1863,12 +1880,12 @@ describe("Machine", () => {
           events: Machine.events(),
           initial: (to) =>
             to.all.initial.resolve(({ target }) =>
-              target(
+              target.decoded(
                 new ParallelRoot({ id: "all" }),
                 (all) =>
                   all
-                    .left(new ParallelLeftDone({ id: "left" }))
-                    .right(new ParallelRightDone({ id: "right" }))
+                    .left.decoded(new ParallelLeftDone({ id: "left" }))
+                    .right.decoded(new ParallelRightDone({ id: "right" }))
               )
             )
         }).handle({
@@ -1909,12 +1926,12 @@ describe("Machine", () => {
           events: Machine.events(),
           initial: (to) =>
             to.all.initial.resolve(({ target }) =>
-              target(
+              target.decoded(
                 new ParallelRoot({ id: "all" }),
                 (all) =>
                   all
-                    .left(new ParallelLeftDone({ id: "left" }))
-                    .right(new ParallelRightDone({ id: "right" }))
+                    .left.decoded(new ParallelLeftDone({ id: "left" }))
+                    .right.decoded(new ParallelRightDone({ id: "right" }))
               )
             )
         }).handle({
@@ -1945,7 +1962,7 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(),
-          initial: (to) => to.done().resolve(({ target }) => target(new ParallelLeftDone({ id: "done" })))
+          initial: (to) => to.done().resolve(({ target }) => target.decoded(new ParallelLeftDone({ id: "done" })))
         }).handle({
           done: { output: () => undefined }
         })
@@ -1964,7 +1981,8 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(),
-          initial: (to) => to.NonEmptyIdle().resolve(({ target }) => target(new NonEmptyIdle({ userId: "user-1" })))
+          initial: (to) =>
+            to.NonEmptyIdle().resolve(({ target }) => target.decoded(new NonEmptyIdle({ userId: "user-1" })))
         })
 
         const error = yield* Machine.encodeSnapshot(machine, {
@@ -1981,7 +1999,8 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(),
-          initial: (to) => to.NonEmptyIdle().resolve(({ target }) => target(new NonEmptyIdle({ userId: "user-1" })))
+          initial: (to) =>
+            to.NonEmptyIdle().resolve(({ target }) => target.decoded(new NonEmptyIdle({ userId: "user-1" })))
         })
 
         const error = yield* Machine.encodeSnapshot(machine, {
@@ -1999,7 +2018,8 @@ describe("Machine", () => {
         const machine = Machine.make({
           states: states.states,
           events: Machine.events(),
-          initial: (to) => to.NonEmptyIdle().resolve(({ target }) => target(new NonEmptyIdle({ userId: "user-1" })))
+          initial: (to) =>
+            to.NonEmptyIdle().resolve(({ target }) => target.decoded(new NonEmptyIdle({ userId: "user-1" })))
         })
 
         const error = yield* Machine.decodeSnapshot(machine, {
@@ -2030,9 +2050,9 @@ describe("Machine", () => {
           events: Machine.events(),
           initial: (to) =>
             to.payment.initial.resolve(({ target }) =>
-              target(
+              target.decoded(
                 new Payment({ id: "payment-1" }),
-                (payment) => payment.entering(new EnteringPayment({ amount: 1 }))
+                (payment) => payment.entering.decoded(new EnteringPayment({ amount: 1 }))
               )
             )
         })
@@ -2059,13 +2079,14 @@ describe("Machine", () => {
         },
         events: Machine.events(Submit),
         input: Input,
-        initial: (to) => to.idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         idle: {
           on: {
             Submit: (to) =>
               to.full.loading().resolve(({ event, state, target }) =>
-                target(new Loading({ requestId: `${state.userId}:${event.value}` }))
+                target.decoded(new Loading({ requestId: `${state.userId}:${event.value}` }))
               )
           }
         }
@@ -2092,16 +2113,17 @@ describe("Machine", () => {
           b: Duplicate
         },
         events: Machine.events(Submit, Reset),
-        initial: (to) => to.a().resolve(({ target }) => target(new Duplicate({ value: "a" })))
+        initial: (to) => to.a().resolve(({ target }) => target.decoded(new Duplicate({ value: "a" })))
       }).handle({
         a: {
           on: {
-            Submit: (to) => to.full.b().resolve(({ event, target }) => target(new Duplicate({ value: event.value })))
+            Submit: (to) =>
+              to.full.b().resolve(({ event, target }) => target.decoded(new Duplicate({ value: event.value })))
           }
         },
         b: {
           on: {
-            Reset: (to) => to.full.a().resolve(({ target }) => target(new Duplicate({ value: "reset" })))
+            Reset: (to) => to.full.a().resolve(({ target }) => target.decoded(new Duplicate({ value: "reset" })))
           }
         }
       })
@@ -2132,11 +2154,12 @@ describe("Machine", () => {
           b: Duplicate
         },
         events: Machine.events(Submit),
-        initial: (to) => to.a().resolve(({ target }) => target(new Duplicate({ value: "a" })))
+        initial: (to) => to.a().resolve(({ target }) => target.decoded(new Duplicate({ value: "a" })))
       }).handle({
         a: {
           on: {
-            Submit: (to) => to.full.b().resolve(({ event, target }) => target(new Duplicate({ value: event.value })))
+            Submit: (to) =>
+              to.full.b().resolve(({ event, target }) => target.decoded(new Duplicate({ value: event.value })))
           }
         }
       })
@@ -2164,12 +2187,12 @@ describe("Machine", () => {
           }
         },
         events: Machine.events(Submit),
-        initial: (to) => to.idle().resolve(({ target }) => target(new Idle({ userId: "user-1" })))
+        initial: (to) => to.idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-1" })))
       }).handle({
         idle: {
           on: {
             Submit: (to) =>
-              to.full.success().resolve(({ event, target }) => target(new Success({ requestId: event.value })))
+              to.full.success().resolve(({ event, target }) => target.decoded(new Success({ requestId: event.value })))
           }
         }
       })
@@ -2215,7 +2238,8 @@ describe("Machine", () => {
       }).handle({
         payment: {
           on: {
-            Authorize: (to) => to.full.failed().resolve(({ target }) => target(new Failed({ message: "parent" })))
+            Authorize: (to) =>
+              to.full.failed().resolve(({ target }) => target.decoded(new Failed({ message: "parent" })))
           },
           states: {
             entering: {
@@ -2224,7 +2248,7 @@ describe("Machine", () => {
                   to.local.authorized().resolve(({ event, containingState, ancestors, target }) => {
                     assert.deepStrictEqual(containingState, payment)
                     assert.deepStrictEqual(ancestors, { payment })
-                    return target(new AuthorizedPayment({ code: event.code }))
+                    return target.decoded(new AuthorizedPayment({ code: event.code }))
                   })
               }
             }
@@ -2272,7 +2296,8 @@ describe("Machine", () => {
       }).handle({
         payment: {
           on: {
-            Authorize: (to) => to.full.failed().resolve(({ target }) => target(new Failed({ message: "parent" })))
+            Authorize: (to) =>
+              to.full.failed().resolve(({ target }) => target.decoded(new Failed({ message: "parent" })))
           },
           states: {
             entering: {
@@ -2283,7 +2308,7 @@ describe("Machine", () => {
                     consume: { target: to.none }
                   }).resolve(({ event, select, decline }, enqueue) => {
                     if (event.code === "child") {
-                      return select.authorize(new AuthorizedPayment({ code: event.code }))
+                      return select.authorize.decoded(new AuthorizedPayment({ code: event.code }))
                     }
                     if (event.code === "consume") return select.consume()
                     enqueue.emit(new Notice({}))
@@ -2336,11 +2361,11 @@ describe("Machine", () => {
         events: Machine.events(),
         initial: (to) =>
           to.workflow.initial.resolve(({ target }) =>
-            target(new Workflow({}), (workflow) => workflow.waiting(new Waiting({ ready: false })))
+            target.decoded(new Workflow({}), (workflow) => workflow.waiting.decoded(new Waiting({ ready: false })))
           )
       }).handle({
         workflow: {
-          always: (to) => to.full.finished().resolve(({ target }) => target(new Finished({}))),
+          always: (to) => to.full.finished().resolve(({ target }) => target.decoded(new Finished({}))),
           states: {
             waiting: {
               always: (to) =>
@@ -2363,7 +2388,7 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Ping),
-        initial: (to) => to.Stable().resolve(({ target }) => target(new Stable({})))
+        initial: (to) => to.Stable().resolve(({ target }) => target.decoded(new Stable({})))
       }).handle({
         Stable: {
           on: {
@@ -2399,7 +2424,7 @@ describe("Machine", () => {
         events: Machine.events(),
         initial: (to) =>
           to.workflow.initial.resolve(({ target }) =>
-            target(new Workflow({}), (workflow) => workflow.complete(new Complete({})))
+            target.decoded(new Workflow({}), (workflow) => workflow.complete.decoded(new Complete({})))
           )
       }).handle({
         workflow: {
@@ -2439,7 +2464,7 @@ describe("Machine", () => {
         events: Machine.events(Ping),
         initial: (to) =>
           to.root.initial.resolve(({ target }) =>
-            target(new Root({}), (root) => root.left(new Left({})).right(new Right({})))
+            target.decoded(new Root({}), (root) => root.left.decoded(new Left({})).right.decoded(new Right({})))
           )
       }).handle({
         root: {
@@ -2447,7 +2472,7 @@ describe("Machine", () => {
             Ping: (to) =>
               to.full.finished().resolve(({ target }) => {
                 parentCalls++
-                return target(new Finished({}))
+                return target.decoded(new Finished({}))
               })
           },
           states: {
@@ -2513,14 +2538,14 @@ describe("Machine", () => {
       }).handle({
         payment: {
           on: {
-            Reset: (to) => to.full.failed().resolve(({ target }) => target(new Failed({ message: "reset" })))
+            Reset: (to) => to.full.failed().resolve(({ target }) => target.decoded(new Failed({ message: "reset" })))
           },
           states: {
             entering: {
               on: {
                 Authorize: (to) =>
                   to.local.authorized().resolve(({ event, target }) =>
-                    target(new AuthorizedPayment({ code: event.code }))
+                    target.decoded(new AuthorizedPayment({ code: event.code }))
                   )
               }
             },
@@ -2578,7 +2603,7 @@ describe("Machine", () => {
       }).handle({
         payment: {
           on: {
-            Reset: (to) => to.full.idle().resolve(({ target }) => target(new Idle({ userId: "user-1" })))
+            Reset: (to) => to.full.idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-1" })))
           }
         }
       })
@@ -2627,23 +2652,23 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Submit),
-        initial: (to) => to.idle().resolve(({ target }) => target(new Idle({ userId: "user-1" })))
+        initial: (to) => to.idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-1" })))
       }).handle({
         idle: {
           on: {
             Submit: (to) =>
               to.full.fulfillment().resolve(({ event, target }) =>
-                target(
+                target.decoded(
                   new Fulfillment({ id: event.value }),
                   (fulfillment) =>
                     fulfillment
-                      .inventory(
+                      .inventory.decoded(
                         new Inventory({ warehouse: "warehouse-1" }),
-                        (inventory) => inventory.reserved(new InventoryReserved({ reservationId: event.value }))
+                        (inventory) => inventory.reserved.decoded(new InventoryReserved({ reservationId: event.value }))
                       )
-                      .shipping(
+                      .shipping.decoded(
                         new Shipping({ address: "Main Street" }),
-                        (shipping) => shipping.quoted(new ShippingQuoted({ quoteId: event.value }))
+                        (shipping) => shipping.quoted.decoded(new ShippingQuoted({ quoteId: event.value }))
                       )
                 )
               )
@@ -2723,9 +2748,9 @@ describe("Machine", () => {
         events: Machine.events(Submit),
         initial: (to) =>
           to.workflow.initial.resolve(({ target }) =>
-            target(
+            target.decoded(
               workflow,
-              (workflow) => workflow.idle(new Idle({ userId: "user-1" }))
+              (workflow) => workflow.idle.decoded(new Idle({ userId: "user-1" }))
             )
           )
       }).handle({
@@ -2735,17 +2760,18 @@ describe("Machine", () => {
               on: {
                 Submit: (to) =>
                   to.local.fulfillment().resolve(({ event, target }) =>
-                    target(
+                    target.decoded(
                       new Fulfillment({ id: event.value }),
                       (fulfillment) =>
                         fulfillment
-                          .inventory(
+                          .inventory.decoded(
                             new Inventory({ warehouse: "warehouse-1" }),
-                            (inventory) => inventory.reserved(new InventoryReserved({ reservationId: event.value }))
+                            (inventory) =>
+                              inventory.reserved.decoded(new InventoryReserved({ reservationId: event.value }))
                           )
-                          .shipping(
+                          .shipping.decoded(
                             new Shipping({ address: "Main Street" }),
-                            (shipping) => shipping.quoted(new ShippingQuoted({ quoteId: event.value }))
+                            (shipping) => shipping.quoted.decoded(new ShippingQuoted({ quoteId: event.value }))
                           )
                     )
                   )
@@ -2850,12 +2876,12 @@ describe("Machine", () => {
                   on: {
                     Submit: (to) =>
                       to.branch.app.flow.fulfillment().resolve(({ event, target }) =>
-                        target(
+                        target.decoded(
                           new Fulfillment({ id: event.value }),
                           (fulfillment) =>
                             fulfillment
-                              .inventory(new Inventory({ warehouse: "warehouse-1" }))
-                              .shipping(new Shipping({ address: "Main Street" }))
+                              .inventory.decoded(new Inventory({ warehouse: "warehouse-1" }))
+                              .shipping.decoded(new Shipping({ address: "Main Street" }))
                         )
                       )
                   }
@@ -2929,17 +2955,17 @@ describe("Machine", () => {
         events: Machine.events(ReserveInventory),
         initial: (to) =>
           to.fulfillment.initial.resolve(({ target }) =>
-            target(
+            target.decoded(
               fulfillment,
               (fulfillment) =>
                 fulfillment
-                  .inventory(
+                  .inventory.decoded(
                     inventory,
-                    (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
+                    (inventory) => inventory.checking.decoded(new CheckingInventory({ sku: "sku-1" }))
                   )
-                  .shipping(
+                  .shipping.decoded(
                     shipping,
-                    (shipping) => shipping.quoting(quoting)
+                    (shipping) => shipping.quoting.decoded(quoting)
                   )
             )
           )
@@ -2952,7 +2978,7 @@ describe("Machine", () => {
                   on: {
                     ReserveInventory: (to) =>
                       to.local.reserved().resolve(({ event, target }) =>
-                        target(new InventoryReserved({ reservationId: event.reservationId }))
+                        target.decoded(new InventoryReserved({ reservationId: event.reservationId }))
                       )
                   }
                 }
@@ -3020,17 +3046,17 @@ describe("Machine", () => {
         events: Machine.events(ReserveInventory),
         initial: (to) =>
           to.fulfillment.initial.resolve(({ target }) =>
-            target(
+            target.decoded(
               fulfillment,
               (fulfillment) =>
                 fulfillment
-                  .inventory(
+                  .inventory.decoded(
                     new Inventory({ warehouse: "warehouse-1" }),
-                    (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
+                    (inventory) => inventory.checking.decoded(new CheckingInventory({ sku: "sku-1" }))
                   )
-                  .shipping(
+                  .shipping.decoded(
                     shipping,
-                    (shipping) => shipping.quoting(quoting)
+                    (shipping) => shipping.quoting.decoded(quoting)
                   )
             )
           )
@@ -3043,10 +3069,10 @@ describe("Machine", () => {
                   on: {
                     ReserveInventory: (to) =>
                       to.branch.fulfillment.inventory().resolve(({ event, target }) =>
-                        target(
+                        target.decoded(
                           nextInventory,
                           (inventory) =>
-                            inventory.reserved(new InventoryReserved({ reservationId: event.reservationId }))
+                            inventory.reserved.decoded(new InventoryReserved({ reservationId: event.reservationId }))
                         )
                       )
                   }
@@ -3116,17 +3142,17 @@ describe("Machine", () => {
         events: Machine.events(ReserveInventory),
         initial: (to) =>
           to.fulfillment.initial.resolve(({ target }) =>
-            target(
+            target.decoded(
               fulfillment,
               (fulfillment) =>
                 fulfillment
-                  .inventory(
+                  .inventory.decoded(
                     inventory,
-                    (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
+                    (inventory) => inventory.checking.decoded(new CheckingInventory({ sku: "sku-1" }))
                   )
-                  .shipping(
+                  .shipping.decoded(
                     shipping,
-                    (shipping) => shipping.quoting(quoting)
+                    (shipping) => shipping.quoting.decoded(quoting)
                   )
             )
           )
@@ -3139,10 +3165,10 @@ describe("Machine", () => {
                   on: {
                     ReserveInventory: (to) =>
                       to.branch.fulfillment.inventory().resolve(({ event, target }) =>
-                        target(
+                        target.decoded(
                           nextInventory,
                           (inventory) =>
-                            inventory.reserved(new InventoryReserved({ reservationId: event.reservationId }))
+                            inventory.reserved.decoded(new InventoryReserved({ reservationId: event.reservationId }))
                         )
                       )
                   }
@@ -3213,17 +3239,17 @@ describe("Machine", () => {
         events: Machine.events(ReserveInventory),
         initial: (to) =>
           to.fulfillment.initial.resolve(({ target }) =>
-            target(
+            target.decoded(
               fulfillment,
               (fulfillment) =>
                 fulfillment
-                  .inventory(
+                  .inventory.decoded(
                     inventory,
-                    (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
+                    (inventory) => inventory.checking.decoded(new CheckingInventory({ sku: "sku-1" }))
                   )
-                  .shipping(
+                  .shipping.decoded(
                     shipping,
-                    (shipping) => shipping.quoting(quoting)
+                    (shipping) => shipping.quoting.decoded(quoting)
                   )
             )
           )
@@ -3236,13 +3262,15 @@ describe("Machine", () => {
                   on: {
                     ReserveInventory: (to) =>
                       to.branch.fulfillment().resolve(({ event, target }) =>
-                        target(
+                        target.decoded(
                           nextFulfillment,
                           (fulfillment) =>
-                            fulfillment.inventory(
+                            fulfillment.inventory.decoded(
                               nextInventory,
                               (inventory) =>
-                                inventory.reserved(new InventoryReserved({ reservationId: event.reservationId }))
+                                inventory.reserved.decoded(
+                                  new InventoryReserved({ reservationId: event.reservationId })
+                                )
                             )
                         )
                       )
@@ -3311,12 +3339,12 @@ describe("Machine", () => {
         events: Machine.events(ReserveInventory),
         initial: (to) =>
           to.payment.initial.resolve(({ target }) =>
-            target(
+            target.decoded(
               payment,
               (payment) =>
-                payment.inventory(
+                payment.inventory.decoded(
                   inventory,
-                  (inventory) => inventory.checking(new CheckingInventory({ sku: "sku-1" }))
+                  (inventory) => inventory.checking.decoded(new CheckingInventory({ sku: "sku-1" }))
                 )
             )
           )
@@ -3329,9 +3357,9 @@ describe("Machine", () => {
                   on: {
                     ReserveInventory: (to) =>
                       to.branch.payment.shipping().resolve(({ event, target }) =>
-                        target(
+                        target.decoded(
                           shipping,
-                          (shipping) => shipping.quoted(new ShippingQuoted({ quoteId: event.reservationId }))
+                          (shipping) => shipping.quoted.decoded(new ShippingQuoted({ quoteId: event.reservationId }))
                         )
                       )
                   }
@@ -3390,14 +3418,15 @@ describe("Machine", () => {
       }).handle({
         payment: {
           on: {
-            Reset: (to) => to.local.entering().resolve(({ target }) => target(new EnteringPayment({ amount: 0 })))
+            Reset: (to) =>
+              to.local.entering().resolve(({ target }) => target.decoded(new EnteringPayment({ amount: 0 })))
           },
           states: {
             entering: {
               on: {
                 Authorize: (to) =>
                   to.local.authorized().resolve(({ event, target }) =>
-                    target(new AuthorizedPayment({ code: event.code }))
+                    target.decoded(new AuthorizedPayment({ code: event.code }))
                   )
               }
             },
@@ -3501,14 +3530,14 @@ describe("Machine", () => {
       }).handle({
         payment: {
           on: {
-            Reset: (to) => to.full.idle().resolve(({ target }) => target(new Idle({ userId: "user-1" })))
+            Reset: (to) => to.full.idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-1" })))
           },
           states: {
             entering: {
               on: {
                 Authorize: (to) =>
                   to.local.authorized().resolve(({ event, target }) =>
-                    target(new AuthorizedPayment({ code: event.code }))
+                    target.decoded(new AuthorizedPayment({ code: event.code }))
                   )
               }
             },
@@ -3587,20 +3616,20 @@ describe("Machine", () => {
       }).handle({
         checkout: {
           on: {
-            Reset: (to) => to.full.failed().resolve(({ target }) => target(new Failed({ message: "reset" })))
+            Reset: (to) => to.full.failed().resolve(({ target }) => target.decoded(new Failed({ message: "reset" })))
           },
           states: {
             inventory: {
               onDone: (to) =>
                 to.branch.checkout.shipped().resolve(({ output, target }) =>
-                  target(new ShippingQuoted({ quoteId: String(output) }))
+                  target.decoded(new ShippingQuoted({ quoteId: String(output) }))
                 ),
               states: {
                 checking: {
                   on: {
                     ReserveInventory: (to) =>
                       to.local.reserved().resolve(({ event, target }) =>
-                        target(new InventoryReserved({ reservationId: event.reservationId }))
+                        target.decoded(new InventoryReserved({ reservationId: event.reservationId }))
                       )
                   }
                 },
@@ -3696,7 +3725,7 @@ describe("Machine", () => {
                   on: {
                     ReserveInventory: (to) =>
                       to.local.reserved().resolve(({ event, target }) =>
-                        target(new InventoryReserved({ reservationId: event.reservationId }))
+                        target.decoded(new InventoryReserved({ reservationId: event.reservationId }))
                       )
                   }
                 }
@@ -3818,7 +3847,7 @@ describe("Machine", () => {
                   on: {
                     ReserveInventory: (to) =>
                       to.local.reserved().resolve(({ event, target }) =>
-                        target(new InventoryReserved({ reservationId: event.reservationId }))
+                        target.decoded(new InventoryReserved({ reservationId: event.reservationId }))
                       )
                   }
                 },
@@ -3833,7 +3862,7 @@ describe("Machine", () => {
                   on: {
                     ReserveInventory: (to) =>
                       to.local.quoted().resolve(({ event, target }) =>
-                        target(new ShippingQuoted({ quoteId: event.reservationId }))
+                        target.decoded(new ShippingQuoted({ quoteId: event.reservationId }))
                       )
                   }
                 },
@@ -3960,7 +3989,7 @@ describe("Machine", () => {
                   on: {
                     ReserveInventory: (to) =>
                       to.local.reserved().resolve(({ event, target }) =>
-                        target(new InventoryReserved({ reservationId: event.reservationId }))
+                        target.decoded(new InventoryReserved({ reservationId: event.reservationId }))
                       )
                   }
                 },
@@ -3974,7 +4003,9 @@ describe("Machine", () => {
                 quoting: {
                   on: {
                     Resolve: (to) =>
-                      to.local.quoted().resolve(({ target }) => target(new ShippingQuoted({ quoteId: "quote-1" })))
+                      to.local.quoted().resolve(({ target }) =>
+                        target.decoded(new ShippingQuoted({ quoteId: "quote-1" }))
+                      )
                   }
                 },
                 quoted: {
@@ -4086,7 +4117,7 @@ describe("Machine", () => {
                   on: {
                     ReserveInventory: (to) =>
                       to.local.reserved().resolve(({ event, target }) =>
-                        target(new InventoryReserved({ reservationId: event.reservationId }))
+                        target.decoded(new InventoryReserved({ reservationId: event.reservationId }))
                       )
                   }
                 }
@@ -4098,7 +4129,7 @@ describe("Machine", () => {
                   on: {
                     ReserveInventory: (to) =>
                       to.local.quoted().resolve(({ event, target }) =>
-                        target(new ShippingQuoted({ quoteId: event.reservationId }))
+                        target.decoded(new ShippingQuoted({ quoteId: event.reservationId }))
                       )
                   }
                 }
@@ -4197,7 +4228,7 @@ describe("Machine", () => {
                     ReserveInventory: (to) =>
                       to.local.reserved().resolve(({ event, target }, enqueue) => {
                         enqueue.raise(new Resolve({}))
-                        return target(
+                        return target.decoded(
                           new InventoryReserved({
                             reservationId: event.reservationId
                           })
@@ -4212,7 +4243,9 @@ describe("Machine", () => {
                 quoting: {
                   on: {
                     Resolve: (to) =>
-                      to.local.quoted().resolve(({ target }) => target(new ShippingQuoted({ quoteId: "raised" })))
+                      to.local.quoted().resolve(({ target }) =>
+                        target.decoded(new ShippingQuoted({ quoteId: "raised" }))
+                      )
                   }
                 }
               }
@@ -4250,7 +4283,7 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: { Idle },
         events: Machine.events(Submit),
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({ userId: "user-1" })))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-1" })))
       })
 
       const actor = yield* Machine.start(machine)
@@ -4264,11 +4297,13 @@ describe("Machine", () => {
         states: { Idle, Loading },
         events: Machine.events(Submit),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
           }
         }
       })
@@ -4292,16 +4327,18 @@ describe("Machine", () => {
       states: { Idle, Loading },
       events: Machine.events(Submit, Reset),
       input: Input,
-      initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+      initial: (to) =>
+        to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
     }).handle({
       Idle: {
         on: {
-          Submit: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+          Submit: (to) =>
+            to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
         }
       },
       Loading: {
         on: {
-          Reset: (to) => to.full.Idle().resolve(({ target }) => target(new Idle({ userId: "user-1" })))
+          Reset: (to) => to.full.Idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-1" })))
         }
       }
     })
@@ -4321,11 +4358,13 @@ describe("Machine", () => {
       },
       events: Machine.events(Submit),
       input: Input,
-      initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+      initial: (to) =>
+        to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
     }).handle({
       Idle: {
         on: {
-          Submit: (to) => to.full.Success().resolve(({ target }) => target(new Success({ requestId: "request-1" })))
+          Submit: (to) =>
+            to.full.Success().resolve(({ target }) => target.decoded(new Success({ requestId: "request-1" })))
         }
       },
       Success: {}
@@ -4343,11 +4382,13 @@ describe("Machine", () => {
         states: { Idle, Success: SuccessOutput },
         events: Machine.events(Submit),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Success().resolve(({ target }) => target(new Success({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Success().resolve(({ target }) => target.decoded(new Success({ requestId: "request-1" })))
           }
         },
         Success: {
@@ -4373,11 +4414,13 @@ describe("Machine", () => {
         states: { Idle, Success: SuccessOutput },
         events: Machine.events(Submit),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Success().resolve(({ target }) => target(new Success({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Success().resolve(({ target }) => target.decoded(new Success({ requestId: "request-1" })))
           }
         },
         Success: {
@@ -4400,7 +4443,7 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: { Success: SuccessOutput },
         events: Machine.events(Submit),
-        initial: (to) => to.Success().resolve(({ target }) => target(new Success({ requestId: "request-1" })))
+        initial: (to) => to.Success().resolve(({ target }) => target.decoded(new Success({ requestId: "request-1" })))
       }).handle({
         Success: {
           output: ({ state }) => {
@@ -4434,7 +4477,7 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: { Success: SuccessOutput },
         events: Machine.events(Submit),
-        initial: (to) => to.Success().resolve(({ target }) => target(new Success({ requestId: "request-1" })))
+        initial: (to) => to.Success().resolve(({ target }) => target.decoded(new Success({ requestId: "request-1" })))
       }).handle({
         Success: {
           output: ({ state }) => {
@@ -4464,11 +4507,13 @@ describe("Machine", () => {
         },
         events: Machine.events(Submit),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Success().resolve(({ target }) => target(new Success({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Success().resolve(({ target }) => target.decoded(new Success({ requestId: "request-1" })))
           }
         },
         Success: {}
@@ -4498,12 +4543,14 @@ describe("Machine", () => {
         },
         events: Machine.events(Submit, Reset),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Success().resolve(({ target }) => target(new Success({ requestId: "request-1" }))),
-            Reset: (to) => to.full.Idle().resolve(({ target }) => target(new Idle({ userId: "user-2" })))
+            Submit: (to) =>
+              to.full.Success().resolve(({ target }) => target.decoded(new Success({ requestId: "request-1" }))),
+            Reset: (to) => to.full.Idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-2" })))
           }
         },
         Success: {}
@@ -4530,11 +4577,12 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: { Idle, Loading },
         events: Machine.events(Submit),
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({ userId: "user-1" })))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-1" })))
       }).handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
           }
         }
       })
@@ -4558,11 +4606,13 @@ describe("Machine", () => {
         states: { Idle, Loading },
         events: Machine.events(Submit),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
           }
         }
       })
@@ -4589,7 +4639,8 @@ describe("Machine", () => {
         },
         events: Machine.events(Submit),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Success: {}
       })
@@ -4608,7 +4659,8 @@ describe("Machine", () => {
         states: { Idle, Loading },
         events: Machine.events(Submit),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Idle: {
           on: {
@@ -4631,11 +4683,13 @@ describe("Machine", () => {
         states: { Idle, Loading },
         events: Machine.events(Submit),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
           }
         }
       })
@@ -4675,11 +4729,13 @@ describe("Machine", () => {
         states: { Idle, Success: SuccessOutput },
         events: Machine.events(Submit),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Success().resolve(({ target }) => target(new Success({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Success().resolve(({ target }) => target.decoded(new Success({ requestId: "request-1" })))
           }
         },
         Success: {
@@ -4710,11 +4766,13 @@ describe("Machine", () => {
         states: { Idle, Loading },
         events: Machine.events(Submit, Reset),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
           }
         }
       })
@@ -4734,18 +4792,20 @@ describe("Machine", () => {
         states: { Idle, Loading, Success: SuccessOutput },
         events: Machine.events(Submit, RequestSucceeded),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       })
       const machine = definition.handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
           }
         },
         Loading: {
           invoke: (from) =>
             from.effect("request", () => Effect.succeed("done:request-1")).onDone((to) =>
-              to.full.Success().resolve(({ output, target }) => target(new Success({ requestId: output })))
+              to.full.Success().resolve(({ output, target }) => target.decoded(new Success({ requestId: output })))
             )
         },
         Success: {
@@ -4775,18 +4835,20 @@ describe("Machine", () => {
         states: { Idle, Loading, Success: SuccessOutput },
         events: Machine.events(Submit, RequestSucceeded),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       })
       const machine = definition.handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
           }
         },
         Loading: {
           invoke: (from) =>
             from.effect("request", () => Effect.succeed("done:request-1")).onDone((to) =>
-              to.full.Success().resolve(({ output, target }) => target(new Success({ requestId: output })))
+              to.full.Success().resolve(({ output, target }) => target.decoded(new Success({ requestId: output })))
             )
         },
         Success: {
@@ -4816,14 +4878,14 @@ describe("Machine", () => {
       const childMachine = Machine.make({
         states: childStates.states,
         events: Machine.events(),
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({ userId: "child" })))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({ userId: "child" })))
       })
       const Child = Machine.child("shared-child", childMachine)
       const parentStates = Machine.states({ Loading })
       const parentMachine = Machine.make({
         states: parentStates.states,
         events: Machine.events(),
-        initial: (to) => to.Loading().resolve(({ target }) => target(new Loading({ requestId: "parent" })))
+        initial: (to) => to.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "parent" })))
       }).handle({
         Loading: {
           invoke: (from) => from.child(Child)
@@ -4867,14 +4929,14 @@ describe("Machine", () => {
       const childMachine = Machine.make({
         states: childStates.states,
         events: Machine.events(),
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({ userId: "child" })))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({ userId: "child" })))
       }).handle({ Idle: {} })
       const Child = Machine.child("owned-child", childMachine)
       const parentStates = Machine.states({ Loading })
       const parentMachine = Machine.make({
         states: parentStates.states,
         events: Machine.events(),
-        initial: (to) => to.Loading().resolve(({ target }) => target(new Loading({ requestId: "parent" })))
+        initial: (to) => to.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "parent" })))
       }).handle({
         Loading: { invoke: (from) => from.child(Child) }
       })
@@ -4904,7 +4966,7 @@ describe("Machine", () => {
         initial: (to) =>
           to.Idle().resolve(({ input, target }) => {
             starts += 1
-            return target(new Idle({ userId: input.userId }))
+            return target.decoded(new Idle({ userId: input.userId }))
           })
       }).handle({ Idle: {} })
       const Child = Machine.child("input-child", childMachine)
@@ -4912,7 +4974,7 @@ describe("Machine", () => {
       const parentMachine = Machine.make({
         states: parentStates.states,
         events: Machine.events(),
-        initial: (to) => to.Loading().resolve(({ target }) => target(new Loading({ requestId: "parent" })))
+        initial: (to) => to.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "parent" })))
       }).handle({
         Loading: {
           invoke: (from) => from.child(Child, { input: { userId: "configured" } })
@@ -4947,7 +5009,8 @@ describe("Machine", () => {
       const childMachine = Machine.make({
         states: childStates.states,
         events: Machine.events(),
-        initial: (to) => to.Success().resolve(({ target }) => target(new Success({ requestId: "child-output" })))
+        initial: (to) =>
+          to.Success().resolve(({ target }) => target.decoded(new Success({ requestId: "child-output" })))
       }).handle({
         Success: { output: ({ state }) => state.requestId }
       })
@@ -4959,12 +5022,12 @@ describe("Machine", () => {
       const parentMachine = Machine.make({
         states: parentStates.states,
         events: Machine.events(ChildFinished),
-        initial: (to) => to.Loading().resolve(({ target }) => target(new Loading({ requestId: "parent" })))
+        initial: (to) => to.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "parent" })))
       }).handle({
         Loading: {
           invoke: (from) =>
             from.child(Child).onDone((to) =>
-              to.full.Success().resolve(({ output, target }) => target(new Success({ requestId: output })))
+              to.full.Success().resolve(({ output, target }) => target.decoded(new Success({ requestId: output })))
             )
         },
         Success: { output: ({ state }) => state.requestId }
@@ -4982,7 +5045,8 @@ describe("Machine", () => {
         states: states.states,
         events: Machine.events(),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Idle: {}
       })
@@ -5011,14 +5075,14 @@ describe("Machine", () => {
       const child = Machine.make({
         states: childStates.states,
         events: Machine.events(),
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({ userId: "child" })))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({ userId: "child" })))
       })
       const Child = Machine.child("child-machine", child)
       const parentStates = Machine.states({ Loading })
       const parent = Machine.make({
         states: parentStates.states,
         events: Machine.events(),
-        initial: (to) => to.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+        initial: (to) => to.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
       }).handle({
         Loading: {
           invoke: (from) => [from.child(Child), from.child(Child)]
@@ -5044,7 +5108,7 @@ describe("Machine", () => {
       const parent = Machine.make({
         states: parentStates.states,
         events: Machine.events(),
-        initial: (to) => to.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+        initial: (to) => to.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
       }).handle({
         Loading: {
           invoke: (
@@ -5071,17 +5135,19 @@ describe("Machine", () => {
         states: { Idle, Loading, Failed: FailedOutput },
         events: Machine.events(Submit, RequestFailed),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
           }
         },
         Loading: {
           invoke: (from) =>
             from.effect("request", () => Effect.fail(error)).onFailure((to) =>
-              to.full.Failed().resolve(({ error, target }) => target(new Failed({ message: error.message })))
+              to.full.Failed().resolve(({ error, target }) => target.decoded(new Failed({ message: error.message })))
             )
         },
         Failed: {
@@ -5111,17 +5177,18 @@ describe("Machine", () => {
         states: { Idle, Loading, Success: SuccessOutput },
         events: Machine.events(Submit),
         internalEvents: Machine.internalEvents(RequestSucceeded),
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({ userId: "user-1" })))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-1" })))
       }).handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
           }
         },
         Loading: {
           invoke: (from) =>
             from.effect("request", () => Effect.succeed("loaded")).onDone((to) =>
-              to.full.Success().resolve(({ output, target }) => target(new Success({ requestId: output })))
+              to.full.Success().resolve(({ output, target }) => target.decoded(new Success({ requestId: output })))
             )
         },
         Success: {
@@ -5141,7 +5208,7 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: { Loading, Success: SuccessOutput },
         events: Machine.events(RequestSucceeded),
-        initial: (to) => to.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+        initial: (to) => to.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
       }).handle({
         Loading: {
           invoke: (from) =>
@@ -5160,7 +5227,7 @@ describe("Machine", () => {
             }).onFailure((to) => to.none),
           on: {
             RequestSucceeded: (to) =>
-              to.full.Success().resolve(({ event, target }) => target(new Success({ requestId: event.value })))
+              to.full.Success().resolve(({ event, target }) => target.decoded(new Success({ requestId: event.value })))
           }
         },
         Success: {
@@ -5180,12 +5247,12 @@ describe("Machine", () => {
       const machine = Machine.make({
         states: { Idle, Loading, Success: SuccessOutput },
         events: Machine.events(Resolve, RequestSucceeded),
-        initial: (to) => to.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+        initial: (to) => to.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
       }).handle({
         Idle: {
           on: {
             RequestSucceeded: (to) =>
-              to.full.Success().resolve(({ event, target }) => target(new Success({ requestId: event.value })))
+              to.full.Success().resolve(({ event, target }) => target.decoded(new Success({ requestId: event.value })))
           }
         },
         Loading: {
@@ -5204,7 +5271,7 @@ describe("Machine", () => {
               })
             }).onFailure((to) => to.none),
           on: {
-            Resolve: (to) => to.full.Idle().resolve(({ target }) => target(new Idle({ userId: "resolved" })))
+            Resolve: (to) => to.full.Idle().resolve(({ target }) => target.decoded(new Idle({ userId: "resolved" })))
           }
         },
         Success: {
@@ -5235,12 +5302,12 @@ describe("Machine", () => {
         states: { Loading, Failed: FailedOutput },
         events: Machine.events(),
         internalEvents: Machine.internalEvents(RequestSucceeded, RequestFailed),
-        initial: (to) => to.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+        initial: (to) => to.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
       }).handle({
         Loading: {
           invoke: (from) =>
             from.effect("request", () => Effect.fail(failure)).onFailure((to) =>
-              to.full.Failed().resolve(({ error, target }) => target(new Failed({ message: error.message })))
+              to.full.Failed().resolve(({ error, target }) => target.decoded(new Failed({ message: error.message })))
             )
         },
         Failed: {
@@ -5262,12 +5329,12 @@ describe("Machine", () => {
         states: { Loading, Success: SuccessOutput },
         events: Machine.events(),
         internalEvents: Machine.internalEvents(RequestSucceeded),
-        initial: (to) => to.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+        initial: (to) => to.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
       }).handle({
         Loading: {
           invoke: (from) =>
             from.effect("request", () => requiredMessage).onDone((to) =>
-              to.full.Success().resolve(({ output, target }) => target(new Success({ requestId: output })))
+              to.full.Success().resolve(({ output, target }) => target.decoded(new Success({ requestId: output })))
             )
         },
         Success: {
@@ -5291,12 +5358,12 @@ describe("Machine", () => {
         states: { Loading, Success: SuccessOutput },
         events: Machine.events(),
         internalEvents: Machine.internalEvents(RequestSucceeded),
-        initial: (to) => to.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+        initial: (to) => to.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
       }).handle({
         Loading: {
           invoke: (from) =>
             from.timer("timeout", "1 hour").onDone((to) =>
-              to.full.Success().resolve(({ target }) => target(new Success({ requestId: "timeout" })))
+              to.full.Success().resolve(({ target }) => target.decoded(new Success({ requestId: "timeout" })))
             )
         },
         Success: {
@@ -5317,7 +5384,8 @@ describe("Machine", () => {
         states: { Idle, Loading, Success: SuccessOutput },
         events: Machine.events(Submit, RequestProgress),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       })
       const onSnapshot: Machine.Machine.InvokeTransition<
         Machine.Machine.States<typeof definition>,
@@ -5337,12 +5405,13 @@ describe("Machine", () => {
         >
       > = (to) =>
         to.full.Success().resolve(({ id, snapshot, target }) =>
-          target(new Success({ requestId: `${id}:${snapshot.state}` }))
+          target.decoded(new Success({ requestId: `${id}:${snapshot.state}` }))
         )
       const machine = definition.handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
           }
         },
         Loading: {
@@ -5380,11 +5449,13 @@ describe("Machine", () => {
         states: { Idle, Loading },
         events: Machine.events(Submit),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
           }
         },
         Loading: {
@@ -5415,7 +5486,8 @@ describe("Machine", () => {
         states: { Idle, Loading, Success: SuccessOutput },
         events: Machine.events(Submit, RequestProgress),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       })
       const onSnapshot: Machine.Machine.InvokeTransition<
         Machine.Machine.States<typeof definition>,
@@ -5439,13 +5511,14 @@ describe("Machine", () => {
           unchanged: { target: to.none }
         }).resolve(({ snapshot, select }) =>
           snapshot.state === "ready"
-            ? select.ready(new Success({ requestId: snapshot.state }))
+            ? select.ready.decoded(new Success({ requestId: snapshot.state }))
             : select.unchanged()
         )
       const machine = definition.handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
           }
         },
         Loading: {
@@ -5499,11 +5572,13 @@ describe("Machine", () => {
         states: { Idle, Loading },
         events: Machine.events(Submit),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
           }
         },
         Loading: {
@@ -5553,20 +5628,23 @@ describe("Machine", () => {
         states: { Idle, Loading, Success: SuccessOutput },
         events: Machine.events(Submit, Resolve, RequestSucceeded),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Idle: {
           on: {
-            Submit: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
           }
         },
         Loading: {
           invoke: (from) =>
             from.logic("request", { address: Machine.childAddress("stopping-request"), logic: childLogic }),
           on: {
-            Resolve: (to) => to.full.Success().resolve(({ target }) => target(new Success({ requestId: "request-1" }))),
+            Resolve: (to) =>
+              to.full.Success().resolve(({ target }) => target.decoded(new Success({ requestId: "request-1" }))),
             RequestSucceeded: (to) =>
-              to.full.Success().resolve(({ event, target }) => target(new Success({ requestId: event.value })))
+              to.full.Success().resolve(({ event, target }) => target.decoded(new Success({ requestId: event.value })))
           }
         },
         Success: {
@@ -5664,7 +5742,7 @@ describe("Machine", () => {
               on: {
                 Authorize: (to) =>
                   to.local.authorized().resolve(({ event, target }) =>
-                    target(new AuthorizedPayment({ code: event.code }))
+                    target.decoded(new AuthorizedPayment({ code: event.code }))
                   )
               }
             },
@@ -5797,7 +5875,7 @@ describe("Machine", () => {
                 checking: {
                   on: {
                     ReserveInventory: (to) =>
-                      to.full.success().resolve(({ target }) => target(new Success({ requestId: "done" })))
+                      to.full.success().resolve(({ target }) => target.decoded(new Success({ requestId: "done" })))
                   }
                 }
               }
@@ -5903,16 +5981,19 @@ describe("Machine", () => {
         states: { Idle, Loading },
         events: Machine.events(Submit),
         input: Input,
-        initial: (to) => to.Idle().resolve(({ input: input, target }) => target(new Idle({ userId: input.userId })))
+        initial: (to) =>
+          to.Idle().resolve(({ input: input, target }) => target.decoded(new Idle({ userId: input.userId })))
       }).handle({
         Idle: {
-          always: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" }))),
+          always: (to) =>
+            to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" }))),
           on: {
-            Submit: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+            Submit: (to) =>
+              to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
           }
         },
         Loading: {
-          always: (to) => to.full.Idle().resolve(({ target }) => target(new Idle({ userId: "user-1" })))
+          always: (to) => to.full.Idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-1" })))
         }
       })
 
@@ -5932,13 +6013,14 @@ describe("Machine", () => {
         id: "InitialLoopMachine",
         states: { Idle, Loading },
         events: Machine.events(),
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({ userId: "user-1" })))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-1" })))
       }).handle({
         Idle: {
-          always: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({ requestId: "request-1" })))
+          always: (to) =>
+            to.full.Loading().resolve(({ target }) => target.decoded(new Loading({ requestId: "request-1" })))
         },
         Loading: {
-          always: (to) => to.full.Idle().resolve(({ target }) => target(new Idle({ userId: "user-1" })))
+          always: (to) => to.full.Idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-1" })))
         }
       })
 
@@ -5972,15 +6054,15 @@ describe("Machine", () => {
         id: "CompletionLoopMachine",
         states: states.states,
         events: Machine.events(Submit),
-        initial: (to) => to.idle().resolve(({ target }) => target(new Idle({ userId: "user-1" })))
+        initial: (to) => to.idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-1" })))
       }).handle({
         idle: {
           on: {
             Submit: (to) =>
               to.full.flow().resolve(({ target }) =>
-                target(
+                target.decoded(
                   new Loading({ requestId: "request-1" }),
-                  (flow) => flow.done(new Success({ requestId: "request-1" }))
+                  (flow) => flow.done.decoded(new Success({ requestId: "request-1" }))
                 )
               )
           }
@@ -5988,9 +6070,9 @@ describe("Machine", () => {
         flow: {
           onDone: (to) =>
             to.full.flow().resolve(({ state, target }) =>
-              target(
+              target.decoded(
                 state,
-                (flow) => flow.done(new Success({ requestId: state.requestId }))
+                (flow) => flow.done.decoded(new Success({ requestId: state.requestId }))
               )
             )
         }
@@ -6042,9 +6124,10 @@ describe("Machine", () => {
       events: Machine.events(AdvanceCounters),
       initial: (to) =>
         to.running.initial.resolve(({ target }) =>
-          target(
+          target.decoded(
             new CounterRunning({}),
-            (running) => running.left(new LeftCounter({ value: 0 })).right(new RightCounter({ value: 0 }))
+            (running) =>
+              running.left.decoded(new LeftCounter({ value: 0 })).right.decoded(new RightCounter({ value: 0 }))
           )
         )
     }).handle({
@@ -6054,7 +6137,7 @@ describe("Machine", () => {
             on: {
               AdvanceCounters: (to) =>
                 to.branch.running.left().resolve(({ state, target }) =>
-                  target(new LeftCounter({ value: state.value + 1 }))
+                  target.decoded(new LeftCounter({ value: state.value + 1 }))
                 )
             }
           },
@@ -6062,7 +6145,7 @@ describe("Machine", () => {
             on: {
               AdvanceCounters: (to) =>
                 to.branch.running.right().resolve(({ state, target }) =>
-                  target(new RightCounter({ value: state.value + 1 }))
+                  target.decoded(new RightCounter({ value: state.value + 1 }))
                 )
             }
           }
@@ -6075,7 +6158,7 @@ describe("Machine", () => {
     return Machine.make({
       states: states.states,
       events: Machine.events(ConcurrentPing),
-      initial: (to) => to.ConcurrentIdle().resolve(({ target }) => target(new ConcurrentIdle({})))
+      initial: (to) => to.ConcurrentIdle().resolve(({ target }) => target.decoded(new ConcurrentIdle({})))
     }).handle({
       ConcurrentIdle: {
         on: {

--- a/test/machine/MachineReferences.test.ts
+++ b/test/machine/MachineReferences.test.ts
@@ -34,7 +34,7 @@ describe("machine reference event channels", () => {
         initial: (to) =>
           to.Idle().resolve(({ target }) => {
             initializations += 1
-            return target(new Idle({}))
+            return target.decoded(new Idle({}))
           })
       }).handle({
         Idle: {
@@ -83,7 +83,7 @@ describe("machine reference event channels", () => {
         states: states.states,
         events: Machine.events(),
         emittedEvents: Emissions,
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
       }).handle({
         Idle: {
           entry: (_, enqueue) => {
@@ -122,7 +122,7 @@ describe("machine reference event channels", () => {
         states: states.states,
         events: Events,
         emittedEvents: Emissions,
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
       }).handle({
         Idle: {
           on: {
@@ -173,7 +173,7 @@ describe("machine reference event channels", () => {
         states: states.states,
         events: Events,
         emittedEvents: Emissions,
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
       }).handle({
         Idle: {
           on: {
@@ -227,7 +227,7 @@ describe("machine reference event channels", () => {
         events: ChildEvents,
         parent: Machine.optionalParent(ParentEvents),
         emittedEvents: ChildEmissions,
-        initial: (to) => to.Waiting().resolve(({ target }) => target(new Waiting({})))
+        initial: (to) => to.Waiting().resolve(({ target }) => target.decoded(new Waiting({})))
       }).handle({
         Waiting: {
           on: {
@@ -238,7 +238,7 @@ describe("machine reference event channels", () => {
                 if (parent !== undefined) {
                   enqueue.sendTo(parent, ParentEvents.ChildReported({ value: 1 }))
                 }
-                return target(new Reported({}))
+                return target.decoded(new Reported({}))
               })
           }
         },
@@ -266,14 +266,15 @@ describe("machine reference event channels", () => {
       const parentMachine = Machine.make({
         states: parentStates.states,
         events: Machine.events(ParentEvents, Notice),
-        initial: (to) => to.Awaiting().resolve(({ target }) => target(new Awaiting({})))
+        initial: (to) => to.Awaiting().resolve(({ target }) => target.decoded(new Awaiting({})))
       }).handle({
         Awaiting: {
           invoke: (from) => from.child(Child),
           on: {
             ChildReported: (to) =>
-              to.full.Finished().resolve(({ target }) => target(new Finished({ source: "parent event" }))),
-            Notice: (to) => to.full.Finished().resolve(({ target }) => target(new Finished({ source: "emission" })))
+              to.full.Finished().resolve(({ target }) => target.decoded(new Finished({ source: "parent event" }))),
+            Notice: (to) =>
+              to.full.Finished().resolve(({ target }) => target.decoded(new Finished({ source: "emission" })))
           }
         },
         Finished: { output: ({ state }) => state.source }
@@ -305,7 +306,7 @@ describe("machine reference event channels", () => {
         states: childStates.states,
         events: Machine.events(),
         parent: Machine.parent(ParentEvents),
-        initial: (to) => to.ChildIdle().resolve(({ target }) => target(new ChildIdle({})))
+        initial: (to) => to.ChildIdle().resolve(({ target }) => target.decoded(new ChildIdle({})))
       })
       const childMachine = childDefinition.handle({
         ChildIdle: {
@@ -323,12 +324,12 @@ describe("machine reference event channels", () => {
       const parentMachine = Machine.make({
         states: parentStates.states,
         events: ParentEvents,
-        initial: (to) => to.ParentWaiting().resolve(({ target }) => target(new ParentWaiting({})))
+        initial: (to) => to.ParentWaiting().resolve(({ target }) => target.decoded(new ParentWaiting({})))
       }).handle({
         ParentWaiting: {
           invoke: (from) => from.child(Child).onFailure((to) => to.none),
           on: {
-            ChildReady: (to) => to.full.ParentDone().resolve(({ target }) => target(new ParentDone({})))
+            ChildReady: (to) => to.full.ParentDone().resolve(({ target }) => target.decoded(new ParentDone({})))
           }
         },
         ParentDone: { output: () => undefined }

--- a/test/machine/MermaidVisualization.test.ts
+++ b/test/machine/MermaidVisualization.test.ts
@@ -54,14 +54,16 @@ const inspection: InspectionApi<TestMachine, { readonly active: boolean }> = {
           key: "approved",
           title: "approved %%\nnow",
           target: "Root.Done",
-          selection: { kind: "state", scope: "local", path: "Root.Done" }
+          selection: { kind: "state", scope: "local", path: "Root.Done" },
+          updates: []
         },
         {
           type: "branch",
           key: "unchanged",
           title: "unchanged",
           target: undefined,
-          selection: { kind: "none", scope: "local", path: undefined }
+          selection: { kind: "none", scope: "local", path: undefined },
+          updates: []
         }
       ]
     },
@@ -72,8 +74,9 @@ const inspection: InspectionApi<TestMachine, { readonly active: boolean }> = {
       acceptance: "declinable",
       branches: [{
         type: "direct",
-        target: "Root.Route",
-        selection: { kind: "choice", scope: "local", path: "Root.Route" }
+        target: "Root.Done",
+        selection: { kind: "state", scope: "local", path: "Root.Done" },
+        updates: ["Root"]
       }]
     }
   ],
@@ -106,7 +109,7 @@ describe("Mermaid visualization", () => {
     assert.include(rendered, "state \"● Choose route (Route)\" as state_1")
     assert.include(rendered, "state state_1 <<choice>>")
     assert.include(rendered, "state_1 --> state_2: choice [approved #37;#37; now]")
-    assert.include(rendered, "state_2 --> state_1: Retry [declinable]")
+    assert.include(rendered, "state_2 --> state_2: Retry [declinable] / update Root")
     assert.notMatch(rendered, /state_1 --> .*otherwise/)
     assert.include(rendered, "state_1: process / worker #37;#37; end note")
     assert.notInclude(rendered, "Candidate events")

--- a/test/machine/PublicPrototype.test.ts
+++ b/test/machine/PublicPrototype.test.ts
@@ -10,7 +10,7 @@ it("uses the public pipeable and inspectable prototypes", () => {
   const machine = Machine.make({
     states: states.states,
     events: Machine.events(Start),
-    initial: (to) => to.Idle().resolve(({ target }) => target(new Idle()))
+    initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle()))
   })
 
   assert.strictEqual(machine.pipe((value) => value), machine)

--- a/test/machine/Resume.test.ts
+++ b/test/machine/Resume.test.ts
@@ -70,7 +70,7 @@ describe("Machine.resume", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(),
-        initial: (to) => to.Inactive().resolve(({ target }) => target(new Inactive({})))
+        initial: (to) => to.Inactive().resolve(({ target }) => target.decoded(new Inactive({})))
       }).handle({
         Root: {
           invoke: (from) => from.logic("root", { address: Machine.childAddress("root"), logic: restoredLogic("root") }),
@@ -180,7 +180,7 @@ describe("Machine.resume", () => {
                 states: {
                   A: {
                     on: {
-                      Advance: (to) => to.local.B().resolve(({ target }) => target(new LeftB({})))
+                      Advance: (to) => to.local.B().resolve(({ target }) => target.decoded(new LeftB({})))
                     }
                   }
                 }
@@ -189,7 +189,7 @@ describe("Machine.resume", () => {
                 states: {
                   A: {
                     on: {
-                      Advance: (to) => to.local.B().resolve(({ target }) => target(new RightB({})))
+                      Advance: (to) => to.local.B().resolve(({ target }) => target.decoded(new RightB({})))
                     }
                   }
                 }
@@ -234,11 +234,11 @@ describe("Machine.resume", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Finish),
-        initial: (to) => to.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+        initial: (to) => to.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
       }).handle({
         Count: {
           on: {
-            Finish: (to) => to.full.Done().resolve(({ target }) => target(new Done({ value: 9 })))
+            Finish: (to) => to.full.Done().resolve(({ target }) => target.decoded(new Done({ value: 9 })))
           }
         },
         Done: { output: ({ state }) => state.value }
@@ -281,7 +281,7 @@ describe("Machine.resume", () => {
       })
         .handle({
           Flow: {
-            onDone: (to) => to.full.Next().resolve(({ target }) => target(new Next({})))
+            onDone: (to) => to.full.Next().resolve(({ target }) => target.decoded(new Next({})))
           },
           Next: {}
         })
@@ -303,10 +303,10 @@ describe("Machine.resume", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Ping),
-        initial: (to) => to.A().resolve(({ target }) => target(new A({})))
+        initial: (to) => to.A().resolve(({ target }) => target.decoded(new A({})))
       }).handle({
         A: {
-          always: (to) => to.full.B().resolve(({ target }) => target(new B({})))
+          always: (to) => to.full.B().resolve(({ target }) => target.decoded(new B({})))
         },
         B: {}
       })
@@ -329,15 +329,15 @@ describe("Machine.resume", () => {
         states: states.states,
         events: Machine.events(Cancel),
         internalEvents: Machine.internalEvents(Timeout),
-        initial: (to) => to.Cancelled().resolve(({ target }) => target(new Cancelled({})))
+        initial: (to) => to.Cancelled().resolve(({ target }) => target.decoded(new Cancelled({})))
       }).handle({
         Waiting: {
           invoke: (from) =>
             from.timer("timeout", "1 second").onDone((to) =>
-              to.full.TimedOut().resolve(({ target }) => target(new TimedOut({})))
+              to.full.TimedOut().resolve(({ target }) => target.decoded(new TimedOut({})))
             ),
           on: {
-            Cancel: (to) => to.full.Cancelled().resolve(({ target }) => target(new Cancelled({})))
+            Cancel: (to) => to.full.Cancelled().resolve(({ target }) => target.decoded(new Cancelled({})))
           }
         },
         Cancelled: {},
@@ -371,12 +371,12 @@ describe("Machine.resume", () => {
         states: states.states,
         events: Machine.events(),
         internalEvents: Machine.internalEvents(LoadedEvent),
-        initial: (to) => to.Loaded().resolve(({ target }) => target(new Loaded({ value: "initial" })))
+        initial: (to) => to.Loaded().resolve(({ target }) => target.decoded(new Loaded({ value: "initial" })))
       }).handle({
         Loading: {
           invoke: (from) =>
             from.effect("load", () => Ref.updateAndGet(runs, (n) => n + 1).pipe(Effect.as("fresh"))).onDone((to) =>
-              to.full.Loaded().resolve(({ output, target }) => target(new Loaded({ value: output })))
+              to.full.Loaded().resolve(({ output, target }) => target.decoded(new Loaded({ value: output })))
             )
         },
         Loaded: {}
@@ -405,7 +405,7 @@ describe("Machine.resume", () => {
         states: states.states,
         events: Machine.events(),
         internalEvents: Machine.internalEvents(FailedEvent),
-        initial: (to) => to.Failed().resolve(({ target }) => target(new Failed({ message: "initial" })))
+        initial: (to) => to.Failed().resolve(({ target }) => target.decoded(new Failed({ message: "initial" })))
       }).handle({
         Loading: {
           invoke: (from) =>
@@ -413,7 +413,7 @@ describe("Machine.resume", () => {
               Ref.update(runs, (n) => n + 1).pipe(
                 Effect.andThen(Effect.fail(new LoadFailure({ message: "offline" })))
               )).onFailure((to) =>
-                to.full.Failed().resolve(({ error, target }) => target(new Failed({ message: error.message })))
+                to.full.Failed().resolve(({ error, target }) => target.decoded(new Failed({ message: error.message })))
               )
         },
         Failed: {}
@@ -442,12 +442,14 @@ describe("Machine.resume", () => {
       const child = Machine.make({
         states: childStates.states,
         events: Machine.events(ChildFinish),
-        initial: (to) => to.ChildIdle().resolve(({ target }) => target(new ChildIdle({ value: 1 })))
+        initial: (to) => to.ChildIdle().resolve(({ target }) => target.decoded(new ChildIdle({ value: 1 })))
       }).handle({
         ChildIdle: {
           on: {
             ChildFinish: (to) =>
-              to.full.ChildDone().resolve(({ state, target }) => target(new ChildDone({ value: state.value + 1 })))
+              to.full.ChildDone().resolve(({ state, target }) =>
+                target.decoded(new ChildDone({ value: state.value + 1 }))
+              )
           }
         },
         ChildDone: { output: ({ state }) => state.value }
@@ -457,12 +459,12 @@ describe("Machine.resume", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(ChildOutput),
-        initial: (to) => to.ChildOutput().resolve(({ target }) => target(new ChildOutput({ value: 0 })))
+        initial: (to) => to.ChildOutput().resolve(({ target }) => target.decoded(new ChildOutput({ value: 0 })))
       }).handle({
         Parent: {
           invoke: (from) =>
             from.child(Child).onDone((to) =>
-              to.full.ChildOutput().resolve(({ output, target }) => target(new ChildOutput({ value: output })))
+              to.full.ChildOutput().resolve(({ output, target }) => target.decoded(new ChildOutput({ value: output })))
             )
         },
         ChildOutput: {}
@@ -556,13 +558,13 @@ describe("Machine.resume", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Add),
-        initial: (to) => to.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+        initial: (to) => to.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
       }).handle({
         Count: {
           on: {
             Add: (to) =>
               to.full.Count().resolve(({ event, state, target }) =>
-                target(new Count({ value: state.value + event.value }))
+                target.decoded(new Count({ value: state.value + event.value }))
               )
           }
         }

--- a/test/machine/RuntimeDifferential.test.ts
+++ b/test/machine/RuntimeDifferential.test.ts
@@ -54,7 +54,7 @@ describe("pure planning and managed runtime differential", () => {
         states: states.states,
         events: Machine.events(Cascade, Ignore, Finish),
         internalEvents: Machine.internalEvents(Increment),
-        initial: (to) => to.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+        initial: (to) => to.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
       }).handle({
         Count: {
           on: {
@@ -64,8 +64,9 @@ describe("pure planning and managed runtime differential", () => {
                 return undefined
               }),
             Increment: (to) =>
-              to.full.Count().resolve(({ state, target }) => target(new Count({ value: state.value + 1 }))),
-            Finish: (to) => to.full.Done().resolve(({ state, target }) => target(new Done({ value: state.value })))
+              to.full.Count().resolve(({ state, target }) => target.decoded(new Count({ value: state.value + 1 }))),
+            Finish: (to) =>
+              to.full.Done().resolve(({ state, target }) => target.decoded(new Done({ value: state.value })))
           }
         },
         Done: { output: ({ state }) => state.value }
@@ -144,9 +145,9 @@ describe("pure planning and managed runtime differential", () => {
         internalEvents: Machine.internalEvents(Bump),
         initial: (to) =>
           to.Running.initial.resolve(({ target }) =>
-            target(
+            target.decoded(
               new Running({}),
-              (running) => running.Left(new Left({ value: 0 })).Right(new Right({ value: 0 }))
+              (running) => running.Left.decoded(new Left({ value: 0 })).Right.decoded(new Right({ value: 0 }))
             )
           )
       }).handle({
@@ -155,7 +156,7 @@ describe("pure planning and managed runtime differential", () => {
             Finish: (to) =>
               to.full.Done().resolve(({ snapshot, target }) => {
                 if (snapshot.path !== "Running") throw new Error("expected Running snapshot")
-                return target(
+                return target.decoded(
                   new Done({
                     value: snapshot.states.Left.value.value + snapshot.states.Right.value.value
                   })
@@ -168,7 +169,7 @@ describe("pure planning and managed runtime differential", () => {
                 Advance: (to) =>
                   to.branch.Running.Left().resolve(({ state, target }, enqueue) => {
                     enqueue.raise(new Bump({}))
-                    return target(new Left({ value: state.value + 1 }))
+                    return target.decoded(new Left({ value: state.value + 1 }))
                   })
               }
             },
@@ -176,11 +177,11 @@ describe("pure planning and managed runtime differential", () => {
               on: {
                 Advance: (to) =>
                   to.branch.Running.Right().resolve(({ state, target }) =>
-                    target(new Right({ value: state.value + 10 }))
+                    target.decoded(new Right({ value: state.value + 10 }))
                   ),
                 Bump: (to) =>
                   to.branch.Running.Right().resolve(({ state, target }) =>
-                    target(new Right({ value: state.value + 100 }))
+                    target.decoded(new Right({ value: state.value + 100 }))
                   ),
                 Inspect: (to) =>
                   to.none.resolve((context) => {
@@ -448,7 +449,7 @@ describe("pure planning and managed runtime differential", () => {
         events: Machine.events(Begin),
         internalEvents: Machine.internalEvents(RaisedOne, RaisedTwo),
         emittedEvents: Machine.emittedEvents(Notice),
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
       }).handle({
         Idle: {
           entry: (_, enqueue) => {
@@ -461,7 +462,7 @@ describe("pure planning and managed runtime differential", () => {
                 record("transition:begin")
                 enqueue.emit(new Notice({ label: "transition" }))
                 enqueue.raise(new RaisedOne({}))
-                return target(new Working({}))
+                return target.decoded(new Working({}))
               })
           }
         },
@@ -482,7 +483,7 @@ describe("pure planning and managed runtime differential", () => {
               to.full.Finished().resolve(({ target }, enqueue) => {
                 record("raised:two")
                 enqueue.emit(new Notice({ label: "raised-two" }))
-                return target(new Finished({}))
+                return target.decoded(new Finished({}))
               })
           }
         },
@@ -561,11 +562,11 @@ describe("pure planning and managed runtime differential", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Ignore, Go),
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
       }).handle({
         Idle: {
           on: {
-            Go: (to) => to.full.Active().resolve(({ target }) => target(new Active({})))
+            Go: (to) => to.full.Active().resolve(({ target }) => target.decoded(new Active({})))
           }
         },
         Active: {}

--- a/test/machine/Scheduling.test.ts
+++ b/test/machine/Scheduling.test.ts
@@ -21,20 +21,21 @@ describe("machine scheduling", () => {
         states: states.states,
         events: Machine.events(StartBurst),
         internalEvents: Machine.internalEvents(Burst),
-        initial: (to) => to.SchedulingActive().resolve(({ target }) => target(new SchedulingActive({ count: 0 })))
+        initial: (to) =>
+          to.SchedulingActive().resolve(({ target }) => target.decoded(new SchedulingActive({ count: 0 })))
       }).handle({
         SchedulingActive: {
           on: {
             StartBurst: (to) =>
               to.full.SchedulingActive().resolve(({ state, target }, enqueue) => {
                 enqueue.raise(new Burst({}))
-                return target(state)
+                return target.decoded(state)
               }),
             Burst: (to) =>
               to.full.SchedulingActive().resolve(({ state, target }, enqueue) => {
                 const count = state.count + 1
                 if (count < burstSize) enqueue.raise(new Burst({}))
-                return target(new SchedulingActive({ count }))
+                return target.decoded(new SchedulingActive({ count }))
               })
           }
         }

--- a/test/machine/SnapshotCodecAdversarial.test.ts
+++ b/test/machine/SnapshotCodecAdversarial.test.ts
@@ -135,7 +135,7 @@ const historyMachine = Machine.make({
   id: "codec-history",
   states: HistoryStates.states,
   events: Machine.events(),
-  initial: (to) => to.Outside().resolve(({ target }) => target(new Outside({})))
+  initial: (to) => to.Outside().resolve(({ target }) => target.decoded(new Outside({})))
 })
 
 const historySnapshot = () =>
@@ -175,7 +175,9 @@ const richMachine = Machine.make({
   events: Machine.events(),
   initial: (to) =>
     to.RichState().resolve(({ target }) =>
-      target(new RichState({ createdAt: new Date("2026-08-19T12:00:00.000Z"), sequence: 42n, missing: undefined }))
+      target.decoded(
+        new RichState({ createdAt: new Date("2026-08-19T12:00:00.000Z"), sequence: 42n, missing: undefined })
+      )
     )
 })
 
@@ -194,7 +196,7 @@ const opaqueMachine = Machine.make({
   id: "codec-opaque",
   states: OpaqueStates.states,
   events: Machine.events(),
-  initial: (to) => to.OpaqueState().resolve(({ target }) => target({ _tag: "CodecOpaqueState", resource: {} }))
+  initial: (to) => to.OpaqueState().resolve(({ target }) => target.decoded({ _tag: "CodecOpaqueState", resource: {} }))
 })
 
 class OutputDone extends Schema.TaggedClass<OutputDone>("CodecOutputDone")("CodecOutputDone", {}) {}
@@ -205,7 +207,7 @@ const outputMachine = Machine.make({
   id: "codec-output",
   states: OutputStates.states,
   events: Machine.events(),
-  initial: (to) => to.OutputDone().resolve(({ target }) => target(new OutputDone({})))
+  initial: (to) => to.OutputDone().resolve(({ target }) => target.decoded(new OutputDone({})))
 })
 
 const expectEncodeFailure = Effect.fnUntraced(function*(snapshot: unknown, boundary?: string) {
@@ -374,10 +376,10 @@ describe("snapshot codec adversarial boundaries", () => {
         id: "codec-automatic-original",
         states: states.states,
         events: Machine.events(),
-        initial: (to) => to.Before().resolve(({ target }) => target(new Before({})))
+        initial: (to) => to.Before().resolve(({ target }) => target.decoded(new Before({})))
       }).handle({
         Before: {
-          always: (to) => to.full.Boundary().resolve(({ target }) => target(new Boundary({})))
+          always: (to) => to.full.Boundary().resolve(({ target }) => target.decoded(new Boundary({})))
         },
         Boundary: {},
         After: {}
@@ -386,11 +388,11 @@ describe("snapshot codec adversarial boundaries", () => {
         id: "codec-automatic-changed",
         states: states.states,
         events: Machine.events(),
-        initial: (to) => to.Before().resolve(({ target }) => target(new Before({})))
+        initial: (to) => to.Before().resolve(({ target }) => target.decoded(new Before({})))
       }).handle({
         Before: {},
         Boundary: {
-          always: (to) => to.full.After().resolve(({ target }) => target(new After({})))
+          always: (to) => to.full.After().resolve(({ target }) => target.decoded(new After({})))
         },
         After: {}
       })

--- a/test/machine/SnapshotContext.test.ts
+++ b/test/machine/SnapshotContext.test.ts
@@ -73,7 +73,7 @@ describe("Machine transition snapshot context", () => {
                       }).resolve(({ snapshot, select }) => {
                         captured = snapshot
                         return States.matches(snapshot, "System.Network.Online")
-                          ? select.online(new Playing({}))
+                          ? select.online.decoded(new Playing({}))
                           : select.unchanged()
                       })
                   }
@@ -112,7 +112,7 @@ describe("Machine transition snapshot context", () => {
                     Disconnect: (to) =>
                       to.local.Playing().resolve(({ snapshot, target }) => {
                         captured.push(snapshot)
-                        return target(new Playing({}))
+                        return target.decoded(new Playing({}))
                       })
                   }
                 }
@@ -125,7 +125,7 @@ describe("Machine transition snapshot context", () => {
                     Disconnect: (to) =>
                       to.local.Offline().resolve(({ snapshot, target }) => {
                         captured.push(snapshot)
-                        return target(new Offline({}))
+                        return target.decoded(new Offline({}))
                       })
                   }
                 }
@@ -166,7 +166,7 @@ describe("Machine transition snapshot context", () => {
                     }).resolve(({ snapshot, select }) => {
                       captured = snapshot
                       return States.matches(snapshot, "System.Network.Online")
-                        ? select.online(new Playing({}))
+                        ? select.online.decoded(new Playing({}))
                         : select.unchanged()
                     })
                 }
@@ -217,12 +217,12 @@ describe("Machine transition snapshot context", () => {
         events: Machine.events(),
         initial: (to) =>
           to.System.initial.resolve(({ target }) =>
-            target(
+            target.decoded(
               new System({}),
               (system) =>
                 system
-                  .Work(new Work({}), (work) => work.Finished(new Finished({})))
-                  .Monitor(new Monitor({}), (monitor) => monitor.Active(new Active({})))
+                  .Work.decoded(new Work({}), (work) => work.Finished.decoded(new Finished({})))
+                  .Monitor.decoded(new Monitor({}), (monitor) => monitor.Active.decoded(new Active({})))
             )
           )
       }).handle({
@@ -232,7 +232,7 @@ describe("Machine transition snapshot context", () => {
               onDone: (to) =>
                 to.local.Restarted().resolve(({ snapshot, target }) => {
                   captured = snapshot
-                  return target(new Restarted({}))
+                  return target.decoded(new Restarted({}))
                 })
             }
           }

--- a/test/machine/StateDefinition.test.ts
+++ b/test/machine/StateDefinition.test.ts
@@ -128,7 +128,7 @@ describe("exact state-definition runtime validation", () => {
     const machine = Machine.make({
       states: states.states,
       events: Machine.events(),
-      initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+      initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
     })
 
     assert.strictEqual(Machine.stateNodes(machine)[0]?.path, "Idle")
@@ -143,7 +143,7 @@ describe("exact state-definition runtime validation", () => {
     const machine = Machine.make({
       states: states.states,
       events: Machine.events(),
-      initial: (to) => to.Opaque().resolve(({ target }) => target({ _tag: "OpaqueState", value: 1 }))
+      initial: (to) => to.Opaque().resolve(({ target }) => target.decoded({ _tag: "OpaqueState", value: 1 }))
     })
 
     assert.strictEqual(Machine.stateNodes(machine)[0]?.path, "Opaque")

--- a/test/machine/StateUpdate.test.ts
+++ b/test/machine/StateUpdate.test.ts
@@ -4,6 +4,162 @@ import { Machine } from "../../src/index.js"
 import { MachineTest } from "../../src/testing/index.js"
 
 describe("state value updates", () => {
+  it.effect("changes topology and one retained owner atomically", () =>
+    Effect.gen(function*() {
+      const State = Schema.TaggedUnion({
+        Ready: { notice: Schema.NullOr(Schema.String) },
+        Idle: {},
+        SavingPlan: { request: Schema.String }
+      })
+      const Event = Schema.TaggedUnion({ CreatePlan: { input: Schema.String }, InvalidPlan: {} })
+      const states = Machine.states({
+        Ready: {
+          schema: State.cases.Ready,
+          initial: "Idle",
+          states: {
+            Idle: State.cases.Idle,
+            SavingPlan: State.cases.SavingPlan
+          }
+        }
+      })
+      let observedEntry: { readonly notice: string | null; readonly request: string } | undefined
+      const machine = Machine.make({
+        states: states.states,
+        events: Machine.events(Event),
+        initial: (to) =>
+          to.Ready.initial.resolve(({ target }) =>
+            target.from({ notice: "Previous notice" }, (ready) => ready.Idle.from())
+          )
+      }).handle({
+        Ready: {
+          states: {
+            Idle: {
+              on: {
+                CreatePlan: (to) =>
+                  to.local.SavingPlan()
+                    .updating(to.branch.Ready)
+                    .resolve(({ current, event, owner, target }) =>
+                      target.from({ request: event.input }).update(
+                        owner.decoded(State.cases.Ready.make({ ...current, notice: null }))
+                      )
+                    ),
+                InvalidPlan: (to) =>
+                  to.local.SavingPlan()
+                    .updating(to.branch.Ready)
+                    .resolve(({ owner, target }) =>
+                      target.from({ request: "invalid" }).update(
+                        owner.from({ notice: 1 } as any)
+                      )
+                    )
+              }
+            },
+            SavingPlan: {
+              entry: ({ ancestors, state }) => {
+                observedEntry = { notice: ancestors.Ready.notice, request: state.request }
+                return undefined
+              }
+            }
+          }
+        }
+      })
+
+      assert.deepStrictEqual(Machine.transitionDefinitions(machine)[0]?.branches, [{
+        type: "direct",
+        target: "Ready.SavingPlan",
+        selection: { kind: "state", scope: "local", path: "Ready.SavingPlan" },
+        updates: ["Ready"]
+      }])
+
+      const initial = yield* Machine.planInitial(machine)
+      const invalid = yield* Machine.plan(machine, initial.state, Event.cases.InvalidPlan.make({})).pipe(Effect.flip)
+      assert.instanceOf(invalid, Machine.MachineSchemaDecodeError)
+      assert.strictEqual(invalid.state, "Ready")
+      assert.strictEqual(observedEntry, undefined)
+
+      const planned = yield* Machine.plan(machine, initial.state, Event.cases.CreatePlan.make({ input: "New plan" }))
+
+      assert.deepStrictEqual(planned.next, {
+        path: "Ready",
+        value: State.cases.Ready.make({ notice: null }),
+        state: {
+          path: "Ready.SavingPlan",
+          value: State.cases.SavingPlan.make({ request: "New plan" })
+        }
+      })
+      assert.deepStrictEqual(observedEntry, { notice: null, request: "New plan" })
+      assert.deepStrictEqual(planned.microsteps[0]?.exitPaths, ["Ready.Idle"])
+      assert.deepStrictEqual(planned.microsteps[0]?.entryPaths, ["Ready.SavingPlan"])
+      assert.deepStrictEqual(planned.microsteps[0]?.transitions[0]?.updates, ["Ready"])
+
+      const trace = yield* MachineTest.run(machine, { events: [Event.cases.CreatePlan.make({ input: "New plan" })] })
+      yield* MachineTest.verify(machine, trace)
+      assert.strictEqual(MachineTest.coverage(machine, trace).microsteps.updates, 1)
+    }))
+
+  it.effect("combines invocation completion with a schema-less destination", () =>
+    Effect.gen(function*() {
+      const State = Schema.TaggedUnion({
+        Ready: { day: Schema.String, notice: Schema.String },
+        Saving: { request: Schema.String }
+      })
+      const states = Machine.states({
+        Ready: {
+          schema: State.cases.Ready,
+          initial: "Saving",
+          states: {
+            Idle: {},
+            Saving: State.cases.Saving
+          }
+        }
+      })
+      let idleSawDay: string | undefined
+      const machine = Machine.make({
+        states: states.states,
+        events: Machine.events(),
+        initial: (to) =>
+          to.Ready.initial.resolve(({ target }) =>
+            target.from(
+              { day: "Sunday", notice: "Saving" },
+              (ready) => ready.Saving.from({ request: "change" })
+            )
+          )
+      }).handle({
+        Ready: {
+          states: {
+            Idle: {
+              entry: ({ ancestors }) => {
+                idleSawDay = ancestors.Ready.day
+                return undefined
+              }
+            },
+            Saving: {
+              invoke: (from) =>
+                from.effect("save", () => Effect.succeed("Monday")).onDone((to) =>
+                  to.local.Idle()
+                    .updating(to.branch.Ready)
+                    .resolve(({ current, output, owner, target }) =>
+                      target.from().update(
+                        owner.decoded(State.cases.Ready.make({ ...current, day: output, notice: "Saved" }))
+                      )
+                    )
+                )
+            }
+          }
+        }
+      })
+
+      const ref = yield* Machine.start(machine)
+      for (let index = 0; index < 5; index += 1) yield* Effect.yieldNow
+      const snapshot = yield* ref.state
+      assert.strictEqual(snapshot.path, "Ready")
+      if (snapshot.path !== "Ready") throw new Error("expected Ready")
+      assert.strictEqual(snapshot.value.day, "Monday")
+      assert.strictEqual(snapshot.value.notice, "Saved")
+      assert.strictEqual(snapshot.state.path, "Ready.Idle")
+      assert.strictEqual(idleSawDay, "Monday")
+      yield* ref.stop
+    }))
+
   it.effect("updates the local owner without changing its active descendants", () =>
     Effect.gen(function*() {
       const State = Schema.TaggedUnion({
@@ -41,8 +197,8 @@ describe("state value updates", () => {
                 idle: {
                   on: {
                     Increment: (to) =>
-                      to.branch.session.update(({ ancestors, target }) =>
-                        target.from({ count: ancestors.session.count + 1 })
+                      to.branch.session.update(({ current, owner }) =>
+                        owner.from({ count: current.count + 1 })
                       )
                   }
                 }
@@ -60,7 +216,8 @@ describe("state value updates", () => {
         branches: [{
           type: "direct",
           target: undefined,
-          selection: { kind: "update", scope: "branch", path: "session" }
+          selection: { kind: "update", scope: "branch", path: "session" },
+          updates: ["session"]
         }]
       }])
 
@@ -83,7 +240,8 @@ describe("state value updates", () => {
         branchIndex: 0,
         branchKey: undefined,
         target: undefined,
-        resolvedTarget: undefined
+        resolvedTarget: undefined,
+        updates: ["session"]
       }])
       assert.deepStrictEqual(planned.microsteps[0]?.exitPaths, [])
       assert.deepStrictEqual(planned.microsteps[0]?.entryPaths, [])
@@ -135,13 +293,15 @@ describe("state value updates", () => {
         key: "changed",
         title: "Value changed",
         target: undefined,
-        selection: { kind: "update", scope: "local", path: "scope" }
+        selection: { kind: "update", scope: "local", path: "scope" },
+        updates: ["scope"]
       }, {
         type: "branch",
         key: "unchanged",
         title: "unchanged",
         target: undefined,
-        selection: { kind: "none", scope: "local", path: undefined }
+        selection: { kind: "none", scope: "local", path: undefined },
+        updates: []
       }])
 
       const initial = yield* Machine.planInitial(machine)
@@ -192,11 +352,10 @@ describe("state value updates", () => {
                 return undefined
               },
               on: {
-                Quiet: (to) =>
-                  to.local.update(({ ancestors, target }) => target.from({ count: ancestors.scope.count + 1 })),
+                Quiet: (to) => to.local.update(({ current, owner }) => owner.from({ count: current.count + 1 })),
                 Loud: (to) =>
                   to.local.update(
-                    ({ ancestors, target }) => target.from({ count: ancestors.scope.count + 1 }),
+                    ({ current, owner }) => owner.from({ count: current.count + 1 }),
                     { reenter: true }
                   )
               }
@@ -238,9 +397,9 @@ describe("state value updates", () => {
           states: {
             idle: {
               always: (to) =>
-                to.local.update(({ ancestors, decline, target }) =>
-                  ancestors.scope.count < 2
-                    ? target.from({ count: ancestors.scope.count + 1 })
+                to.local.update(({ current, decline, owner }) =>
+                  current.count < 2
+                    ? owner.from({ count: current.count + 1 })
                     : decline(), { declinable: true })
             }
           }
@@ -284,8 +443,7 @@ describe("state value updates", () => {
             a: {
               on: {
                 Leave: (to) => to.full.outside().resolve(({ target }) => target.from()),
-                Update: (to) =>
-                  to.local.update(({ ancestors, target }) => target.from({ count: ancestors.root.count + 1 }))
+                Update: (to) => to.local.update(({ current, owner }) => owner.from({ count: current.count + 1 }))
               }
             }
           }
@@ -365,9 +523,7 @@ describe("state value updates", () => {
                 idle: {
                   on: {
                     Update: (to) =>
-                      to.branch.root.update(({ ancestors, target }) =>
-                        target.from({ revision: ancestors.root.revision + 1 })
-                      )
+                      to.branch.root.update(({ current, owner }) => owner.from({ revision: current.revision + 1 }))
                   }
                 }
               }
@@ -408,7 +564,7 @@ describe("state value updates", () => {
           states: {
             idle: {
               on: {
-                Break: (to) => to.local.update(({ target }) => target.from({ count: "bad" } as any))
+                Break: (to) => to.local.update(({ owner }) => owner.from({ count: "bad" } as any))
               }
             }
           }
@@ -444,7 +600,7 @@ describe("state value updates", () => {
             idle: {
               invoke: (from) =>
                 from.effect("load", () => Effect.sync(() => ++starts)).onDone((to) =>
-                  to.local.update(({ output, target }) => target.from({ count: output }))
+                  to.local.update(({ output, owner }) => owner.from({ count: output }))
                 )
             }
           }
@@ -485,11 +641,11 @@ describe("state value updates", () => {
             idle: {
               on: {
                 Update: (to) =>
-                  to.local.update(({ self, target }, enqueue) => {
+                  to.local.update(({ self, owner }, enqueue) => {
                     enqueue.raise(Events.Raised())
                     enqueue.emit(Emissions.Changed({ count: 1 }))
                     enqueue.sendTo(self, Events.Raised())
-                    return target.from({ count: 1 })
+                    return owner.from({ count: 1 })
                   }),
                 Raised: (to) => to.none
               }

--- a/test/machine/Totality.test.ts
+++ b/test/machine/Totality.test.ts
@@ -257,11 +257,11 @@ describe("machine operation totality", () => {
       const machine = Machine.make({
         states: states.states,
         events: Machine.events(Finish),
-        initial: (to) => to.Value().resolve(({ target }) => target({ _tag: "Value", amount: 42 }))
+        initial: (to) => to.Value().resolve(({ target }) => target.decoded({ _tag: "Value", amount: 42 }))
       }).handle({
         Value: {
           on: {
-            Finish: (to) => to.full.Done().resolve(({ target }) => target({ _tag: "Done" }))
+            Finish: (to) => to.full.Done().resolve(({ target }) => target.decoded({ _tag: "Done" }))
           }
         },
         Done: { output: () => 42 }

--- a/test/machine/Visualization.test.ts
+++ b/test/machine/Visualization.test.ts
@@ -102,17 +102,22 @@ const makeMachine = (unsafeStart = false) =>
                 Start: unsafeStart ?
                   (to) =>
                     to.full.disabled().resolve(({ target }) =>
-                      ({ ...target(new Disabled({})), path: "application.workflow.idle" }) as any
+                      ({ ...target.decoded(new Disabled({})), path: "application.workflow.idle" }) as any
                     ) :
                   (to) =>
-                    to.local.running().resolve(({ target }) =>
-                      target(new Running({}), (running) => running.editing(new Editing({})))
-                    ),
-                Refresh: (to) => to.local.update(({ target }) => target(new Workflow({})))
+                    to.local.running()
+                      .updating(to.branch.application.workflow)
+                      .resolve(({ owner, target }) =>
+                        target.decoded(
+                          new Running({}),
+                          (running) => running.editing.decoded(new Editing({}))
+                        ).update(owner.decoded(new Workflow({})))
+                      ),
+                Refresh: (to) => to.local.update(({ owner }) => owner.decoded(new Workflow({})))
               }
             },
             running: {
-              initialize: ({ builder }) => builder(new Editing({}))
+              initialize: ({ builder }) => builder.decoded(new Editing({}))
             }
           }
         },
@@ -120,7 +125,7 @@ const makeMachine = (unsafeStart = false) =>
           states: {
             online: {
               on: {
-                Disconnect: (to) => to.local.offline().resolve(({ target }) => target(new Offline({})))
+                Disconnect: (to) => to.local.offline().resolve(({ target }) => target.decoded(new Offline({})))
               }
             }
           }
@@ -153,7 +158,7 @@ const lifecycleDefinition = Machine.make({
   id: "lifecycle-inspection",
   states: LifecycleStates.states,
   events: Machine.events(),
-  initial: (to) => to.idle().resolve(({ target }) => target(new Idle({})))
+  initial: (to) => to.idle().resolve(({ target }) => target.decoded(new Idle({})))
 })
 
 const makeLifecycleMachine = (unsafe: "always" | "done" | undefined = undefined) =>
@@ -161,14 +166,14 @@ const makeLifecycleMachine = (unsafe: "always" | "done" | undefined = undefined)
     idle: {
       always: (to) =>
         to.full.workflow().resolve(({ target }) => {
-          const selected = target(new Workflow({}), (workflow) => workflow.complete(new Complete({})))
+          const selected = target.decoded(new Workflow({}), (workflow) => workflow.complete.decoded(new Complete({})))
           return unsafe === "always" ? ({ ...selected, path: "idle" } as any) : selected
         })
     },
     workflow: {
       onDone: (to) =>
         to.full.disabled().resolve(({ target }) => {
-          const selected = target(new Disabled({}))
+          const selected = target.decoded(new Disabled({}))
           return unsafe === "done" ? ({ ...selected, path: "workflow" } as any) : selected
         })
     }
@@ -235,7 +240,8 @@ describe("Machine structural visualization", () => {
         branches: [{
           type: "direct",
           target: "application.workflow.running",
-          selection: { path: "application.workflow.running", kind: "state", scope: "local" }
+          selection: { path: "application.workflow.running", kind: "state", scope: "local" },
+          updates: ["application.workflow"]
         }]
       },
       {
@@ -246,7 +252,8 @@ describe("Machine structural visualization", () => {
         branches: [{
           type: "direct",
           target: undefined,
-          selection: { path: "application.workflow", kind: "update", scope: "local" }
+          selection: { path: "application.workflow", kind: "update", scope: "local" },
+          updates: ["application.workflow"]
         }]
       },
       {
@@ -257,7 +264,8 @@ describe("Machine structural visualization", () => {
         branches: [{
           type: "direct",
           target: "application.connection.offline",
-          selection: { path: "application.connection.offline", kind: "state", scope: "local" }
+          selection: { path: "application.connection.offline", kind: "state", scope: "local" },
+          updates: []
         }]
       }
     ])
@@ -287,7 +295,8 @@ describe("Machine structural visualization", () => {
         branches: [{
           type: "direct",
           target: undefined,
-          selection: { path: undefined, kind: "none", scope: "local" }
+          selection: { path: undefined, kind: "none", scope: "local" },
+          updates: []
         }]
       },
       {
@@ -298,7 +307,8 @@ describe("Machine structural visualization", () => {
         branches: [{
           type: "direct",
           target: undefined,
-          selection: { path: undefined, kind: "none", scope: "local" }
+          selection: { path: undefined, kind: "none", scope: "local" },
+          updates: []
         }]
       },
       {
@@ -309,7 +319,8 @@ describe("Machine structural visualization", () => {
         branches: [{
           type: "direct",
           target: undefined,
-          selection: { path: undefined, kind: "none", scope: "local" }
+          selection: { path: undefined, kind: "none", scope: "local" },
+          updates: []
         }]
       }
     ])
@@ -331,7 +342,8 @@ describe("Machine structural visualization", () => {
           branches: [{
             type: "direct",
             target: "workflow",
-            selection: { path: "workflow", kind: "state", scope: "full" }
+            selection: { path: "workflow", kind: "state", scope: "full" },
+            updates: []
           }]
         },
         {
@@ -342,7 +354,8 @@ describe("Machine structural visualization", () => {
           branches: [{
             type: "direct",
             target: "disabled",
-            selection: { path: "disabled", kind: "state", scope: "full" }
+            selection: { path: "disabled", kind: "state", scope: "full" },
+            updates: []
           }]
         }
       ])
@@ -377,7 +390,7 @@ describe("Machine structural visualization", () => {
         "│  ├─ ● workflow [compound, initial: idle]",
         "│  │  ├─ ● idle",
         "│  │  │  ├─ ◇ on: Start",
-        "│  │  │  │  └┄ → running",
+        "│  │  │  │  └┄ → running / update application.workflow",
         "│  │  │  └─ ◇ on: Refresh",
         "│  │  │     └┄ update application.workflow",
         "│  │  ├─ ○ running [compound, initial: editing]",
@@ -406,7 +419,7 @@ describe("Machine structural visualization", () => {
     assert.include(rendered, "state_5 --> [*]")
     assert.include(rendered, "state \"○ recent [history: shallow]\" as state_6")
     assert.include(rendered, "[*] --> state_0")
-    assert.include(rendered, "state_2 --> state_3: Start")
+    assert.include(rendered, "state_2 --> state_3: Start / update application.workflow")
     assert.include(rendered, "state_2: Refresh / update application.workflow")
     assert.include(rendered, "state_8 --> state_9: Disconnect")
     assert.notMatch(rendered, /state_\d+ --> state_\d+: Refresh/)

--- a/test/machine/visualization/mermaid.ts
+++ b/test/machine/visualization/mermaid.ts
@@ -166,14 +166,19 @@ export const makeMermaidRenderer = <Machine extends MachineValue, Snapshot>(
     const source = ids.get(definition.source)
     if (source === undefined) continue
     for (const branch of definition.branches) {
-      if (branch.selection.kind === "update" && branch.selection.path !== undefined) {
+      if (branch.target === undefined && branch.updates.length > 0) {
         lines.push(
-          `  ${source}: ${branchLabel(definition, branch)} / update ${escapeText(branch.selection.path)}`
+          `  ${source}: ${branchLabel(definition, branch)} / update ${escapeText(branch.updates.join(", "))}`
         )
         continue
       }
       const target = branch.target === undefined ? undefined : ids.get(branch.target)
-      if (target !== undefined) lines.push(`  ${source} --> ${target}: ${branchLabel(definition, branch)}`)
+      if (target !== undefined) {
+        const updates = branch.updates.length === 0
+          ? ""
+          : ` / update ${escapeText(branch.updates.join(", "))}`
+        lines.push(`  ${source} --> ${target}: ${branchLabel(definition, branch)}${updates}`)
+      }
     }
   }
 

--- a/test/machine/visualization/model.ts
+++ b/test/machine/visualization/model.ts
@@ -51,6 +51,7 @@ export interface TransitionDefinition {
         readonly scope: "local" | "branch" | "full" | "initial" | undefined
         readonly path: string | undefined
       }
+      readonly updates: ReadonlyArray<string>
     }
     | {
       readonly type: "branch"
@@ -62,6 +63,7 @@ export interface TransitionDefinition {
         readonly scope: "local" | "branch" | "full" | "initial" | undefined
         readonly path: string | undefined
       }
+      readonly updates: ReadonlyArray<string>
     }
   >
 }

--- a/test/machine/visualization/text.ts
+++ b/test/machine/visualization/text.ts
@@ -21,20 +21,21 @@ interface TransitionLabel {
 const triggerLabels = (definitions: ReadonlyArray<TransitionDefinition>): ReadonlyArray<TransitionLabel> =>
   definitions.flatMap((definition) => {
     const branches = definition.branches.flatMap((branch) => {
-      if (branch.selection.kind === "update" && branch.selection.path !== undefined) {
+      if (branch.target === undefined && branch.updates.length > 0) {
         return [
           branch.type === "direct"
-            ? `update ${branch.selection.path}`
-            : `[${branch.title}] update ${branch.selection.path}`
+            ? `update ${branch.updates.join(", ")}`
+            : `[${branch.title}] update ${branch.updates.join(", ")}`
         ]
       }
       if (branch.target === undefined) return []
 
       const target = branch.target.slice(branch.target.lastIndexOf(".") + 1)
+      const updates = branch.updates.length === 0 ? "" : ` / update ${branch.updates.join(", ")}`
       return [
         branch.type === "direct" ?
-          `→ ${target}` :
-          `[${branch.title}] → ${target}`
+          `→ ${target}${updates}` :
+          `[${branch.title}] → ${target}${updates}`
       ]
     })
     if (branches.length === 0) return []

--- a/test/testing/Coverage.test.ts
+++ b/test/testing/Coverage.test.ts
@@ -20,16 +20,16 @@ const CounterStates = Machine.states({ count: Count, done: Done })
 const counterMachine = Machine.make({
   states: CounterStates.states,
   events: Machine.events(Add, Finish),
-  initial: (to) => to.count().resolve(({ target }) => target(new Count({ value: 0 })))
+  initial: (to) => to.count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
 }).handle({
   count: {
     on: {
       Add: (to) =>
         to.full.count().resolve(
-          ({ event, state, target }) => target(new Count({ value: state.value + event.amount })),
+          ({ event, state, target }) => target.decoded(new Count({ value: state.value + event.amount })),
           { reenter: true, declinable: true }
         ),
-      Finish: (to) => to.full.done().resolve(({ target }) => target(new Done({})))
+      Finish: (to) => to.full.done().resolve(({ target }) => target.decoded(new Done({})))
     }
   },
   done: {}
@@ -44,14 +44,14 @@ const opaqueMachine = Machine.make({
   states: OpaqueStates.states,
   events: Machine.events(),
   input: Schema.Any,
-  initial: (to) => to.opaque().resolve(({ input: payload, target }) => target(new Opaque({ payload })))
+  initial: (to) => to.opaque().resolve(({ input: payload, target }) => target.decoded(new Opaque({ payload })))
 })
 
 const StartupStates = Machine.states({ count: Count })
 const startupMachine = Machine.make({
   states: StartupStates.states,
   events: Machine.events(Add),
-  initial: (to) => to.count().resolve(({ target }) => target(new Count({ value: 0 })))
+  initial: (to) => to.count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
 }).handle({
   count: {
     always: (to) =>
@@ -60,12 +60,14 @@ const startupMachine = Machine.make({
         unchanged: { target: to.none }
       }).resolve(({ state, select }) =>
         state.value === 0
-          ? select.zero(new Count({ value: 1 }))
+          ? select.zero.decoded(new Count({ value: 1 }))
           : select.unchanged()
       ),
     on: {
       Add: (to) =>
-        to.full.count().resolve(({ event, state, target }) => target(new Count({ value: state.value + event.amount })))
+        to.full.count().resolve(({ event, state, target }) =>
+          target.decoded(new Count({ value: state.value + event.amount }))
+        )
     }
   }
 })
@@ -77,7 +79,7 @@ class Select extends Schema.TaggedClass<Select>("CoverageSelect")("Select", {
 const branchMachine = Machine.make({
   states: StartupStates.states,
   events: Machine.events(Select),
-  initial: (to) => to.count().resolve(({ target }) => target(new Count({ value: 0 })))
+  initial: (to) => to.count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
 }).handle({
   count: {
     on: {
@@ -107,7 +109,7 @@ const EventStates = Machine.states({ count: Count })
 const finiteEventMachine = Machine.make({
   states: EventStates.states,
   events: Machine.events(TickEvent, ChoiceEvent),
-  initial: (to) => to.count().resolve(({ target }) => target(new Count({ value: 0 })))
+  initial: (to) => to.count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
 }).handle({
   count: {
     on: {
@@ -120,7 +122,7 @@ const finiteEventMachine = Machine.make({
 const openEventMachine = Machine.make({
   states: EventStates.states,
   events: Machine.events(OpenEvent),
-  initial: (to) => to.count().resolve(({ target }) => target(new Count({ value: 0 })))
+  initial: (to) => to.count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
 }).handle({ count: {} })
 
 const event = (_tag: string): { readonly _tag: string } => ({ _tag })

--- a/test/testing/Exploration.test.ts
+++ b/test/testing/Exploration.test.ts
@@ -20,14 +20,14 @@ const States = Machine.states({ counter: Counter })
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(Increment, Reset, Corrupt),
-  initial: (to) => to.counter().resolve(({ target }) => target(new Counter({ count: 0 })))
+  initial: (to) => to.counter().resolve(({ target }) => target.decoded(new Counter({ count: 0 })))
 }).handle({
   counter: {
     on: {
       Increment: (to) =>
-        to.full.counter().resolve(({ state, target }) => target(new Counter({ count: state.count + 1 }))),
-      Reset: (to) => to.full.counter().resolve(({ target }) => target(new Counter({ count: 0 }))),
-      Corrupt: (to) => to.full.counter().resolve(({ target }) => target(new Counter({ count: -1 })))
+        to.full.counter().resolve(({ state, target }) => target.decoded(new Counter({ count: state.count + 1 }))),
+      Reset: (to) => to.full.counter().resolve(({ target }) => target.decoded(new Counter({ count: 0 }))),
+      Corrupt: (to) => to.full.counter().resolve(({ target }) => target.decoded(new Counter({ count: -1 })))
     }
   }
 })
@@ -38,7 +38,7 @@ const finiteEvents = ({ snapshot }: MachineTest.ExplorationStateContext<typeof m
 const branchMachine = Machine.make({
   states: States.states,
   events: Machine.events(Select),
-  initial: (to) => to.counter().resolve(({ target }) => target(new Counter({ count: 0 })))
+  initial: (to) => to.counter().resolve(({ target }) => target.decoded(new Counter({ count: 0 })))
 }).handle({
   counter: {
     on: {
@@ -387,7 +387,8 @@ describe("MachineTest bounded exploration", () => {
         states: States.states,
         events: Machine.events(Increment),
         input: Seed,
-        initial: (to) => to.counter().resolve(({ input, target }) => target(new Counter({ count: input.count })))
+        initial: (to) =>
+          to.counter().resolve(({ input, target }) => target.decoded(new Counter({ count: input.count })))
       }).handle({ counter: {} })
       const explored = yield* MachineTest.explore(inputMachine, {
         input: new Seed({ count: 7 }),

--- a/test/testing/Invariant.test.ts
+++ b/test/testing/Invariant.test.ts
@@ -22,17 +22,17 @@ const makeAccountMachine = (withdraw: (balance: number, amount: number) => numbe
   Machine.make({
     states: States.states,
     events: Machine.events(Withdraw, Deposit),
-    initial: (to) => to.account().resolve(({ target }) => target(new Account({ balance: 10 })))
+    initial: (to) => to.account().resolve(({ target }) => target.decoded(new Account({ balance: 10 })))
   }).handle({
     account: {
       on: {
         Withdraw: (to) =>
           to.full.account().resolve(({ event, state, target }) =>
-            target(new Account({ balance: withdraw(state.balance, event.amount) }))
+            target.decoded(new Account({ balance: withdraw(state.balance, event.amount) }))
           ),
         Deposit: (to) =>
           to.full.account().resolve(({ event, state, target }) =>
-            target(new Account({ balance: state.balance + event.amount }))
+            target.decoded(new Account({ balance: state.balance + event.amount }))
           )
       }
     }

--- a/test/testing/MachineTest.test.ts
+++ b/test/testing/MachineTest.test.ts
@@ -30,14 +30,16 @@ const makeTraceMachine = (onAction: () => void) =>
     events: Machine.events(Start, Add),
     input: TestInput,
     initial: (to) =>
-      to.Ready().resolve(({ input, target }) => target(new Ready({ count: input.userId.length - input.userId.length })))
+      to.Ready().resolve(({ input, target }) =>
+        target.decoded(new Ready({ count: input.userId.length - input.userId.length }))
+      )
   }).handle({
     Idle: {
       on: {
         Start: (to) =>
           to.full.Ready().resolve(({ target }) => {
             onAction()
-            return target(new Ready({ count: 0 }))
+            return target.decoded(new Ready({ count: 0 }))
           })
       }
     },
@@ -46,7 +48,7 @@ const makeTraceMachine = (onAction: () => void) =>
         Add: (to) =>
           to.full.Ready().resolve(({ event, state, target }) => {
             onAction()
-            return target(new Ready({ count: state.count + event.amount }))
+            return target.decoded(new Ready({ count: state.count + event.amount }))
           })
       }
     }
@@ -101,7 +103,7 @@ describe("MachineTest", () => {
       states: States.states,
       events: Machine.events(),
       input: PositiveInput,
-      initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({ userId: "user-1" })))
+      initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-1" })))
     })
 
     const generated = MachineTest.scenarios(machine)
@@ -119,7 +121,7 @@ describe("MachineTest", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(),
-      initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({ userId: "user-1" })))
+      initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({ userId: "user-1" })))
     })
 
     assert.throws(
@@ -193,12 +195,12 @@ describe("MachineTest", () => {
         events: Machine.events(Stop),
         initial: (to) =>
           to.app.initial.resolve(({ target }) =>
-            target(
+            target.decoded(
               new App({}),
               (app) =>
                 app
-                  .left(new Left({}), (left) => left.idle(new LeftIdle({})))
-                  .right(new Right({}), (right) => right.idle(new RightIdle({})))
+                  .left.decoded(new Left({}), (left) => left.idle.decoded(new LeftIdle({})))
+                  .right.decoded(new Right({}), (right) => right.idle.decoded(new RightIdle({})))
             )
           )
       }).handle({
@@ -208,7 +210,7 @@ describe("MachineTest", () => {
               states: {
                 idle: {
                   on: {
-                    Stop: (to) => to.full.disabled().resolve(({ target }) => target(new Disabled({})))
+                    Stop: (to) => to.full.disabled().resolve(({ target }) => target.decoded(new Disabled({})))
                   }
                 }
               }
@@ -217,7 +219,7 @@ describe("MachineTest", () => {
               states: {
                 idle: {
                   on: {
-                    Stop: (to) => to.full.disabled().resolve(({ target }) => target(new Disabled({})))
+                    Stop: (to) => to.full.disabled().resolve(({ target }) => target.decoded(new Disabled({})))
                   }
                 }
               }
@@ -243,7 +245,8 @@ describe("MachineTest", () => {
         branchIndex: 0,
         branchKey: undefined,
         target: "disabled",
-        resolvedTarget: "disabled"
+        resolvedTarget: "disabled",
+        updates: []
       }])
     }))
 

--- a/test/testing/Probe.test.ts
+++ b/test/testing/Probe.test.ts
@@ -24,27 +24,27 @@ const machine = Machine.make({
   states: states.states,
   events: Machine.events(Increment, Noop, Ignored, Decline, Burst, Reenter),
   internalEvents: Machine.internalEvents(RaisedIncrement),
-  initial: (to) => to.Counter().resolve(({ target }) => target(new Counter({ count: 0 })))
+  initial: (to) => to.Counter().resolve(({ target }) => target.decoded(new Counter({ count: 0 })))
 }).handle({
   Counter: {
     on: {
       Increment: (to) =>
         to.full.Counter().resolve(({ event, state, target }) =>
-          target(new Counter({ count: state.count + event.amount }))
+          target.decoded(new Counter({ count: state.count + event.amount }))
         ),
       Noop: (to) => to.none,
       Decline: (to) => to.none.resolve(({ decline }) => decline(), { declinable: true }),
       Reenter: (to) =>
-        to.full.Counter().resolve(({ state, target }) => target(new Counter({ count: state.count })), {
+        to.full.Counter().resolve(({ state, target }) => target.decoded(new Counter({ count: state.count })), {
           reenter: true
         }),
       Burst: (to) =>
         to.full.Counter().resolve(({ state, target }, enqueue) => {
           enqueue.raise(new RaisedIncrement({}))
-          return target(new Counter({ count: state.count + 1 }))
+          return target.decoded(new Counter({ count: state.count + 1 }))
         }),
       RaisedIncrement: (to) =>
-        to.full.Counter().resolve(({ state, target }) => target(new Counter({ count: state.count + 10 })))
+        to.full.Counter().resolve(({ state, target }) => target.decoded(new Counter({ count: state.count + 10 })))
     }
   }
 })
@@ -154,11 +154,11 @@ describe("MachineTest probe", () => {
       const invokeMachine = Machine.make({
         states: invokeStates.states,
         events: Machine.events(Load),
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
       }).handle({
         Idle: {
           on: {
-            Load: (to) => to.full.Loading().resolve(({ target }) => target(new Loading({})))
+            Load: (to) => to.full.Loading().resolve(({ target }) => target.decoded(new Loading({})))
           }
         },
         Loading: {

--- a/test/testing/ReferenceModel.test.ts
+++ b/test/testing/ReferenceModel.test.ts
@@ -987,10 +987,16 @@ describe("MachineTest finite-model reference interpreter", () => {
         events: Machine.events(Local, Exit),
         initial: (to) =>
           to.root.initial.resolve(({ target }) =>
-            target({ _tag: "Root", version: 0 }, (regions) =>
+            target.decoded({ _tag: "Root", version: 0 }, (regions) =>
               regions
-                .left({ _tag: "Left", version: 0 }, (left) => left.idle({ _tag: "LeftIdle", version: 0 }))
-                .right({ _tag: "Right", version: 0 }, (right) => right.idle({ _tag: "RightIdle", version: 0 })))
+                .left.decoded(
+                  { _tag: "Left", version: 0 },
+                  (left) => left.idle.decoded({ _tag: "LeftIdle", version: 0 })
+                )
+                .right.decoded(
+                  { _tag: "Right", version: 0 },
+                  (right) => right.idle.decoded({ _tag: "RightIdle", version: 0 })
+                ))
           )
       }).handle({
         root: {
@@ -999,8 +1005,10 @@ describe("MachineTest finite-model reference interpreter", () => {
               states: {
                 idle: {
                   on: {
-                    Local: (to) => to.local.done().resolve(({ target }) => target({ _tag: "LeftDone", version: 1 })),
-                    Exit: (to) => to.full.outside().resolve(({ target }) => target({ _tag: "Outside", version: 1 }))
+                    Local: (to) =>
+                      to.local.done().resolve(({ target }) => target.decoded({ _tag: "LeftDone", version: 1 })),
+                    Exit: (to) =>
+                      to.full.outside().resolve(({ target }) => target.decoded({ _tag: "Outside", version: 1 }))
                   }
                 }
               }
@@ -1009,8 +1017,10 @@ describe("MachineTest finite-model reference interpreter", () => {
               states: {
                 idle: {
                   on: {
-                    Local: (to) => to.local.idle().resolve(({ target }) => target({ _tag: "RightIdle", version: 1 })),
-                    Exit: (to) => to.local.idle().resolve(({ target }) => target({ _tag: "RightIdle", version: 2 }))
+                    Local: (to) =>
+                      to.local.idle().resolve(({ target }) => target.decoded({ _tag: "RightIdle", version: 1 })),
+                    Exit: (to) =>
+                      to.local.idle().resolve(({ target }) => target.decoded({ _tag: "RightIdle", version: 2 }))
                   }
                 }
               }

--- a/test/testing/Runtime.test.ts
+++ b/test/testing/Runtime.test.ts
@@ -27,17 +27,17 @@ const makeCounterMachine = () =>
     states: CounterStates.states,
     events: Machine.events(Add),
     internalEvents: Machine.internalEvents(InternalAdd),
-    initial: (to) => to.Counter().resolve(({ target }) => target(new Counter({ count: 0 })))
+    initial: (to) => to.Counter().resolve(({ target }) => target.decoded(new Counter({ count: 0 })))
   }).handle({
     Counter: {
       on: {
         Add: (to) =>
           to.full.Counter().resolve(({ event, state, target }) =>
-            target(new Counter({ count: state.count + event.amount }))
+            target.decoded(new Counter({ count: state.count + event.amount }))
           ),
         InternalAdd: (to) =>
           to.full.Counter().resolve(({ event, state, target }) =>
-            target(new Counter({ count: state.count + event.amount }))
+            target.decoded(new Counter({ count: state.count + event.amount }))
           )
       }
     }
@@ -47,23 +47,23 @@ const causalMachine = Machine.make({
   states: CounterStates.states,
   events: Machine.events(Add, Noop, Ignored, Burst),
   internalEvents: Machine.internalEvents(InternalAdd),
-  initial: (to) => to.Counter().resolve(({ target }) => target(new Counter({ count: 0 })))
+  initial: (to) => to.Counter().resolve(({ target }) => target.decoded(new Counter({ count: 0 })))
 }).handle({
   Counter: {
     on: {
       Add: (to) =>
         to.full.Counter().resolve(({ event, state, target }) =>
-          target(new Counter({ count: state.count + event.amount }))
+          target.decoded(new Counter({ count: state.count + event.amount }))
         ),
       Noop: (to) => to.none,
       Burst: (to) =>
         to.full.Counter().resolve(({ state, target }, enqueue) => {
           enqueue.raise(new InternalAdd({ amount: 10 }))
-          return target(new Counter({ count: state.count + 1 }))
+          return target.decoded(new Counter({ count: state.count + 1 }))
         }),
       InternalAdd: (to) =>
         to.full.Counter().resolve(({ event, state, target }) =>
-          target(new Counter({ count: state.count + event.amount }))
+          target.decoded(new Counter({ count: state.count + event.amount }))
         )
     }
   }
@@ -247,12 +247,12 @@ describe("MachineTest runtime commands", () => {
         states: states.states,
         events: Machine.events(),
         internalEvents: Machine.internalEvents(Timeout),
-        initial: (to) => to.Waiting().resolve(({ target }) => target(new Waiting({})))
+        initial: (to) => to.Waiting().resolve(({ target }) => target.decoded(new Waiting({})))
       }).handle({
         Waiting: {
           invoke: (from) =>
             from.timer("timeout", "1 second").onDone((to) =>
-              to.full.TimedOut().resolve(({ target }) => target(new TimedOut({})))
+              to.full.TimedOut().resolve(({ target }) => target.decoded(new TimedOut({})))
             )
         },
         TimedOut: {}
@@ -727,12 +727,12 @@ describe("MachineTest causal runtime commands", () => {
         states: states.states,
         events: Machine.events(),
         internalEvents: Machine.internalEvents(Timeout),
-        initial: (to) => to.Waiting().resolve(({ target }) => target(new Waiting({})))
+        initial: (to) => to.Waiting().resolve(({ target }) => target.decoded(new Waiting({})))
       }).handle({
         Waiting: {
           invoke: (from) =>
             from.timer("timeout", "1 second").onDone((to) =>
-              to.full.TimedOut().resolve(({ target }) => target(new TimedOut({})))
+              to.full.TimedOut().resolve(({ target }) => target.decoded(new TimedOut({})))
             )
         },
         TimedOut: {}

--- a/test/testing/Verification.test.ts
+++ b/test/testing/Verification.test.ts
@@ -34,11 +34,12 @@ const NavigationStates = Machine.states({
 const navigationMachine = Machine.make({
   states: NavigationStates.states,
   events: Machine.events(Go),
-  initial: (to) => to.off().resolve(({ target }) => target(new Off({})))
+  initial: (to) => to.off().resolve(({ target }) => target.decoded(new Off({})))
 }).handle({
   off: {
     on: {
-      Go: (to) => to.full.app().resolve(({ target }) => target(new App({}), (app) => app.two(new Two({}))))
+      Go: (to) =>
+        to.full.app().resolve(({ target }) => target.decoded(new App({}), (app) => app.two.decoded(new Two({}))))
     }
   }
 })
@@ -46,12 +47,14 @@ const navigationMachine = Machine.make({
 const raisedNavigationMachine = Machine.make({
   states: NavigationStates.states,
   events: Machine.events(Go),
-  initial: (to) => to.off().resolve(({ target }) => target(new Off({})))
+  initial: (to) => to.off().resolve(({ target }) => target.decoded(new Off({})))
 }).handle({
   off: {
-    always: (to) => to.full.app().resolve(({ target }) => target(new App({}), (app) => app.one(new One({})))),
+    always: (to) =>
+      to.full.app().resolve(({ target }) => target.decoded(new App({}), (app) => app.one.decoded(new One({})))),
     on: {
-      Go: (to) => to.full.app().resolve(({ target }) => target(new App({}), (app) => app.one(new One({}))))
+      Go: (to) =>
+        to.full.app().resolve(({ target }) => target.decoded(new App({}), (app) => app.one.decoded(new One({}))))
     }
   }
 })
@@ -61,12 +64,12 @@ const CounterStates = Machine.states({ counter: Counter })
 const counterMachine = Machine.make({
   states: CounterStates.states,
   events: Machine.events(Increment, Noop),
-  initial: (to) => to.counter().resolve(({ target }) => target(new Counter({ count: 0 })))
+  initial: (to) => to.counter().resolve(({ target }) => target.decoded(new Counter({ count: 0 })))
 }).handle({
   counter: {
     on: {
       Increment: (to) =>
-        to.full.counter().resolve(({ state, target }) => target(new Counter({ count: state.count + 1 }))),
+        to.full.counter().resolve(({ state, target }) => target.decoded(new Counter({ count: state.count + 1 }))),
       Noop: (to) => to.none
     }
   }
@@ -75,7 +78,7 @@ const counterMachine = Machine.make({
 const conditionalMachine = Machine.make({
   states: CounterStates.states,
   events: Machine.events(Select),
-  initial: (to) => to.counter().resolve(({ target }) => target(new Counter({ count: 0 })))
+  initial: (to) => to.counter().resolve(({ target }) => target.decoded(new Counter({ count: 0 })))
 }).handle({
   counter: {
     on: {
@@ -88,7 +91,7 @@ const conditionalMachine = Machine.make({
           event.value < 0
             ? select.negative()
             : event.value === 0
-            ? select.zero(new Counter({ count: 0 }))
+            ? select.zero.decoded(new Counter({ count: 0 }))
             : select.positive()
         )
     }
@@ -98,7 +101,7 @@ const conditionalMachine = Machine.make({
 const invokedMachine = Machine.make({
   states: CounterStates.states,
   events: Machine.events(),
-  initial: (to) => to.counter().resolve(({ target }) => target(new Counter({ count: 0 })))
+  initial: (to) => to.counter().resolve(({ target }) => target.decoded(new Counter({ count: 0 })))
 }).handle({
   counter: {
     invoke: (
@@ -128,7 +131,7 @@ const RoutedStartupStates = Machine.states({
 const routedStartupMachine = Machine.make({
   states: RoutedStartupStates.states,
   events: Machine.events(),
-  initial: (to) => to.a.initial.resolve(({ target }) => target(new StartupA({}), (a) => a.route()))
+  initial: (to) => to.a.initial.resolve(({ target }) => target.decoded(new StartupA({}), (a) => a.route()))
 }).handle({
   a: {
     states: {
@@ -136,7 +139,7 @@ const routedStartupMachine = Machine.make({
         choice: (to) => to.local.second().resolve(({ target }) => target())
       },
       second: {
-        choice: (to) => to.full.b().resolve(({ target }) => target(new StartupB({})))
+        choice: (to) => to.full.b().resolve(({ target }) => target.decoded(new StartupB({})))
       }
     }
   },
@@ -164,7 +167,9 @@ const choiceResolutionMachine = Machine.make({
   states: ChoiceResolutionStates.states,
   events: Machine.events(Route),
   initial: (to) =>
-    to.flow.initial.resolve(({ target }) => target(new ChoiceFlow({}), (flow) => flow.ready(new ChoiceReady({}))))
+    to.flow.initial.resolve(({ target }) =>
+      target.decoded(new ChoiceFlow({}), (flow) => flow.ready.decoded(new ChoiceReady({})))
+    )
 }).handle({
   flow: {
     states: {
@@ -177,7 +182,7 @@ const choiceResolutionMachine = Machine.make({
         choice: (to) => to.local.second().resolve(({ target }) => target())
       },
       second: {
-        choice: (to) => to.local.routed().resolve(({ target }) => target(new ChoiceRouted({})))
+        choice: (to) => to.local.routed().resolve(({ target }) => target.decoded(new ChoiceRouted({})))
       },
       routed: {}
     }
@@ -189,16 +194,18 @@ const reentryMachine = Machine.make({
   events: Machine.events(Restart),
   initial: (to) =>
     to.app.initial.resolve(({ target }) =>
-      target(
+      target.decoded(
         new App({}),
-        (app) => app.one(new One({}))
+        (app) => app.one.decoded(new One({}))
       )
     )
 }).handle({
   app: {
     on: {
       Restart: (to) =>
-        to.full.app().resolve(({ target }) => target(new App({}), (app) => app.one(new One({}))), { reenter: true })
+        to.full.app().resolve(({ target }) => target.decoded(new App({}), (app) => app.one.decoded(new One({}))), {
+          reenter: true
+        })
     }
   }
 })
@@ -223,9 +230,9 @@ const parallelMachine = Machine.make({
   events: Machine.events(),
   initial: (to) =>
     to.dashboard.initial.resolve(({ target }) =>
-      target(
+      target.decoded(
         new Dashboard({}),
-        (dashboard) => dashboard.left(new Left({})).right(new Right({}))
+        (dashboard) => dashboard.left.decoded(new Left({})).right.decoded(new Right({}))
       )
     )
 }).handle({ dashboard: {} })
@@ -268,12 +275,12 @@ const historyMachine = Machine.make({
   events: Machine.events(Leave, Resume),
   initial: (to) =>
     to.workspace.initial.resolve(({ target }) =>
-      target(
+      target.decoded(
         new Workspace({}),
         (workspace) =>
-          workspace.editor(
+          workspace.editor.decoded(
             new Editor({}),
-            (editor) => editor.editing(new Editing({ revision: 1 }))
+            (editor) => editor.editing.decoded(new Editing({ revision: 1 }))
           )
       )
     )
@@ -282,33 +289,33 @@ const historyMachine = Machine.make({
     history: {
       recent: {
         default: ({ target }) =>
-          target.workspace(
+          target.workspace.decoded(
             new Workspace({}),
             (workspace) =>
-              workspace.editor(
+              workspace.editor.decoded(
                 new Editor({}),
-                (editor) => editor.editing(new Editing({ revision: 0 }))
+                (editor) => editor.editing.decoded(new Editing({ revision: 0 }))
               )
           )
       },
       exact: {
         default: ({ target }) =>
-          target.workspace(
+          target.workspace.decoded(
             new Workspace({}),
             (workspace) =>
-              workspace.editor(
+              workspace.editor.decoded(
                 new Editor({}),
-                (editor) => editor.editing(new Editing({ revision: 0 }))
+                (editor) => editor.editing.decoded(new Editing({ revision: 0 }))
               )
           )
       }
     },
     on: {
-      Leave: (to) => to.full.away().resolve(({ target }) => target(new Away({})))
+      Leave: (to) => to.full.away().resolve(({ target }) => target.decoded(new Away({})))
     },
     states: {
       editor: {
-        initialize: ({ builder }) => builder(new Editing({ revision: 0 }))
+        initialize: ({ builder }) => builder.decoded(new Editing({ revision: 0 }))
       }
     }
   },
@@ -374,7 +381,7 @@ const CompletionStates = Machine.states({
 const completionMachine = Machine.make({
   states: CompletionStates.states,
   events: Machine.events(),
-  initial: (to) => to.finished().resolve(({ target }) => target(new Finished({})))
+  initial: (to) => to.finished().resolve(({ target }) => target.decoded(new Finished({})))
 }).handle({
   finished: {
     output: () => "complete"
@@ -404,14 +411,14 @@ const doneTransitionMachine = Machine.make({
   events: Machine.events(),
   initial: (to) =>
     to.workflow.initial.resolve(({ target }) =>
-      target(
+      target.decoded(
         new Workflow({}),
-        (workflow) => workflow.finished(new Finished({}))
+        (workflow) => workflow.finished.decoded(new Finished({}))
       )
     )
 }).handle({
   workflow: {
-    onDone: (to) => to.full.archived().resolve(({ target }) => target(new Archived({}))),
+    onDone: (to) => to.full.archived().resolve(({ target }) => target.decoded(new Archived({}))),
     states: {
       finished: {
         output: () => "workflow-output"
@@ -425,9 +432,9 @@ const nestedCompletionMachine = Machine.make({
   events: Machine.events(),
   initial: (to) =>
     to.workflow.initial.resolve(({ target }) =>
-      target(
+      target.decoded(
         new Workflow({}),
-        (workflow) => workflow.finished(new Finished({}))
+        (workflow) => workflow.finished.decoded(new Finished({}))
       )
     )
 }).handle({
@@ -1144,7 +1151,8 @@ describe("MachineTest.verify", () => {
         branchIndex: 0,
         branchKey: undefined,
         target: undefined,
-        resolvedTarget: undefined
+        resolvedTarget: undefined,
+        updates: []
       }
       const microstep: MachineTest.Microstep<typeof invokedMachine> = {
         next: trace.initial.startingState,

--- a/test/unstable/cluster/ClusterMachine.test.ts
+++ b/test/unstable/cluster/ClusterMachine.test.ts
@@ -60,7 +60,7 @@ const makeCounter = (state: {
     states: CounterStates.states,
     events: Machine.events(Increment, Fail, Finish, RaiseFromAction, SpawnFromAction),
     emittedEvents: Machine.emittedEvents(Changed),
-    initial: (to) => to.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+    initial: (to) => to.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
   }).handle({
     Count: {
       entry: () => {
@@ -75,24 +75,24 @@ const makeCounter = (state: {
             state.inFlight -= 1
             const value = current.value + event.by
             enqueue.emit(new Changed({ value }))
-            return target(new Count({ value }))
+            return target.decoded(new Count({ value }))
           }),
         Fail: (to) =>
           to.full.Count().resolve(({ state: current, target }, enqueue) => {
             enqueue.emit(new Changed({ value: 999 }))
-            return target(current)
+            return target.decoded(current)
           }),
         Finish: (to) =>
-          to.full.Done().resolve(({ state: current, target }) => target(new Done({ value: current.value }))),
+          to.full.Done().resolve(({ state: current, target }) => target.decoded(new Done({ value: current.value }))),
         RaiseFromAction: (to) =>
           to.full.Count().resolve(({ state: current, target }, enqueue) => {
             enqueue.raise(new Increment({ by: 1, block: false }))
-            return target(current)
+            return target.decoded(current)
           }),
         SpawnFromAction: (to) =>
           to.full.Count().resolve(({ state: current, target }, enqueue) => {
             enqueue.stop(UnsupportedChild)
-            return target(current)
+            return target.decoded(current)
           })
       }
     },
@@ -364,11 +364,11 @@ describe("ClusterMachine", () => {
       const opaqueMachine = Machine.make({
         states: opaqueStates.states,
         events: Machine.events(Fail),
-        initial: (to) => to.OpaqueState().resolve(({ target }) => target({ _tag: "OpaqueState", resource }))
+        initial: (to) => to.OpaqueState().resolve(({ target }) => target.decoded({ _tag: "OpaqueState", resource }))
       }).handle({
         OpaqueState: {
           on: {
-            Fail: (to) => to.full.OpaqueState().resolve(({ state: current, target }) => target(current))
+            Fail: (to) => to.full.OpaqueState().resolve(({ state: current, target }) => target.decoded(current))
           }
         }
       })
@@ -619,7 +619,7 @@ describe("ClusterMachine", () => {
         id: "Invoked",
         states: states.states,
         events: Machine.events(Increment),
-        initial: (to) => to.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+        initial: (to) => to.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
       }).handle({
         Count: {
           invoke: (from) => from.effect("child", () => Effect.void).onDone((to) => to.none)

--- a/test/unstable/reactivity/AtomMachine.test.ts
+++ b/test/unstable/reactivity/AtomMachine.test.ts
@@ -68,12 +68,14 @@ const makeCounterMachine = () =>
   Machine.make({
     states: CounterStates.states,
     events: Machine.events(Finish),
-    initial: (to) => to.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+    initial: (to) => to.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
   }).handle({
     Count: {
       on: {
         Finish: (to) =>
-          to.full.Count().resolve(({ state, event, target }) => target(new Count({ value: state.value + event.by })))
+          to.full.Count().resolve(({ state, event, target }) =>
+            target.decoded(new Count({ value: state.value + event.by }))
+          )
       }
     },
     Done: {}
@@ -106,7 +108,7 @@ describe("AtomMachine", () => {
         states: states.states,
         events: Machine.events(),
         emittedEvents: Emissions,
-        initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+        initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
       }).handle({
         Idle: {
           entry: (_, enqueue) => {
@@ -148,7 +150,7 @@ describe("AtomMachine", () => {
         initial: (to) =>
           to.Count().resolve(({ target }) => {
             initialCalls += 1
-            return target(new Count({ value: 0 }))
+            return target.decoded(new Count({ value: 0 }))
           })
       }).handle({
         Count: {
@@ -163,7 +165,7 @@ describe("AtomMachine", () => {
           on: {
             Finish: (to) =>
               to.full.Count().resolve(({ event, state, target }) =>
-                target(new Count({ value: state.value + event.by }))
+                target.decoded(new Count({ value: state.value + event.by }))
               )
           }
         },
@@ -207,17 +209,18 @@ describe("AtomMachine", () => {
       const parent = Machine.make({
         states: { Count, ValueRead },
         events: Machine.events(Finish, ReadValue),
-        initial: (to) => to.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+        initial: (to) => to.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
       }).handle({
         Count: {
           on: {
-            Finish: (to) => to.full.ValueRead().resolve(({ target }) => target(new ValueRead({ value: "active" })))
+            Finish: (to) =>
+              to.full.ValueRead().resolve(({ target }) => target.decoded(new ValueRead({ value: "active" })))
           }
         },
         ValueRead: {
           invoke: (from) => from.child(Child).onDone((to) => to.none),
           on: {
-            ReadValue: (to) => to.full.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+            ReadValue: (to) => to.full.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
           }
         }
       })
@@ -310,7 +313,7 @@ describe("AtomMachine", () => {
       const parent = Machine.make({
         states: { Count },
         events: Machine.events(),
-        initial: (to) => to.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+        initial: (to) => to.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
       }).handle({
         Count: {
           invoke: (from) =>
@@ -426,10 +429,10 @@ describe("AtomMachine", () => {
         events: Machine.events(),
         initial: (to) =>
           to.Ready.initial.resolve(({ target }) =>
-            target(new Ready({}), (ready) =>
+            target.decoded(new Ready({}), (ready) =>
               ready
-                .editor(new Editor({}), (editor) => editor.Editing(new Editing({})))
-                .network(new Network({}), (network) => network.Online(new Online({}))))
+                .editor.decoded(new Editor({}), (editor) => editor.Editing.decoded(new Editing({})))
+                .network.decoded(new Network({}), (network) => network.Online.decoded(new Online({}))))
           )
       }).handle({
         Ready: {
@@ -559,12 +562,14 @@ describe("AtomMachine", () => {
           }
         },
         events: Machine.events(Finish),
-        initial: (to) => to.Count().resolve(({ target }) => target(new Count({ value: 1 })))
+        initial: (to) => to.Count().resolve(({ target }) => target.decoded(new Count({ value: 1 })))
       }).handle({
         Count: {
           on: {
             Finish: (to) =>
-              to.full.Done().resolve(({ state, event, target }) => target(new Done({ value: state.value + event.by })))
+              to.full.Done().resolve(({ state, event, target }) =>
+                target.decoded(new Done({ value: state.value + event.by }))
+              )
           }
         },
         Done: {

--- a/typetest/machine/Activities.tst.ts
+++ b/typetest/machine/Activities.tst.ts
@@ -10,7 +10,7 @@ const States = Machine.states({ Loading, Dynamic })
 const machine = Machine.make({
   states: States.states,
   events: Machine.events(TimedOut),
-  initial: (to) => to.Loading().resolve(({ target }) => (target(new Loading({}))))
+  initial: (to) => to.Loading().resolve(({ target }) => (target.decoded(new Loading({}))))
 }).handle({
   Loading: {
     invoke: (from) => from.timer("timeout", "1 second").onDone((to) => to.none)

--- a/typetest/machine/Annotations.tst.ts
+++ b/typetest/machine/Annotations.tst.ts
@@ -40,7 +40,9 @@ const machine = Machine.make({
   states: States.states,
   events: Machine.events(),
   initial: (to) =>
-    to.Workflow.initial.resolve(({ target }) => (target(new Workflow({}), (workflow) => workflow.Idle(new Idle({})))))
+    to.Workflow.initial.resolve((
+      { target }
+    ) => (target.decoded(new Workflow({}), (workflow) => workflow.Idle.decoded(new Idle({})))))
 })
 
 describe("Machine state annotations", () => {

--- a/typetest/machine/Choice.tst.ts
+++ b/typetest/machine/Choice.tst.ts
@@ -35,7 +35,7 @@ describe("Machine choice pseudo-states", () => {
       states: States.states,
       events: Machine.events(),
       initial: (to) =>
-        to.Flow.initial.resolve(({ target }) => (target(new Flow({ score: 80 }), (flow) => flow.Routing())))
+        to.Flow.initial.resolve(({ target }) => (target.decoded(new Flow({ score: 80 }), (flow) => flow.Routing())))
     })
     expect(Machine.planInitial).type.not.toBeCallableWith(incomplete)
     const complete = incomplete.handle({
@@ -49,7 +49,7 @@ describe("Machine choice pseudo-states", () => {
                 expect(context.containingState).type.toBe<Flow>()
                 expect(context.ancestors.Flow).type.toBe<Flow>()
                 expect(context.event).type.toBe<Machine.Machine.LifecycleEvent<readonly []>>()
-                return context.target(new Approved({}))
+                return context.target.decoded(new Approved({}))
               })
           }
         }
@@ -63,7 +63,7 @@ describe("Machine choice pseudo-states", () => {
       states: States.states,
       events: Machine.events(),
       initial: (to) =>
-        to.Flow.initial.resolve(({ target }) => (target(new Flow({ score: 80 }), (flow) => flow.Routing())))
+        to.Flow.initial.resolve(({ target }) => (target.decoded(new Flow({ score: 80 }), (flow) => flow.Routing())))
     })
     machine.handle({
       Flow: {
@@ -72,7 +72,7 @@ describe("Machine choice pseudo-states", () => {
             choice: (to) =>
               to.local.Approved().resolve(({ target }) =>
                 // @ts-expect-error!
-                Effect.succeed(target(new Approved({})))
+                Effect.succeed(target.decoded(new Approved({})))
               )
           }
         }
@@ -102,7 +102,7 @@ describe("Machine choice pseudo-states", () => {
       states: States.states,
       events: Machine.events(),
       initial: (to) =>
-        to.Flow.initial.resolve(({ target }) => (target(new Flow({ score: 80 }), (flow) => flow.Routing())))
+        to.Flow.initial.resolve(({ target }) => (target.decoded(new Flow({ score: 80 }), (flow) => flow.Routing())))
     })
     const invalidHandlers = [
       { entry: () => undefined },
@@ -126,7 +126,7 @@ describe("Machine choice pseudo-states", () => {
       states: States.states,
       events: Machine.events(),
       initial: (to) =>
-        to.Flow.initial.resolve(({ target }) => (target(new Flow({ score: 80 }), (flow) => flow.Routing())))
+        to.Flow.initial.resolve(({ target }) => (target.decoded(new Flow({ score: 80 }), (flow) => flow.Routing())))
     })
     base.handle({
       Flow: {
@@ -134,8 +134,8 @@ describe("Machine choice pseudo-states", () => {
           Routing: {
             choice: (to) =>
               to.local.Rejected().resolve(({ target: selectedTarget }) => {
-                expect(selectedTarget).type.not.toBeCallableWith(new Approved({}))
-                return selectedTarget(new Rejected({}))
+                expect(selectedTarget.decoded).type.not.toBeCallableWith(new Approved({}))
+                return selectedTarget.decoded(new Rejected({}))
               })
           }
         }

--- a/typetest/machine/DeepHandlers.tst.ts
+++ b/typetest/machine/DeepHandlers.tst.ts
@@ -140,21 +140,21 @@ const deepHistoryFallback = (
     "Root.L1.L2.L3.L4.L5.L6.L7.L8.L9.L10.Hub"
   >
 ) =>
-  target.Root(
+  target.Root.decoded(
     new Root({}),
     (root) =>
-      root.L1(new Branch({}), (l1) =>
-        l1.L2(new Branch({}), (l2) =>
-          l2.L3(new Branch({}), (l3) =>
-            l3.L4(new Branch({}), (l4) =>
-              l4.L5(new Branch({}), (l5) =>
-                l5.L6(new Branch({}), (l6) =>
-                  l6.L7(new Branch({}), (l7) =>
-                    l7.L8(new Branch({}), (l8) =>
-                      l8.L9(new Branch({}), (l9) =>
-                        l9.L10(new Branch({}), (l10) =>
-                          l10.Hub(new Hub({}), (hub) =>
-                            hub.Idle(new Idle({})))))))))))))
+      root.L1.decoded(new Branch({}), (l1) =>
+        l1.L2.decoded(new Branch({}), (l2) =>
+          l2.L3.decoded(new Branch({}), (l3) =>
+            l3.L4.decoded(new Branch({}), (l4) =>
+              l4.L5.decoded(new Branch({}), (l5) =>
+                l5.L6.decoded(new Branch({}), (l6) =>
+                  l6.L7.decoded(new Branch({}), (l7) =>
+                    l7.L8.decoded(new Branch({}), (l8) =>
+                      l8.L9.decoded(new Branch({}), (l9) =>
+                        l9.L10.decoded(new Branch({}), (l10) =>
+                          l10.Hub.decoded(new Hub({}), (hub) =>
+                            hub.Idle.decoded(new Idle({})))))))))))))
   )
 
 const makeDeepMachine = () =>

--- a/typetest/machine/DynamicChildren.tst.ts
+++ b/typetest/machine/DynamicChildren.tst.ts
@@ -18,7 +18,7 @@ describe("dynamic child machines", () => {
     events: Machine.events(ChildEvent),
     input: Input,
     parent: Machine.parent(ParentEvents),
-    initial: (to) => to.ChildIdle().resolve(({ input, target }) => target(new ChildIdle({ id: input.id })))
+    initial: (to) => to.ChildIdle().resolve(({ input, target }) => target.decoded(new ChildIdle({ id: input.id })))
   }).handle({
     ChildIdle: {
       on: { ChildEvent: (to) => to.none }
@@ -28,7 +28,7 @@ describe("dynamic child machines", () => {
   const voidChildMachine = Machine.make({
     states: { ChildIdle },
     events: Machine.events(),
-    initial: (to) => to.ChildIdle().resolve(({ target }) => target(new ChildIdle({ id: "void" })))
+    initial: (to) => to.ChildIdle().resolve(({ target }) => target.decoded(new ChildIdle({ id: "void" })))
   }).handle({ ChildIdle: {} })
   const VoidChild = Machine.childFamily(voidChildMachine)
 
@@ -43,7 +43,7 @@ describe("dynamic child machines", () => {
     Machine.make({
       states: { ParentIdle },
       events: Machine.events(ParentNotice, OtherEvent),
-      initial: (to) => to.ParentIdle().resolve(({ target }) => target(new ParentIdle({})))
+      initial: (to) => to.ParentIdle().resolve(({ target }) => target.decoded(new ParentIdle({})))
     }).handle({
       ParentIdle: {
         invoke: (from) =>
@@ -75,7 +75,7 @@ describe("dynamic child machines", () => {
     Machine.make({
       states: { ParentIdle },
       events: Machine.events(OtherEvent),
-      initial: (to) => to.ParentIdle().resolve(({ target }) => target(new ParentIdle({})))
+      initial: (to) => to.ParentIdle().resolve(({ target }) => target.decoded(new ParentIdle({})))
     }).handle({
       ParentIdle: {
         invoke: (from) =>

--- a/typetest/machine/EventByTag.tst.ts
+++ b/typetest/machine/EventByTag.tst.ts
@@ -35,7 +35,7 @@ describe("Machine.EventByTag", () => {
     Machine.make({
       states: states.states,
       events: Machine.events(FiniteUnion),
-      initial: (to) => to.Idle().resolve(({ target }) => (target(new Idle({}))))
+      initial: (to) => to.Idle().resolve(({ target }) => (target.decoded(new Idle({}))))
     }).handle({
       Idle: {
         on: {

--- a/typetest/machine/History.tst.ts
+++ b/typetest/machine/History.tst.ts
@@ -102,16 +102,16 @@ const NestedStates = Machine.states({
 const completeNestedFallback = (
   target: Machine.Machine.HistoryDefaultTargetBuilder<typeof NestedStates.states, "App.Workspace">
 ) =>
-  target.App(
+  target.App.decoded(
     new App({ session: "fallback" }),
     (app) => {
       expect(app).type.not.toHaveProperty("Settings")
-      return app.Workspace(
+      return app.Workspace.decoded(
         new Workspace({}),
         (workspace) =>
           workspace
-            .Editor(new Editor({}), (editor) => editor.Editing(new Editing({})))
-            .Sidebar(new Sidebar({}))
+            .Editor.decoded(new Editor({}), (editor) => editor.Editing.decoded(new Editing({})))
+            .Sidebar.decoded(new Sidebar({}))
       )
     }
   )
@@ -152,9 +152,9 @@ describe("Machine history states", () => {
         expect(to).type.not.toHaveProperty("recent")
         expect(to).type.not.toHaveProperty("exact")
         return to.checkout.initial.resolve(({ target }) =>
-          target(
+          target.decoded(
             new Checkout({ orderId: "order-1" }),
-            (checkout) => checkout.shipping(new Shipping({ address: "Main Street" }))
+            (checkout) => checkout.shipping.decoded(new Shipping({ address: "Main Street" }))
           )
         )
       }
@@ -169,7 +169,7 @@ describe("Machine history states", () => {
     const definition = Machine.make({
       states: States.states,
       events: Machine.events(Resume),
-      initial: (to) => to.support().resolve(({ target }) => (target(new Support({}))))
+      initial: (to) => to.support().resolve(({ target }) => (target.decoded(new Support({}))))
     })
     const incomplete = definition.handle({
       support: {
@@ -198,7 +198,7 @@ describe("Machine history states", () => {
     const definition = Machine.make({
       states: States.states,
       events: Machine.events(Resume),
-      initial: (to) => to.support().resolve(({ target }) => (target(new Support({}))))
+      initial: (to) => to.support().resolve(({ target }) => (target.decoded(new Support({}))))
     })
     const incomplete = definition.handle({
       support: {
@@ -219,17 +219,17 @@ describe("Machine history states", () => {
               expect(target).type.toBe<
                 Machine.Machine.HistoryDefaultTargetBuilder<typeof States.states, "checkout">
               >()
-              return target.checkout(
+              return target.checkout.decoded(
                 new Checkout({ orderId: "fallback" }),
-                (checkout) => checkout.shipping(new Shipping({ address: "" }))
+                (checkout) => checkout.shipping.decoded(new Shipping({ address: "" }))
               )
             }
           },
           exact: {
             default: ({ target }) =>
-              target.checkout(
+              target.checkout.decoded(
                 new Checkout({ orderId: "fallback" }),
-                (checkout) => checkout.shipping(new Shipping({ address: "" }))
+                (checkout) => checkout.shipping.decoded(new Shipping({ address: "" }))
               )
           }
         },
@@ -239,7 +239,7 @@ describe("Machine history states", () => {
               expect(state).type.toBe<Payment>()
               expect(containingState).type.toBe<Checkout>()
               expect(ancestors).type.toBe<{ readonly checkout: Checkout }>()
-              return builder(new CardEntry({ cardNumber: `attempt-${state.attempt}` }))
+              return builder.decoded(new CardEntry({ cardNumber: `attempt-${state.attempt}` }))
             }
           }
         }
@@ -253,7 +253,7 @@ describe("Machine history states", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(Resume),
-      initial: (to) => to.support().resolve(({ target }) => (target(new Support({}))))
+      initial: (to) => to.support().resolve(({ target }) => (target.decoded(new Support({}))))
     })
 
     machine.handle({
@@ -262,17 +262,17 @@ describe("Machine history states", () => {
           recent: {
             default: ({ target }) => {
               expect(target).type.not.toHaveProperty("support")
-              return target.checkout(
+              return target.checkout.decoded(
                 new Checkout({ orderId: "fallback" }),
-                (checkout) => checkout.shipping(new Shipping({ address: "" }))
+                (checkout) => checkout.shipping.decoded(new Shipping({ address: "" }))
               )
             }
           },
           exact: {
             default: ({ target }) =>
-              target.checkout(
+              target.checkout.decoded(
                 new Checkout({ orderId: "fallback" }),
-                (checkout) => checkout.shipping(new Shipping({ address: "" }))
+                (checkout) => checkout.shipping.decoded(new Shipping({ address: "" }))
               )
           }
         }
@@ -284,8 +284,8 @@ describe("Machine history states", () => {
         states: {
           payment: {
             initialize: ({ builder }) => {
-              expect(builder).type.not.toBeCallableWith(new Verifying({ challengeId: "wrong-child" }))
-              return builder(new CardEntry({ cardNumber: "" }))
+              expect(builder.decoded).type.not.toBeCallableWith(new Verifying({ challengeId: "wrong-child" }))
+              return builder.decoded(new CardEntry({ cardNumber: "" }))
             }
           }
         }
@@ -309,7 +309,7 @@ describe("Machine history states", () => {
     const machine = Machine.make({
       states: NestedStates.states,
       events: Machine.events(Resume),
-      initial: (to) => to.Closed().resolve(({ target }) => (target(new Closed({}))))
+      initial: (to) => to.Closed().resolve(({ target }) => (target.decoded(new Closed({}))))
     })
 
     const complete = machine.handle({
@@ -435,7 +435,7 @@ describe("Machine history states", () => {
     const machine = Machine.make({
       states: NestedStates.states,
       events: Machine.events(Resume),
-      initial: (to) => to.Closed().resolve(({ target }) => (target(new Closed({}))))
+      initial: (to) => to.Closed().resolve(({ target }) => (target.decoded(new Closed({}))))
     })
     expect(machine.handle).type.not.toBeCallableWith({
       App: {
@@ -456,23 +456,23 @@ describe("Machine history states", () => {
     const definition = Machine.make({
       states: States.states,
       events: Machine.events(Resume),
-      initial: (to) => to.support().resolve(({ target }) => (target(new Support({}))))
+      initial: (to) => to.support().resolve(({ target }) => (target.decoded(new Support({}))))
     })
     const afterDefaults = definition.handle({
       checkout: {
         history: {
           recent: {
             default: ({ target }) =>
-              target.checkout(
+              target.checkout.decoded(
                 new Checkout({ orderId: "fallback" }),
-                (checkout) => checkout.shipping(new Shipping({ address: "" }))
+                (checkout) => checkout.shipping.decoded(new Shipping({ address: "" }))
               )
           },
           exact: {
             default: ({ target }) =>
-              target.checkout(
+              target.checkout.decoded(
                 new Checkout({ orderId: "fallback" }),
-                (checkout) => checkout.shipping(new Shipping({ address: "" }))
+                (checkout) => checkout.shipping.decoded(new Shipping({ address: "" }))
               )
           }
         }
@@ -485,22 +485,22 @@ describe("Machine history states", () => {
         history: {
           recent: {
             default: ({ target }) =>
-              target.checkout(
+              target.checkout.decoded(
                 new Checkout({ orderId: "fallback" }),
-                (checkout) => checkout.shipping(new Shipping({ address: "" }))
+                (checkout) => checkout.shipping.decoded(new Shipping({ address: "" }))
               )
           },
           exact: {
             default: ({ target }) =>
-              target.checkout(
+              target.checkout.decoded(
                 new Checkout({ orderId: "fallback" }),
-                (checkout) => checkout.shipping(new Shipping({ address: "" }))
+                (checkout) => checkout.shipping.decoded(new Shipping({ address: "" }))
               )
           }
         },
         states: {
           payment: {
-            initialize: ({ state, builder }) => builder(new CardEntry({ cardNumber: String(state.attempt) }))
+            initialize: ({ state, builder }) => builder.decoded(new CardEntry({ cardNumber: String(state.attempt) }))
           }
         }
       }
@@ -538,7 +538,7 @@ describe("Machine history states", () => {
     const machine = Machine.make({
       states: DeepOnlyStates.states,
       events: Machine.events(Resume),
-      initial: (to) => to.support().resolve(({ target }) => (target(new Support({}))))
+      initial: (to) => to.support().resolve(({ target }) => (target.decoded(new Support({}))))
     }).handle({
       checkout: {
         history: {
@@ -589,22 +589,22 @@ describe("Machine history states", () => {
     const machine = Machine.make({
       states: ParallelStates.states,
       events: Machine.events(Resume),
-      initial: (to) => to.support().resolve(({ target }) => (target(new Support({}))))
+      initial: (to) => to.support().resolve(({ target }) => (target.decoded(new Support({}))))
     })
     const complete = machine.handle({
       outer: {
         history: {
           recent: {
             default: ({ target }) =>
-              target.outer(
+              target.outer.decoded(
                 new Checkout({ orderId: "fallback" }),
                 (outer) =>
-                  outer.all(
+                  outer.all.decoded(
                     new Payment({ attempt: 1 }),
                     (all) =>
                       all
-                        .shipping(new Shipping({ address: "" }))
-                        .card(new CardEntry({ cardNumber: "" }))
+                        .shipping.decoded(new Shipping({ address: "" }))
+                        .card.decoded(new CardEntry({ cardNumber: "" }))
                   )
               )
           }
@@ -614,8 +614,8 @@ describe("Machine history states", () => {
             initialize: ({ state, builder }) => {
               expect(state).type.toBe<Payment>()
               return builder
-                .shipping(new Shipping({ address: `attempt-${state.attempt}` }))
-                .card(new CardEntry({ cardNumber: "" }))
+                .shipping.decoded(new Shipping({ address: `attempt-${state.attempt}` }))
+                .card.decoded(new CardEntry({ cardNumber: "" }))
             }
           }
         }
@@ -632,7 +632,7 @@ describe("Machine history states", () => {
               readonly [typeof Resume],
               readonly [],
               "outer.all"
-            >) => builder.shipping(new Shipping({ address: "missing-card" }))
+            >) => builder.shipping.decoded(new Shipping({ address: "missing-card" }))
           }
         }
       }

--- a/typetest/machine/InitialEntry.tst.ts
+++ b/typetest/machine/InitialEntry.tst.ts
@@ -20,7 +20,7 @@ const States = Machine.states({
 const base = Machine.make({
   states: States.states,
   events: Machine.events(Open),
-  initial: (to) => to.closed().resolve(({ target }) => (target(new Closed({}))))
+  initial: (to) => to.closed().resolve(({ target }) => (target.decoded(new Closed({}))))
 })
 
 describe("declared initial entry types", () => {
@@ -28,7 +28,7 @@ describe("declared initial entry types", () => {
     base.handle({
       closed: {
         on: {
-          Open: (to) => to.full.opened.initial.resolve(({ target }) => target(new Opened({ id: "team-1" })))
+          Open: (to) => to.full.opened.initial.resolve(({ target }) => target.decoded(new Opened({ id: "team-1" })))
         }
       },
       // @ts-expect-error!
@@ -51,9 +51,9 @@ describe("declared initial entry types", () => {
         on: {
           Open: (to) =>
             to.full.opened().resolve(({ target }) =>
-              target(
+              target.decoded(
                 new Opened({ id: "team-1" }),
-                (opened) => opened.loading(new Loading({}))
+                (opened) => opened.loading.decoded(new Loading({}))
               )
             )
         }
@@ -70,12 +70,12 @@ describe("declared initial entry types", () => {
             to.full.opened().resolve(({ target }) => {
               expect(to.full.opened.initial).type.not.toBeAssignableTo<() => unknown>()
               expect(target).type.toHaveProperty("initial")
-              expect(target.initial).type.not.toBeCallableWith()
-              expect(target.initial).type.toBeCallableWith(new Opened({ id: "team-1" }))
+              expect(target.initial.decoded).type.not.toBeCallableWith()
+              expect(target.initial.decoded).type.toBeCallableWith(new Opened({ id: "team-1" }))
               expect(target.initial.from).type.toBeCallableWith({ id: "team-1" })
-              return target(
+              return target.decoded(
                 new Opened({ id: "team-1" }),
-                (opened) => opened.loading(new Loading({}))
+                (opened) => opened.loading.decoded(new Loading({}))
               )
             })
         }

--- a/typetest/machine/Inspection.tst.ts
+++ b/typetest/machine/Inspection.tst.ts
@@ -26,7 +26,8 @@ describe("Machine inspection", () => {
   const machine = Machine.make({
     states: States.states,
     events: Machine.events(Reset),
-    initial: (to) => to.root.initial.resolve(({ target }) => target(new Root({}), (root) => root.idle(new Idle({}))))
+    initial: (to) =>
+      to.root.initial.resolve(({ target }) => target.decoded(new Root({}), (root) => root.idle.decoded(new Idle({}))))
   }).handle({
     root: {
       on: {
@@ -40,7 +41,7 @@ describe("Machine inspection", () => {
     const executable = Machine.make({
       states: FlatStates.states,
       events: Machine.events(Reset),
-      initial: (to) => to.Idle().resolve(({ target }) => (target(new Idle({}))))
+      initial: (to) => to.Idle().resolve(({ target }) => (target.decoded(new Idle({}))))
     }).handle({
       Idle: {
         on: {
@@ -147,7 +148,7 @@ describe("Machine inspection", () => {
     const choiceMachine = Machine.make({
       states: ChoiceStates.states,
       events: Machine.events(),
-      initial: (to) => to.Flow.initial.resolve(({ target }) => (target(new Root({}), (flow) => flow.Routing())))
+      initial: (to) => to.Flow.initial.resolve(({ target }) => (target.decoded(new Root({}), (flow) => flow.Routing())))
     })
     const flow = Machine.stateNodes(choiceMachine).find((node) => node.type === "compound")!
     const routing = Machine.stateNodes(choiceMachine).find((node) => node.type === "choice")!
@@ -193,12 +194,12 @@ describe("Machine inspection", () => {
     const flat = Machine.make({
       states: FlatStates.states,
       events: Machine.events(Reset),
-      initial: (to) => to.idle().resolve(({ target }) => (target(new Idle({}))))
+      initial: (to) => to.idle().resolve(({ target }) => (target.decoded(new Idle({}))))
     })
     flat.handle({
       idle: {
         on: {
-          Reset: (to) => to.full.running().resolve(({ target }) => target(new Running({})))
+          Reset: (to) => to.full.running().resolve(({ target }) => target.decoded(new Running({})))
         }
       }
     })

--- a/typetest/machine/Machine.tst.ts
+++ b/typetest/machine/Machine.tst.ts
@@ -140,7 +140,9 @@ describe("Machine", () => {
     }
   })
 
-  type ChildBuilder<Method> = Method extends (value: any, build: (builder: infer Builder) => any) => any ? Builder
+  type ChildBuilder<Method> = Method extends {
+    readonly decoded: (value: any, build: (builder: infer Builder) => any) => any
+  } ? Builder
     : never
   type IsCallable<A> = A extends (...args: ReadonlyArray<any>) => any ? true : false
 
@@ -328,17 +330,17 @@ describe("Machine", () => {
   })
 
   it("states selects state values and snapshots with type-safe paths", () => {
-    const snapshot = UpInitial(
+    const snapshot = UpInitial.decoded(
       new Up({ id: "up-1" }),
       (up) =>
         up
-          .auth(
+          .auth.decoded(
             new Auth({ userId: "guest" }),
-            (auth) => auth.signedOut(new SignedOut({}))
+            (auth) => auth.signedOut.decoded(new SignedOut({}))
           )
-          .sync(
+          .sync.decoded(
             new Sync({ enabled: true }),
-            (sync) => sync.idle(new SyncIdle({}))
+            (sync) => sync.idle.decoded(new SyncIdle({}))
           )
     )
 
@@ -409,7 +411,7 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     })
 
     expect(machine.states).type.toBe<typeof UpStates.states>()
@@ -427,10 +429,10 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     })
 
-    const encoded = Machine.encodeSnapshot(machine, DownInitial(new Down({})))
+    const encoded = Machine.encodeSnapshot(machine, DownInitial.decoded(new Down({})))
     expect<Effect.Success<typeof encoded>>().type.toBe<Machine.Machine.EncodedSnapshot>()
     expect<Effect.Error<typeof encoded>>().type.toBe<Machine.MachineSchemaEncodeError>()
     expect<Effect.Services<typeof encoded>>().type.toBe<never>()
@@ -448,7 +450,7 @@ describe("Machine", () => {
     const definition = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     })
     const machine = definition.handle({
       down: {
@@ -468,7 +470,7 @@ describe("Machine", () => {
           readonly input: void
           readonly target: Machine.Machine.SelectionBuilder<ReturnType<typeof selectDown>>
         }
-      ) => Effect.succeed(target(new Down({}))))
+      ) => Effect.succeed(target.decoded(new Down({}))))
     expect(definition.handle).type.not.toBeCallableWith({
       down: { entry: () => Effect.void }
     })
@@ -481,7 +483,7 @@ describe("Machine", () => {
       states: UpStates.states,
       events: Machine.events(SignIn),
       emittedEvents: Machine.emittedEvents(SignInCompleted),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     }).handle({
       down: {
         on: {
@@ -495,7 +497,7 @@ describe("Machine", () => {
               expect(enqueue.sendTo).type.not.toBeCallableWith(worker, new Down({}))
               expect(enqueue.stop).type.toBeCallableWith(worker)
               expect(enqueue.stop).type.not.toBeCallableWith("worker")
-              return target(new Down({}))
+              return target.decoded(new Down({}))
             })
         }
       }
@@ -545,14 +547,14 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     })
 
     machine.handle({
       down: {
         invoke: (from) =>
           from.effect("valid", () => Effect.succeed(1)).onDone((to) =>
-            to.full.down().resolve(({ target }) => target(new Down({})))
+            to.full.down().resolve(({ target }) => target.decoded(new Down({})))
           )
       }
     })
@@ -566,7 +568,7 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     })
 
     machine.handle({
@@ -575,7 +577,7 @@ describe("Machine", () => {
           from.effect("dynamic", ({ state }) => {
             expect(state).type.toBe<Down>()
             return Effect.succeed(state._tag)
-          }).onDone((to) => to.full.down().resolve(({ target }) => target(new Down({}))))
+          }).onDone((to) => to.full.down().resolve(({ target }) => target.decoded(new Down({}))))
       }
     })
   })
@@ -590,7 +592,7 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => target(new Down({})))
+      initial: (to) => to.down().resolve(({ target }) => target.decoded(new Down({})))
     })
     const handled = machine.handle({
       down: {
@@ -664,7 +666,7 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     })
 
     machine.handle({
@@ -685,7 +687,7 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     })
 
     machine.handle({
@@ -749,7 +751,7 @@ describe("Machine", () => {
       states: UpStates.states,
       events: Machine.events(SignIn),
       internalEvents: Machine.internalEvents(SignInCompleted),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     }).handle({
       down: {
         on: {
@@ -777,12 +779,12 @@ describe("Machine", () => {
     expect<Parameters<Ref["send"]>[0]>().type.toBe<Machine.Machine.EventInput<SignIn>>()
     expect(Machine.plan).type.toBeCallableWith(
       machine,
-      DownInitial(new Down({})),
+      DownInitial.decoded(new Down({})),
       new SignIn({ userId: "user-1" })
     )
     expect(Machine.plan).type.not.toBeCallableWith(
       machine,
-      DownInitial(new Down({})),
+      DownInitial.decoded(new Down({})),
       new SignInCompleted({ userId: "user-1" })
     )
     const publicEvents = Machine.events(SignIn)
@@ -804,7 +806,7 @@ describe("Machine", () => {
       states: UpStates.states,
       events: Machine.events(SignIn),
       internalEvents: Machine.internalEvents(SignInCompleted),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     })
 
     type Selector = Machine.Machine.InvokeSelector<
@@ -840,7 +842,7 @@ describe("Machine", () => {
     Machine.make({
       states: states.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.source().resolve(({ target }) => (target(new Up({ id: "up-1" }))))
+      initial: (to) => to.source().resolve(({ target }) => (target.decoded(new Up({ id: "up-1" }))))
     }).handle({
       source: {
         on: {
@@ -871,7 +873,7 @@ describe("Machine", () => {
       events: Machine.events(SignIn),
       emittedEvents: Machine.emittedEvents(SignIn),
       input: ChildInput,
-      initial: (to) => to.done().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.done().resolve(({ target }) => (target.decoded(new Down({}))))
     }).handle({
       done: {
         output: () => new SignIn({ userId: "child" })
@@ -883,7 +885,7 @@ describe("Machine", () => {
     const parent = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     })
     type ParentInvokeSelector = Machine.Machine.InvokeSelector<
       typeof UpStates.states,
@@ -922,7 +924,7 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     })
 
     machine.handle({
@@ -978,11 +980,11 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     }).handle({
       down: {
         on: {
-          SignIn: (to) => to.full.down().resolve(({ target }) => target(new Down({})))
+          SignIn: (to) => to.full.down().resolve(({ target }) => target.decoded(new Down({})))
         }
       }
     })
@@ -1019,26 +1021,26 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     })
 
     expect(Machine.plan).type.toBeCallableWith(
       machine,
-      DownInitial(new Down({})),
+      DownInitial.decoded(new Down({})),
       new SignIn({
         userId: "user-1"
       })
     )
     const planned = Machine.plan(
       machine,
-      DownInitial(new Down({})),
+      DownInitial.decoded(new Down({})),
       new SignIn({ userId: "user-1" })
     )
     expect<Effect.Error<typeof planned>>().type.toBe<
       Machine.InfiniteTransitionError | Machine.MachineSchemaDecodeError
     >()
-    expect(Machine.enabled).type.toBeCallableWith(machine, DownInitial(new Down({})))
-    expect(Machine.isFinal).type.toBeCallableWith(machine, DownInitial(new Down({})))
+    expect(Machine.enabled).type.toBeCallableWith(machine, DownInitial.decoded(new Down({})))
+    expect(Machine.isFinal).type.toBeCallableWith(machine, DownInitial.decoded(new Down({})))
 
     expect(Machine.plan).type.not.toBeCallableWith(machine, new Down({}), new SignIn({ userId: "user-1" }))
     expect(Machine.enabled).type.not.toBeCallableWith(machine, new Down({}))
@@ -1049,7 +1051,7 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     })
 
     expect<IsCallable<typeof machine.handle>>().type.toBe<true>()
@@ -1073,7 +1075,7 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => target(new Down({})))
+      initial: (to) => to.down().resolve(({ target }) => target.decoded(new Down({})))
     })
 
     machine.handle({
@@ -1100,17 +1102,17 @@ describe("Machine", () => {
             }).resolve(({ event, select, state }) => {
               expect(event).type.toBe<SignIn>()
               expect(state).type.toBe<Down>()
-              expect(select.recognized).type.toBeCallableWith(new Down({}))
+              expect(select.recognized.decoded).type.toBeCallableWith(new Down({}))
               expect(select.measured).type.toBeCallableWith()
               switch (event.userId.length) {
                 case 0:
                   return select.measured()
                 case 1:
-                  return select.named(new Down({}))
+                  return select.named.decoded(new Down({}))
                 case 2:
                   return select.active()
                 default:
-                  return select.recognized(new Down({}))
+                  return select.recognized.decoded(new Down({}))
               }
             }, { reenter: true })
         }
@@ -1147,7 +1149,7 @@ describe("Machine", () => {
               expect(context.decline()).type.toBe<Machine.Machine.Declined>()
               if (context.event.userId === "decline") return context.decline()
               if (context.event.userId === "consume") return context.select.consumed()
-              return context.select.accepted(new Down({}))
+              return context.select.accepted.decoded(new Down({}))
             }, { declinable: true })
         }
       }
@@ -1248,7 +1250,7 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     })
 
     machine.handle({
@@ -1262,7 +1264,7 @@ describe("Machine", () => {
                     to.local.signedIn().resolve(({ event, state, target }) => {
                       expect(event).type.toBe<SignIn>()
                       expect(state).type.toBe<SignedOut>()
-                      return target(new SignedIn({ userId: event.userId }))
+                      return target.decoded(new SignedIn({ userId: event.userId }))
                     })
                 }
               }
@@ -1277,7 +1279,7 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     })
 
     machine.handle({
@@ -1303,7 +1305,9 @@ describe("Machine", () => {
               signedOut: {
                 on: {
                   SignIn: (to) =>
-                    to.local.signedIn().resolve(({ event, target }) => target(new SignedIn({ userId: event.userId })))
+                    to.local.signedIn().resolve(({ event, target }) =>
+                      target.decoded(new SignedIn({ userId: event.userId }))
+                    )
                 }
               }
             }
@@ -1328,17 +1332,17 @@ describe("Machine", () => {
       states: UpStates.states,
       events: Machine.events(SignIn),
       initial: (to) =>
-        to.up.initial.resolve(({ target }) => (target(
+        to.up.initial.resolve(({ target }) => (target.decoded(
           new Up({ id: "up-1" }),
           (up) =>
             up
-              .auth(
+              .auth.decoded(
                 new Auth({ userId: "user-1" }),
-                (auth) => auth.signedOut(new SignedOut({}))
+                (auth) => auth.signedOut.decoded(new SignedOut({}))
               )
-              .sync(
+              .sync.decoded(
                 new Sync({ enabled: true }),
-                (sync) => sync.idle(new SyncIdle({}))
+                (sync) => sync.idle.decoded(new SyncIdle({}))
               )
         )))
     }).handle({
@@ -1350,7 +1354,7 @@ describe("Machine", () => {
                 expect(event).type.toBe<SignIn | Machine.InitialEvent>()
                 expect(output).type.toBe<undefined>()
                 expect(state).type.toBe<Auth>()
-                return target(new Down({}))
+                return target.decoded(new Down({}))
               }),
             states: {
               signedIn: {}
@@ -1362,17 +1366,17 @@ describe("Machine", () => {
 
     const planned = Machine.plan(
       machine,
-      UpInitial(
+      UpInitial.decoded(
         new Up({ id: "up-1" }),
         (up) =>
           up
-            .auth(
+            .auth.decoded(
               new Auth({ userId: "user-1" }),
-              (auth) => auth.signedOut(new SignedOut({}))
+              (auth) => auth.signedOut.decoded(new SignedOut({}))
             )
-            .sync(
+            .sync.decoded(
               new Sync({ enabled: true }),
-              (sync) => sync.idle(new SyncIdle({}))
+              (sync) => sync.idle.decoded(new SyncIdle({}))
             )
       ),
       new SignIn({ userId: "user-1" })
@@ -1385,7 +1389,7 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     })
 
     expect(machine.handle).type.not.toHaveProperty("up")
@@ -1399,7 +1403,7 @@ describe("Machine", () => {
     const definition = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => target(new Down({})))
+      initial: (to) => to.down().resolve(({ target }) => target.decoded(new Down({})))
     })
 
     const first = definition.handle({ down: {} })
@@ -1421,7 +1425,7 @@ describe("Machine", () => {
       },
       events: Machine.events(SignIn),
       initial: (to) =>
-        to.down().resolve(({ target }) => (target(
+        to.down().resolve(({ target }) => (target.decoded(
           new Down({})
         )))
     }).handle({
@@ -1447,7 +1451,7 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.signedIn().resolve(({ target }) => (target(new SignedIn({ userId: "user-1" }))))
+      initial: (to) => to.signedIn().resolve(({ target }) => (target.decoded(new SignedIn({ userId: "user-1" }))))
     }).handle({
       signedIn: {
         output: ({ state }) => state.userId
@@ -1478,7 +1482,7 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.signedIn().resolve(({ target }) => (target(new SignedIn({ userId: "user-1" }))))
+      initial: (to) => to.signedIn().resolve(({ target }) => (target.decoded(new SignedIn({ userId: "user-1" }))))
     })
     type ForgedCompleteMachine = Machine.Machine<
       typeof States.states,
@@ -1538,7 +1542,7 @@ describe("Machine", () => {
     const machine = Machine.make({
       states: States.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.active().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.active().resolve(({ target }) => (target.decoded(new Down({}))))
     }).handle({
       succeeded: {
         output: ({ state }) => state.userId
@@ -1550,7 +1554,7 @@ describe("Machine", () => {
     const activeOnly = Machine.make({
       states: { active: Down },
       events: Machine.events(SignIn),
-      initial: (to) => to.active().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.active().resolve(({ target }) => (target.decoded(new Down({}))))
     })
     const activeRef = Machine.start(activeOnly)
     expect<Effect.Success<Effect.Success<typeof activeRef>["join"]>>().type.toBe<never>()
@@ -1579,7 +1583,7 @@ describe("Machine", () => {
       initial: (to) =>
         to.auth.initial.resolve((
           { target }
-        ) => (target(new Auth({ userId: "user-1" }), (auth) => auth.signedOut(new SignedOut({})))))
+        ) => (target.decoded(new Auth({ userId: "user-1" }), (auth) => auth.signedOut.decoded(new SignedOut({})))))
     })
 
     machine.handle({
@@ -1587,7 +1591,7 @@ describe("Machine", () => {
         onDone: (to) =>
           to.full.down().resolve(({ output, target }) => {
             expect(output).type.toBe<string>()
-            return target(new Down({}))
+            return target.decoded(new Down({}))
           }),
         states: {
           signedIn: {
@@ -1619,7 +1623,7 @@ describe("Machine", () => {
       initial: (to) =>
         to.auth.initial.resolve((
           { target }
-        ) => (target(new Auth({ userId: "user-1" }), (auth) => auth.signedOut(new SignedOut({})))))
+        ) => (target.decoded(new Auth({ userId: "user-1" }), (auth) => auth.signedOut.decoded(new SignedOut({})))))
     })
 
     expect(machine.handle).type.not.toBeCallableWith({
@@ -1661,7 +1665,7 @@ describe("Machine", () => {
       initial: (to) =>
         to.payment.initial.resolve((
           { target }
-        ) => (target(new Payment({}), (payment) => payment.pending(new PendingPayment({})))))
+        ) => (target.decoded(new Payment({}), (payment) => payment.pending.decoded(new PendingPayment({})))))
     })
 
     machine.handle({
@@ -1735,12 +1739,12 @@ describe("Machine", () => {
       states: States.states,
       events: Machine.events(SignIn),
       initial: (to) =>
-        to.up.initial.resolve(({ target }) => (target(
+        to.up.initial.resolve(({ target }) => (target.decoded(
           new Up({ id: "up-1" }),
           (up) =>
             up
-              .auth(new Auth({ userId: "user-1" }), (auth) => auth.signedOut(new SignedOut({})))
-              .sync(new Sync({ enabled: true }), (sync) => sync.idle(new SyncIdle({})))
+              .auth.decoded(new Auth({ userId: "user-1" }), (auth) => auth.signedOut.decoded(new SignedOut({})))
+              .sync.decoded(new Sync({ enabled: true }), (sync) => sync.idle.decoded(new SyncIdle({})))
         )))
     })
 
@@ -1812,9 +1816,9 @@ describe("Machine", () => {
       states: States.states,
       events: Machine.events(SignIn),
       initial: (to) =>
-        to.up.initial.resolve(({ target }) => (target(
+        to.up.initial.resolve(({ target }) => (target.decoded(
           new Up({ id: "up-1" }),
-          (up) => up.auth(new Auth({ userId: "user-1" }), (auth) => auth.signedOut(new SignedOut({})))
+          (up) => up.auth.decoded(new Auth({ userId: "user-1" }), (auth) => auth.signedOut.decoded(new SignedOut({})))
         )))
     })
 
@@ -1837,17 +1841,17 @@ describe("Machine", () => {
   })
 
   it("initial builder constructs typed initial snapshots", () => {
-    const snapshot = UpInitial(
+    const snapshot = UpInitial.decoded(
       new Up({ id: "up-1" }),
       (up) =>
         up
-          .auth(
+          .auth.decoded(
             new Auth({ userId: "guest" }),
-            (auth) => auth.signedOut(new SignedOut({}))
+            (auth) => auth.signedOut.decoded(new SignedOut({}))
           )
-          .sync(
+          .sync.decoded(
             new Sync({ enabled: true }),
-            (sync) => sync.idle(new SyncIdle({}))
+            (sync) => sync.idle.decoded(new SyncIdle({}))
           )
     )
 
@@ -1863,12 +1867,12 @@ describe("Machine", () => {
   })
 
   it("initial builder rejects incomplete parallel callbacks", () => {
-    expect(UpInitial).type.not.toBeCallableWith(
+    expect(UpInitial.decoded).type.not.toBeCallableWith(
       new Up({ id: "up-1" }),
       (up: ChildBuilder<typeof UpInitial>) =>
-        up.auth(
+        up.auth.decoded(
           new Auth({ userId: "guest" }),
-          (auth) => auth.signedOut(new SignedOut({}))
+          (auth) => auth.signedOut.decoded(new SignedOut({}))
         )
     )
   })
@@ -1877,7 +1881,7 @@ describe("Machine", () => {
     const up = null as unknown as ChildBuilder<typeof UpInitial>
     const auth = null as unknown as ChildBuilder<typeof up.auth>
 
-    expect(auth.signedOut).type.toBeCallableWith(new SignedOut({}))
+    expect(auth.signedOut.decoded).type.toBeCallableWith(new SignedOut({}))
     expect(auth).type.not.toHaveProperty("signedIn")
   })
 
@@ -1885,36 +1889,36 @@ describe("Machine", () => {
     const up = null as unknown as ChildBuilder<typeof UpInitial>
     const sync = null as unknown as ChildBuilder<typeof up.sync>
 
-    expect(DownInitial).type.not.toBeCallableWith(new Up({ id: "up-1" }))
-    expect(UpInitial).type.not.toBeCallableWith(
+    expect(DownInitial.decoded).type.not.toBeCallableWith(new Up({ id: "up-1" }))
+    expect(UpInitial.decoded).type.not.toBeCallableWith(
       new Auth({ userId: "guest" }),
       (up: ChildBuilder<typeof UpInitial>) =>
         up
-          .auth(
+          .auth.decoded(
             new Auth({ userId: "guest" }),
-            (auth) => auth.signedOut(new SignedOut({}))
+            (auth) => auth.signedOut.decoded(new SignedOut({}))
           )
-          .sync(
+          .sync.decoded(
             new Sync({ enabled: true }),
-            (sync) => sync.idle(new SyncIdle({}))
+            (sync) => sync.idle.decoded(new SyncIdle({}))
           )
     )
-    expect(up.auth).type.not.toBeCallableWith(
+    expect(up.auth.decoded).type.not.toBeCallableWith(
       new Up({ id: "up-1" }),
-      (auth: ChildBuilder<typeof up.auth>) => auth.signedOut(new SignedOut({}))
+      (auth: ChildBuilder<typeof up.auth>) => auth.signedOut.decoded(new SignedOut({}))
     )
-    expect(sync.idle).type.not.toBeCallableWith(new Syncing({ requestId: "sync-1" }))
+    expect(sync.idle.decoded).type.not.toBeCallableWith(new Syncing({ requestId: "sync-1" }))
   })
 
   it("initial builder removes parallel region methods after they are called", () => {
     const up = null as unknown as ChildBuilder<typeof UpInitial>
-    const afterAuth = up.auth(
+    const afterAuth = up.auth.decoded(
       new Auth({ userId: "guest" }),
-      (auth) => auth.signedOut(new SignedOut({}))
+      (auth) => auth.signedOut.decoded(new SignedOut({}))
     )
-    const complete = afterAuth.sync(
+    const complete = afterAuth.sync.decoded(
       new Sync({ enabled: true }),
-      (sync) => sync.idle(new SyncIdle({}))
+      (sync) => sync.idle.decoded(new SyncIdle({}))
     )
 
     expect(afterAuth).type.not.toHaveProperty("auth")
@@ -1925,17 +1929,17 @@ describe("Machine", () => {
 
   it("target.full constructs typed full snapshots", () => {
     const context = null as unknown as SignInContext
-    const snapshot = context.target.full.up(
+    const snapshot = context.target.full.up.decoded(
       new Up({ id: "up-1" }),
       (up) =>
         up
-          .auth(
+          .auth.decoded(
             new Auth({ userId: "guest" }),
-            (auth) => auth.signedIn(new SignedIn({ userId: "user-1" }))
+            (auth) => auth.signedIn.decoded(new SignedIn({ userId: "user-1" }))
           )
-          .sync(
+          .sync.decoded(
             new Sync({ enabled: true }),
-            (sync) => sync.syncing(new Syncing({ requestId: "sync-1" }))
+            (sync) => sync.syncing.decoded(new Syncing({ requestId: "sync-1" }))
           )
     )
 
@@ -2263,12 +2267,12 @@ describe("Machine", () => {
   it("target.full requires every parallel region", () => {
     const context = null as unknown as SignInContext
 
-    expect(context.target.full.up).type.not.toBeCallableWith(
+    expect(context.target.full.up.decoded).type.not.toBeCallableWith(
       new Up({ id: "up-1" }),
       (up: ChildBuilder<typeof context.target.full.up>) =>
-        up.auth(
+        up.auth.decoded(
           new Auth({ userId: "guest" }),
-          (auth) => auth.signedIn(new SignedIn({ userId: "user-1" }))
+          (auth) => auth.signedIn.decoded(new SignedIn({ userId: "user-1" }))
         )
     )
   })
@@ -2278,23 +2282,23 @@ describe("Machine", () => {
     const up = null as unknown as ChildBuilder<typeof context.target.full.up>
     const auth = null as unknown as ChildBuilder<typeof up.auth>
 
-    expect(auth.signedOut).type.toBeCallableWith(new SignedOut({}))
-    expect(auth.signedIn).type.toBeCallableWith(new SignedIn({ userId: "user-1" }))
+    expect(auth.signedOut.decoded).type.toBeCallableWith(new SignedOut({}))
+    expect(auth.signedIn.decoded).type.toBeCallableWith(new SignedIn({ userId: "user-1" }))
   })
 
   it("target.local requires every region when entering an inactive nested parallel state", () => {
     const context = null as unknown as NestedIdleContext
-    const target = context.target.local.work(
+    const target = context.target.local.work.decoded(
       new Payment({}),
       (work) =>
         work
-          .auth(
+          .auth.decoded(
             new Auth({ userId: "guest" }),
-            (auth) => auth.signedIn(new SignedIn({ userId: "user-1" }))
+            (auth) => auth.signedIn.decoded(new SignedIn({ userId: "user-1" }))
           )
-          .sync(
+          .sync.decoded(
             new Sync({ enabled: true }),
-            (sync) => sync.syncing(new Syncing({ requestId: "sync-1" }))
+            (sync) => sync.syncing.decoded(new Syncing({ requestId: "sync-1" }))
           )
     )
 
@@ -2302,40 +2306,40 @@ describe("Machine", () => {
       Machine.Machine.Target<typeof NestedParallelStates.states, "root.work">
     >()
     expect(target.path).type.toBe<"root.work">()
-    expect(context.target.local.work).type.not.toBeCallableWith(
+    expect(context.target.local.work.decoded).type.not.toBeCallableWith(
       new Payment({}),
       (work: ChildBuilder<typeof context.target.local.work>) =>
-        work.auth(
+        work.auth.decoded(
           new Auth({ userId: "guest" }),
-          (auth) => auth.signedOut(new SignedOut({}))
+          (auth) => auth.signedOut.decoded(new SignedOut({}))
         )
     )
   })
 
   it("target.branch requires every region when entering an inactive nested parallel state", () => {
     const context = null as unknown as NestedIdleContext
-    const target = context.target.branch.root.work(
+    const target = context.target.branch.root.work.decoded(
       new Payment({}),
       (work) =>
         work
-          .auth(
+          .auth.decoded(
             new Auth({ userId: "guest" }),
-            (auth) => auth.signedOut(new SignedOut({}))
+            (auth) => auth.signedOut.decoded(new SignedOut({}))
           )
-          .sync(
+          .sync.decoded(
             new Sync({ enabled: true }),
-            (sync) => sync.idle(new SyncIdle({}))
+            (sync) => sync.idle.decoded(new SyncIdle({}))
           )
     )
 
     expect(target.path).type.toBe<"root.work">()
     expect(context.target.branch.root.work).type.not.toHaveProperty("auth")
-    expect(context.target.branch.root.work).type.not.toBeCallableWith(
+    expect(context.target.branch.root.work.decoded).type.not.toBeCallableWith(
       new Payment({}),
       (work: ChildBuilder<typeof context.target.branch.root.work>) =>
-        work.auth(
+        work.auth.decoded(
           new Auth({ userId: "guest" }),
-          (auth) => auth.signedOut(new SignedOut({}))
+          (auth) => auth.signedOut.decoded(new SignedOut({}))
         )
     )
   })
@@ -2343,24 +2347,24 @@ describe("Machine", () => {
   it("nested parallel target builders remove regions and validate payloads", () => {
     const context = null as unknown as NestedIdleContext
     const work = null as unknown as ChildBuilder<typeof context.target.local.work>
-    const afterAuth = work.auth(
+    const afterAuth = work.auth.decoded(
       new Auth({ userId: "guest" }),
-      (auth) => auth.signedOut(new SignedOut({}))
+      (auth) => auth.signedOut.decoded(new SignedOut({}))
     )
 
     expect(afterAuth).type.not.toHaveProperty("auth")
     expect(afterAuth).type.toHaveProperty("sync")
-    expect(work.auth).type.not.toBeCallableWith(
+    expect(work.auth.decoded).type.not.toBeCallableWith(
       new Sync({ enabled: true }),
-      (auth: ChildBuilder<typeof work.auth>) => auth.signedOut(new SignedOut({}))
+      (auth: ChildBuilder<typeof work.auth>) => auth.signedOut.decoded(new SignedOut({}))
     )
   })
 
   it("target.branch keeps partial navigation for an already-active parallel state", () => {
     const context = null as unknown as NestedActiveContext
-    const target = context.target.branch.root.work.sync(
+    const target = context.target.branch.root.work.sync.decoded(
       new Sync({ enabled: true }),
-      (sync) => sync.syncing(new Syncing({ requestId: "sync-1" }))
+      (sync) => sync.syncing.decoded(new Syncing({ requestId: "sync-1" }))
     )
 
     expect(context.target.branch.root.work).type.toHaveProperty("auth")
@@ -2370,7 +2374,7 @@ describe("Machine", () => {
 
   it("target.local constructs typed local leaf targets", () => {
     const context = null as unknown as SignedOutContext
-    const target = context.target.local.signedIn(new SignedIn({ userId: "user-1" }))
+    const target = context.target.local.signedIn.decoded(new SignedIn({ userId: "user-1" }))
 
     expect(target).type.toBeAssignableTo<
       Machine.Machine.Target<typeof UpStates.states, "up.auth.signedIn">
@@ -2382,21 +2386,22 @@ describe("Machine", () => {
   it("target.local exposes the source compound children when the source is compound", () => {
     const context = null as unknown as AuthContext
 
-    expect(context.target.local.signedOut).type.toBeCallableWith(new SignedOut({}))
-    expect(context.target.local.signedIn).type.toBeCallableWith(new SignedIn({ userId: "user-1" }))
+    expect(context.target.local.signedOut.decoded).type.toBeCallableWith(new SignedOut({}))
+    expect(context.target.local.signedIn.decoded).type.toBeCallableWith(new SignedIn({ userId: "user-1" }))
   })
 
   it("target.local.with checks the local compound value", () => {
     const context = null as unknown as SignedOutContext
-    const target = context.target.local.with(
+    const target = context.target.local.with.decoded(
       new Auth({ userId: "user-1" }),
-      (auth) => auth.signedIn(new SignedIn({ userId: "user-1" }))
+      (auth) => auth.signedIn.decoded(new SignedIn({ userId: "user-1" }))
     )
 
     expect(target.path).type.toBe<"up.auth.signedIn">()
-    expect(context.target.local.with).type.not.toBeCallableWith(
+    expect(context.target.local.with.decoded).type.not.toBeCallableWith(
       new Up({ id: "up-1" }),
-      (auth: ChildBuilder<typeof context.target.local.with>) => auth.signedIn(new SignedIn({ userId: "user-1" }))
+      (auth: ChildBuilder<typeof context.target.local.with>) =>
+        auth.signedIn.decoded(new SignedIn({ userId: "user-1" }))
     )
   })
 
@@ -2406,7 +2411,7 @@ describe("Machine", () => {
     expect(context.target.local).type.not.toHaveProperty("sync")
     expect(context.target.local).type.not.toHaveProperty("down")
     expect(context.target.local).type.not.toHaveProperty("idle")
-    expect(context.target.local.signedIn).type.not.toBeCallableWith(new SignedOut({}))
+    expect(context.target.local.signedIn.decoded).type.not.toBeCallableWith(new SignedOut({}))
   })
 
   it("target.local exposes no methods outside a compound scope", () => {
@@ -2429,9 +2434,9 @@ describe("Machine", () => {
 
   it("target.branch constructs typed partial branch targets", () => {
     const context = null as unknown as SignedOutContext
-    const target = context.target.branch.up.sync(
+    const target = context.target.branch.up.sync.decoded(
       new Sync({ enabled: true }),
-      (sync) => sync.syncing(new Syncing({ requestId: "sync-1" }))
+      (sync) => sync.syncing.decoded(new Syncing({ requestId: "sync-1" }))
     )
 
     expect(target).type.toBeAssignableTo<
@@ -2443,12 +2448,12 @@ describe("Machine", () => {
 
   it("target.branch can replace ancestors before selecting a leaf", () => {
     const context = null as unknown as SignedOutContext
-    const target = context.target.branch.up(
+    const target = context.target.branch.up.decoded(
       new Up({ id: "up-2" }),
       (up) =>
-        up.auth(
+        up.auth.decoded(
           new Auth({ userId: "user-1" }),
-          (auth) => auth.signedIn(new SignedIn({ userId: "user-1" }))
+          (auth) => auth.signedIn.decoded(new SignedIn({ userId: "user-1" }))
         )
     )
 
@@ -2459,13 +2464,14 @@ describe("Machine", () => {
   it("target.branch rejects non-leaf targets and wrong values", () => {
     const context = null as unknown as SignedOutContext
 
-    expect(context.target.branch.up).type.not.toBeCallableWith(new Up({ id: "up-1" }))
-    expect(context.target.branch.up.sync).type.not.toBeCallableWith(new Sync({ enabled: true }))
-    expect(context.target.branch.up.sync).type.not.toBeCallableWith(
+    expect(context.target.branch.up.decoded).type.not.toBeCallableWith(new Up({ id: "up-1" }))
+    expect(context.target.branch.up.sync.decoded).type.not.toBeCallableWith(new Sync({ enabled: true }))
+    expect(context.target.branch.up.sync.decoded).type.not.toBeCallableWith(
       new Auth({ userId: "user-1" }),
-      (sync: ChildBuilder<typeof context.target.branch.up.sync>) => sync.syncing(new Syncing({ requestId: "sync-1" }))
+      (sync: ChildBuilder<typeof context.target.branch.up.sync>) =>
+        sync.syncing.decoded(new Syncing({ requestId: "sync-1" }))
     )
-    expect(context.target.branch.up.auth.signedIn).type.not.toBeCallableWith(new SignedOut({}))
+    expect(context.target.branch.up.auth.signedIn.decoded).type.not.toBeCallableWith(new SignedOut({}))
   })
 
   it("target is not callable", () => {
@@ -2480,7 +2486,7 @@ describe("Machine", () => {
     const definition = Machine.make({
       states: UpStates.states,
       events: Machine.events(SignIn),
-      initial: (to) => to.down().resolve(({ target }) => (target(new Down({}))))
+      initial: (to) => to.down().resolve(({ target }) => (target.decoded(new Down({}))))
     })
 
     expect(definition.handle).type.not.toBeCallableWith({

--- a/typetest/machine/MachineReferences.tst.ts
+++ b/typetest/machine/MachineReferences.tst.ts
@@ -34,7 +34,7 @@ describe("machine reference event channels", () => {
     internalEvents: InternalEvents,
     parent: Machine.optionalParent(ParentEvents),
     emittedEvents: Emissions,
-    initial: (to) => to.Idle().resolve(({ target }) => (target(new Idle({}))))
+    initial: (to) => to.Idle().resolve(({ target }) => (target.decoded(new Idle({}))))
   }).handle({
     Idle: {
       on: {
@@ -59,7 +59,7 @@ describe("machine reference event channels", () => {
     const independentMachine = Machine.make({
       states: states.states,
       events: Events,
-      initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+      initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
     }).handle({
       Idle: {
         on: {
@@ -79,7 +79,7 @@ describe("machine reference event channels", () => {
       internalEvents: InternalEvents,
       parent: Machine.optionalParent(ParentEvents),
       emittedEvents: Emissions,
-      initial: (to) => to.Idle().resolve(({ target }) => (target(new Idle({}))))
+      initial: (to) => to.Idle().resolve(({ target }) => (target.decoded(new Idle({}))))
     }).handle({
       Idle: {
         on: {
@@ -110,7 +110,7 @@ describe("machine reference event channels", () => {
     const compatible = Machine.make({
       states: states.states,
       events: Machine.events(Ping, ParentEvents),
-      initial: (to) => to.Idle().resolve(({ target }) => (target(new Idle({}))))
+      initial: (to) => to.Idle().resolve(({ target }) => (target.decoded(new Idle({}))))
     })
     compatible.handle({
       Idle: { invoke: (from) => from.child(Child) }
@@ -119,7 +119,7 @@ describe("machine reference event channels", () => {
     const incompatible = Machine.make({
       states: states.states,
       events: Machine.events(Ping, OtherParentEvent),
-      initial: (to) => to.Idle().resolve(({ target }) => (target(new Idle({}))))
+      initial: (to) => to.Idle().resolve(({ target }) => (target.decoded(new Idle({}))))
     })
     expect(incompatible.handle).type.not.toBeCallableWith({
       Idle: {
@@ -169,7 +169,7 @@ describe("machine reference event channels", () => {
       internalEvents: InternalEvents,
       parent: Machine.parent(ParentEvents),
       emittedEvents: Emissions,
-      initial: (to) => to.Idle().resolve(({ target }) => (target(new Idle({}))))
+      initial: (to) => to.Idle().resolve(({ target }) => (target.decoded(new Idle({}))))
     }).handle({
       Idle: {
         invoke: (from) =>

--- a/typetest/machine/Readiness.tst.ts
+++ b/typetest/machine/Readiness.tst.ts
@@ -26,7 +26,7 @@ const choiceStates = Machine.states({
 const choiceIncomplete = Machine.make({
   states: choiceStates.states,
   events: Machine.events(Tick),
-  initial: (to) => to.Ready().resolve(({ target }) => (target(new Ready({}))))
+  initial: (to) => to.Ready().resolve(({ target }) => (target.decoded(new Ready({}))))
 })
 const choiceSnapshot = { path: "Ready" as const, value: new Ready({}) }
 
@@ -45,7 +45,7 @@ const historyStates = Machine.states({
 const historyIncomplete = Machine.make({
   states: historyStates.states,
   events: Machine.events(Tick),
-  initial: (to) => to.Ready().resolve(({ target }) => (target(new Ready({}))))
+  initial: (to) => to.Ready().resolve(({ target }) => (target.decoded(new Ready({}))))
 })
 const historySnapshot = { path: "Ready" as const, value: new Ready({}) }
 
@@ -61,7 +61,7 @@ const outputStates = Machine.states({
 const outputIncomplete = Machine.make({
   states: outputStates.states,
   events: Machine.events(Tick),
-  initial: (to) => to.Ready().resolve(({ target }) => (target(new Ready({}))))
+  initial: (to) => to.Ready().resolve(({ target }) => (target.decoded(new Ready({}))))
 })
 const outputSnapshot = { path: "Ready" as const, value: new Ready({}) }
 type InvokeSelector = Machine.Machine.InvokeSelector<
@@ -138,21 +138,21 @@ describe("executable machine readiness", () => {
     const complete = Machine.make({
       states: completeStates.states,
       events: Machine.events(Tick),
-      initial: (to) => to.Ready().resolve(({ target }) => (target(new Ready({}))))
+      initial: (to) => to.Ready().resolve(({ target }) => (target.decoded(new Ready({}))))
     }).handle({
       Flow: {
         history: {
           recent: {
             default: ({ target }) =>
-              target.Flow(
+              target.Flow.decoded(
                 new Flow({}),
-                (flow) => flow.Idle(new Idle({}))
+                (flow) => flow.Idle.decoded(new Idle({}))
               )
           }
         },
         states: {
           Route: {
-            choice: (to) => to.local.Idle().resolve(({ target }) => target(new Idle({})))
+            choice: (to) => to.local.Idle().resolve(({ target }) => target.decoded(new Idle({})))
           },
           Done: {
             output: ({ state }) => state.value

--- a/typetest/machine/Resume.tst.ts
+++ b/typetest/machine/Resume.tst.ts
@@ -14,11 +14,11 @@ const machine = Machine.make({
   states: States.states,
   events: Machine.events(Tick),
   input: Schema.Struct({ seed: Schema.Number }),
-  initial: (to) => to.Idle().resolve(({ input: input, target }) => (target(new Idle({ value: input.seed }))))
+  initial: (to) => to.Idle().resolve(({ input: input, target }) => (target.decoded(new Idle({ value: input.seed }))))
 }).handle({
   Idle: {
     on: {
-      Tick: (to) => to.full.Idle().resolve(({ state, target }) => target(new Idle({ value: state.value + 1 })))
+      Tick: (to) => to.full.Idle().resolve(({ state, target }) => target.decoded(new Idle({ value: state.value + 1 })))
     }
   }
 })

--- a/typetest/machine/SnapshotContext.tst.ts
+++ b/typetest/machine/SnapshotContext.tst.ts
@@ -38,12 +38,12 @@ describe("Machine transition snapshot context", () => {
       states: States.states,
       events: Machine.events(Advance),
       initial: (to) =>
-        to.Root.initial.resolve(({ target }) => (target(
+        to.Root.initial.resolve(({ target }) => (target.decoded(
           new Root({}),
           (root) =>
             root
-              .Left(new Left({}), (left) => left.LeftIdle(new LeftIdle({})))
-              .Right(new Right({}), (right) => right.RightIdle(new RightIdle({})))
+              .Left.decoded(new Left({}), (left) => left.LeftIdle.decoded(new LeftIdle({})))
+              .Right.decoded(new Right({}), (right) => right.RightIdle.decoded(new RightIdle({})))
         )))
     }).handle({
       Root: {
@@ -55,7 +55,7 @@ describe("Machine transition snapshot context", () => {
                 expect(States.matches).type.toBeCallableWith(snapshot, "Root.Right.RightIdle")
                 expect(States.get).type.toBeCallableWith(snapshot, "Root.Right.RightIdle")
                 expect(States.getSnapshot).type.toBeCallableWith(snapshot, "Root.Right.RightIdle")
-                return target(new LeftIdle({}))
+                return target.decoded(new LeftIdle({}))
               }),
             states: {
               LeftIdle: {
@@ -69,7 +69,7 @@ describe("Machine transition snapshot context", () => {
                     to.local.LeftDone().resolve(({ snapshot, target }) => {
                       expect(snapshot).type.toBe<Machine.Machine.Snapshot<typeof States.states>>()
                       expect(States.matches(snapshot, "Root.Right.RightIdle")).type.toBe<boolean>()
-                      return target(new LeftDone({}))
+                      return target.decoded(new LeftDone({}))
                     })
                 }
               }
@@ -96,7 +96,7 @@ describe("Machine transition snapshot context", () => {
     Machine.make({
       states: choiceStates.states,
       events: Machine.events(),
-      initial: (to) => to.Flow.initial.resolve(({ target }) => (target(new Flow({}), (flow) => flow.Routing())))
+      initial: (to) => to.Flow.initial.resolve(({ target }) => (target.decoded(new Flow({}), (flow) => flow.Routing())))
     }).handle({
       Flow: {
         entry: (context) => {
@@ -107,7 +107,7 @@ describe("Machine transition snapshot context", () => {
             choice: (to) =>
               to.local.Active().resolve((context) => {
                 expect(context).type.not.toHaveProperty("snapshot")
-                return context.target(new Active({}))
+                return context.target.decoded(new Active({}))
               })
           }
         }

--- a/typetest/machine/StateUpdate.tst.ts
+++ b/typetest/machine/StateUpdate.tst.ts
@@ -48,12 +48,15 @@ describe("Machine state-value updates", () => {
       events: Machine.events(Tick),
       initial: (to) =>
         to.root.initial.resolve(({ target }) =>
-          target(new Root({ revision: 0 }), (root) =>
-            root.work(
+          target.decoded(new Root({ revision: 0 }), (root) =>
+            root.work.decoded(
               new Work({ revision: 0 }),
               (work) =>
-                work.auth(new Auth({ user: "" }), (auth) => auth.signedOut(new SignedOut({})))
-                  .sync(new Sync({ cursor: 0 }), (sync) => sync.idle(new Idle({})))
+                work.auth.decoded(
+                  new Auth({ user: "" }),
+                  (auth) => auth.signedOut.decoded(new SignedOut({}))
+                )
+                  .sync.decoded(new Sync({ cursor: 0 }), (sync) => sync.idle.decoded(new Idle({})))
             ))
         )
     })
@@ -79,11 +82,12 @@ describe("Machine state-value updates", () => {
                         expect(to.history).type.not.toHaveProperty("update")
                         expect(to.none).type.not.toHaveProperty("update")
 
-                        return to.local.update(({ state, target }) => {
+                        return to.local.update(({ current, owner, state }) => {
                           expect(state).type.toBe<SignedOut>()
-                          expect(target).type.toBeCallableWith(new Auth({ user: "next" }))
-                          expect(target.from).type.toBeCallableWith({ user: "next" })
-                          return target(new Auth({ user: "next" }))
+                          expect(current).type.toBe<Auth>()
+                          expect(owner.decoded).type.toBeCallableWith(new Auth({ user: "next" }))
+                          expect(owner.from).type.toBeCallableWith({ user: "next" })
+                          return owner.decoded(new Auth({ user: "next" }))
                         }, { reenter: true })
                       }
                     }
@@ -95,6 +99,61 @@ describe("Machine state-value updates", () => {
         }
       }
     })
+  })
+
+  it("requires a declared retained owner to be replaced by the combined resolver", () => {
+    const transition = null as unknown as Machine.Machine.TransitionSelector<
+      typeof States.states,
+      readonly [typeof Tick],
+      readonly [],
+      "root.work.auth.signedOut",
+      Machine.Machine.HandlerContext<
+        typeof States.states,
+        readonly [typeof Tick],
+        readonly [],
+        "root.work.auth.signedOut",
+        "Tick",
+        never,
+        never
+      >,
+      false,
+      "required"
+    >
+
+    transition.local.signedIn()
+      .updating(transition.branch.root.work.auth)
+      .resolve(({ current, owner, target }) => {
+        expect(current).type.toBe<Auth>()
+        expect(owner.from).type.toBeCallableWith({ user: "next" })
+        expect(owner.decoded).type.toBeCallableWith(new Auth({ user: "next" }))
+        // @ts-expect-error! Decoded construction is named and the target itself is not callable.
+        target(new SignedIn({}))
+        expect(target.from).type.toBeCallableWith({})
+        expect(target.decoded).type.toBeCallableWith(new SignedIn({}))
+        return target.decoded(new SignedIn({})).update(
+          owner.decoded(new Auth({ user: "next" }))
+        )
+      })
+
+    transition.local.signedIn()
+      .updating(transition.branch.root.work.auth)
+      .resolve(
+        // @ts-expect-error! Declaring `.updating(...)` requires the resolver to finish with `.update(...)`.
+        ({ target }) => target.decoded(new SignedIn({}))
+      )
+
+    transition.local.signedIn().updating(
+      // @ts-expect-error! The sibling sync owner does not contain the source and destination.
+      transition.branch.root.work.sync
+    )
+
+    expect(transition.branches).type.not.toBeCallableWith({
+      changed: {
+        target: transition.local.signedIn().updating(transition.branch.root.work.auth)
+      }
+    })
+
+    expect(transition.full.structural()).type.not.toHaveProperty("updating")
   })
 
   it("supports named update branches and rejects missing update evidence", () => {
@@ -121,7 +180,7 @@ describe("Machine state-value updates", () => {
       unchanged: { target: update.none }
     }).resolve(({ select }) => select.changed.from({ revision: 1 }))
 
-    update.local.update(({ target }) => target.from({ user: "next" }), { declinable: true })
+    update.local.update(({ owner }) => owner.from({ user: "next" }), { declinable: true })
     update.local.update(({ decline }) => decline(), { declinable: true })
 
     update.local.update(

--- a/typetest/testing/Coverage.tst.ts
+++ b/typetest/testing/Coverage.tst.ts
@@ -14,11 +14,11 @@ describe("MachineTest coverage and observed graph", () => {
   const machine = Machine.make({
     states: States.states,
     events: Machine.events(Start),
-    initial: (to) => to.idle().resolve(({ target }) => (target(new Idle({}))))
+    initial: (to) => to.idle().resolve(({ target }) => (target.decoded(new Idle({}))))
   }).handle({
     idle: {
       on: {
-        Start: (to) => to.full.done().resolve(({ target }) => target(new Done({})))
+        Start: (to) => to.full.done().resolve(({ target }) => target.decoded(new Done({})))
       }
     },
     done: {}

--- a/typetest/testing/Exploration.tst.ts
+++ b/typetest/testing/Exploration.tst.ts
@@ -15,7 +15,7 @@ describe("MachineTest exploration", () => {
     events: Machine.events(Increment),
     internalEvents: Machine.internalEvents(Internal),
     input: Input,
-    initial: (to) => to.counter().resolve(({ input, target }) => target(new Counter({ count: input.seed })))
+    initial: (to) => to.counter().resolve(({ input, target }) => target.decoded(new Counter({ count: input.seed })))
   }).handle({
     counter: {
       on: {
@@ -75,7 +75,7 @@ describe("MachineTest exploration", () => {
     const noInput = Machine.make({
       states: States.states,
       events: Machine.events(Increment),
-      initial: (to) => to.counter().resolve(({ target }) => (target(new Counter({ count: 0 }))))
+      initial: (to) => to.counter().resolve(({ target }) => (target.decoded(new Counter({ count: 0 }))))
     }).handle({ counter: {} })
     type Options = MachineTest.ExploreOptions<typeof noInput, string>
     expect<Options["input"]>().type.toBe<undefined>()

--- a/typetest/testing/Invariant.tst.ts
+++ b/typetest/testing/Invariant.tst.ts
@@ -13,7 +13,7 @@ describe("MachineTest invariants", () => {
     states: States.states,
     events: Machine.events(Tick),
     internalEvents: Machine.internalEvents(Internal),
-    initial: (to) => to.idle().resolve(({ target }) => (target(new Idle({ count: 0 }))))
+    initial: (to) => to.idle().resolve(({ target }) => (target.decoded(new Idle({ count: 0 }))))
   }).handle({
     idle: {
       on: {

--- a/typetest/testing/MachineTest.tst.ts
+++ b/typetest/testing/MachineTest.tst.ts
@@ -18,7 +18,7 @@ describe("MachineTest", () => {
     events: Machine.events(PublicEvent),
     internalEvents: Machine.internalEvents(InternalEvent),
     input: Input,
-    initial: (to) => to.idle().resolve(({ target }) => (target(new Idle({}))))
+    initial: (to) => to.idle().resolve(({ target }) => (target.decoded(new Idle({}))))
   }).handle({
     idle: {
       on: {
@@ -51,7 +51,7 @@ describe("MachineTest", () => {
     const noInput = Machine.make({
       states: States.states,
       events: Machine.events(PublicEvent),
-      initial: (to) => to.idle().resolve(({ target }) => (target(new Idle({}))))
+      initial: (to) => to.idle().resolve(({ target }) => (target.decoded(new Idle({}))))
     }).handle({ idle: {} })
     type Scenario = MachineTest.Scenario<typeof noInput>
     type Options = MachineTest.ScenarioOptions<typeof noInput>
@@ -97,7 +97,7 @@ describe("MachineTest", () => {
     const invokedMachine = Machine.make({
       states: States.states,
       events: Machine.events(PublicEvent),
-      initial: (to) => to.idle().resolve(({ target }) => (target(new Idle({}))))
+      initial: (to) => to.idle().resolve(({ target }) => (target.decoded(new Idle({}))))
     }).handle({
       idle: {
         invoke: (from) =>

--- a/typetest/testing/Probe.tst.ts
+++ b/typetest/testing/Probe.tst.ts
@@ -15,7 +15,7 @@ describe("MachineTest probe", () => {
     states: states.states,
     events: Machine.events(PublicEvent),
     internalEvents: Machine.internalEvents(InternalEvent),
-    initial: (to) => to.State().resolve(({ target }) => (target(new State({ count: 0 }))))
+    initial: (to) => to.State().resolve(({ target }) => (target.decoded(new State({ count: 0 }))))
   }).handle({
     State: {
       on: {

--- a/typetest/testing/Verification.tst.ts
+++ b/typetest/testing/Verification.tst.ts
@@ -11,7 +11,7 @@ describe("MachineTest.verify", () => {
   const machine = Machine.make({
     states: States.states,
     events: Machine.events(Tick),
-    initial: (to) => to.idle().resolve(({ target }) => (target(new Idle({}))))
+    initial: (to) => to.idle().resolve(({ target }) => (target.decoded(new Idle({}))))
   }).handle({ idle: {} })
 
   const trace = {} as MachineTest.Trace<typeof machine>

--- a/typetest/unstable/cluster/ClusterMachine.tst.ts
+++ b/typetest/unstable/cluster/ClusterMachine.tst.ts
@@ -70,13 +70,15 @@ describe("ClusterMachine", () => {
     id: "Counter",
     states: states.states,
     events: Machine.events(Increment, Reset),
-    initial: (to) => to.Count().resolve(({ target }) => (target(new Count({ value: 0 }))))
+    initial: (to) => to.Count().resolve(({ target }) => (target.decoded(new Count({ value: 0 }))))
   }).handle({
     Count: {
       on: {
         Increment: (to) =>
-          to.full.Count().resolve(({ event, state, target }) => target(new Count({ value: state.value + event.by }))),
-        Reset: (to) => to.full.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+          to.full.Count().resolve(({ event, state, target }) =>
+            target.decoded(new Count({ value: state.value + event.by }))
+          ),
+        Reset: (to) => to.full.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
       }
     }
   })
@@ -92,7 +94,7 @@ describe("ClusterMachine", () => {
       states: states.states,
       events: Machine.events(Increment),
       internalEvents: Machine.internalEvents(Reset),
-      initial: (to) => to.Count().resolve(({ target }) => (target(new Count({ value: 0 }))))
+      initial: (to) => to.Count().resolve(({ target }) => (target.decoded(new Count({ value: 0 }))))
     })
     const internalBridge = ClusterMachine.make("InternalCounterEntity", internalMachine, {
       version: "1"
@@ -114,7 +116,8 @@ describe("ClusterMachine", () => {
       states: states.states,
       events: Machine.events(Reset),
       input: Input,
-      initial: (to) => to.Count().resolve(({ input: input, target }) => (target(new Count({ value: input.value }))))
+      initial: (to) =>
+        to.Count().resolve(({ input: input, target }) => (target.decoded(new Count({ value: input.value }))))
     })
 
     expect(ClusterMachine.make).type.not.toBeCallableWith(
@@ -145,7 +148,7 @@ describe("ClusterMachine", () => {
       states: resourceStates.states,
       events: Machine.events(ResourceEvent),
       initial: (to) =>
-        to.ResourceState().resolve(({ target }) => target(new ResourceState({ resource: { close() {} } })))
+        to.ResourceState().resolve(({ target }) => target.decoded(new ResourceState({ resource: { close() {} } })))
     })
 
     expect(ClusterMachine.make).type.not.toBeCallableWith(
@@ -157,7 +160,7 @@ describe("ClusterMachine", () => {
     const unknownEventMachine = Machine.make({
       states: states.states,
       events: Machine.events(UnknownEvent),
-      initial: (to) => to.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+      initial: (to) => to.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
     })
 
     expect(ClusterMachine.make).type.not.toBeCallableWith(
@@ -172,7 +175,7 @@ describe("ClusterMachine", () => {
     const anyOutputMachine = Machine.make({
       states: anyOutputStates.states,
       events: Machine.events(Reset),
-      initial: (to) => to.Done().resolve(({ target }) => target(new Done({ value: "done" })))
+      initial: (to) => to.Done().resolve(({ target }) => target.decoded(new Done({ value: "done" })))
     }).handle({
       Done: { output: () => null }
     })
@@ -189,7 +192,7 @@ describe("ClusterMachine", () => {
     const neverOutputMachine = Machine.make({
       states: neverOutputStates.states,
       events: Machine.events(Reset),
-      initial: (to) => to.Done().resolve(({ target }) => target(new Done({ value: "done" })))
+      initial: (to) => to.Done().resolve(({ target }) => target.decoded(new Done({ value: "done" })))
     }).handle({
       Done: {
         output: () => {
@@ -208,7 +211,8 @@ describe("ClusterMachine", () => {
     const scheduledMachine = Machine.make({
       states: scheduledStates.states,
       events: Machine.events(Reset),
-      initial: (to) => to.Scheduled().resolve(({ target }) => target(new Scheduled({ at: new Date("2026-08-19") })))
+      initial: (to) =>
+        to.Scheduled().resolve(({ target }) => target.decoded(new Scheduled({ at: new Date("2026-08-19") })))
     })
 
     expect(ClusterMachine.make).type.toBeCallableWith(
@@ -221,7 +225,7 @@ describe("ClusterMachine", () => {
       states: states.states,
       events: Machine.events(Reset),
       internalEvents: Machine.internalEvents(ResourceEvent),
-      initial: (to) => to.Count().resolve(({ target }) => target(new Count({ value: 0 })))
+      initial: (to) => to.Count().resolve(({ target }) => target.decoded(new Count({ value: 0 })))
     })
 
     expect(ClusterMachine.make).type.toBeCallableWith(
@@ -242,7 +246,7 @@ describe("ClusterMachine", () => {
     const incomplete = Machine.make({
       states: outputStates.states,
       events: Machine.events(Reset),
-      initial: (to) => to.Done().resolve(({ target }) => (target(new Done({ value: "done" }))))
+      initial: (to) => to.Done().resolve(({ target }) => (target.decoded(new Done({ value: "done" }))))
     })
 
     expect(ClusterMachine.make).type.not.toBeCallableWith(
@@ -281,7 +285,7 @@ describe("ClusterMachine", () => {
     const contextualMachine = Machine.make({
       states: contextualStates.states,
       events: Machine.events(Reset),
-      initial: (to) => to.ContextualCount().resolve(({ target }) => (target(new ContextualCount({ value: 0 }))))
+      initial: (to) => to.ContextualCount().resolve(({ target }) => (target.decoded(new ContextualCount({ value: 0 }))))
     })
     const layer = ClusterMachine.make("ContextualCounter", contextualMachine, { version: "1" }).toLayer()
 

--- a/typetest/unstable/reactivity/AtomMachine.tst.ts
+++ b/typetest/unstable/reactivity/AtomMachine.tst.ts
@@ -113,7 +113,7 @@ const makeMachine = () =>
   Machine.make({
     states: States.states,
     events: Machine.events(Tick),
-    initial: (to) => to.Idle().resolve(({ target }) => (target(new Idle({}))))
+    initial: (to) => to.Idle().resolve(({ target }) => (target.decoded(new Idle({}))))
   }).handle({
     Idle: {}
   })
@@ -123,7 +123,7 @@ const makeEmittingMachine = () =>
     states: States.states,
     events: Machine.events(Tick),
     emittedEvents: Emissions,
-    initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+    initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
   }).handle({
     Idle: {}
   })
@@ -135,7 +135,7 @@ describe("AtomMachine", () => {
     const parentMachine = Machine.make({
       states: States.states,
       events: Machine.events(),
-      initial: (to) => to.Idle().resolve(({ target }) => (target(new Idle({}))))
+      initial: (to) => to.Idle().resolve(({ target }) => (target.decoded(new Idle({}))))
     }).handle({
       Idle: {
         invoke: (from) => from.child(Child)
@@ -179,7 +179,7 @@ describe("AtomMachine", () => {
       states: States.states,
       events: Machine.events(),
       emittedEvents: Emissions,
-      initial: (to) => to.Idle().resolve(({ target }) => target(new Idle({})))
+      initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
     }).handle({
       Idle: {
         invoke: (from) => from.child(Child)
@@ -350,12 +350,12 @@ describe("AtomMachine", () => {
       states: States.states,
       events: Machine.events(Tick),
       internalEvents: Machine.internalEvents(InternalTick),
-      initial: (to) => to.Idle().resolve(({ target }) => (target(new Idle({}))))
+      initial: (to) => to.Idle().resolve(({ target }) => (target.decoded(new Idle({}))))
     }).handle({
       Idle: {
         on: {
-          Tick: (to) => to.full.Idle().resolve(({ target }) => target(new Idle({}))),
-          InternalTick: (to) => to.full.Idle().resolve(({ target }) => target(new Idle({})))
+          Tick: (to) => to.full.Idle().resolve(({ target }) => target.decoded(new Idle({}))),
+          InternalTick: (to) => to.full.Idle().resolve(({ target }) => target.decoded(new Idle({})))
         }
       }
     })
@@ -378,7 +378,7 @@ describe("AtomMachine", () => {
     const incomplete = Machine.make({
       states: OutputStates.states,
       events: Machine.events(Tick),
-      initial: (to) => to.Idle().resolve(({ target }) => (target(new Idle({}))))
+      initial: (to) => to.Idle().resolve(({ target }) => (target.decoded(new Idle({}))))
     })
     const runtime = Atom.runtime(Layer.empty)
     const bound = AtomMachine.bind(runtime)


### PR DESCRIPTION
## Summary

- make state construction modes explicit with `.from(...)` for schema make input and `.decoded(...)` for already-decoded values, removing callable valued builders
- add `.updating(ownerSelector)` so one retained valued ancestor can be replaced atomically with a local or branch topology change; the resolver must call destination `.update(...)` at compile time
- align generic and indexed planning, conflict handling, inspection, visualization, verification, persistence-compatible snapshots, tests, benchmarks, consumer fixtures, and documentation with the combined instruction

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change `src/` or `package.json`

Adds a minor changeset because this is a breaking pre-1.0 public API change.

## Validation

- [x] `pnpm check`
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required

Local `pnpm perf:types` and `pnpm perf:runtime` also passed.