### PR TITLE
Fix published Oxlint plugin entrypoints

### DIFF
--- a/.changeset/smooth-melons-load.md
+++ b/.changeset/smooth-melons-load.md
@@ -1,0 +1,7 @@
+---
+"@typeonce/oxlint-plugin-effect-machine": patch
+---
+
+Fix the published plugin entrypoints so Oxlint loads built JavaScript instead of TypeScript source under `node_modules`.
+
+Upgrade from `0.26.0` without changing the Oxlint configuration. Both the package root and the recommended configuration now resolve to built files.

--- a/packages/oxlint-plugin/package.json
+++ b/packages/oxlint-plugin/package.json
@@ -27,31 +27,19 @@
   ],
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
     "./recommended": {
-      "types": "./src/recommended.ts",
-      "import": "./src/recommended.ts"
+      "types": "./dist/recommended.d.ts",
+      "import": "./dist/recommended.js"
     },
     "./package.json": "./package.json",
     "./internal/*": null
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
-    "exports": {
-      ".": {
-        "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
-      },
-      "./recommended": {
-        "types": "./dist/recommended.d.ts",
-        "import": "./dist/recommended.js"
-      },
-      "./package.json": "./package.json",
-      "./internal/*": null
-    }
+    "provenance": true
   },
   "scripts": {
     "build": "tsc -b tsconfig.build.json",

--- a/scripts/oxlint-plugin-pack-check.mjs
+++ b/scripts/oxlint-plugin-pack-check.mjs
@@ -25,11 +25,19 @@ const run = (command, args, options = {}) => {
 }
 
 try {
-  const packed = run("pnpm", ["pack", "--pack-destination", destination], {
+  const packed = run("npm", [
+    "pack",
+    "--cache",
+    join(destination, "npm-cache"),
+    "--pack-destination",
+    destination,
+    "--json"
+  ], {
     cwd: packageRoot
   })
-  const archive = packed.stdout.trim().split("\n").at(-1)
-  if (archive === undefined) throw new Error("pnpm pack did not return an archive path")
+  const filename = JSON.parse(packed.stdout).at(0)?.filename
+  if (filename === undefined) throw new Error("npm pack did not return an archive filename")
+  const archive = join(destination, filename)
 
   const listing = run("tar", ["-tzf", archive]).stdout.trim().split("\n")
   const required = [
@@ -63,6 +71,28 @@ try {
     }, null, 2)
   )
   run("pnpm", ["install", "--prefer-offline", "--ignore-scripts"], { cwd: consumer })
+  const installedManifest = JSON.parse(
+    await readFile(
+      join(
+        consumer,
+        "node_modules",
+        "@typeonce",
+        "oxlint-plugin-effect-machine",
+        "package.json"
+      ),
+      "utf8"
+    )
+  )
+  const rootExport = installedManifest.exports?.["."]
+  const recommendedExport = installedManifest.exports?.["./recommended"]
+  if (
+    rootExport?.types !== "./dist/index.d.ts" ||
+    rootExport?.import !== "./dist/index.js" ||
+    recommendedExport?.types !== "./dist/recommended.d.ts" ||
+    recommendedExport?.import !== "./dist/recommended.js"
+  ) {
+    throw new Error("packed plugin entrypoints do not resolve to built files")
+  }
   await writeFile(
     join(consumer, ".oxlintrc.json"),
     JSON.stringify({


### PR DESCRIPTION
## Summary

- Publish the plugin root and recommended configuration from built JavaScript and declarations.
- Exercise the raw npm pack path in the consumer smoke test so source entrypoints cannot be published again.
- Add a patch changeset; the fixed package group will release all three packages at 0.26.1.

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change a publishable package

## Validation

- [x] pnpm check
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required

Local functional smoke tests also passed with pnpm perf:types and pnpm perf:runtime. The pull request workflows classified the package-metadata and release-test change as not requiring base-versus-PR measurement.