### PR TITLE
Publish the devtools example gallery

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           stars="$(gh api "repos/$GITHUB_REPOSITORY" --jq .stargazers_count)"
           echo "API_REFERENCE_GITHUB_STARS=$stars" >> "$GITHUB_ENV"
-      - run: pnpm docs:site
+      - run: pnpm website
         env:
           API_REFERENCE_BASE_PATH: ${{ steps.pages.outputs.base_path }}
       - uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -38,7 +38,12 @@ jobs:
         run: |
           stars="$(gh api "repos/$GITHUB_REPOSITORY" --jq .stargazers_count)"
           echo "API_REFERENCE_GITHUB_STARS=$stars" >> "$GITHUB_ENV"
-      - run: pnpm website
+      - run: |
+          pnpm docs:site
+          pnpm devtools build \
+            --root ../.. \
+            --include "packages/devtools/src/internal/browser/{example-machine,*-example}.ts" \
+            --out-dir ../../.data/api-reference-site/v4/devtools
         env:
           API_REFERENCE_BASE_PATH: ${{ steps.pages.outputs.base_path }}
       - uses: actions/upload-pages-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,13 +69,19 @@ ensures every reflection can be consumed by the site-facing normalizer. It runs
 as part of `pnpm check`.
 
 `pnpm docs:site` turns that dataset into a multi-page static website under
-`.data/api-reference-site/v4` and creates its Pagefind search index. Run
-`pnpm docs:site:serve` to preview the latest generated site locally. Site output
-is also generated data and is not committed.
+`.data/api-reference-site/v4` and creates its Pagefind search index.
+`pnpm devtools:site` generates the devtools example-machine gallery under the
+isolated `.data/api-reference-site/v4/devtools` route. Run `pnpm website` to
+build both sites in deployment order, then `pnpm docs:site:serve` to preview the
+main site at `http://127.0.0.1:4173/` and the gallery at
+`http://127.0.0.1:4173/devtools/`. Site output is generated data and is not
+committed.
 
 The release workflow calls the GitHub Pages workflow after Changesets publishes
 a package. The Pages workflow can also be run manually to deploy the current
-commit before a release without invoking the package-release job. Pages supplies
+commit before a release without invoking the package-release job. It uploads the
+combined `pnpm website` output, keeping the API reference at the Pages root and
+the devtools gallery under `/devtools/`. Pages supplies
 `API_REFERENCE_BASE_PATH` during the build so project URLs and custom domains
 use the same generated site without configuration edits. It also reads the
 repository star count through GitHub's API and supplies it as

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,18 +70,27 @@ as part of `pnpm check`.
 
 `pnpm docs:site` turns that dataset into a multi-page static website under
 `.data/api-reference-site/v4` and creates its Pagefind search index.
-`pnpm devtools:site` generates the devtools example-machine gallery under the
-isolated `.data/api-reference-site/v4/devtools` route. Run `pnpm website` to
-build both sites in deployment order, then `pnpm docs:site:serve` to preview the
-main site at `http://127.0.0.1:4173/` and the gallery at
+Generate the devtools example-machine gallery under the isolated
+`.data/api-reference-site/v4/devtools` route after building the main site:
+
+```sh
+pnpm docs:site
+pnpm devtools build \
+  --root ../.. \
+  --include "packages/devtools/src/internal/browser/{example-machine,*-example}.ts" \
+  --out-dir ../../.data/api-reference-site/v4/devtools
+```
+
+Run `pnpm docs:site:serve` to preview the main site at
+`http://127.0.0.1:4173/` and the gallery at
 `http://127.0.0.1:4173/devtools/`. Site output is generated data and is not
 committed.
 
 The release workflow calls the GitHub Pages workflow after Changesets publishes
 a package. The Pages workflow can also be run manually to deploy the current
 commit before a release without invoking the package-release job. It uploads the
-combined `pnpm website` output, keeping the API reference at the Pages root and
-the devtools gallery under `/devtools/`. Pages supplies
+combined output, keeping the API reference at the Pages root and the devtools
+gallery under `/devtools/`. Pages supplies
 `API_REFERENCE_BASE_PATH` during the build so project URLs and custom domains
 use the same generated site without configuration edits. It also reads the
 repository star count through GitHub's API and supplies it as

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
     "docs:site:test": "node --test scripts/api-reference-site/*.test.mjs",
     "docs:site:check": "pnpm docs:site:test && pnpm docs:api && node scripts/api-reference-site/generate.mjs --check",
     "docs:site:serve": "node scripts/api-reference-site/serve.mjs",
-    "devtools:site": "pnpm --dir packages/devtools dev build --root ../.. --include \"packages/devtools/src/internal/browser/{example-machine,*-example}.ts\" --out-dir ../../.data/api-reference-site/v4/devtools",
-    "website": "pnpm docs:site && pnpm devtools:site",
     "test:consumer": "node scripts/test-consumer.mjs",
     "pack:check": "node scripts/pack-check.mjs",
     "devtools:pack-check": "node scripts/devtools-pack-check.mjs",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "docs:site:test": "node --test scripts/api-reference-site/*.test.mjs",
     "docs:site:check": "pnpm docs:site:test && pnpm docs:api && node scripts/api-reference-site/generate.mjs --check",
     "docs:site:serve": "node scripts/api-reference-site/serve.mjs",
+    "devtools:site": "pnpm --dir packages/devtools dev build --root ../.. --include \"packages/devtools/src/internal/browser/{example-machine,*-example}.ts\" --out-dir ../../.data/api-reference-site/v4/devtools",
+    "website": "pnpm docs:site && pnpm devtools:site",
     "test:consumer": "node scripts/test-consumer.mjs",
     "pack:check": "node scripts/pack-check.mjs",
     "devtools:pack-check": "node scripts/devtools-pack-check.mjs",


### PR DESCRIPTION
## Summary

- Build the devtools example machines into the existing GitHub Pages artifact under `/devtools/`.
- Keep the API reference at the site root and give the gallery its own assets and data directory.
- Document the deployment-order build commands and local preview route.

## Changeset

- [ ] Added or updated for a library or package-metadata change
- [x] Not required because this PR does not change a publishable package

## Validation

- [x] `pnpm check`
- [x] Automated type-performance measurement was not required
- [x] Automated runtime- and memory-performance measurement was not required
- [x] `pnpm docs:site`
- [x] Devtools static build generated all 11 example machines
- [x] Main site, `/devtools/`, and `/devtools/machines.json` returned HTTP 200 locally