### PR TITLE
Add React-owned machine atoms

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -13,7 +13,7 @@ Do not create a major changeset before 1.0. Backward compatibility is not a desi
 
 ## Synchronized package versions
 
-`@typeonce/effect-machine`, `@typeonce/effect-machine-devtools`, and `@typeonce/oxlint-plugin-effect-machine` belong to the same Changesets fixed group. Keep their package versions equal and use `workspace:^` for the devtools dependency on core. A release affecting any package publishes all three at the same version, so users can select compatible packages by matching their versions.
+`@typeonce/effect-machine`, `@typeonce/effect-machine-react`, `@typeonce/effect-machine-devtools`, and `@typeonce/oxlint-plugin-effect-machine` belong to the same Changesets fixed group. Keep their package versions equal and use `workspace:^` for package dependencies on core. A release affecting any package publishes all four at the same version, so users can select compatible packages by matching their versions.
 
 ## Writing changelog entries
 

--- a/.changeset/calm-machines-own.md
+++ b/.changeset/calm-machines-own.md
@@ -1,0 +1,15 @@
+---
+"@typeonce/effect-machine": minor
+"@typeonce/effect-machine-react": minor
+---
+
+Add `@typeonce/effect-machine-react` with `useMachineAtom` for owning and mounting one stable machine atom without subscribing its React owner to machine state.
+
+Typed state-path projections now return the same atom for repeated calls with the same machine and path. Descendants can select state-owned data directly during render:
+
+```tsx
+const machine = useMachineAtom(() => MachineAtoms.make(AuthMachine, input))
+const editing = useAtomSuspense(AtomMachine.selectSnapshot(machine, "Editing")).value
+```
+
+Startup input is captured when React creates the owner. Send an event to update the running workflow, or change the owner's React key to replace the machine.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,6 +5,7 @@
   "fixed": [
     [
       "@typeonce/effect-machine",
+      "@typeonce/effect-machine-react",
       "@typeonce/effect-machine-devtools",
       "@typeonce/oxlint-plugin-effect-machine"
     ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ When compatibility, convenience, concision, and semantic clarity conflict, prefe
 ## Experimental versioning
 
 - The library is experimental and pre-1.0. Public additions and breaking API changes use a minor changeset; compatible fixes and implementation improvements use a patch changeset. Do not create major changesets before 1.0.
-- `@typeonce/effect-machine`, `@typeonce/effect-machine-devtools`, and `@typeonce/oxlint-plugin-effect-machine` release from one Changesets fixed group and must always have the same version. Keep their package versions, workspace dependency, and release configuration synchronized so users can install matching versions for compatibility.
+- `@typeonce/effect-machine`, `@typeonce/effect-machine-react`, `@typeonce/effect-machine-devtools`, and `@typeonce/oxlint-plugin-effect-machine` release from one Changesets fixed group and must always have the same version. Keep their package versions, workspace dependencies, and release configuration synchronized so users can install matching versions for compatibility.
 - Backward compatibility is not currently a design goal. Change or remove an existing API whenever a clearer, safer, smaller long-term design replaces it.
 - Do not add deprecated aliases, compatibility wrappers, or parallel APIs solely to preserve an inferior existing design unless the user explicitly requests them.
 - Explain the resulting API and direct migration in changesets. Do not use changelog entries to credit an external library or narrate implementation history.

--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ statechart, and the result runs as an Effect-managed machine.
 
 ## Packages
 
-The workspace publishes three packages at the same version:
+The workspace publishes four packages at the same version:
 
 - [`@typeonce/effect-machine`](./packages/effect-machine/README.md) contains the machine runtime, testing modules, and documentation.
+- [`@typeonce/effect-machine-react`](./packages/effect-machine-react/README.md) owns machine atoms in React without subscribing their owners to machine state.
 - [`@typeonce/effect-machine-devtools`](./packages/devtools/README.md) contains the publishable local machine visualizer and CLI.
 - [`@typeonce/oxlint-plugin-effect-machine`](./packages/oxlint-plugin/README.md) checks Effect Machine models for common structural mistakes.
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "pnpm --recursive --filter \"./packages/**\" run build",
     "test": "node --expose-gc ./node_modules/vitest/vitest.mjs run",
-    "test:types": "pnpm --dir packages/effect-machine test:types",
+    "test:types": "pnpm --recursive --filter \"./packages/effect-machine*\" run test:types",
     "devtools": "pnpm --dir packages/devtools dev",
     "visualizer": "pnpm devtools",
     "visualizer:build": "pnpm --dir packages/devtools build",
@@ -25,9 +25,10 @@
     "docs:site:serve": "node scripts/api-reference-site/serve.mjs",
     "test:consumer": "node scripts/test-consumer.mjs",
     "pack:check": "node scripts/pack-check.mjs",
+    "react:pack-check": "node scripts/react-pack-check.mjs",
     "devtools:pack-check": "node scripts/devtools-pack-check.mjs",
     "oxlint-plugin:pack-check": "node scripts/oxlint-plugin-pack-check.mjs",
-    "check": "pnpm format:check && pnpm check:architecture && pnpm check:ci && pnpm docs:api:check && pnpm docs:site:check && pnpm typecheck && pnpm build && pnpm test && pnpm test:types && pnpm test:consumer && pnpm pack:check && pnpm devtools:pack-check && pnpm oxlint-plugin:pack-check",
+    "check": "pnpm format:check && pnpm check:architecture && pnpm check:ci && pnpm docs:api:check && pnpm docs:site:check && pnpm typecheck && pnpm build && pnpm test && pnpm test:types && pnpm test:consumer && pnpm pack:check && pnpm react:pack-check && pnpm devtools:pack-check && pnpm oxlint-plugin:pack-check",
     "changeset": "changeset",
     "version-packages": "changeset version && dprint fmt",
     "release": "pnpm build && changeset publish"

--- a/packages/effect-machine-react/LICENSE
+++ b/packages/effect-machine-react/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sandro Maglione
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/effect-machine-react/NOTICE
+++ b/packages/effect-machine-react/NOTICE
@@ -1,0 +1,3 @@
+Portions are adapted from the Effect project, which is distributed under the
+MIT License. See https://github.com/Effect-TS/effect and the source history for
+authorship and provenance.

--- a/packages/effect-machine-react/README.md
+++ b/packages/effect-machine-react/README.md
@@ -1,0 +1,26 @@
+# @typeonce/effect-machine-react
+
+React ownership hooks for machine atoms created by
+[`@typeonce/effect-machine`](../effect-machine/README.md).
+
+```tsx
+import { useMachineAtom } from "@typeonce/effect-machine-react"
+
+function AuthProvider({ input, children }: Props) {
+  const machine = useMachineAtom(() => MachineAtoms.make(AuthMachine, input))
+
+  return (
+    <AuthContext.Provider value={machine}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+```
+
+`useMachineAtom` strongly owns one machine atom, mounts it after commit, and
+does not subscribe the owner to machine state. Descendants subscribe to the
+specific state paths they render with `AtomMachine.select`,
+`AtomMachine.selectSnapshot`, or `AtomMachine.matches`.
+
+Machine input is startup-only. Send an event to update a running workflow, or
+change the provider's React `key` to replace it with a new machine.

--- a/packages/effect-machine-react/package.json
+++ b/packages/effect-machine-react/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@typeonce/effect-machine-react",
+  "version": "0.28.0",
+  "description": "React ownership hooks for Effect Machine atoms",
+  "author": "Sandro Maglione",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/typeonce-dev/effect-machine.git",
+    "directory": "packages/effect-machine-react"
+  },
+  "bugs": {
+    "url": "https://github.com/typeonce-dev/effect-machine/issues"
+  },
+  "homepage": "https://github.com/typeonce-dev/effect-machine/tree/main/packages/effect-machine-react#readme",
+  "type": "module",
+  "license": "MIT",
+  "sideEffects": false,
+  "files": [
+    "src/**/*.ts",
+    "dist",
+    "README.md",
+    "LICENSE",
+    "NOTICE"
+  ],
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./package.json": "./package.json"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b tsconfig.build.json",
+    "check": "tsc -b tsconfig.json",
+    "test:types": "tstyche"
+  },
+  "dependencies": {
+    "@typeonce/effect-machine": "workspace:^"
+  },
+  "peerDependencies": {
+    "@effect/atom-react": "4.0.0-rc.112",
+    "effect": "4.0.0-rc.112",
+    "react": ">=19.0.0 <20.0.0",
+    "scheduler": ">=0.25.0 <0.28.0"
+  },
+  "devDependencies": {
+    "@effect/atom-react": "4.0.0-rc.112",
+    "@testing-library/react": "16.3.0",
+    "@types/react": "19.2.16",
+    "@types/react-dom": "19.2.3",
+    "effect": "4.0.0-rc.112",
+    "jsdom": "27.2.0",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "scheduler": "0.27.0",
+    "tstyche": "7.2.1",
+    "typescript": "6.0.3",
+    "vitest": "4.1.10"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/effect-machine-react/src/MachineAtom.ts
+++ b/packages/effect-machine-react/src/MachineAtom.ts
@@ -1,0 +1,29 @@
+/**
+ * React ownership for machine atoms.
+ *
+ * @since 0.29.0
+ */
+"use client"
+
+import { useAtomMount } from "@effect/atom-react"
+import type { AtomMachine } from "@typeonce/effect-machine/reactivity"
+import * as React from "react"
+
+type AnyMachineAtom = AtomMachine.MachineAtom<any, never, any, any, any, any>
+
+/**
+ * Creates one machine atom for a committed React owner and mounts its machine
+ * reference without subscribing the owner to machine state.
+ *
+ * The factory is startup-only. Later changes to values captured by the factory
+ * do not replace the machine. Send an event to change a running workflow, or
+ * change the owner's React `key` to create a new machine.
+ *
+ * @category hooks
+ * @since 0.29.0
+ */
+export const useMachineAtom = <A extends AnyMachineAtom>(create: () => A): A => {
+  const [machine] = React.useState(create)
+  useAtomMount(machine.ref)
+  return machine
+}

--- a/packages/effect-machine-react/src/index.ts
+++ b/packages/effect-machine-react/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * React ownership hooks for Effect Machine atoms.
+ *
+ * @since 0.29.0
+ */
+
+export * from "./MachineAtom.js"

--- a/packages/effect-machine-react/test/MachineAtom.test.tsx
+++ b/packages/effect-machine-react/test/MachineAtom.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+
+import { RegistryContext, useAtomSuspense } from "@effect/atom-react"
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react"
+import { Effect, Option, Schema } from "effect"
+import { AtomRegistry } from "effect/unstable/reactivity"
+import * as React from "react"
+import { renderToString } from "react-dom/server"
+import { afterEach, assert, describe, it } from "vitest"
+import { Machine } from "../../effect-machine/src/index.js"
+import { AtomMachine } from "../../effect-machine/src/unstable/reactivity/index.js"
+import { useMachineAtom } from "../src/index.js"
+
+class Active extends Schema.TaggedClass<Active>("Active")("Active", {
+  value: Schema.Number
+}) {}
+class Increment extends Schema.TaggedClass<Increment>("Increment")("Increment", {}) {}
+
+const States = Machine.states({ Active })
+
+const trackedMachine = (onStart: () => void) =>
+  Machine.make({
+    states: States.states,
+    events: Machine.events(Increment),
+    input: Schema.Number,
+    initial: (to) =>
+      to.Active().resolve(({ input, target }) => {
+        onStart()
+        return target.decoded(new Active({ value: input }))
+      })
+  }).handle({
+    Active: {
+      on: {
+        Increment: (to) =>
+          to.full.Active().resolve(({ state, target }) => target.decoded(new Active({ value: state.value + 1 })))
+      }
+    }
+  })
+
+afterEach(cleanup)
+
+describe("useMachineAtom", () => {
+  it("keeps the owner unsubscribed while a state-path reader updates", async () => {
+    const machine = trackedMachine(() => {})
+    const registry = AtomRegistry.make({ defaultIdleTTL: 1_000 })
+    const makeOwned = () => AtomMachine.make(machine, 0)
+    let current: ReturnType<typeof makeOwned> | undefined
+    let ownerRenders = 0
+    let readerRenders = 0
+
+    function Reader({ owned }: { readonly owned: NonNullable<typeof current> }) {
+      readerRenders++
+      const active = useAtomSuspense(AtomMachine.select(owned, "Active")).value
+      return <span data-testid="value">{Option.getOrThrow(active).value}</span>
+    }
+
+    function Owner() {
+      ownerRenders++
+      const owned = useMachineAtom(() => AtomMachine.make(machine, 0))
+      current = owned
+      return (
+        <React.Suspense fallback="starting">
+          <Reader owned={owned} />
+        </React.Suspense>
+      )
+    }
+
+    const view = render(
+      <RegistryContext.Provider value={registry}>
+        <Owner />
+      </RegistryContext.Provider>
+    )
+
+    await waitFor(() => assert.strictEqual(screen.getByTestId("value").textContent, "0"))
+    const initialOwnerRenders = ownerRenders
+    const initialReaderRenders = readerRenders
+
+    await act(() => {
+      registry.set(current!.send, new Increment({}))
+    })
+
+    await waitFor(() => assert.strictEqual(screen.getByTestId("value").textContent, "1"))
+    assert.strictEqual(ownerRenders, initialOwnerRenders)
+    assert.ok(readerRenders > initialReaderRenders)
+
+    view.unmount()
+    registry.dispose()
+  })
+
+  it("owns one committed machine without making startup input reactive", async () => {
+    let starts = 0
+    const machine = trackedMachine(() => {
+      starts++
+    })
+    const makeOwned = (input: number) => AtomMachine.make(machine, input)
+    let current: ReturnType<typeof makeOwned> | undefined
+    const registry = AtomRegistry.make({ defaultIdleTTL: 1_000 })
+
+    function Owner({ input }: { readonly input: number }) {
+      const owned = useMachineAtom(() => AtomMachine.make(machine, input))
+      React.useEffect(() => {
+        current = owned
+      }, [owned])
+      return null
+    }
+
+    const view = render(
+      <RegistryContext.Provider value={registry}>
+        <React.StrictMode>
+          <Owner input={1} />
+        </React.StrictMode>
+      </RegistryContext.Provider>
+    )
+
+    await waitFor(() => assert.strictEqual(starts, 1))
+    const first = current!
+    assert.deepStrictEqual(await Effect.runPromise(AtomRegistry.getResult(registry, first.result)), {
+      path: "Active",
+      value: new Active({ value: 1 })
+    })
+
+    view.rerender(
+      <RegistryContext.Provider value={registry}>
+        <React.StrictMode>
+          <Owner input={2} />
+        </React.StrictMode>
+      </RegistryContext.Provider>
+    )
+
+    assert.strictEqual(current, first)
+    assert.strictEqual(starts, 1)
+    assert.strictEqual((await Effect.runPromise(AtomRegistry.getResult(registry, first.result))).value.value, 1)
+
+    view.rerender(
+      <RegistryContext.Provider value={registry}>
+        <React.StrictMode>
+          <Owner key="replacement" input={2} />
+        </React.StrictMode>
+      </RegistryContext.Provider>
+    )
+
+    await waitFor(() => assert.strictEqual(starts, 2))
+    assert.notStrictEqual(current, first)
+    assert.strictEqual((await Effect.runPromise(AtomRegistry.getResult(registry, current!.result))).value.value, 2)
+
+    view.unmount()
+    registry.dispose()
+  })
+
+  it("runs the same machine atom independently in each registry", async () => {
+    let starts = 0
+    const machine = trackedMachine(() => {
+      starts++
+    })
+    const bridge = AtomMachine.make(machine, 1)
+    const firstRegistry = AtomRegistry.make({ defaultIdleTTL: 1_000 })
+    const secondRegistry = AtomRegistry.make({ defaultIdleTTL: 1_000 })
+
+    function Owner() {
+      useMachineAtom(() => bridge)
+      return null
+    }
+
+    const view = render(
+      <>
+        <RegistryContext.Provider value={firstRegistry}>
+          <Owner />
+        </RegistryContext.Provider>
+        <RegistryContext.Provider value={secondRegistry}>
+          <Owner />
+        </RegistryContext.Provider>
+      </>
+    )
+
+    await waitFor(() => assert.strictEqual(starts, 2))
+    const first = await Effect.runPromise(AtomRegistry.getResult(firstRegistry, bridge.ref))
+    const second = await Effect.runPromise(AtomRegistry.getResult(secondRegistry, bridge.ref))
+    assert.notStrictEqual(first, second)
+
+    view.unmount()
+    firstRegistry.dispose()
+    secondRegistry.dispose()
+  })
+
+  it("releases its mount when the owner unmounts", async () => {
+    const machine = trackedMachine(() => {})
+    const registry = AtomRegistry.make({ defaultIdleTTL: 0, timeoutResolution: 1 })
+    const makeOwned = () => AtomMachine.make(machine, 1)
+    let current: ReturnType<typeof makeOwned> | undefined
+
+    function Owner() {
+      const owned = useMachineAtom(() => AtomMachine.make(machine, 1))
+      React.useEffect(() => {
+        current = owned
+      }, [owned])
+      return null
+    }
+
+    const view = render(
+      <RegistryContext.Provider value={registry}>
+        <Owner />
+      </RegistryContext.Provider>
+    )
+
+    await waitFor(() => assert.ok(current !== undefined))
+    const ref = await Effect.runPromise(AtomRegistry.getResult(registry, current!.ref))
+    view.unmount()
+
+    await waitFor(async () => {
+      assert.strictEqual((await Effect.runPromise(ref.snapshot)).status, "stopped")
+    })
+    registry.dispose()
+  })
+
+  it("does not start the machine during server rendering", () => {
+    let starts = 0
+    const machine = trackedMachine(() => {
+      starts++
+    })
+    const registry = AtomRegistry.make()
+
+    function Owner() {
+      useMachineAtom(() => AtomMachine.make(machine, 1))
+      return null
+    }
+
+    renderToString(
+      <RegistryContext.Provider value={registry}>
+        <Owner />
+      </RegistryContext.Provider>
+    )
+
+    assert.strictEqual(starts, 0)
+    registry.dispose()
+  })
+})

--- a/packages/effect-machine-react/tsconfig.build.json
+++ b/packages/effect-machine-react/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/effect-machine-react/tsconfig.json
+++ b/packages/effect-machine-react/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "references": [
+    { "path": "../effect-machine" }
+  ],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/packages/effect-machine-react/typetest/MachineAtom.tst.ts
+++ b/packages/effect-machine-react/typetest/MachineAtom.tst.ts
@@ -1,0 +1,26 @@
+import { Schema } from "effect"
+import { expect } from "tstyche"
+import { Machine } from "../../effect-machine/src/index.js"
+import { AtomMachine } from "../../effect-machine/src/unstable/reactivity/index.js"
+import { useMachineAtom } from "../src/index.js"
+
+class Idle extends Schema.TaggedClass<Idle>("Idle")("Idle", {}) {}
+class Continue extends Schema.TaggedClass<Continue>("Continue")("Continue", {}) {}
+
+const States = Machine.states({ Idle })
+const machine = Machine.make({
+  states: States.states,
+  events: Machine.events(Continue),
+  initial: (to) => to.Idle().resolve(({ target }) => target.decoded(new Idle({})))
+}).handle({
+  Idle: {
+    on: {
+      Continue: (to) => to.none
+    }
+  }
+})
+const expected = AtomMachine.make(machine)
+
+const owned = useMachineAtom(() => AtomMachine.make(machine))
+
+expect(owned).type.toBe<typeof expected>()

--- a/packages/effect-machine/README.md
+++ b/packages/effect-machine/README.md
@@ -750,13 +750,21 @@ applications. Service-free machines can use `AtomMachine.make(Counter)`.
 The bridge exposes `ref`, `snapshot`, `state`, fail-aware `result`, writable
 `send` and `stop` atoms, and `child(descriptor)`. Use `AtomMachine.select`,
 `AtomMachine.selectSnapshot`, and `AtomMachine.matches` for typed,
-equality-aware derivations. Hooks from `@effect/atom-react` use a shared default
-registry. Add `RegistryProvider` only when a subtree needs separate registry
-identity or disposal.
+equality-aware derivations. Repeating one of these calls with the same bridge
+and state path returns the same atom.
 
-For a machine with startup input, `AtomMachine.family` uses that input as the
-family key and exposes direct atom families. Each returned atom retains its
-private machine bridge while preserving lazy registry startup and disposal:
+Use `useMachineAtom` from `@typeonce/effect-machine-react` when one React
+subtree owns the machine. It mounts the machine without subscribing the owner
+to state. Pass the returned machine atom through props or Context, then call
+`useAtomSuspense(AtomMachine.selectSnapshot(machine, path))` in the descendant
+that renders that state slot. Hooks from `@effect/atom-react` use a shared
+default registry. Add `RegistryProvider` only when a subtree needs separate
+registry identity or disposal.
+
+When consumers need keyed lookup for a machine with startup input,
+`AtomMachine.family` uses that input as the family key and exposes direct atom
+families. Each returned atom retains its private machine bridge while
+preserving lazy registry startup and disposal:
 
 ```ts
 const processAtoms = AtomMachine.bind(runtime).family(processMachine, {

--- a/packages/effect-machine/docs/effect-atom-react.md
+++ b/packages/effect-machine/docs/effect-atom-react.md
@@ -1,208 +1,293 @@
-# Effect Atom and React patterns
+# Effect Atom and React
 
-This guide records the folder organization and four integration patterns
-validated in the process app. Use the API reference for individual AtomMachine
-operations. Read the [Effect Machine agent guide](./agent-guide.md) for
-statechart modeling, transitions, services, and testing.
+React code should own one stable machine atom, pass it through props or
+Context, and subscribe in the descendants that render machine state. Keep the
+machine definition free of React dependencies.
+
+Read the [Effect Machine agent guide](./agent-guide.md) for statechart
+modeling, transitions, services, and testing.
 
 ## Recommended folder structure
 
 ```text
 src/
-├── context/                 # Optional React Context adapters
-│   ├── dialog-context.tsx
-│   └── process-context.tsx
+├── context/
+│   └── auth-machine-context.tsx  # React ownership and distribution
 ├── lib/
-│   ├── atom-runtime.ts      # Shared bound AtomMachine runtime
-│   └── services/            # Generic Effect business services
-│       └── query-processor.ts
+│   ├── atom-runtime.ts           # Shared bound AtomMachine runtime
+│   └── services/
 └── machines/
-    ├── counter/
-    │   ├── machine.ts       # Machine implementation
-    │   └── atom.ts          # Focused atoms for React
-    ├── process/
-    │   ├── machine.ts
-    │   └── atom.ts
-    └── dialog/
-        ├── machine.ts
-        └── atom.ts
+    └── auth-machine.ts           # States, events, and behavior
 ```
 
-Keep these responsibilities separate:
+`machine.ts` owns the workflow. A Context module only creates and distributes
+the machine atom. State-slot components decide which state paths they render.
 
-- `machine.ts` defines states, events, transitions, statechart behavior, and
-  Effect service requirements. It has no React dependency.
-- `atom.ts` adapts that machine to the shared bound AtomMachine runtime and
-  exports the focused atoms React needs.
-- `lib/services/` contains reusable business services used by machines.
-- `context/` is optional. It only distributes an already-created machine scope
-  through a React subtree.
-- `lib/atom-runtime.ts` binds AtomMachine once to the application's Effect
-  service layer:
+Bind service-backed machines once at the application runtime:
 
 ```ts
 import { AtomMachine } from "@typeonce/effect-machine/reactivity"
 import { Atom } from "effect/unstable/reactivity"
-import { QueryProcessor } from "./services/query-processor"
+import { AppLayer } from "./app-layer"
 
-const atomRuntime = Atom.runtime(QueryProcessor.layer)
+const atomRuntime = Atom.runtime(AppLayer)
 
-export const machineAtoms = AtomMachine.bind(atomRuntime)
+export const MachineAtoms = AtomMachine.bind(atomRuntime)
 ```
 
-Each `machineAtoms.make` call still creates an independent machine bridge.
+Service-free machines can use `AtomMachine.make` directly.
 
-## 1. One global actor with no input
+## Own a machine in one React subtree
 
-Use a module-level bridge when a no-input machine intentionally has one
-application-wide instance:
-
-```ts
-import { machineAtoms } from "@/lib/atom-runtime"
-import { AtomMachine } from "@typeonce/effect-machine/reactivity"
-import { counterMachine } from "./machine"
-
-export const counterMachineAtom = machineAtoms.make(counterMachine)
-
-export const counterStateAtom = AtomMachine.select(
-  counterMachineAtom,
-  "counter"
-)
-```
-
-"Global" means every import reaches this bridge under the same atom registry.
-Consumers read `counterStateAtom` and use `counterMachineAtom.send` directly.
-Do not add a redundant `counterSendAtom` alias.
-
-## 2. A keyed machine with startup input
-
-`AtomMachine.family` uses the machine input as both startup input and family
-key. It returns one direct atom family for each entry in `atoms`:
-
-```ts
-import { machineAtoms } from "@/lib/atom-runtime"
-import { AtomMachine } from "@typeonce/effect-machine/reactivity"
-import { processMachine } from "./machine"
-
-export const processAtoms = machineAtoms.family(processMachine, {
-  atoms: {
-    details: AtomMachine.select("process"),
-    result: AtomMachine.select("process.Ready"),
-    send: (machine) => machine.send
-  },
-  label: (input, name) => `process:${input.query}:${name}`
-})
-```
-
-React consumes each projected family directly:
+Use `useMachineAtom` when a provider, route, dialog, or other React subtree
+owns one machine instance:
 
 ```tsx
-const input = { query }
-const details = useAtomValue(processAtoms.details(input))
-const send = useAtomSet(processAtoms.send(input))
-```
+import { useMachineAtom } from "@typeonce/effect-machine-react"
+import { createContext, type ReactNode, useContext } from "react"
+import { AuthMachine, type AuthMachineInput } from "../machines/auth-machine"
+import { MachineAtoms } from "../lib/atom-runtime"
 
-Each public atom retains its private machine bridge. Keeping only `details` or
-only `send` is safe. The bridge still starts lazily in the registry and stops
-when that registry releases or disposes it. A writable source remains writable,
-and a projection keeps the source atom's equality function.
+const makeAuthMachine = (input: AuthMachineInput) => MachineAtoms.make(AuthMachine, input)
+type AuthMachineAtom = ReturnType<typeof makeAuthMachine>
 
-The family uses Effect `Equal` and `Hash` semantics. Equal records such as
-`{ query: "effect" }` select the same family value even when reconstructed.
-Keep inputs immutable because mutating a hashed key makes later lookup
-unreliable. Different input values select independent machines. If a changing
-value should update one running workflow, model the change as an event instead
-of putting it in the machine input.
+const AuthMachineContext = createContext<AuthMachineAtom | null>(null)
 
-Service-free machines use the module function directly:
-
-```ts
-export const processAtoms = AtomMachine.family(processMachine, {
-  atoms: {
-    details: AtomMachine.select("process"),
-    send: (machine) => machine.send
-  }
-})
-```
-
-## 3. Reusing one machine definition for multiple instances
-
-Define the dialog adapter once:
-
-```ts
-import { machineAtoms } from "@/lib/atom-runtime"
-import { AtomMachine } from "@typeonce/effect-machine/reactivity"
-import { dialogMachine } from "./machine"
-
-export function makeDialogScope() {
-  const machine = machineAtoms.make(dialogMachine)
-
-  return {
-    isOpenAtom: AtomMachine.matches(machine, "Open"),
-    isClosedAtom: AtomMachine.matches(machine, "Closed"),
-    openStateAtom: AtomMachine.select(machine, "Open"),
-    sendAtom: machine.send
-  }
-}
-
-export type DialogScope = ReturnType<typeof makeDialogScope>
-```
-
-### React-tree-owned instance
-
-```tsx
-const DialogContext = createContext<DialogScope | null>(null)
-
-export function DialogProvider({ children }: { children: ReactNode }) {
-  const [scope] = useState(makeDialogScope)
+export function AuthMachineProvider({
+  children,
+  input
+}: {
+  readonly children: ReactNode
+  readonly input: AuthMachineInput
+}) {
+  const machine = useMachineAtom(() => makeAuthMachine(input))
 
   return (
-    <DialogContext.Provider value={scope}>
+    <AuthMachineContext.Provider value={machine}>
       {children}
-    </DialogContext.Provider>
+    </AuthMachineContext.Provider>
+  )
+}
+
+export function useAuthMachine(): AuthMachineAtom {
+  const machine = useContext(AuthMachineContext)
+  if (machine === null) {
+    throw new Error("useAuthMachine must be used inside AuthMachineProvider")
+  }
+  return machine
+}
+```
+
+The provider strongly owns the complete `MachineAtom`. The hook mounts
+`machine.ref` after React commits the owner, but it does not read `state`,
+`snapshot`, or `result`. Machine updates therefore do not rerender the
+provider.
+
+The factory captures startup input once. A later `input` prop change does not
+replace the running workflow. Send an event when the change belongs to that
+workflow. Change the provider's React key when React should own a new machine:
+
+```tsx
+<AuthMachineProvider key={attemptId} input={input}>
+  <AuthCard />
+</AuthMachineProvider>
+```
+
+Put the owner above a Suspense boundary. React can then retain the same machine
+while a state-reading descendant suspends.
+
+## Render state-owned data
+
+Subscribe in the smallest component that renders a state path:
+
+```tsx
+import { useAtomSuspense } from "@effect/atom-react"
+import { AtomMachine } from "@typeonce/effect-machine/reactivity"
+import { Option } from "effect"
+
+function EditingFields() {
+  const machine = useAuthMachine()
+  const editing = useAtomSuspense(
+    AtomMachine.selectSnapshot(machine, "Editing")
+  ).value
+
+  return Option.match(editing, {
+    onNone: () => null,
+    onSome: ({ value }) => <EmailField email={value.email} />
+  })
+}
+```
+
+`AtomMachine.select` returns the selected state value.
+`AtomMachine.selectSnapshot` also retains the selected state's child topology.
+Both return `Option.none()` while the path is inactive. Do not replace that
+absence with an empty string, `null`, or a global boolean.
+
+Repeated calls with the same machine and path return the same atom, so path
+selection is safe during render without `useMemo`. Equal selected values do not
+notify the component.
+
+Nested paths keep the same ownership:
+
+```tsx
+function PasswordField() {
+  const machine = useAuthMachine()
+  const password = useAtomSuspense(
+    AtomMachine.select(machine, "Editing.Password")
+  ).value
+
+  return Option.match(password, {
+    onNone: () => null,
+    onSome: ({ password }) => <input type="password" value={password} />
+  })
+}
+```
+
+Place independent subscriptions in independent descendants:
+
+```tsx
+function AuthCard() {
+  return (
+    <>
+      <EditingFields />
+      <VerificationFields />
+      <FailureMessage />
+      <SubmitButton />
+    </>
   )
 }
 ```
 
-Each provider owns one independent dialog. Descendants use a small
-`useDialog()` hook and subscribe to the focused atom they need. Pass
-`DialogScope` through props when Context is unnecessary. Do not add a wrapper
-component whose only job is forwarding the scope.
+Atom granularity cannot isolate hooks that all live in `AuthCard`. Any selected
+change rerenders the component that called the hook.
 
-For a no-input machine, use one module-level bridge or an explicitly owned
-React scope. Do not add a family key that the machine does not consume. When an
-ID is part of startup semantics, declare it in the machine input and use
-`AtomMachine.family`.
+## Send without subscribing
 
-## 4. Selecting process-owned child machines
+Use the writable atom directly:
 
-Bind a machine definition once when a parent owns a runtime-sized set of child
-machines:
+```tsx
+import { useAtomSet } from "@effect/atom-react"
 
-```ts
-const Plant = Machine.childFamily(plantMachine)
+function SubmitButton() {
+  const machine = useAuthMachine()
+  const send = useAtomSet(machine.send)
 
-export const centralMachineAtom = machineAtoms.make(centralMachine)
-
-export const plantAtoms = AtomMachine.familyChild(centralMachineAtom, {
-  child: (plantId: string) => Plant(plantId),
-  atoms: {
-    state: (plant) => plant.state,
-    isBroken: AtomMachine.matchesChild("Broken"),
-    send: (plant) => plant.send,
-    stop: (plant) => plant.stop
-  }
-})
-
-const broken = useAtomValue(plantAtoms.isBroken(plantId))
-const send = useAtomSet(plantAtoms.send(plantId))
+  return (
+    <button onClick={() => send({ _tag: "Submitted" })}>
+      Continue
+    </button>
+  )
+}
 ```
 
-`familyChild` keeps child lookup separate from root machine startup. Each
-projected atom retains the child bridge returned for its key.
+`useAtomSet` mounts the writable atom and does not subscribe the component to
+its value.
 
-`Plant(plantId)` may be reconstructed wherever the id is available. Child
-lookup and bridge reuse match by machine identity and id, not descriptor object
-identity. Before the parent spawns that child, selectors contain `Option.none`
-and `matchesChild` is `false`. They follow the child after startup and return to
-the inactive values after it stops.
+## Whole-result and custom selections
+
+Reading the full result is correct when a component renders the complete
+machine state:
+
+```tsx
+function AuthScreen() {
+  const machine = useAuthMachine()
+  const state = useAtomSuspense(machine.result).value
+
+  return AuthStates.match(state, {
+    Editing: (editing) => <EditingScreen state={editing} />,
+    Verification: (verification) => <VerificationScreen state={verification} />,
+    Failed: (failed) => <FailureScreen state={failed} />
+  })
+}
+```
+
+That component rerenders for every result change. Current
+`@effect/atom-react` does not select from the successful value in
+`useAtomSuspense`. Until it does, use typed path selectors for state-owned UI,
+or declare a custom derived atom once in a strongly owned scope. Do not create
+a fresh derived atom on every render.
+
+## Share a keyed machine outside one React owner
+
+`AtomMachine.family` is for registry-owned machines that unrelated consumers
+find by startup input. It is not the default for one React-owned workflow.
+
+```ts
+export const processAtoms = MachineAtoms.family(ProcessMachine, {
+  atoms: {
+    details: AtomMachine.select("Processing"),
+    ready: AtomMachine.matches("Ready"),
+    send: (machine) => machine.send
+  }
+})
+```
+
+Consumers use the input as the shared identity key:
+
+```tsx
+const details = useAtomSuspense(processAtoms.details(input)).value
+const send = useAtomSet(processAtoms.send(input))
+```
+
+Each public projection retains its private machine owner. Keeping only
+`details(input)` or `send(input)` is safe. Do not return a weakly held composite
+scope and retain only one field from it.
+
+Family keys use Effect `Equal` and `Hash` semantics. Keep them immutable. If a
+changing value should update one running workflow, model it as an event instead
+of changing the family key.
+
+## Module-owned machines
+
+A no-input machine may intentionally have one module-owned identity:
+
+```ts
+export const CounterMachineAtom = MachineAtoms.make(CounterMachine)
+export const CounterStateAtom = AtomMachine.select(CounterMachineAtom, "Count")
+```
+
+Every consumer using the same `AtomRegistry` reaches the same running machine.
+Different registries still run independent instances.
+
+## Child machines
+
+Direct child selectors follow the active child and preserve inactivity:
+
+```tsx
+const editor = machine.child(Editor)
+const editing = useAtomSuspense(
+  AtomMachine.selectSnapshotChild(editor, "Editing")
+).value
+```
+
+An inactive child or path returns `Option.none()`. Re-entry follows the
+replacement child instance.
+
+Use `AtomMachine.familyChild` when a parent owns a runtime-sized set of keyed
+children:
+
+```ts
+const Plant = Machine.childFamily(PlantMachine)
+
+export const plantAtoms = AtomMachine.familyChild(CentralMachineAtom, {
+  child: (plantId: string) => Plant(plantId),
+  atoms: {
+    broken: AtomMachine.matchesChild("Broken"),
+    state: (plant) => plant.state,
+    send: (plant) => plant.send
+  }
+})
+```
+
+## Registry and rendering semantics
+
+A `MachineAtom` identifies one machine per `AtomRegistry`. Passing the same
+machine atom through two registry providers creates two independent runtimes.
+Unmounting a React owner releases its mount. The registry stops the machine
+after its final subscription and configured idle retention expire.
+`registry.dispose()` stops it immediately.
+
+`useMachineAtom` does not start a machine during server rendering because
+React effects do not run on the server. Reading a machine atom during server
+render follows `@effect/atom-react` server-read behavior, so choose an explicit
+client boundary when server startup would be undesirable.

--- a/packages/effect-machine/docs/machine-review.md
+++ b/packages/effect-machine/docs/machine-review.md
@@ -65,11 +65,24 @@ const handlers = {
 Review check: search for `.resolve(...)` callbacks that only return an empty
 `target.from()` and remove the callback.
 
-## Use retained families for keyed machine input
+## Choose React ownership or keyed family lookup
 
-Effect Atom keeps a family value for an equal key while that returned value is
-reachable. Current runtimes may hold family values through `WeakRef`. Retaining
-one field from a composite family value does not retain the composite itself:
+Use `useMachineAtom` when one React subtree owns the workflow, including a
+machine with startup input:
+
+```tsx
+const machine = useMachineAtom(() => machineAtoms.make(processMachine, input))
+```
+
+Pass the stable machine through props or Context. Startup input is captured
+once. Send an event to change the running workflow, or change the owner's React
+key to replace it.
+
+Use `AtomMachine.family` when unrelated consumers must find one shared machine
+by its startup input. Effect Atom keeps a family value for an equal key while
+that returned value is reachable. Current runtimes may hold family values
+through `WeakRef`. Retaining one field from a composite family value does not
+retain the composite itself:
 
 ```ts
 // Unsafe when consumers retain only stateAtom or sendAtom
@@ -82,8 +95,8 @@ const processScope = Atom.family((input: ProcessInput) => {
 })
 ```
 
-Use `AtomMachine.family` for an input-bearing machine. It returns direct atom
-families whose atoms retain the private machine bridge:
+`AtomMachine.family` returns direct atom families whose atoms retain the
+private machine bridge:
 
 ```ts
 export const processAtoms = machineAtoms.family(processMachine, {
@@ -101,14 +114,14 @@ No component `useMemo` is needed. The registry retains the public atom while a
 hook subscribes to it, and that atom retains the machine owner. Equal inputs
 use Effect `Equal` and `Hash` semantics and select the same family value.
 
-For a no-input machine, use one module-level bridge or a lazy
-`useState(makeScope)` value owned by a React subtree. Do not add an unused key.
+For a no-input machine, use one module-level bridge or `useMachineAtom` in the
+owning React subtree. Do not add an unused family key.
 
 Review check: search for composite `Atom.family` values that own a machine,
-`useMemo` around family lookup, and component-local calls to
-`machineAtoms.make`. Replace an input-bearing machine with
-`AtomMachine.family`. Give a no-input instance an explicit module or React-tree
-owner.
+`useMemo` around family lookup, repeated input propagation through one React
+subtree, and component-local calls to `machineAtoms.make` without a stable
+owner. Choose `AtomMachine.family` only when consumers need shared keyed
+lookup.
 
 ## Justify each `RegistryProvider`
 

--- a/packages/effect-machine/src/internal/machine/atom.ts
+++ b/packages/effect-machine/src/internal/machine/atom.ts
@@ -557,6 +557,41 @@ const selectSnapshotByPath = <
 ): Option.Option<SnapshotByIdentifier<State, Path>> =>
   Topology.getSnapshotByPath(snapshot, path) as Option.Option<SnapshotByIdentifier<State, Path>>
 
+type SelectorKind =
+  | "matches"
+  | "matchesChild"
+  | "select"
+  | "selectChild"
+  | "selectSnapshot"
+  | "selectSnapshotChild"
+
+const selectorsByBridge = new WeakMap<object, Map<SelectorKind, Map<string, Atom.Atom<any>>>>()
+
+const cachedSelector = <A>(
+  bridge: object,
+  kind: SelectorKind,
+  path: string,
+  make: () => Atom.Atom<A>
+): Atom.Atom<A> => {
+  let selectorsByKind = selectorsByBridge.get(bridge)
+  if (selectorsByKind === undefined) {
+    selectorsByKind = new Map()
+    selectorsByBridge.set(bridge, selectorsByKind)
+  }
+  let selectorsByPath = selectorsByKind.get(kind)
+  if (selectorsByPath === undefined) {
+    selectorsByPath = new Map()
+    selectorsByKind.set(kind, selectorsByPath)
+  }
+  const cached = selectorsByPath.get(path)
+  if (cached !== undefined) {
+    return cached as Atom.Atom<A>
+  }
+  const selector = make()
+  selectorsByPath.set(path, selector)
+  return selector
+}
+
 export const select = <
   State extends Machine.Machine.AtomicSnapshot<string, unknown>,
   Event,
@@ -571,8 +606,14 @@ export const select = <
 ): Atom.Atom<
   AsyncResult.AsyncResult<Option.Option<SnapshotValueByIdentifier<State, Path>>, StartError | Error>
 > =>
-  Atom.mapResult(self.result, (snapshot) => selectValueByPath(snapshot, path)).pipe(
-    Atom.withEquality(Equal.equals)
+  cachedSelector(
+    self,
+    "select",
+    path,
+    () =>
+      Atom.mapResult(self.result, (snapshot) => selectValueByPath(snapshot, path)).pipe(
+        Atom.withEquality(Equal.equals)
+      )
   )
 
 export const selectSnapshot = <
@@ -589,8 +630,14 @@ export const selectSnapshot = <
 ): Atom.Atom<
   AsyncResult.AsyncResult<Option.Option<SnapshotByIdentifier<State, Path>>, StartError | Error>
 > =>
-  Atom.mapResult(self.result, (snapshot) => selectSnapshotByPath(snapshot, path)).pipe(
-    Atom.withEquality(Equal.equals)
+  cachedSelector(
+    self,
+    "selectSnapshot",
+    path,
+    () =>
+      Atom.mapResult(self.result, (snapshot) => selectSnapshotByPath(snapshot, path)).pipe(
+        Atom.withEquality(Equal.equals)
+      )
   )
 
 export const selectChild = <
@@ -606,10 +653,11 @@ export const selectChild = <
     StartError | RefError<Machine.ChildMachine.Ref<Child>>
   >
 > =>
-  Atom.mapResult(
-    self.result,
-    Option.flatMap((snapshot) => selectValueByPath(snapshot, path))
-  ).pipe(Atom.withEquality(Equal.equals))
+  cachedSelector(self, "selectChild", path, () =>
+    Atom.mapResult(
+      self.result,
+      Option.flatMap((snapshot) => selectValueByPath(snapshot, path))
+    ).pipe(Atom.withEquality(Equal.equals)))
 
 export const selectSnapshotChild = <
   Child extends Machine.ChildMachine.Any,
@@ -624,10 +672,11 @@ export const selectSnapshotChild = <
     StartError | RefError<Machine.ChildMachine.Ref<Child>>
   >
 > =>
-  Atom.mapResult(
-    self.result,
-    Option.flatMap((snapshot) => selectSnapshotByPath(snapshot, path))
-  ).pipe(Atom.withEquality(Equal.equals))
+  cachedSelector(self, "selectSnapshotChild", path, () =>
+    Atom.mapResult(
+      self.result,
+      Option.flatMap((snapshot) => selectSnapshotByPath(snapshot, path))
+    ).pipe(Atom.withEquality(Equal.equals)))
 
 export const matches = <
   State extends Machine.Machine.AtomicSnapshot<string, unknown>,
@@ -641,8 +690,14 @@ export const matches = <
   self: MachineAtom<State, Event, Error, Output, StartError, Emitted>,
   path: Path
 ): Atom.Atom<AsyncResult.AsyncResult<boolean, StartError | Error>> =>
-  Atom.mapResult(self.result, (snapshot) => Option.isSome(Topology.getSnapshotByPath(snapshot, path))).pipe(
-    Atom.withEquality(Equal.equals)
+  cachedSelector(
+    self,
+    "matches",
+    path,
+    () =>
+      Atom.mapResult(self.result, (snapshot) => Option.isSome(Topology.getSnapshotByPath(snapshot, path))).pipe(
+        Atom.withEquality(Equal.equals)
+      )
   )
 
 export const matchesChild = <
@@ -655,10 +710,11 @@ export const matchesChild = <
 ): Atom.Atom<
   AsyncResult.AsyncResult<boolean, StartError | RefError<Machine.ChildMachine.Ref<Child>>>
 > =>
-  Atom.mapResult(
-    self.result,
-    Option.exists((snapshot) => Option.isSome(Topology.getSnapshotByPath(snapshot, path)))
-  ).pipe(Atom.withEquality(Equal.equals))
+  cachedSelector(self, "matchesChild", path, () =>
+    Atom.mapResult(
+      self.result,
+      Option.exists((snapshot) => Option.isSome(Topology.getSnapshotByPath(snapshot, path)))
+    ).pipe(Atom.withEquality(Equal.equals)))
 
 type MachineResumeRequirementsOf<M extends Machine.Machine.Any> = MachineResumeRequirements<
   Machine.Machine.Services<M>,

--- a/packages/effect-machine/src/unstable/reactivity/AtomMachine.ts
+++ b/packages/effect-machine/src/unstable/reactivity/AtomMachine.ts
@@ -387,8 +387,8 @@ type EnsureValuedSelectorPath<State, Path extends string> = [Path] extends [Valu
  * Selects the typed value for an active state path.
  *
  * Valid paths and their selected value types are inferred from the bridge.
- * The derived atom suppresses structurally equal updates. Keep the returned
- * atom stable when constructing it inside a component.
+ * The derived atom suppresses structurally equal updates. Repeated calls with
+ * the same bridge and path return the same atom.
  *
  * **Example**
  *
@@ -465,8 +465,8 @@ export const select: {
  * Selects the typed logical snapshot for an active state path.
  *
  * Unlike {@link select}, the selected value retains its child snapshot
- * topology. The derived atom suppresses structurally equal updates. Keep the
- * returned atom stable when constructing it inside a component.
+ * topology. The derived atom suppresses structurally equal updates. Repeated
+ * calls with the same bridge and path return the same atom.
  *
  * @category combinators
  * @since 0.7.0
@@ -519,8 +519,8 @@ export const selectSnapshot: {
  * Selects the typed value for an active state path in a directly owned child.
  *
  * Valid paths and their selected value types are inferred from the child
- * bridge. An inactive child produces `Option.none()`. Keep the returned atom
- * stable when constructing it inside a component.
+ * bridge. An inactive child produces `Option.none()`. Repeated calls with the
+ * same child bridge and path return the same atom.
  *
  * **Example**
  *
@@ -578,7 +578,8 @@ export const selectChild: {
  *
  * An inactive child or state path produces `Option.none()`. Unlike
  * {@link selectChild}, the selected value retains its child snapshot topology.
- * The derived atom suppresses structurally equal updates.
+ * The derived atom suppresses structurally equal updates. Repeated calls with
+ * the same child bridge and path return the same atom.
  *
  * @category combinators
  * @since 0.7.0
@@ -625,8 +626,9 @@ export const selectSnapshotChild: {
  * Returns whether a state path is active.
  *
  * Valid paths are inferred from the bridge snapshot.
- * The derived atom suppresses equal updates. Runtime failures remain in the
- * typed failure channel.
+ * The derived atom suppresses equal updates. Repeated calls with the same
+ * bridge and path return the same atom. Runtime failures remain in the typed
+ * failure channel.
  *
  * **Example**
  *
@@ -697,8 +699,8 @@ export const matches: {
  * Returns whether a state path is active in a directly owned child.
  *
  * Valid paths are inferred from the child bridge snapshot.
- * An inactive child produces `false`. Keep the returned atom stable when
- * constructing it inside a component.
+ * An inactive child produces `false`. Repeated calls with the same child
+ * bridge and path return the same atom.
  *
  * @category combinators
  * @since 0.4.0

--- a/packages/effect-machine/test/unstable/reactivity/AtomMachine.test.ts
+++ b/packages/effect-machine/test/unstable/reactivity/AtomMachine.test.ts
@@ -158,6 +158,12 @@ describe("AtomMachine", () => {
       const selected = AtomMachine.select(bridge, "Idle")
       const selectedSnapshot = AtomMachine.selectSnapshot(bridge, "Idle")
       const matched = AtomMachine.matches(bridge, "Idle")
+      assert.strictEqual(AtomMachine.select(bridge, "Idle"), selected)
+      assert.strictEqual(AtomMachine.select("Idle")(bridge), selected)
+      assert.strictEqual(AtomMachine.selectSnapshot(bridge, "Idle"), selectedSnapshot)
+      assert.strictEqual(AtomMachine.selectSnapshot("Idle")(bridge), selectedSnapshot)
+      assert.strictEqual(AtomMachine.matches(bridge, "Idle"), matched)
+      assert.strictEqual(AtomMachine.matches("Idle")(bridge), matched)
       const observed = yield* AtomMachine.emissions(bridge).pipe(
         Stream.take(1),
         Stream.runCollect,
@@ -270,6 +276,12 @@ describe("AtomMachine", () => {
       const selectedCount = AtomMachine.selectChild(childAtoms, "Count")
       const selectedCountSnapshot = AtomMachine.selectSnapshotChild(childAtoms, "Count")
       const countMatches = AtomMachine.matchesChild(childAtoms, "Count")
+      assert.strictEqual(AtomMachine.selectChild(childAtoms, "Count"), selectedCount)
+      assert.strictEqual(AtomMachine.selectChild("Count")(childAtoms), selectedCount)
+      assert.strictEqual(AtomMachine.selectSnapshotChild(childAtoms, "Count"), selectedCountSnapshot)
+      assert.strictEqual(AtomMachine.selectSnapshotChild("Count")(childAtoms), selectedCountSnapshot)
+      assert.strictEqual(AtomMachine.matchesChild(childAtoms, "Count"), countMatches)
+      assert.strictEqual(AtomMachine.matchesChild("Count")(childAtoms), countMatches)
       const parentRef = yield* AtomRegistry.getResult(registry, parentAtoms.ref)
       const directChild = yield* parentRef.child(Child)
       assert(Option.isNone(directChild))
@@ -460,6 +472,22 @@ describe("AtomMachine", () => {
       })()
       assert.strictEqual(await waitForCollection(weak), true)
     }
+  })
+
+  it("does not retain abandoned bridges through the selector cache", async () => {
+    if (globalThis.gc === undefined) return
+
+    const refs = (() => {
+      const bridge = AtomMachine.make(makeCounterMachine())
+      const selector = AtomMachine.selectSnapshot(bridge, "Count")
+      return {
+        bridge: new WeakRef(bridge),
+        selector: new WeakRef(selector)
+      }
+    })()
+
+    assert.strictEqual(await waitForCollection(refs.selector), true)
+    assert.strictEqual(await waitForCollection(refs.bridge), true)
   })
 
   it.effect("retains one keyed machine owner through every public projection", () =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
         version: 2.31.0(@types/node@25.7.0)
       '@effect/vitest':
         specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.10(@types/node@25.7.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.10(@types/node@25.7.0)(jsdom@27.2.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 25.7.0
         version: 25.7.0
@@ -47,7 +47,7 @@ importers:
         version: 8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@types/node@25.7.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.7.0)(jsdom@27.2.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/devtools:
     dependencies:
@@ -87,7 +87,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.10(@types/node@25.7.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.10(@types/node@25.7.0)(jsdom@27.2.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 25.7.0
         version: 25.7.0
@@ -105,7 +105,50 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@types/node@25.7.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.7.0)(jsdom@27.2.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
+
+  packages/effect-machine-react:
+    dependencies:
+      '@typeonce/effect-machine':
+        specifier: workspace:^
+        version: link:../effect-machine
+    devDependencies:
+      '@effect/atom-react':
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(react@19.2.7)(scheduler@0.27.0)
+      '@testing-library/react':
+        specifier: 16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react':
+        specifier: 19.2.16
+        version: 19.2.16
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.16)
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+      jsdom:
+        specifier: 27.2.0
+        version: 27.2.0
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+      scheduler:
+        specifier: 0.27.0
+        version: 0.27.0
+      tstyche:
+        specifier: 7.2.1
+        version: 7.2.1(typescript@6.0.3)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@25.7.0)(jsdom@27.2.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/oxlint-plugin:
     dependencies:
@@ -121,9 +164,29 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@types/node@25.7.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.7.0)(jsdom@27.2.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
+
+  '@acemir/cssom@0.9.31':
+    resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@asamuzakjp/css-color@4.1.2':
+    resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
@@ -183,6 +246,42 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.2.1':
+    resolution: {integrity: sha512-YpAJZhaHplYQkG8ib+/Fx5Y0eF2lVWi3tIvMJA6i39TLyUNp2439cifzW8VMjhlqrBjHzK5hVGugRRm2zTKI/A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.9':
+    resolution: {integrity: sha512-iGGw4OsAYsS6pD29MdJ2bX/nJx65a04ZZiw6x+VwWlP2DdXf6f++Zmuv/OzALpdyfVhjbduIIF2cXM7HWBIe9A==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@dprint/android-arm64@0.55.2':
     resolution: {integrity: sha512-cywqM0E2h8lCA/b5BMFcuascaGuekm2lnyKb5hRH9juKbsqKeR8A7qf2p3nVWRQ8cM7djOnQwhy8ecQ3qd6j9A==}
@@ -267,6 +366,13 @@ packages:
     resolution: {integrity: sha512-UTiDSShHbrkx+z719/MffgwGYD8PaypdVmG4vVJVjmF5Hoin6EfugHhSoBf8+G6U9rF+uDIIl0idZq+6Bifzwg==}
     cpu: [x64]
     os: [win32]
+
+  '@effect/atom-react@4.0.0-rc.112':
+    resolution: {integrity: sha512-Ksf90KQa6D4UDnMj4M84arlVKNIuwxxF2GvgXBzuaYi2LsgririsUhKQ5SYaK1euf8oIYeamEuthoZSbUQmIhw==}
+    peerDependencies:
+      effect: 4.0.0-rc.112
+      react: '>=19.0.0 <20.0.0'
+      scheduler: '>=0.25.0 <0.28.0'
 
   '@effect/platform-browser@4.0.0-rc.112':
     resolution: {integrity: sha512-GSlqNDnjILz2EqOFPhVdMEHxlPq6SGb8+KOpNnLfRvVJjXRTMawEO+v1PCuwt2CHAqESbJAa2Nk+qcQvTrv4MQ==}
@@ -842,8 +948,30 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.0':
+    resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -862,6 +990,14 @@ packages:
 
   '@types/node@25.7.0':
     resolution: {integrity: sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.16':
+    resolution: {integrity: sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -898,6 +1034,10 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -906,11 +1046,18 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -927,6 +1074,9 @@ packages:
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -958,6 +1108,37 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  cssstyle@5.3.7:
+    resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
+    engines: {node: '>=20'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@6.0.1:
+    resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
+    engines: {node: '>=20'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -969,6 +1150,9 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dprint@0.55.2:
     resolution: {integrity: sha512-1d4D4SB9KiD2qFnBWbl3aoYjLvPVpZoth28yxTT00xJv2yXugdz0Xoyv7sGG0w0hzE6hQZMgd6B333GnySDpGQ==}
@@ -987,6 +1171,10 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
@@ -1066,9 +1254,25 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   human-id@4.2.0:
     resolution: {integrity: sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==}
     hasBin: true
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.3:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
@@ -1090,6 +1294,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
@@ -1101,6 +1308,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-yaml@3.15.0:
     resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
@@ -1108,6 +1318,15 @@ packages:
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
+
+  jsdom@27.2.0:
+    resolution: {integrity: sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -1196,8 +1415,16 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1205,6 +1432,9 @@ packages:
   markdown-it@14.3.0:
     resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
     hasBin: true
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mdurl@2.1.0:
     resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
@@ -1229,6 +1459,9 @@ packages:
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   msgpackr-extract@3.0.4:
     resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
@@ -1293,6 +1526,9 @@ packages:
     resolution: {integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==}
     hasBin: true
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1332,8 +1568,16 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   pure-rand@8.4.2:
@@ -1344,6 +1588,18 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -1356,6 +1612,10 @@ packages:
   redis@6.2.1:
     resolution: {integrity: sha512-Z9VHtgYs48PiQC77X9O2Er8Hj4T+5BtFjT91/vi5Is1D04N72cA946ZslM1ImJw8ZctFBZWAVjM7S5wJNeHMpg==}
     engines: {node: '>= 20.0.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -1378,6 +1638,13 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -1427,6 +1694,9 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -1446,9 +1716,24 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.11:
+    resolution: {integrity: sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==}
+
+  tldts@7.4.11:
+    resolution: {integrity: sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1578,6 +1863,31 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1600,12 +1910,47 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
 snapshots:
+
+  '@acemir/cssom@0.9.31': {}
+
+  '@asamuzakjp/css-color@4.1.2':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/runtime@7.29.7': {}
 
@@ -1752,6 +2097,30 @@ snapshots:
       human-id: 4.2.0
       prettier: 2.8.8
 
+  '@csstools/color-helpers@6.1.1': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.9(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@dprint/android-arm64@0.55.2':
     optional: true
 
@@ -1797,6 +2166,12 @@ snapshots:
   '@dprint/win32-x64@0.55.2':
     optional: true
 
+  '@effect/atom-react@4.0.0-rc.112(effect@4.0.0-rc.112)(react@19.2.7)(scheduler@0.27.0)':
+    dependencies:
+      effect: 4.0.0-rc.112
+      react: 19.2.7
+      scheduler: 0.27.0
+
   '@effect/platform-browser@4.0.0-rc.112(effect@4.0.0-rc.112)':
     dependencies:
       effect: 4.0.0-rc.112
@@ -1821,10 +2196,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/vitest@4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.10(@types/node@25.7.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.10(@types/node@25.7.0)(jsdom@27.2.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
       effect: 4.0.0-rc.112
-      vitest: 4.1.10(@types/node@25.7.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@25.7.0)(jsdom@27.2.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -2165,10 +2540,33 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.16
+      '@types/react-dom': 19.2.3(@types/react@19.2.16)
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -2188,6 +2586,14 @@ snapshots:
   '@types/node@25.7.0':
     dependencies:
       undici-types: 7.21.0
+
+  '@types/react-dom@19.2.3(@types/react@19.2.16)':
+    dependencies:
+      '@types/react': 19.2.16
+
+  '@types/react@19.2.16':
+    dependencies:
+      csstype: 3.2.3
 
   '@types/unist@3.0.3': {}
 
@@ -2236,15 +2642,23 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  agent-base@7.1.4: {}
+
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
 
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-union@2.1.0: {}
 
@@ -2255,6 +2669,10 @@ snapshots:
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   brace-expansion@5.0.9:
     dependencies:
@@ -2282,6 +2700,33 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  cssstyle@5.3.7:
+    dependencies:
+      '@asamuzakjp/css-color': 4.1.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.9(css-tree@3.2.1)
+      css-tree: 3.2.1
+      lru-cache: 11.5.2
+
+  csstype@3.2.3: {}
+
+  data-urls@6.0.1:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 15.1.0
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decimal.js@10.6.0: {}
+
+  dequal@2.0.3: {}
+
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
@@ -2289,6 +2734,8 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dom-accessibility-api@0.5.16: {}
 
   dprint@0.55.2:
     optionalDependencies:
@@ -2321,6 +2768,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   entities@4.5.0: {}
+
+  entities@8.0.0: {}
 
   es-module-lexer@2.3.1: {}
 
@@ -2426,7 +2875,29 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   human-id@4.2.0: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.7.3:
     dependencies:
@@ -2442,6 +2913,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
@@ -2449,6 +2922,8 @@ snapshots:
   is-windows@1.0.2: {}
 
   isexe@2.0.0: {}
+
+  js-tokens@4.0.0: {}
 
   js-yaml@3.15.0:
     dependencies:
@@ -2458,6 +2933,33 @@ snapshots:
   js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@27.2.0:
+    dependencies:
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.8.1
+      cssstyle: 5.3.7
+      data-urls: 6.0.1
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.21.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -2522,7 +3024,11 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  lru-cache@11.5.2: {}
+
   lunr@2.3.9: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -2536,6 +3042,8 @@ snapshots:
       mdurl: 2.1.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
+
+  mdn-data@2.27.1: {}
 
   mdurl@2.1.0: {}
 
@@ -2553,6 +3061,8 @@ snapshots:
       brace-expansion: 5.0.9
 
   mri@1.2.0: {}
+
+  ms@2.1.3: {}
 
   msgpackr-extract@3.0.4:
     dependencies:
@@ -2633,6 +3143,10 @@ snapshots:
       '@pagefind/windows-arm64': 1.5.2
       '@pagefind/windows-x64': 1.5.2
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -2657,13 +3171,30 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   punycode.js@2.3.1: {}
+
+  punycode@2.3.1: {}
 
   pure-rand@8.4.2: {}
 
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react@19.2.7: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -2684,6 +3215,8 @@ snapshots:
     transitivePeerDependencies:
       - '@node-rs/xxhash'
       - '@opentelemetry/api'
+
+  require-from-string@2.0.2: {}
 
   resolve-from@5.0.0: {}
 
@@ -2718,6 +3251,12 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
+
   semver@7.8.5: {}
 
   shebang-command@2.0.0:
@@ -2751,6 +3290,8 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   term-size@2.2.1: {}
 
   tinybench@2.9.0: {}
@@ -2764,9 +3305,23 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.4.11: {}
+
+  tldts@7.4.11:
+    dependencies:
+      tldts-core: 7.4.11
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.11
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tslib@2.8.1:
     optional: true
@@ -2815,7 +3370,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@25.7.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@25.7.0)(jsdom@27.2.0)(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@25.7.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
@@ -2839,8 +3394,28 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.7.0
+      jsdom: 27.2.0
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
 
   which@2.0.2:
     dependencies:
@@ -2852,5 +3427,9 @@ snapshots:
       stackback: 0.0.2
 
   ws@8.21.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yaml@2.9.0: {}

--- a/scripts/check-changeset.mjs
+++ b/scripts/check-changeset.mjs
@@ -36,10 +36,12 @@ const releaseFiles = changedFiles.filter(
   (path) =>
     path.startsWith("src/") ||
     path.startsWith("packages/effect-machine/src/") ||
+    path.startsWith("packages/effect-machine-react/src/") ||
     path.startsWith("packages/devtools/src/") ||
     path.startsWith("packages/oxlint-plugin/src/") ||
     path === "package.json" ||
     path === "packages/effect-machine/package.json" ||
+    path === "packages/effect-machine-react/package.json" ||
     path === "packages/devtools/package.json" ||
     path === "packages/oxlint-plugin/package.json"
 )

--- a/scripts/ci-changes.mjs
+++ b/scripts/ci-changes.mjs
@@ -24,7 +24,9 @@ export const classifyChanges = ({
   changedFiles
 }) => {
   const sourceChanged = changedFiles.some((path) =>
-    path.startsWith("src/") || path.startsWith("packages/effect-machine/src/")
+    path.startsWith("src/") ||
+    path.startsWith("packages/effect-machine/src/") ||
+    path.startsWith("packages/effect-machine-react/src/")
   )
   const dependencyChanged = relevantDependenciesChanged(beforePackageJson, afterPackageJson)
   const classifierChanged = changedFiles.includes("scripts/ci-changes.mjs")

--- a/scripts/react-pack-check.mjs
+++ b/scripts/react-pack-check.mjs
@@ -1,0 +1,85 @@
+import { spawnSync } from "node:child_process"
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+
+const repositoryRoot = resolve(import.meta.dirname, "..")
+const destination = await mkdtemp(join(tmpdir(), "effect-machine-react-pack-"))
+const consumer = join(destination, "consumer")
+
+const run = (command, args, options = {}) => {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    ...options
+  })
+  if (result.status !== 0) {
+    throw new Error(
+      [`${command} ${args.join(" ")} failed`, result.stdout?.trim(), result.stderr?.trim()]
+        .filter(Boolean)
+        .join("\n")
+    )
+  }
+  return result
+}
+
+const pack = (directory) => {
+  const result = run("pnpm", ["pack", "--pack-destination", destination], { cwd: directory })
+  const archive = result.stdout.trim().split("\n").at(-1)
+  if (archive === undefined) throw new Error(`pnpm pack did not return an archive for ${directory}`)
+  return archive
+}
+
+try {
+  const coreArchive = pack(join(repositoryRoot, "packages", "effect-machine"))
+  const reactRoot = join(repositoryRoot, "packages", "effect-machine-react")
+  const reactArchive = pack(reactRoot)
+  const reactPackage = JSON.parse(await readFile(join(reactRoot, "package.json")))
+
+  const listing = run("tar", ["-tzf", reactArchive]).stdout.trim().split("\n")
+  for (const required of [
+    "package/dist/index.js",
+    "package/dist/index.d.ts",
+    "package/dist/MachineAtom.js",
+    "package/dist/MachineAtom.d.ts",
+    "package/src/index.ts",
+    "package/src/MachineAtom.ts",
+    "package/package.json",
+    "package/README.md",
+    "package/LICENSE",
+    "package/NOTICE"
+  ]) {
+    if (!listing.includes(required)) throw new Error(`tarball is missing ${required}`)
+  }
+  const forbidden = listing.filter((file) => /^package\/(?:test|typetest)\//.test(file))
+  if (forbidden.length > 0) throw new Error(`tarball contains repository files:\n${forbidden.join("\n")}`)
+
+  await mkdir(consumer, { recursive: true })
+  await writeFile(join(consumer, "package.json"), JSON.stringify({
+    private: true,
+    type: "module",
+    dependencies: {
+      "@effect/atom-react": reactPackage.peerDependencies["@effect/atom-react"],
+      "@typeonce/effect-machine": `file:${coreArchive}`,
+      "@typeonce/effect-machine-react": `file:${reactArchive}`,
+      effect: reactPackage.peerDependencies.effect,
+      react: "19.2.7",
+      scheduler: "0.27.0"
+    }
+  }, null, 2))
+  await writeFile(
+    join(consumer, "pnpm-workspace.yaml"),
+    `packages:\n  - .\noverrides:\n  "@typeonce/effect-machine": "file:${coreArchive}"\n`
+  )
+
+  run("pnpm", ["install", "--prefer-offline", "--ignore-scripts"], { cwd: consumer })
+  run(process.execPath, [
+    "--input-type=module",
+    "--eval",
+    `const module = await import("@typeonce/effect-machine-react");
+     if (typeof module.useMachineAtom !== "function") throw new Error("useMachineAtom is not exported");`
+  ], { cwd: consumer })
+
+  console.log(`React package verification passed (${listing.length} files)`)
+} finally {
+  await rm(destination, { recursive: true, force: true })
+}

--- a/scripts/release-contract.test.mjs
+++ b/scripts/release-contract.test.mjs
@@ -8,20 +8,24 @@ const repositoryRoot = resolve(import.meta.dirname, "..")
 const readJson = async (path) => JSON.parse(await readFile(resolve(repositoryRoot, path), "utf8"))
 
 test("all Effect Machine packages release with the same version", async () => {
-  const [changesets, core, devtools, oxlintPlugin] = await Promise.all([
+  const [changesets, core, react, devtools, oxlintPlugin] = await Promise.all([
     readJson(".changeset/config.json"),
     readJson("packages/effect-machine/package.json"),
+    readJson("packages/effect-machine-react/package.json"),
     readJson("packages/devtools/package.json"),
     readJson("packages/oxlint-plugin/package.json")
   ])
 
+  assert.equal(react.version, core.version)
   assert.equal(devtools.version, core.version)
   assert.equal(oxlintPlugin.version, core.version)
+  assert.equal(react.dependencies[core.name], "workspace:^")
   assert.equal(devtools.dependencies[core.name], "workspace:^")
   assert.ok(
     changesets.fixed.some((group) =>
-      group.length === 3 &&
+      group.length === 4 &&
       group.includes(core.name) &&
+      group.includes(react.name) &&
       group.includes(devtools.name) &&
       group.includes(oxlintPlugin.name)
     ),

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -3,6 +3,7 @@
   "extends": "./tsconfig.base.json",
   "include": [],
   "references": [
-    { "path": "packages/effect-machine" }
+    { "path": "packages/effect-machine" },
+    { "path": "packages/effect-machine-react" }
   ]
 }

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,10 +1,11 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.base.json",
-  "include": ["packages/*/test/**/*.ts"],
+  "include": ["packages/*/test/**/*.ts", "packages/*/test/**/*.tsx"],
   "exclude": ["**/dist/**", "**/node_modules/**", "references/**"],
   "references": [
-    { "path": "packages/effect-machine" }
+    { "path": "packages/effect-machine" },
+    { "path": "packages/effect-machine-react" }
   ],
   "compilerOptions": {
     "composite": false,
@@ -14,9 +15,11 @@
     "declarationMap": false,
     "sourceMap": false,
     "types": ["node", "vitest/globals"],
+    "jsx": "react-jsx",
     "paths": {
       "@typeonce/effect-machine": ["./packages/effect-machine/src/index.ts"],
-      "@typeonce/effect-machine/*": ["./packages/effect-machine/src/*.ts"]
+      "@typeonce/effect-machine/*": ["./packages/effect-machine/src/*.ts"],
+      "@typeonce/effect-machine-react": ["./packages/effect-machine-react/src/index.ts"]
     }
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config"
 
 export default defineConfig({
   test: {
-    include: ["packages/*/test/**/*.test.ts"]
+    include: ["packages/*/test/**/*.test.ts", "packages/*/test/**/*.test.tsx"]
   }
 })


### PR DESCRIPTION
## Summary

- add `@typeonce/effect-machine-react` with `useMachineAtom` for stable React ownership without whole-machine subscriptions
- make state-path selector atoms stable for repeated machine/path lookups, including child selectors, while preserving weak lifetime semantics
- document React-owned state-slot rendering and retain `AtomMachine.family` for shared keyed lookup
- add React lifecycle, render-isolation, registry, SSR, selector-identity, GC-retention, type, and packed-consumer coverage

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change a publishable package

## Validation

- [x] `pnpm check`
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required

<!--
The type- and runtime-performance workflows measure only relevant changes and post their base-versus-PR comparisons automatically.
Do not copy a manually measured table into this description.
-->
