### PR TITLE
Fix machine boundary validation and implementation ownership

### DIFF
--- a/.changeset/consistent-machine-boundaries.md
+++ b/.changeset/consistent-machine-boundaries.md
@@ -1,0 +1,9 @@
+---
+"@typeonce/effect-machine": patch
+"@typeonce/effect-machine-devtools": patch
+"@typeonce/oxlint-plugin-effect-machine": patch
+---
+
+Align `Machine.can` types with its existing support for public and internal events. Querying an internal event does not make it sendable through `MachineRef.send`. Preserve interruption during snapshot encoding and decoding, validate reused event and emission values, and capture machine definitions independently of caller mutations.
+
+Make `MachineTest.verify` lazy and compare decoded values without lossy JSON serialization. Serialize concurrent devtools refreshes, stop watcher work with its server scope, and prevent lint rules from matching shadowed machine bindings.

--- a/packages/devtools/src/MachineRegistry.ts
+++ b/packages/devtools/src/MachineRegistry.ts
@@ -33,7 +33,7 @@ export interface Options extends ProjectInspector.InspectOptions {
 }
 
 /**
- * Failure while starting the initial project inspection.
+ * Failure while inspecting the project, during startup or an explicit refresh.
  *
  * @category errors
  * @since 0.23.0
@@ -60,8 +60,9 @@ export class MachineRegistry extends Context.Service<MachineRegistry, {
 }>()("@typeonce/effect-machine-devtools/MachineRegistry") {}
 
 /**
- * Builds a scoped registry that scans immediately and refreshes after relevant
- * source file changes.
+ * Builds a registry that scans immediately. Call `refresh` to inspect again.
+ * Concurrent refreshes run sequentially and publish increasing revisions.
+ * `DevServer.run` installs the file watcher that triggers automatic refreshes.
  *
  * @category layers
  * @since 0.23.0

--- a/packages/devtools/src/internal/devServer.ts
+++ b/packages/devtools/src/internal/devServer.ts
@@ -1,5 +1,6 @@
 import { type ChokidarOptions, type FSWatcher, watch } from "chokidar"
 import * as Effect from "effect/Effect"
+import type * as Scope from "effect/Scope"
 import * as Stream from "effect/Stream"
 import type { IncomingMessage, ServerResponse } from "node:http"
 import { isAbsolute, relative, resolve } from "node:path"
@@ -117,11 +118,12 @@ const acquire = (
       })
   })
 
-const acquireWatcher = (
+export const acquireWatcher = (
   options: DevServer.Options,
   registry: MachineRegistry.MachineRegistry["Service"]
-): Effect.Effect<FSWatcher> =>
-  Effect.sync(() => {
+): Effect.Effect<FSWatcher, never, Scope.Scope> =>
+  Effect.gen(function*() {
+    const scope = yield* Effect.scope
     let refreshTimer: ReturnType<typeof setTimeout> | undefined
     const watcher = watch(options.root, watcherOptions(options))
     watcher.on("all", (_event, file) => {
@@ -130,16 +132,20 @@ const acquireWatcher = (
       refreshTimer = setTimeout(() => {
         Effect.runFork(
           registry.refresh.pipe(
-            Effect.catch((cause) => Effect.logWarning("Machine reload failed", cause))
+            Effect.catch((cause) => Effect.logWarning("Machine reload failed", cause)),
+            Effect.forkIn(scope)
           )
         )
       }, options.debounce ?? 150)
     })
-    watcher.on("close", () => {
-      if (refreshTimer !== undefined) clearTimeout(refreshTimer)
-    })
+    yield* Effect.addFinalizer(() =>
+      Effect.promise(async () => {
+        if (refreshTimer !== undefined) clearTimeout(refreshTimer)
+        await watcher.close()
+      })
+    )
     watcher.on("error", (cause) => {
-      Effect.runFork(Effect.logError("Machine file watcher failed", cause))
+      Effect.runFork(Effect.logError("Machine file watcher failed", cause).pipe(Effect.forkIn(scope)))
     })
     return watcher
   })
@@ -166,10 +172,7 @@ export const run = (
       acquire(ErrorType, options, registry),
       (server) => Effect.promise(() => server.close())
     )
-    yield* Effect.acquireRelease(
-      acquireWatcher(options, registry),
-      (watcher) => Effect.promise(() => watcher.close())
-    )
+    yield* acquireWatcher(options, registry)
     const address = server.resolvedUrls?.local[0] ?? `http://${options.host}:${options.port}/`
     yield* Effect.logInfo(`Effect Machine visualizer: ${address}`)
     return yield* Effect.never

--- a/packages/devtools/src/internal/machineRegistry.ts
+++ b/packages/devtools/src/internal/machineRegistry.ts
@@ -89,28 +89,28 @@ const make = (api: PublicApi, options: MachineRegistry.Options) =>
       results: []
     })
 
-    const refresh = SubscriptionRef.get(state).pipe(
-      Effect.flatMap((current) =>
-        inspector.inspect({
-          ...options,
-          revision: current.revision + 1,
-          retainedCandidates: retainedCandidates(current.results)
-        }).pipe(
-          Effect.map((results): MachineRegistry.Snapshot => ({
+    const refresh = SubscriptionRef.modifyEffect(state, (current) =>
+      inspector.inspect({
+        ...options,
+        revision: current.revision + 1,
+        retainedCandidates: retainedCandidates(current.results)
+      }).pipe(
+        Effect.map((results) => {
+          const next: MachineRegistry.Snapshot = {
             protocolVersion: DevToolsProtocol.protocolVersion,
             revision: current.revision + 1,
             results: reconcile(current.results, results)
-          }))
-        )
-      ),
-      Effect.tap((next) => SubscriptionRef.set(state, next)),
-      Effect.mapError((cause) =>
-        new api.RegistryError({
-          message: `Could not inspect Effect Machine definitions under ${options.root}`,
-          cause
+          }
+          return [next, next] as const
         })
+      )).pipe(
+        Effect.mapError((cause) =>
+          new api.RegistryError({
+            message: `Could not inspect Effect Machine definitions under ${options.root}`,
+            cause
+          })
+        )
       )
-    )
 
     yield* refresh
 

--- a/packages/devtools/test/MachineRegistry.test.ts
+++ b/packages/devtools/test/MachineRegistry.test.ts
@@ -1,10 +1,48 @@
 import { assert, describe, it } from "@effect/vitest"
+import { Deferred, Effect, Fiber } from "effect"
 import * as DevToolsProtocol from "../src/DevToolsProtocol.js"
 import { machine } from "../src/internal/browser/example-machine.js"
 import { reconcile } from "../src/internal/machineRegistry.js"
 import * as MachineDocument from "../src/MachineDocument.js"
+import * as Registry from "../src/MachineRegistry.js"
+import * as Inspector from "../src/ProjectInspector.js"
 
 describe("MachineRegistry", () => {
+  it.effect("serializes overlapping refreshes and increments each revision", () =>
+    Effect.gen(function*() {
+      const started = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      const revisions: Array<number | undefined> = []
+      const inspector = Inspector.ProjectInspector.of({
+        discover: () => Effect.succeed([]),
+        evaluate: () => Effect.succeed([]),
+        inspect: (options) =>
+          Effect.gen(function*() {
+            revisions.push(options.revision)
+            if (revisions.length === 2) {
+              yield* Deferred.succeed(started, undefined)
+              yield* Deferred.await(release)
+            }
+            return []
+          })
+      })
+      yield* Effect.gen(function*() {
+        const registry = yield* Registry.MachineRegistry
+        const first = yield* Effect.forkScoped(registry.refresh)
+        yield* Deferred.await(started)
+        const second = yield* Effect.forkScoped(registry.refresh, { startImmediately: true })
+        assert.deepStrictEqual(revisions, [1, 2])
+        yield* Deferred.succeed(release, undefined)
+        assert.strictEqual((yield* Fiber.join(first)).revision, 2)
+        assert.strictEqual((yield* Fiber.join(second)).revision, 3)
+        assert.strictEqual((yield* registry.get).revision, 3)
+      }).pipe(
+        Effect.provide(Registry.layer({ root: "." })),
+        Effect.provideService(Inspector.ProjectInspector, inspector),
+        Effect.scoped
+      )
+    }))
+
   it("keeps the last valid document when a reload fails", () => {
     const document = MachineDocument.make(machine, {
       source: { file: "src/workflow.ts", exportName: "workflow" }

--- a/packages/devtools/test/WatcherScope.test.ts
+++ b/packages/devtools/test/WatcherScope.test.ts
@@ -1,0 +1,68 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Deferred, Effect, Stream } from "effect"
+import { EventEmitter } from "node:events"
+import { vi } from "vitest"
+import { acquireWatcher } from "../src/internal/devServer.js"
+import type { MachineRegistry } from "../src/MachineRegistry.js"
+
+vi.mock("chokidar", () => ({ watch: () => currentWatcher }))
+
+class Watcher extends EventEmitter {
+  closed = false
+  async close() {
+    this.closed = true
+    this.removeAllListeners()
+  }
+}
+let currentWatcher = new Watcher()
+const options = { root: "/project", host: "127.0.0.1", port: 5173, debounce: 0 }
+const snapshot = { protocolVersion: 2 as const, revision: 1, results: [] }
+
+describe("file watcher scope", () => {
+  it.effect("interrupts an in-flight inspection when the server scope closes", () =>
+    Effect.gen(function*() {
+      currentWatcher = new Watcher()
+      const started = yield* Deferred.make<void>()
+      let interrupted = false
+      const registry: MachineRegistry["Service"] = {
+        get: Effect.succeed(snapshot),
+        changes: Stream.empty,
+        refresh: Deferred.succeed(started, undefined).pipe(
+          Effect.andThen(Effect.never),
+          Effect.onInterrupt(() =>
+            Effect.sync(() => {
+              interrupted = true
+            })
+          )
+        )
+      }
+      yield* Effect.gen(function*() {
+        yield* acquireWatcher(options, registry)
+        currentWatcher.emit("all", "change", "/project/workflow.ts")
+        yield* Deferred.await(started)
+      }).pipe(Effect.scoped)
+      assert.isTrue(interrupted)
+      assert.isTrue(currentWatcher.closed)
+    }))
+
+  it.effect("cancels a pending debounce timer on scope closure", () =>
+    Effect.gen(function*() {
+      currentWatcher = new Watcher()
+      let refreshes = 0
+      const registry: MachineRegistry["Service"] = {
+        get: Effect.succeed(snapshot),
+        changes: Stream.empty,
+        refresh: Effect.sync(() => {
+          refreshes++
+          return snapshot
+        })
+      }
+      yield* Effect.gen(function*() {
+        yield* acquireWatcher(options, registry)
+        currentWatcher.emit("all", "change", "/project/workflow.ts")
+      }).pipe(Effect.scoped)
+      yield* Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, 5)))
+      assert.strictEqual(refreshes, 0)
+      assert.isTrue(currentWatcher.closed)
+    }))
+})

--- a/packages/effect-machine/src/Machine.ts
+++ b/packages/effect-machine/src/Machine.ts
@@ -27,6 +27,7 @@ import type {
 import * as internal from "./internal/machine/machine.js"
 import { InitialEventTypeId } from "./internal/machine/machine.js"
 import type { EnsureExecutable } from "./internal/machine/readiness.js"
+import type { ExcludeCompatibleRuntime } from "./internal/machine/requirements.js"
 import type * as internalRuntime from "./internal/machine/runtime.js"
 import type * as StateDefinition from "./internal/machine/stateDefinition.js"
 import type * as Topology from "./internal/machine/topology.js"
@@ -630,14 +631,6 @@ export declare namespace Runtime {
     }
   }
 }
-
-type ExcludeCompatibleRuntime<Requirements, Events, Emits> = Requirements extends Runtime.Requirement<
-  infer RequiredEvents,
-  infer RequiredEmits
-> ? IsAny<Requirements> extends true ? Requirements
-  : [RequiredEvents] extends [Events] ? [RequiredEmits] extends [Emits] ? never : Requirements
-  : Requirements
-  : Requirements
 
 type IncompatibleRuntime<Requirements, Events, Emits> = Requirements extends Runtime.Requirement<
   infer RequiredEvents,
@@ -5380,8 +5373,9 @@ export declare namespace Machine {
    *
    * Handlers return snapshots for complete state replacement, target builder
    * results for path-safe partial transitions, state-value updates, or
-   * `target.none()` for an explicitly targetless transition. Raw decoded state
-   * values and `void` are not accepted at transition boundaries.
+   * an explicit targetless result. In a machine definition, select `to.none`;
+   * its optional resolver returns `undefined`. Raw decoded state values are
+   * not accepted as transition targets.
    *
    * @category utility types
    * @since 0.4.0
@@ -9312,23 +9306,38 @@ export const enabled: <
  * they accept the event. Any commands, emissions, or raised events collected
  * during that check are discarded.
  *
- * Event input is decoded through the machine's public event protocol. Invalid
- * input fails with `MachineSchemaDecodeError`. Final snapshots and valid events
+ * Event input is decoded through the machine's public and internal event protocols.
+ * Invalid input fails with `MachineSchemaDecodeError`. Final snapshots and valid events
  * with no accepting handler return `false`.
  *
  * **Gotchas**
  *
  * This query does not execute transitions or stabilize the resulting machine.
  * It does not run entry, exit, always, completion, child lifecycle, or command
- * effects. A `true` result therefore describes event acceptance only.
+ * effects. A `true` result therefore describes event acceptance only, for this
+ * snapshot. It does not guarantee acceptance after the machine advances.
+ *
+ * This Effect can also be used by machine effects to query internal events.
+ * Synchronous transition resolvers cannot execute it. Querying an internal event
+ * does not make that event available to `MachineRef.send`.
  *
  * **Example**
  *
  * ```ts
- * const canCheckout = Machine.can(checkoutMachine)
+ * import { Machine } from "@typeonce/effect-machine"
+ * import { Effect, Schema } from "effect"
  *
- * const canSubmit = yield* canCheckout(snapshot, {
- *   _tag: "SubmitOrder"
+ * const internalEvents = Machine.internalEvents(Schema.TaggedStruct("Loaded", {}))
+ * const machine = Machine.make({
+ *   states: { Idle: {} },
+ *   events: Machine.events(),
+ *   internalEvents,
+ *   initial: (to) => to.Idle()
+ * }).handle({ Idle: { on: { Loaded: (to) => to.none } } })
+ *
+ * export const canLoad = Effect.gen(function*() {
+ *   const initial = yield* Machine.planInitial(machine)
+ *   return yield* Machine.can(machine, initial.state, internalEvents.Loaded())
  * })
  * ```
  *
@@ -9373,7 +9382,7 @@ export const can: {
       & Machine.RootCompatible<ParentEvents>
   ): (
     state: Machine.Snapshot<States>,
-    event: Machine.EventInputOf<InputEvents>
+    event: Machine.EventInputOf<Events>
   ) => Effect.Effect<boolean, MachineSchemaDecodeError>
   <
     const States extends Machine.StateSchemas,
@@ -9411,12 +9420,12 @@ export const can: {
       & EnsureExecutable<States, UnhandledStates, OutputStates>
       & Machine.RootCompatible<ParentEvents>,
     state: Machine.Snapshot<States>,
-    event: Machine.EventInputOf<InputEvents>
+    event: Machine.EventInputOf<Events>
   ): Effect.Effect<boolean, MachineSchemaDecodeError>
 } = internal.can as any
 
 /**
- * Plans the next state snapshot synchronously.
+ * Returns an Effect that plans the next state snapshot without running command effects.
  *
  * **Details**
  *

--- a/packages/effect-machine/src/internal/machine/atom.ts
+++ b/packages/effect-machine/src/internal/machine/atom.ts
@@ -18,6 +18,7 @@ import type * as Machine from "../../Machine.js"
 import type { Bound, ChildMachineAtom, MachineAtom } from "../../unstable/reactivity/AtomMachine.js"
 import * as internalMachine from "./machine.js"
 import type { EnsureExecutable } from "./readiness.js"
+import type { ExcludeCompatibleRuntime as ExcludeCompatibleMachineRuntime, IsAny } from "./requirements.js"
 import * as Topology from "./topology.js"
 
 export class NotReadyError extends Data.TaggedError("NotReadyError") {}
@@ -35,15 +36,6 @@ const ExternalRequirementsTypeId = "~effect/reactivity/AtomMachine/ExternalRequi
 type EnsureNoExternalRequirements<Requirements> = [ExternalRequirements<Requirements>] extends [never] ? unknown : {
   readonly [ExternalRequirementsTypeId]: ExternalRequirements<Requirements>
 }
-
-type IsAny<A> = 0 extends (1 & A) ? true : false
-
-type ExcludeCompatibleMachineRuntime<Requirements, Events, Emits> = Requirements extends
-  Machine.Runtime.Requirement<infer RequiredEvents, infer RequiredEmits> ?
-  IsAny<Requirements> extends true ? Requirements
-  : [RequiredEvents] extends [Events] ? [RequiredEmits] extends [Emits] ? never : Requirements
-  : Requirements
-  : Requirements
 
 type MachineRequirements<InitialR, R, Events, Emits> = ExcludeCompatibleMachineRuntime<
   Machine.ExecutionServices<InitialR | R>,

--- a/packages/effect-machine/src/internal/machine/childRegistry.ts
+++ b/packages/effect-machine/src/internal/machine/childRegistry.ts
@@ -1,0 +1,141 @@
+/** Owns child reservations and ordered observer buffers for one local runtime. */
+import * as Deferred from "effect/Deferred"
+import * as Effect from "effect/Effect"
+import * as Option from "effect/Option"
+import type * as Scope from "effect/Scope"
+import type { MachineRef } from "./runtime.js"
+
+export type ChildDescriptor = {
+  readonly id: string
+  readonly machine: object
+}
+
+export type ChildEntry =
+  | {
+    readonly _tag: "Starting"
+    readonly token: symbol
+    readonly ownerKey?: string
+    readonly ownerPath?: string
+    ownerActive?: boolean
+  }
+  | {
+    readonly _tag: "Started"
+    readonly token: symbol
+    readonly descriptor: ChildDescriptor | undefined
+    readonly ref: MachineRef<any, any, any, any>
+    readonly ownerKey?: string
+    readonly ownerPath?: string
+    ownerActive?: boolean
+  }
+
+export type ChildSelector = string | ChildDescriptor
+export type ChildKey = string | symbol
+
+type ChildObservation = Option.Option<MachineRef<any, any, any, any>>
+type ChildObservationBatch = [ChildObservation, ...Array<ChildObservation>]
+
+export interface ChildObserver {
+  readonly child: ChildSelector
+  readonly id: string
+  values: ChildObservationBatch | undefined
+  waiter: Deferred.Deferred<void> | undefined
+}
+
+export const offerChildObservation = (
+  observer: ChildObserver,
+  value: ChildObservation
+): void => {
+  if (observer.values === undefined) {
+    observer.values = [value]
+  } else {
+    observer.values.push(value)
+  }
+  if (observer.waiter !== undefined) {
+    const waiter = observer.waiter
+    observer.waiter = undefined
+    Deferred.doneUnsafe(waiter, Effect.void)
+  }
+}
+
+export const takeChildObservations = (
+  observer: ChildObserver
+): Effect.Effect<ChildObservationBatch> =>
+  Effect.suspend(() => {
+    if (observer.values !== undefined) {
+      const values = observer.values
+      observer.values = undefined
+      return Effect.succeed(values)
+    }
+    const waiter = Deferred.makeUnsafe<void>()
+    observer.waiter = waiter
+    return Deferred.await(waiter).pipe(Effect.andThen(takeChildObservations(observer)))
+  })
+
+export interface ChildRegistry {
+  closed: boolean
+  readonly children: Map<ChildKey, ChildEntry>
+  observers: Set<ChildObserver> | undefined
+  scope: Scope.Closeable | undefined
+}
+
+export const matchesChild = (
+  entry: ChildEntry,
+  child: ChildSelector
+): entry is Extract<ChildEntry, { readonly _tag: "Started" }> =>
+  entry._tag === "Started" && (typeof child === "string" || (
+    entry.descriptor !== undefined &&
+    entry.descriptor.id === child.id &&
+    entry.descriptor.machine === child.machine
+  ))
+
+export const selectRegistryChild = (
+  registry: ChildRegistry,
+  id: string,
+  child: ChildSelector
+): ChildObservation => {
+  if (registry.closed) return Option.none()
+  const entry = registry.children.get(id)
+  return entry !== undefined && matchesChild(entry, child) ? Option.some(entry.ref) : Option.none()
+}
+
+export const publishRegistryChange = (registry: ChildRegistry): void => {
+  if (registry.observers === undefined) return
+  for (const observer of registry.observers) {
+    offerChildObservation(observer, selectRegistryChild(registry, observer.id, observer.child))
+  }
+}
+
+export const unregisterChild = (registry: ChildRegistry, key: ChildKey, token: symbol): void => {
+  const entry = registry.children.get(key)
+  if (entry === undefined || entry.token !== token) return
+  registry.children.delete(key)
+  if (typeof key === "string") publishRegistryChange(registry)
+}
+
+export const registerChild = (
+  registry: ChildRegistry,
+  key: ChildKey,
+  token: symbol,
+  ref: MachineRef<any, any, any, any>,
+  descriptor: ChildDescriptor | undefined
+): boolean => {
+  const entry = registry.children.get(key)
+  if (registry.closed || entry === undefined || entry._tag !== "Starting" || entry.token !== token) {
+    return false
+  }
+  registry.children.delete(key)
+  const started: ChildEntry = entry.ownerKey === undefined
+    ? { _tag: "Started", token, descriptor, ref }
+    : {
+      _tag: "Started",
+      token,
+      descriptor,
+      ref,
+      ownerKey: entry.ownerKey,
+      ownerPath: entry.ownerPath!,
+      ownerActive: entry.ownerActive === true
+    }
+  registry.children.set(key, started)
+  if (typeof key === "string") publishRegistryChange(registry)
+  return true
+}

--- a/packages/effect-machine/src/internal/machine/cluster.ts
+++ b/packages/effect-machine/src/internal/machine/cluster.ts
@@ -16,6 +16,7 @@ import type { Checkpoint, ClusterMachine, LoadResult } from "../../unstable/clus
 import * as internalMachine from "./machine.js"
 import * as Protocol from "./protocol.js"
 import type { EnsureExecutable } from "./readiness.js"
+import type { ExcludeCompatibleRuntime } from "./requirements.js"
 
 type EntityAddress = EntityAddress.EntityAddress
 type PersistenceError = ClusterError.PersistenceError
@@ -98,16 +99,6 @@ type SendRpc<Events extends ReadonlyArray<Machine.Machine.TaggedSchema>> = Rpc.R
 type MachineEvents<M extends Machine.Machine.Any> = Machine.Machine.InputEvents<M>
 
 type MachineEmits<M extends Machine.Machine.Any> = Machine.Machine.Emits<M>
-
-type IsAny<A> = 0 extends (1 & A) ? true : false
-
-type ExcludeCompatibleRuntime<Requirements, Events, Emits> = Requirements extends Machine.Runtime.Requirement<
-  infer RequiredEvents,
-  infer RequiredEmits
-> ? IsAny<Requirements> extends true ? Requirements
-  : [RequiredEvents] extends [Events] ? [RequiredEmits] extends [Emits] ? never : Requirements
-  : Requirements
-  : Requirements
 
 const hasInvokes = (machine: Machine.Machine.Any): boolean =>
   Reflect.ownKeys(machine.handlers).some((key) => machine.handlers[key as string]?.invoke !== undefined)

--- a/packages/effect-machine/src/internal/machine/configuration.ts
+++ b/packages/effect-machine/src/internal/machine/configuration.ts
@@ -642,6 +642,14 @@ export const normalizeConfigurationEffect = <const States extends Machine.StateS
 ): Effect.Effect<ActiveConfiguration, MachineSchemaDecodeError> =>
   configurationFromSnapshotEffect(machine, state).pipe(
     Effect.catchCause((cause) => {
+      if (Cause.hasInterrupts(cause)) {
+        return Effect.failCause(Cause.map(cause, (error) =>
+          error instanceof MachineSchemaDecodeError ? error : new MachineSchemaDecodeError({
+            machineId: machine.id,
+            boundary: "configuration",
+            cause: Cause.fail(error)
+          })))
+      }
       const error = Cause.findErrorOption(cause)
       return Option.isSome(error) && error.value instanceof MachineSchemaDecodeError
         ? Effect.fail(error.value)

--- a/packages/effect-machine/src/internal/machine/invocation.ts
+++ b/packages/effect-machine/src/internal/machine/invocation.ts
@@ -10,6 +10,7 @@ import * as Stream from "effect/Stream"
 import type { ChildMachine, ChildOwner, Inspection, Logic, Machine } from "../../Machine.js"
 import * as Configuration from "./configuration.js"
 import { InfiniteTransitionError, MachineSchemaDecodeError, StoppedError } from "./errors.js"
+import * as InvocationDefinition from "./invocationDefinition.js"
 import * as InvocationEvent from "./invocationEvent.js"
 import * as Planner from "./planner.js"
 import * as Runtime from "./runtime.js"
@@ -74,7 +75,7 @@ const makeChildOwner = (scope: Runtime.ProcessScope<any>): ChildOwner<any> => ({
 })
 
 const resolveOne = (
-  raw: Record<PropertyKey, any>,
+  raw: InvocationDefinition.InvocationDefinition,
   context: Machine.InvokeContext<any, any, any, any>,
   path: string
 ): AnyConfig => {
@@ -134,7 +135,7 @@ const resolveOne = (
     }
   }
   if ("child" in raw) {
-    const descriptor = raw.child as ChildMachine.Any
+    const descriptor = raw.child
     return {
       id: descriptor.id,
       address: descriptor.id,
@@ -148,7 +149,8 @@ const resolveOne = (
       onSnapshot: raw.onSnapshot
     }
   }
-  throw new Error("Machine invoke must define exactly one of effect, stream, after, logic, or child")
+  const unsupported: never = raw
+  throw new Error(`Unsupported captured machine invocation: ${String(unsupported)}`)
 }
 
 /** @internal */
@@ -266,12 +268,12 @@ const startStaticChild = (
   scope: Runtime.ProcessScope<any>,
   ownedChildren: Runtime.OwnedChildRuntime,
   path: string,
-  raw: Record<PropertyKey, any>
+  raw: Extract<InvocationDefinition.InvocationDefinition, { readonly child: ChildMachine.Any }>
 ): Effect.Effect<void, any, any> => {
   // A zero-input child has no entry-context dependency. Reuse the descriptor's
   // source function so each running parent does not retain a resolved config
   // object and an otherwise redundant source closure.
-  const descriptor = raw.child as ChildMachine.Any
+  const descriptor = raw.child
   return startResolved(
     scope,
     ownedChildren,
@@ -313,7 +315,9 @@ export const startAll = (
         ancestors: Configuration.getParentValues(machine, configuration, path),
         event
       }
-      return InvocationEvent.definitions(Configuration.getStateConfigByPath(machine, path)?.invoke).map((definition) =>
+      return InvocationDefinition.definitions(Configuration.getStateConfigByPath(machine, path)?.invoke).map((
+        definition
+      ) =>
         "child" in definition && !("input" in definition)
           ? startStaticChild(scope, ownedChildren, path, definition)
           : start(scope, ownedChildren, path, resolveOne(definition, context, path))

--- a/packages/effect-machine/src/internal/machine/invocationDefinition.ts
+++ b/packages/effect-machine/src/internal/machine/invocationDefinition.ts
@@ -1,0 +1,52 @@
+import type * as Duration from "effect/Duration"
+import type * as Effect from "effect/Effect"
+import type * as Stream from "effect/Stream"
+import type { ChildMachine, Logic, Machine } from "../../Machine.js"
+import type { EventTransition } from "./transition.js"
+
+// Source callbacks cross the erased machine-definition boundary here. Their
+// state, event, error and service relationships are checked by the public builder.
+type Context = Machine.InvokeContext<any, any, any, any>
+interface Outcomes {
+  readonly onDone?: EventTransition<any, any, any, any>
+  readonly onFailure?: EventTransition<any, any, any, any>
+  readonly onElement?: EventTransition<any, any, any, any>
+  readonly onSnapshot?: EventTransition<any, any, any, any>
+}
+
+export type InvocationDefinition =
+  & Outcomes
+  & (
+    | { readonly id: string; readonly effect: (context: Context) => Effect.Effect<unknown, unknown, unknown> }
+    | { readonly id: string; readonly stream: (context: Context) => Stream.Stream<unknown, unknown, unknown> }
+    | { readonly id: string; readonly after: Duration.Input | ((context: Context) => Duration.Input) }
+    | {
+      readonly id: string
+      readonly address: string
+      readonly logic: Logic<any, any, any, any, any> | ((context: Context) => Logic<any, any, any, any, any>)
+    }
+    | { readonly child: ChildMachine.Any; readonly input?: unknown }
+  )
+
+/** Captures exactly one invocation source before any planner or runtime sees it. */
+export const capture = (config: Record<PropertyKey, unknown>, path: string): InvocationDefinition => {
+  const sources = ["effect", "stream", "after", "logic", "child"].filter((key) => key in config)
+  if (sources.length !== 1) {
+    throw new Error(`Machine invocation for state "${path}" must define exactly one source`)
+  }
+  if (sources[0] !== "child" && typeof config.id !== "string") {
+    throw new Error(`Machine invocation for state "${path}" requires a string id`)
+  }
+  if ((sources[0] === "effect" || sources[0] === "stream") && typeof config[sources[0]] !== "function") {
+    throw new Error(`Machine invocation for state "${path}" requires a source callback`)
+  }
+  return Object.freeze(config) as unknown as InvocationDefinition
+}
+
+/** Only captured state handlers cross this erased boundary. */
+export const definitions = (invoke: unknown): ReadonlyArray<InvocationDefinition> =>
+  invoke === undefined
+    ? []
+    : Array.isArray(invoke)
+    ? invoke as ReadonlyArray<InvocationDefinition>
+    : [invoke as InvocationDefinition]

--- a/packages/effect-machine/src/internal/machine/invocationEvent.ts
+++ b/packages/effect-machine/src/internal/machine/invocationEvent.ts
@@ -78,11 +78,3 @@ export const snapshot = (path: string, id: string, value: unknown): InvocationEv
 /** @internal */
 export const isInvocationEvent = (value: unknown): value is InvocationEvent =>
   typeof value === "object" && value !== null && InvocationEventTypeId in value
-
-/** @internal */
-export const definitions = (invoke: unknown): ReadonlyArray<Record<PropertyKey, any>> => {
-  if (invoke === undefined) return []
-  return Array.isArray(invoke)
-    ? invoke as ReadonlyArray<Record<PropertyKey, any>>
-    : [invoke as Record<PropertyKey, any>]
-}

--- a/packages/effect-machine/src/internal/machine/machine.ts
+++ b/packages/effect-machine/src/internal/machine/machine.ts
@@ -21,7 +21,6 @@ import type {
   MachineSchemaEncodeError,
   Parent,
   ParentMode,
-  Runtime,
   RuntimeOutcome,
   SpawnOptions,
   StoppedError
@@ -29,14 +28,23 @@ import type {
 import * as Activities from "./activities.js"
 import * as Configuration from "./configuration.js"
 import type { ChildAlreadyExistsError, InfiniteTransitionError, StartupError } from "./errors.js"
+import * as InvocationDefinition from "./invocationDefinition.js"
 import * as internalPlanner from "./planner.js"
 import * as internalProcess from "./process.js"
 import * as Protocol from "./protocol.js"
 import type { EnsureExecutable } from "./readiness.js"
+import type { ExcludeCompatibleRuntime } from "./requirements.js"
 import * as internalRuntime from "./runtime.js"
 import * as Serialization from "./serialization.js"
 import * as StateDefinition from "./stateDefinition.js"
-import { ChildMachineLogicTypeId, SnapshotBuilderStateTypeId } from "./symbols.js"
+import { ChildMachineLogicTypeId } from "./symbols.js"
+import {
+  getLocalTargetScope,
+  getTargetBuilderNode,
+  makeSnapshotBuilder,
+  makeTargetBuilder,
+  withFrom
+} from "./targetBuilder.js"
 import * as Topology from "./topology.js"
 
 export {
@@ -56,15 +64,8 @@ export const InvokeTypeId: unique symbol = Symbol.for("effect/Machine/Invoke")
 export const TransitionTypeId: unique symbol = Symbol.for("effect/Machine/Transition")
 const InvokeBuilderDescriptorTypeId: unique symbol = Symbol("effect/Machine/InvokeBuilderDescriptor")
 const ChildMachineTypeId = "~effect/Machine/ChildMachine"
-type IsAny<A> = 0 extends 1 & A ? true : false
 type MachineRuntimeRequirement = internalRuntime.MachineRuntime
-type ExcludeCompatibleRuntime<Requirements, Events, Emits> = Requirements extends Runtime.Requirement<
-  infer RequiredEvents,
-  infer RequiredEmits
-> ? IsAny<Requirements> extends true ? Requirements
-  : [RequiredEvents] extends [Events] ? [RequiredEmits] extends [Emits] ? never : Requirements
-  : Requirements
-  : Requirements
+
 type SpawnRequirements<Requirements> = Exclude<Requirements, Scope.Scope>
 type SpawnIdError<Options extends SpawnOptions> = "id" extends keyof Options ? Options extends {
     readonly id?: infer Id
@@ -1005,9 +1006,9 @@ const captureInvokeDefinition = (
         captured[key] = captureTransition(captured[key], stateNodes, path, key)
       }
     }
-    return captured
+    return InvocationDefinition.capture(captured, path)
   })
-  if (Array.isArray(authored)) return capturedDefinitions
+  if (Array.isArray(authored)) return Object.freeze(capturedDefinitions)
   return capturedDefinitions[0]
 }
 
@@ -1028,6 +1029,14 @@ const flattenHandlers = (
       throw new Error(`Machine expected state "${path}" handler to be an object`)
     }
     const { states: childConfig, ...stateConfig } = nodeConfig as Record<string, unknown>
+    if (typeof stateConfig.history === "object" && stateConfig.history !== null) {
+      stateConfig.history = Object.freeze(Object.fromEntries(
+        Object.entries(stateConfig.history).map(([key, entry]) => [
+          key,
+          typeof entry === "object" && entry !== null ? Object.freeze({ ...entry }) : entry
+        ])
+      ))
+    }
     const on = stateConfig.on
     if (typeof on === "object" && on !== null) {
       const capturedOn = captureEventHandlers(on, stateNodes, path)
@@ -1113,511 +1122,6 @@ export const isFinal = <
   >,
   state: Machine.Snapshot<States>
 ): state is Machine.SnapshotContainingFinal<States, FinalStates> => internalPlanner.isFinal(machine as any, state)
-
-type SnapshotBuilderOptions = {
-  readonly mode: "initial" | "full"
-  readonly prefix: string
-}
-
-type FromMethodKind = "leaf" | "nested"
-
-const withFrom = <Method extends (value: unknown, ...args: ReadonlyArray<any>) => unknown>(
-  method: Method,
-  kind: FromMethodKind,
-  valued: boolean
-): {
-  readonly decoded?: Method
-  readonly from: (...args: ReadonlyArray<any>) => unknown
-} => {
-  const builder: Record<string, unknown> = {}
-  if (valued) {
-    Object.defineProperty(builder, "decoded", {
-      value: method,
-      enumerable: false
-    })
-  }
-  Object.defineProperty(builder, "from", {
-    value: (...args: ReadonlyArray<any>) => {
-      if (!valued) {
-        return method(undefined, ...args)
-      }
-      const omitted = args.length === 0 || (kind === "nested" && args.length === 1 && typeof args[0] === "function")
-      const input = omitted ? {} : args[0]
-      const rest = omitted ? args : args.slice(1)
-      return method(Topology.makeStateInput(input), ...rest)
-    },
-    enumerable: false
-  })
-  return builder as {
-    readonly decoded?: Method
-    readonly from: (...args: ReadonlyArray<any>) => unknown
-  }
-}
-
-const withInitial = <Builder extends object>(
-  builder: Builder,
-  path: string,
-  valued: boolean,
-  values?: Readonly<Record<string, unknown>>
-): Builder => {
-  const initial = withFrom(
-    (value: unknown) => Topology.makeInitialTarget(path, value, values),
-    "leaf",
-    valued
-  )
-  Object.defineProperty(builder, "initial", {
-    value: initial,
-    enumerable: false
-  })
-  return builder
-}
-
-const makeSnapshotBuilder = (
-  states: Machine.StateTree,
-  options: SnapshotBuilderOptions
-): unknown => {
-  const builder: Record<string, unknown> = {}
-  for (const key of Object.keys(states)) {
-    const definition = states[key]!
-    const pseudoType = (definition as { readonly type?: unknown }).type
-    if (pseudoType === "history") {
-      continue
-    }
-    const path = options.prefix === "" ? key : `${options.prefix}.${key}`
-    if (pseudoType === "choice") {
-      builder[key] = () => Topology.makeChoiceTarget(path, getParentPathRuntime(path))
-      continue
-    }
-    const node = Topology.getStateNodeDefinition(path, definition)
-    const method = withFrom(
-      (value: unknown, selector?: (builder: unknown) => unknown) =>
-        makeSnapshotForNode(definition, key, value, selector, options),
-      node.states === undefined ? "leaf" : "nested",
-      node.schema !== undefined
-    )
-    builder[key] = node.states === undefined || options.mode !== "full" || options.prefix !== ""
-      ? method
-      : withInitial(method, path, node.schema !== undefined)
-  }
-  return builder
-}
-
-const makeParallelSnapshotBuilder = (
-  states: Machine.StateTree,
-  options: SnapshotBuilderOptions,
-  regions: Readonly<Record<string, unknown>>
-): unknown => {
-  const builder: Record<string, unknown> = {}
-  Object.defineProperty(builder, SnapshotBuilderStateTypeId, {
-    value: regions,
-    enumerable: false
-  })
-  for (const key of Object.keys(states)) {
-    const definition = states[key]!
-    const pseudoType = (definition as { readonly type?: unknown }).type
-    if (pseudoType === "history" || pseudoType === "choice") {
-      continue
-    }
-    if (hasProperty(regions, key)) {
-      continue
-    }
-    const path = options.prefix === "" ? key : `${options.prefix}.${key}`
-    const node = Topology.getStateNodeDefinition(path, definition)
-    const method = withFrom(
-      (value: unknown, selector?: (builder: unknown) => unknown) => {
-        const nextRegions: Record<string, unknown> = {}
-        for (const regionKey of Object.keys(regions)) {
-          nextRegions[regionKey] = regions[regionKey]
-        }
-        nextRegions[key] = makeSnapshotForNode(definition, key, value, selector, options)
-        return makeParallelSnapshotBuilder(states, options, nextRegions)
-      },
-      node.states === undefined ? "leaf" : "nested",
-      node.schema !== undefined
-    )
-    builder[key] = method
-  }
-  return builder
-}
-
-const getParallelSnapshotBuilderRegions = (
-  path: string,
-  states: Machine.StateTree,
-  builder: unknown
-): Readonly<Record<string, unknown>> => {
-  if (typeof builder !== "object" || builder === null || !hasProperty(builder, SnapshotBuilderStateTypeId)) {
-    throw new Error(`Machine expected parallel state "${path}" builder callback to return a builder`)
-  }
-  const regions = (builder as { readonly [SnapshotBuilderStateTypeId]: Readonly<Record<string, unknown>> })[
-    SnapshotBuilderStateTypeId
-  ]
-  for (const key of Object.keys(states)) {
-    const pseudoType = (states[key] as { readonly type?: unknown }).type
-    if (pseudoType === "history" || pseudoType === "choice") {
-      continue
-    }
-    if (!hasProperty(regions, key)) {
-      throw new Error(`Machine expected parallel state "${path}" builder callback to provide region "${key}"`)
-    }
-  }
-  return regions
-}
-
-const makeSnapshotForNode = (
-  definition: Machine.TaggedSchema | Machine.StateNodeConfig,
-  key: string,
-  value: unknown,
-  selector: ((builder: unknown) => unknown) | undefined,
-  options: SnapshotBuilderOptions
-): Record<string, unknown> => {
-  const path = options.prefix === "" ? key : `${options.prefix}.${key}`
-  const node = Topology.getStateNodeDefinition(path, definition)
-  const snapshot: Record<string, unknown> = {
-    path,
-    value
-  }
-  if (node.states === undefined) {
-    return snapshot
-  }
-  if (selector === undefined) {
-    throw new Error(`Machine expected state "${path}" builder to provide active child states`)
-  }
-  if (node.type === "parallel") {
-    const builder = makeParallelSnapshotBuilder(node.states, { ...options, prefix: path }, {})
-    const selected = selector(builder)
-    snapshot.states = getParallelSnapshotBuilderRegions(path, node.states, selected)
-    return snapshot
-  }
-  const childStates = options.mode === "initial" && node.initial !== undefined
-    ? { [node.initial]: node.states[node.initial]! }
-    : node.states
-  const selected = selector(makeSnapshotBuilder(childStates, { ...options, prefix: path }))
-  snapshot.state = selected
-  return snapshot
-}
-
-const getTargetBuilderNode = (
-  stateNodes: Machine.StateNodes,
-  path: string
-): Machine.StateNode => {
-  const node = stateNodes.byPath.get(path)
-  if (node === undefined) {
-    throw new Error(`Machine expected state path "${path}" to exist`)
-  }
-  return node
-}
-
-const getLocalTargetScope = (
-  stateNodes: Machine.StateNodes,
-  source: string
-): string | undefined => {
-  let current: string | undefined = source
-  while (current !== undefined) {
-    const node = stateNodes.byPath.get(current)
-    if (node === undefined) {
-      return undefined
-    }
-    if (node.type === "compound") {
-      return node.path
-    }
-    current = node.parent
-  }
-  return undefined
-}
-
-const hasTargetValues = (
-  values: Readonly<Record<string, unknown>> | undefined
-): values is Readonly<Record<string, unknown>> => values !== undefined && Object.keys(values).length > 0
-
-const makeTargetWithValues = (
-  path: string,
-  value: unknown,
-  values: Readonly<Record<string, unknown>> | undefined
-): Machine.Target<any, any> =>
-  hasTargetValues(values)
-    ? Topology.makeTarget(path as any, value as any, { values: values as any })
-    : Topology.makeTarget(path as any, value as any)
-
-const getTargetBuilderDefinition = (
-  states: Machine.StateTree,
-  targetPath: string
-): Machine.TaggedSchema | Machine.StateNodeConfig => {
-  let children = states
-  let path = ""
-  let definition: Machine.TaggedSchema | Machine.StateNodeConfig | undefined
-  for (const key of targetPath.split(".")) {
-    if (!hasProperty(children, key)) {
-      throw new Error(`Machine expected state path "${targetPath}" to exist`)
-    }
-    definition = children[key]!
-    path = path === "" ? key : `${path}.${key}`
-    const node = Topology.getStateNodeDefinition(path, definition)
-    children = node.states ?? {}
-  }
-  return definition!
-}
-
-const makeParallelTarget = (
-  states: Machine.StateTree,
-  node: Machine.StateNode,
-  value: unknown,
-  selector: ((builder: unknown) => unknown) | undefined,
-  values: Readonly<Record<string, unknown>> | undefined
-): Machine.Target<any, any> => {
-  if (selector === undefined) {
-    throw new Error(`Machine expected parallel target "${node.path}" builder to provide every active region`)
-  }
-  const snapshot = makeSnapshotForNode(
-    getTargetBuilderDefinition(states, node.path),
-    node.key,
-    value,
-    selector,
-    { mode: "full", prefix: node.parent ?? "" }
-  )
-  return Topology.makeTarget(node.path as any, value as any, {
-    snapshot: snapshot as any,
-    values: values as any
-  })
-}
-
-const extendTargetValues = (
-  values: Readonly<Record<string, unknown>> | undefined,
-  path: string,
-  value: unknown
-): Readonly<Record<string, unknown>> => {
-  const next: Record<string, unknown> = {}
-  if (values !== undefined) {
-    for (const key of Object.keys(values)) {
-      next[key] = values[key]
-    }
-  }
-  next[path] = value
-  return next
-}
-
-const makeLocalTargetChildBuilder = (
-  states: Machine.StateTree,
-  stateNodes: Machine.StateNodes,
-  parentPath: string,
-  values: Readonly<Record<string, unknown>> | undefined,
-  source: string
-): unknown => {
-  const parent = getTargetBuilderNode(stateNodes, parentPath)
-  const builder: Record<string, unknown> = {}
-  for (
-    const childPath of Array.from(stateNodes.byPath.values())
-      .filter((node) => node.parent === parent.path && node.type !== "history")
-      .map((node) => node.path)
-  ) {
-    const child = getTargetBuilderNode(stateNodes, childPath)
-    if (child.type === "choice") {
-      builder[child.key] = () => Topology.makeChoiceTarget(child.path, parent.path, values)
-      continue
-    }
-    const method = withFrom(
-      (value: unknown, selector?: (builder: unknown) => unknown) => {
-        if (child.type === "atomic" || child.type === "final") {
-          return makeTargetWithValues(child.path, value, values)
-        }
-        if (child.type === "parallel") {
-          if (source !== child.path && !source.startsWith(`${child.path}.`)) {
-            return makeParallelTarget(states, child, value, selector, values)
-          }
-          if (selector === undefined) {
-            throw new Error(`Machine expected target "${child.path}" builder to provide an active child state`)
-          }
-          return selector(makeLocalTargetChildBuilder(
-            states,
-            stateNodes,
-            child.path,
-            child.schema === undefined ? values : extendTargetValues(values, child.path, value),
-            source
-          ))
-        }
-        if (selector === undefined) {
-          throw new Error(`Machine expected target "${child.path}" builder to provide an active child state`)
-        }
-        return selector(makeLocalTargetChildBuilder(
-          states,
-          stateNodes,
-          child.path,
-          child.schema === undefined ? values : extendTargetValues(values, child.path, value),
-          source
-        ))
-      },
-      child.type === "atomic" || child.type === "final" ? "leaf" : "nested",
-      child.schema !== undefined
-    )
-    builder[child.key] = child.type === "atomic" || child.type === "final"
-      ? method
-      : withInitial(method, child.path, child.schema !== undefined, values)
-  }
-  return builder
-}
-
-const makeLocalTargetBuilder = (
-  states: Machine.StateTree,
-  stateNodes: Machine.StateNodes,
-  source: string
-): unknown => {
-  const scope = getLocalTargetScope(stateNodes, source)
-  if (scope === undefined) {
-    return {}
-  }
-  const builder = makeLocalTargetChildBuilder(states, stateNodes, scope, undefined, source) as Record<string, unknown>
-  const scopeNode = getTargetBuilderNode(stateNodes, scope)
-  if (scopeNode.schema !== undefined) {
-    builder.with = withFrom(
-      (value: unknown, selector?: (builder: unknown) => unknown) => {
-        if (selector === undefined) {
-          throw new Error(`Machine expected target "${scope}" builder to provide an active child state`)
-        }
-        return selector(makeLocalTargetChildBuilder(states, stateNodes, scope, { [scope]: value }, source))
-      },
-      "nested",
-      true
-    )
-  }
-  return builder
-}
-
-const addBranchTargetChildren = (
-  builder: Record<string, unknown>,
-  states: Machine.StateTree,
-  stateNodes: Machine.StateNodes,
-  parentPath: string,
-  values: Readonly<Record<string, unknown>> | undefined,
-  source: string
-): void => {
-  const parent = getTargetBuilderNode(stateNodes, parentPath)
-  for (
-    const childPath of Array.from(stateNodes.byPath.values())
-      .filter((node) => node.parent === parent.path && node.type !== "history")
-      .map((node) => node.path)
-  ) {
-    const child = getTargetBuilderNode(stateNodes, childPath)
-    if (child.type === "choice") {
-      builder[child.key] = () => Topology.makeChoiceTarget(child.path, parent.path, values)
-      continue
-    }
-    builder[child.key] = makeBranchTargetNodeBuilder(states, stateNodes, child.path, values, source)
-  }
-}
-
-const makeBranchTargetNodeBuilder = (
-  states: Machine.StateTree,
-  stateNodes: Machine.StateNodes,
-  path: string,
-  values: Readonly<Record<string, unknown>> | undefined,
-  source: string
-): unknown => {
-  const node = getTargetBuilderNode(stateNodes, path)
-  if (node.type === "atomic" || node.type === "final") {
-    return withFrom(
-      (value: unknown) => makeTargetWithValues(node.path, value, values),
-      "leaf",
-      node.schema !== undefined
-    )
-  }
-  const builder = withFrom(
-    (value: unknown, selector?: (builder: unknown) => unknown) => {
-      if (node.type === "parallel") {
-        if (source !== node.path && !source.startsWith(`${node.path}.`)) {
-          return makeParallelTarget(states, node, value, selector, values)
-        }
-        if (selector === undefined) {
-          throw new Error(`Machine expected target "${node.path}" builder to provide an active child state`)
-        }
-        const nextBuilder: Record<string, unknown> = {}
-        addBranchTargetChildren(
-          nextBuilder,
-          states,
-          stateNodes,
-          node.path,
-          node.schema === undefined ? values : extendTargetValues(values, node.path, value),
-          source
-        )
-        return selector(nextBuilder)
-      }
-      if (selector === undefined) {
-        throw new Error(`Machine expected target "${node.path}" builder to provide an active child state`)
-      }
-      const nextBuilder: Record<string, unknown> = {}
-      addBranchTargetChildren(
-        nextBuilder,
-        states,
-        stateNodes,
-        node.path,
-        node.schema === undefined ? values : extendTargetValues(values, node.path, value),
-        source
-      )
-      return selector(nextBuilder)
-    },
-    "nested",
-    node.schema !== undefined
-  ) as unknown as Record<string, unknown>
-  withInitial(builder, node.path, node.schema !== undefined, values)
-  if (node.type !== "parallel" || source === node.path || source.startsWith(`${node.path}.`)) {
-    addBranchTargetChildren(builder, states, stateNodes, node.path, values, source)
-  }
-  return builder
-}
-
-const makeBranchTargetBuilder = (
-  states: Machine.StateTree,
-  stateNodes: Machine.StateNodes,
-  source: string
-): unknown => {
-  const rootPath = source.split(".")[0]!
-  const root = getTargetBuilderNode(stateNodes, rootPath)
-  return {
-    [root.key]: makeBranchTargetNodeBuilder(states, stateNodes, root.path, undefined, source)
-  }
-}
-
-const makeHistoryTargetBuilder = (
-  states: Machine.StateTree,
-  prefix: string
-): unknown => {
-  const builder: Record<string, unknown> = {}
-  for (const key of Object.keys(states)) {
-    const path = prefix === "" ? key : `${prefix}.${key}`
-    const definition = Topology.getStateNodeDefinition(path, states[key]!)
-    if (definition.type === "history") {
-      const parent = getParentPathRuntime(path)
-      builder[key] = () => Topology.makeHistoryTarget(path, parent)
-      continue
-    }
-    if (definition.states !== undefined) {
-      builder[key] = makeHistoryTargetBuilder(definition.states, path)
-    }
-  }
-  return builder
-}
-
-const getParentPathRuntime = (path: string): string => {
-  const separator = path.lastIndexOf(".")
-  if (separator < 0) {
-    throw new Error(`Machine expected history state "${path}" to have an active parent`)
-  }
-  return path.slice(0, separator)
-}
-
-const makeTargetBuilder = <const States extends Machine.StateSchemas>(
-  states: States,
-  stateNodes: Machine.StateNodes
-) => {
-  const full = makeSnapshotBuilder(states, { mode: "full", prefix: "" }) as Machine.FullTargetBuilder<States>
-  const history = makeHistoryTargetBuilder(states, "") as Machine.HistoryTargetBuilder<States>
-  return <Source extends Machine.StateNodeIdentifier<States>>(source: Source): Machine.TargetBuilder<States, Source> =>
-    ({
-      none: Topology.makeNoTarget,
-      local: makeLocalTargetBuilder(states, stateNodes, source),
-      branch: makeBranchTargetBuilder(states, stateNodes, source),
-      full,
-      history
-    }) as Machine.TargetBuilder<States, Source>
-}
 
 const makeInitialSelector = (stateNodes: Machine.StateNodes): unknown => {
   const selector: Record<string, unknown> = {}
@@ -1851,19 +1355,20 @@ export const make: Make = (<
   }
 ): MakeResult<States, InputEvents, Emits, Input, InitialE, InitialR, InternalEvents, ParentDeclaration> => {
   StateDefinition.validateStateDefinitions(config.states, "Machine.make")
+  const states = StateDefinition.captureStateDefinitions(config.states)
   const self = Object.create(Proto)
-  self.states = config.states
+  self.states = states
   self.events = config.events
   self.internalEvents = config.internalEvents ?? Protocol.makeEventProtocol("internal", [] as const)
   self.emittedEvents = config.emittedEvents ?? Protocol.makeEventProtocol("emitted", [] as const)
   self.parent = config.parent
   self.input = config.input
   self.id = config.id
-  self.stateNodes = Topology.compileStateNodes(config.states)
-  const compiledInitial = compileInitial(config.initial, config.states, self.stateNodes)
+  self.stateNodes = Topology.compileStateNodes(states)
+  const compiledInitial = compileInitial(config.initial, states, self.stateNodes)
   self.initial = compiledInitial.initial
   self.initialDefinition = compiledInitial.definition
-  self.makeTargetBuilder = makeTargetBuilder(config.states, self.stateNodes)
+  self.makeTargetBuilder = makeTargetBuilder(states, self.stateNodes)
   self.handlers = Object.create(null)
   self.handle = makeHandle(self)
   Protocol.setProtocol(self)

--- a/packages/effect-machine/src/internal/machine/planner.ts
+++ b/packages/effect-machine/src/internal/machine/planner.ts
@@ -40,6 +40,7 @@ import {
 } from "./configuration.js"
 import { InfiniteTransitionError, MachineSchemaDecodeError, StartupError, StoppedError } from "./errors.js"
 import { getStateInitializeValues, makeStateInitializeBuilder } from "./initialization.js"
+import * as InvocationDefinition from "./invocationDefinition.js"
 import * as InvocationEvent from "./invocationEvent.js"
 import { decodeEventSync, decodeInputSync, decodeStateValueSync } from "./protocol.js"
 import { InitialEventTypeId } from "./symbols.js"
@@ -59,6 +60,11 @@ import {
   makeTarget,
   TargetSnapshotTypeId
 } from "./topology.js"
+import type {
+  EventTransition,
+  TransitionEvaluator,
+  TransitionHandler as CapturedTransitionHandler
+} from "./transition.js"
 
 export type MicrostepPlan<State, Event, E, R> = {
   readonly next: State
@@ -104,21 +110,12 @@ export type MacrostepPlan<State, Event, E, R, Output> =
     }
   )
 
-export type TransitionHandler<States extends Machine.StateSchemas, E, R, Context> = (
-  context: Context,
-  enqueue: Enqueue<any, any>
-) => Machine.HandlerResult<States, E, R> | Machine.Declined
-
-type TransitionEvaluation<States extends Machine.StateSchemas, E, R> = {
-  readonly result: Machine.HandlerResult<States, E, R> | Machine.Declined
-  readonly branchIndex: number
-  readonly branchKey: string | undefined
-}
-
-type TransitionEvaluator<States extends Machine.StateSchemas, E, R, Context> = (
-  context: Context,
-  enqueue: Enqueue<any, any>
-) => TransitionEvaluation<States, E, R>
+export type TransitionHandler<States extends Machine.StateSchemas, E, R, Context> = CapturedTransitionHandler<
+  States,
+  E,
+  R,
+  Context
+>
 
 type PlanningMachineReferences = {
   readonly self: MachineTarget<any>
@@ -169,16 +166,6 @@ const resolveMachineReferences = (
   rootMachineReferences.set(machine, root)
   return root
 }
-
-type EventTransition<States extends Machine.StateSchemas, E, R, Context> =
-  | TransitionHandler<States, E, R, Context>
-  | {
-    readonly reenter?: boolean
-    readonly declinable?: boolean
-    readonly targets?: ReadonlyArray<string>
-    readonly transition: TransitionHandler<States, E, R, Context>
-    readonly evaluate?: TransitionEvaluator<States, E, R, Context>
-  }
 
 export type MicrostepTransition<States extends Machine.StateSchemas, E, R, Context> = {
   readonly reenter: boolean
@@ -1024,7 +1011,7 @@ const selectInvocationTransition = <
 ): ReadonlyArray<SelectedTransition<States, E, R, any>> => {
   if (!configuration.active.has(event.path)) return []
   const config = machine.handlers[event.path] as Machine.AnyStateConfig | undefined
-  const invoke = InvocationEvent.definitions(config?.invoke).find((definition) => {
+  const invoke = InvocationDefinition.definitions(config?.invoke).find((definition) => {
     const id = "child" in definition ? definition.child?.id : definition.id
     return String(id) === event.id
   })

--- a/packages/effect-machine/src/internal/machine/process.ts
+++ b/packages/effect-machine/src/internal/machine/process.ts
@@ -16,18 +16,9 @@ import type { StoppedError } from "./errors.js"
 import * as ExecutionPlan from "./executionPlan.js"
 import * as Invocation from "./invocation.js"
 import * as internalPlanner from "./planner.js"
+import type { ExcludeCompatibleRuntime } from "./requirements.js"
 import * as internalRuntime from "./runtime.js"
 import * as Serialization from "./serialization.js"
-
-type IsAny<A> = 0 extends (1 & A) ? true : false
-
-type ExcludeCompatibleRuntime<Requirements, Events, Emits> = Requirements extends Runtime.Requirement<
-  infer RequiredEvents,
-  infer RequiredEmits
-> ? IsAny<Requirements> extends true ? Requirements
-  : [RequiredEvents] extends [Events] ? [RequiredEmits] extends [Emits] ? never : Requirements
-  : Requirements
-  : Requirements
 
 type ProcessEntry<States extends Machine.StateSchemas, Input extends Schema.Top> =
   | {

--- a/packages/effect-machine/src/internal/machine/protocol.ts
+++ b/packages/effect-machine/src/internal/machine/protocol.ts
@@ -24,9 +24,7 @@ interface MachineProtocolSchemas {
   readonly event: Schema.Top
   readonly emit: Schema.Top
   readonly eventConstructors: ReadonlySet<object>
-  readonly trustedEvents: WeakSet<object>
   readonly emissionConstructors: ReadonlySet<object>
-  readonly trustedEmissions: WeakSet<object>
 }
 
 interface EventProtocolDefinition {
@@ -171,9 +169,7 @@ export const setProtocol = (machine: Machine.Any): void => {
     event: Schema.Union(events),
     emit: Schema.Union(emittedEvents),
     eventConstructors: collectEventConstructors(events),
-    trustedEvents: new WeakSet(),
-    emissionConstructors: collectEventConstructors(emittedEvents),
-    trustedEmissions: new WeakSet()
+    emissionConstructors: collectEventConstructors(emittedEvents)
   })
 }
 
@@ -419,11 +415,6 @@ const decodeEventConstruction = (
           })
         )
       )
-    ),
-    Effect.tap((event) =>
-      Effect.sync(() =>
-        (boundary === "event" ? protocol.trustedEvents : protocol.trustedEmissions).add(event as object)
-      )
     )
   )
 }
@@ -453,12 +444,8 @@ const decodeEventConstructionSync = (
     boundary,
     event: String(construction._tag)
   })
-  ;(boundary === "event" ? protocol.trustedEvents : protocol.trustedEmissions).add(event as object)
   return event
 }
-
-const isTrustedEvent = (protocol: MachineProtocolSchemas, event: unknown): boolean =>
-  typeof event === "object" && event !== null && protocol.trustedEvents.has(event)
 
 export const decodeInput = <Input extends Schema.Top>(
   machine: Machine.Any,
@@ -478,10 +465,9 @@ export const decodeEvent = <const Events extends ReadonlyArray<Machine.TaggedSch
       MachineSchemaDecodeError
     >
   }
-  if (isTrustedEvent(protocol, event)) {
-    return Effect.succeed(event as Machine.EventOf<Events>)
-  }
   const eventName = getEventName(event)
+  // Decoded objects can escape to user code and be mutated. Validation is local
+  // to this delivery; object identity is never evidence of continued validity.
   return decodeBoundary<Machine.EventOf<Events>>(
     machine,
     protocol.event,
@@ -497,9 +483,6 @@ export const decodeEventSync = <const Events extends ReadonlyArray<Machine.Tagge
   const protocol = getProtocolSchemas(machine)
   if (isEventConstruction(event)) {
     return decodeEventConstructionSync(machine, protocol, event, "event") as Machine.EventOf<Events>
-  }
-  if (isTrustedEvent(protocol, event)) {
-    return event as Machine.EventOf<Events>
   }
   const eventName = getEventName(event)
   return decodeBoundarySync<Machine.EventOf<Events>>(
@@ -521,9 +504,6 @@ export const decodeEmit = <const Emits extends ReadonlyArray<Machine.TaggedSchem
       MachineSchemaDecodeError
     >
   }
-  if (typeof event === "object" && event !== null && protocol.trustedEmissions.has(event)) {
-    return Effect.succeed(event as Machine.EmitOf<Emits>)
-  }
   const eventName = getEventName(event)
   return decodeBoundary<Machine.EmitOf<Emits>>(
     machine,
@@ -540,9 +520,6 @@ export const decodeEmitSync = <const Emits extends ReadonlyArray<Machine.TaggedS
   const protocol = getProtocolSchemas(machine)
   if (isEventConstruction(event)) {
     return decodeEventConstructionSync(machine, protocol, event, "emission") as Machine.EmitOf<Emits>
-  }
-  if (typeof event === "object" && event !== null && protocol.trustedEmissions.has(event)) {
-    return event as Machine.EmitOf<Emits>
   }
   const eventName = getEventName(event)
   return decodeBoundarySync<Machine.EmitOf<Emits>>(

--- a/packages/effect-machine/src/internal/machine/requirements.ts
+++ b/packages/effect-machine/src/internal/machine/requirements.ts
@@ -1,0 +1,11 @@
+import type { Runtime } from "../../Machine.js"
+
+export type IsAny<A> = 0 extends (1 & A) ? true : false
+
+export type ExcludeCompatibleRuntime<Requirements, Events, Emits> = Requirements extends Runtime.Requirement<
+  infer RequiredEvents,
+  infer RequiredEmits
+> ? IsAny<Requirements> extends true ? Requirements
+  : [RequiredEvents] extends [Events] ? [RequiredEmits] extends [Emits] ? never : Requirements
+  : Requirements
+  : Requirements

--- a/packages/effect-machine/src/internal/machine/runtime.ts
+++ b/packages/effect-machine/src/internal/machine/runtime.ts
@@ -18,36 +18,25 @@ import * as Scope from "effect/Scope"
 import * as Stream from "effect/Stream"
 import * as SynchronizedRef from "effect/SynchronizedRef"
 import type * as Take from "effect/Take"
+import type { RuntimeOutcome as PublicRuntimeOutcome, RuntimeSnapshot as PublicRuntimeSnapshot } from "../../Machine.js"
 import type { ChildMachine, Inspection, Machine as MachineDefinition, MachineTarget } from "../../Machine.js"
+import {
+  type ChildDescriptor,
+  type ChildEntry,
+  type ChildKey,
+  type ChildObserver,
+  type ChildRegistry,
+  type ChildSelector,
+  matchesChild,
+  offerChildObservation,
+  registerChild,
+  selectRegistryChild,
+  takeChildObservations,
+  unregisterChild
+} from "./childRegistry.js"
 import { ChildAlreadyExistsError, StoppedError } from "./errors.js"
 import * as InspectionRuntime from "./inspectionRuntime.js"
 import { ChildMachineLogicTypeId } from "./symbols.js"
-
-type ChildDescriptor = {
-  readonly id: string
-  readonly machine: object
-}
-
-type ChildEntry =
-  | {
-    readonly _tag: "Starting"
-    readonly token: symbol
-    readonly ownerKey?: string
-    readonly ownerPath?: string
-    ownerActive?: boolean
-  }
-  | {
-    readonly _tag: "Started"
-    readonly token: symbol
-    readonly descriptor: ChildDescriptor | undefined
-    readonly ref: MachineRef<any, any, any, any>
-    readonly ownerKey?: string
-    readonly ownerPath?: string
-    ownerActive?: boolean
-  }
-
-type ChildSelector = string | ChildDescriptor
-type ChildKey = string | symbol
 
 /** @internal */
 export const activeSnapshotObserver: unique symbol = Symbol.for("effect/Machine/activeSnapshotObserver")
@@ -131,134 +120,7 @@ type InspectedOffer<Event> = (
   deferred?: Deferred.Deferred<AcknowledgedDelivery<unknown>, unknown>
 ) => Effect.Effect<void, StoppedError>
 
-type ChildObservation = Option.Option<MachineRef<any, any, any, any>>
-type ChildObservationBatch = [ChildObservation, ...Array<ChildObservation>]
-
-interface ChildObserver {
-  readonly child: ChildSelector
-  readonly id: string
-  values: ChildObservationBatch | undefined
-  waiter: Deferred.Deferred<void> | undefined
-}
-
-const offerChildObservation = (
-  observer: ChildObserver,
-  value: ChildObservation
-): void => {
-  if (observer.values === undefined) {
-    observer.values = [value]
-  } else {
-    observer.values.push(value)
-  }
-  if (observer.waiter !== undefined) {
-    const waiter = observer.waiter
-    observer.waiter = undefined
-    Deferred.doneUnsafe(waiter, Effect.void)
-  }
-}
-
-const takeChildObservations = (
-  observer: ChildObserver
-): Effect.Effect<ChildObservationBatch> =>
-  Effect.suspend(() => {
-    if (observer.values !== undefined) {
-      const values = observer.values
-      observer.values = undefined
-      return Effect.succeed(values)
-    }
-    const waiter = Deferred.makeUnsafe<void>()
-    observer.waiter = waiter
-    return Deferred.await(waiter).pipe(Effect.andThen(takeChildObservations(observer)))
-  })
-
-interface ChildRegistry {
-  closed: boolean
-  readonly children: Map<ChildKey, ChildEntry>
-  observers: Set<ChildObserver> | undefined
-  scope: Scope.Closeable | undefined
-}
-
-const matchesChild = (
-  entry: ChildEntry,
-  child: ChildSelector
-): entry is Extract<ChildEntry, { readonly _tag: "Started" }> =>
-  entry._tag === "Started" && (typeof child === "string" || (
-    entry.descriptor !== undefined &&
-    entry.descriptor.id === child.id &&
-    entry.descriptor.machine === child.machine
-  ))
-
-const selectRegistryChild = (
-  registry: ChildRegistry,
-  id: string,
-  child: ChildSelector
-): ChildObservation => {
-  if (registry.closed) return Option.none()
-  const entry = registry.children.get(id)
-  return entry !== undefined && matchesChild(entry, child) ? Option.some(entry.ref) : Option.none()
-}
-
-const publishRegistryChange = (registry: ChildRegistry): void => {
-  if (registry.observers === undefined) return
-  for (const observer of registry.observers) {
-    offerChildObservation(observer, selectRegistryChild(registry, observer.id, observer.child))
-  }
-}
-
-const unregisterChild = (registry: ChildRegistry, key: ChildKey, token: symbol): void => {
-  const entry = registry.children.get(key)
-  if (entry === undefined || entry.token !== token) return
-  registry.children.delete(key)
-  if (typeof key === "string") publishRegistryChange(registry)
-}
-
-const registerChild = (
-  registry: ChildRegistry,
-  key: ChildKey,
-  token: symbol,
-  ref: MachineRef<any, any, any, any>,
-  descriptor: ChildDescriptor | undefined
-): boolean => {
-  const entry = registry.children.get(key)
-  if (registry.closed || entry === undefined || entry._tag !== "Starting" || entry.token !== token) {
-    return false
-  }
-  registry.children.delete(key)
-  const started: ChildEntry = entry.ownerKey === undefined
-    ? { _tag: "Started", token, descriptor, ref }
-    : {
-      _tag: "Started",
-      token,
-      descriptor,
-      ref,
-      ownerKey: entry.ownerKey,
-      ownerPath: entry.ownerPath!,
-      ownerActive: entry.ownerActive === true
-    }
-  registry.children.set(key, started)
-  if (typeof key === "string") publishRegistryChange(registry)
-  return true
-}
-
-export type RuntimeSnapshot<State, Error = never, Output = never> =
-  | {
-    readonly status: "active"
-    readonly state: State
-  }
-  | {
-    readonly status: "done"
-    readonly state: State
-    readonly output: Output
-  }
-  | {
-    readonly status: "error"
-    readonly state: State
-    readonly cause: Cause.Cause<Error>
-  }
-  | {
-    readonly status: "stopped"
-    readonly state: State
-  }
+export type RuntimeSnapshot<State, Error = never, Output = never> = PublicRuntimeSnapshot<State, Error, Output>
 
 interface VersionedSnapshot<State, Error, Output> {
   readonly revision: number
@@ -274,38 +136,7 @@ type VersionedSnapshotBatch<State, Error, Output> = [
   ...Array<VersionedSnapshot<State, Error, Output>>
 ]
 
-export type RuntimeOutcome<State, Error = never, Output = never> =
-  | {
-    readonly _tag: "Done"
-    readonly output: Output
-    readonly snapshot: Extract<RuntimeSnapshot<State, Error, Output>, { readonly status: "done" }>
-  }
-  | {
-    readonly _tag: "Failure"
-    readonly error: Error
-    readonly cause: Cause.Cause<Error>
-    readonly snapshot: Extract<RuntimeSnapshot<State, Error, Output>, { readonly status: "error" }>
-  }
-  | {
-    readonly _tag: "Defect"
-    readonly defect: unknown
-    readonly cause: Cause.Cause<Error>
-    readonly snapshot: Extract<RuntimeSnapshot<State, Error, Output>, { readonly status: "error" }>
-  }
-  | {
-    readonly _tag: "Interrupted"
-    readonly cause: Cause.Cause<Error>
-    readonly snapshot: Extract<RuntimeSnapshot<State, Error, Output>, { readonly status: "error" }>
-  }
-  | {
-    readonly _tag: "Cause"
-    readonly cause: Cause.Cause<Error>
-    readonly snapshot: Extract<RuntimeSnapshot<State, Error, Output>, { readonly status: "error" }>
-  }
-  | {
-    readonly _tag: "Stopped"
-    readonly snapshot: Extract<RuntimeSnapshot<State, Error, Output>, { readonly status: "stopped" }>
-  }
+export type RuntimeOutcome<State, Error = never, Output = never> = PublicRuntimeOutcome<State, Error, Output>
 
 export interface MachineRef<out State, in Event, out Error = never, out Output = never, out Emitted = never> {
   readonly id: string

--- a/packages/effect-machine/src/internal/machine/serialization.ts
+++ b/packages/effect-machine/src/internal/machine/serialization.ts
@@ -206,6 +206,16 @@ const failEncodeCause = (
   machine: Machine.Any,
   cause: Cause.Cause<unknown>
 ): Effect.Effect<never, MachineSchemaEncodeError> => {
+  if (Cause.hasInterrupts(cause)) {
+    return Effect.failCause(
+      Cause.map(cause, (error) =>
+        error instanceof MachineSchemaEncodeError ? error : new MachineSchemaEncodeError({
+          machineId: machine.id,
+          boundary: "configuration",
+          cause: Cause.fail(error)
+        }))
+    )
+  }
   const error = Cause.findErrorOption(cause)
   return Option.isSome(error) && error.value instanceof MachineSchemaEncodeError
     ? Effect.fail(error.value)
@@ -222,6 +232,16 @@ const failDecodeCause = (
   machine: Machine.Any,
   cause: Cause.Cause<unknown>
 ): Effect.Effect<never, MachineSchemaDecodeError> => {
+  if (Cause.hasInterrupts(cause)) {
+    return Effect.failCause(
+      Cause.map(cause, (error) =>
+        error instanceof MachineSchemaDecodeError ? error : new MachineSchemaDecodeError({
+          machineId: machine.id,
+          boundary: "configuration",
+          cause: Cause.fail(error)
+        }))
+    )
+  }
   const error = Cause.findErrorOption(cause)
   return Option.isSome(error) && error.value instanceof MachineSchemaDecodeError
     ? Effect.fail(error.value)

--- a/packages/effect-machine/src/internal/machine/targetBuilder.ts
+++ b/packages/effect-machine/src/internal/machine/targetBuilder.ts
@@ -1,0 +1,510 @@
+/** Constructs decoded snapshots and transition targets from a captured state tree. */
+import { hasProperty } from "effect/Predicate"
+import type { Machine } from "../../Machine.js"
+import { SnapshotBuilderStateTypeId } from "./symbols.js"
+import * as Topology from "./topology.js"
+
+type SnapshotBuilderOptions = {
+  readonly mode: "initial" | "full"
+  readonly prefix: string
+}
+
+type FromMethodKind = "leaf" | "nested"
+
+export const withFrom = <Method extends (value: unknown, ...args: ReadonlyArray<any>) => unknown>(
+  method: Method,
+  kind: FromMethodKind,
+  valued: boolean
+): {
+  readonly decoded?: Method
+  readonly from: (...args: ReadonlyArray<any>) => unknown
+} => {
+  const builder: Record<string, unknown> = {}
+  if (valued) {
+    Object.defineProperty(builder, "decoded", {
+      value: method,
+      enumerable: false
+    })
+  }
+  Object.defineProperty(builder, "from", {
+    value: (...args: ReadonlyArray<any>) => {
+      if (!valued) {
+        return method(undefined, ...args)
+      }
+      const omitted = args.length === 0 || (kind === "nested" && args.length === 1 && typeof args[0] === "function")
+      const input = omitted ? {} : args[0]
+      const rest = omitted ? args : args.slice(1)
+      return method(Topology.makeStateInput(input), ...rest)
+    },
+    enumerable: false
+  })
+  return builder as {
+    readonly decoded?: Method
+    readonly from: (...args: ReadonlyArray<any>) => unknown
+  }
+}
+
+const withInitial = <Builder extends object>(
+  builder: Builder,
+  path: string,
+  valued: boolean,
+  values?: Readonly<Record<string, unknown>>
+): Builder => {
+  const initial = withFrom(
+    (value: unknown) => Topology.makeInitialTarget(path, value, values),
+    "leaf",
+    valued
+  )
+  Object.defineProperty(builder, "initial", {
+    value: initial,
+    enumerable: false
+  })
+  return builder
+}
+
+export const makeSnapshotBuilder = (
+  states: Machine.StateTree,
+  options: SnapshotBuilderOptions
+): unknown => {
+  const builder: Record<string, unknown> = {}
+  for (const key of Object.keys(states)) {
+    const definition = states[key]!
+    const pseudoType = (definition as { readonly type?: unknown }).type
+    if (pseudoType === "history") {
+      continue
+    }
+    const path = options.prefix === "" ? key : `${options.prefix}.${key}`
+    if (pseudoType === "choice") {
+      builder[key] = () => Topology.makeChoiceTarget(path, getParentPathRuntime(path))
+      continue
+    }
+    const node = Topology.getStateNodeDefinition(path, definition)
+    const method = withFrom(
+      (value: unknown, selector?: (builder: unknown) => unknown) =>
+        makeSnapshotForNode(definition, key, value, selector, options),
+      node.states === undefined ? "leaf" : "nested",
+      node.schema !== undefined
+    )
+    builder[key] = node.states === undefined || options.mode !== "full" || options.prefix !== ""
+      ? method
+      : withInitial(method, path, node.schema !== undefined)
+  }
+  return builder
+}
+
+const makeParallelSnapshotBuilder = (
+  states: Machine.StateTree,
+  options: SnapshotBuilderOptions,
+  regions: Readonly<Record<string, unknown>>
+): unknown => {
+  const builder: Record<string, unknown> = {}
+  Object.defineProperty(builder, SnapshotBuilderStateTypeId, {
+    value: regions,
+    enumerable: false
+  })
+  for (const key of Object.keys(states)) {
+    const definition = states[key]!
+    const pseudoType = (definition as { readonly type?: unknown }).type
+    if (pseudoType === "history" || pseudoType === "choice") {
+      continue
+    }
+    if (hasProperty(regions, key)) {
+      continue
+    }
+    const path = options.prefix === "" ? key : `${options.prefix}.${key}`
+    const node = Topology.getStateNodeDefinition(path, definition)
+    const method = withFrom(
+      (value: unknown, selector?: (builder: unknown) => unknown) => {
+        const nextRegions: Record<string, unknown> = {}
+        for (const regionKey of Object.keys(regions)) {
+          nextRegions[regionKey] = regions[regionKey]
+        }
+        nextRegions[key] = makeSnapshotForNode(definition, key, value, selector, options)
+        return makeParallelSnapshotBuilder(states, options, nextRegions)
+      },
+      node.states === undefined ? "leaf" : "nested",
+      node.schema !== undefined
+    )
+    builder[key] = method
+  }
+  return builder
+}
+
+const getParallelSnapshotBuilderRegions = (
+  path: string,
+  states: Machine.StateTree,
+  builder: unknown
+): Readonly<Record<string, unknown>> => {
+  if (typeof builder !== "object" || builder === null || !hasProperty(builder, SnapshotBuilderStateTypeId)) {
+    throw new Error(`Machine expected parallel state "${path}" builder callback to return a builder`)
+  }
+  const regions = (builder as { readonly [SnapshotBuilderStateTypeId]: Readonly<Record<string, unknown>> })[
+    SnapshotBuilderStateTypeId
+  ]
+  for (const key of Object.keys(states)) {
+    const pseudoType = (states[key] as { readonly type?: unknown }).type
+    if (pseudoType === "history" || pseudoType === "choice") {
+      continue
+    }
+    if (!hasProperty(regions, key)) {
+      throw new Error(`Machine expected parallel state "${path}" builder callback to provide region "${key}"`)
+    }
+  }
+  return regions
+}
+
+const makeSnapshotForNode = (
+  definition: Machine.TaggedSchema | Machine.StateNodeConfig,
+  key: string,
+  value: unknown,
+  selector: ((builder: unknown) => unknown) | undefined,
+  options: SnapshotBuilderOptions
+): Record<string, unknown> => {
+  const path = options.prefix === "" ? key : `${options.prefix}.${key}`
+  const node = Topology.getStateNodeDefinition(path, definition)
+  const snapshot: Record<string, unknown> = {
+    path,
+    value
+  }
+  if (node.states === undefined) {
+    return snapshot
+  }
+  if (selector === undefined) {
+    throw new Error(`Machine expected state "${path}" builder to provide active child states`)
+  }
+  if (node.type === "parallel") {
+    const builder = makeParallelSnapshotBuilder(node.states, { ...options, prefix: path }, {})
+    const selected = selector(builder)
+    snapshot.states = getParallelSnapshotBuilderRegions(path, node.states, selected)
+    return snapshot
+  }
+  const childStates = options.mode === "initial" && node.initial !== undefined
+    ? { [node.initial]: node.states[node.initial]! }
+    : node.states
+  const selected = selector(makeSnapshotBuilder(childStates, { ...options, prefix: path }))
+  snapshot.state = selected
+  return snapshot
+}
+
+export const getTargetBuilderNode = (
+  stateNodes: Machine.StateNodes,
+  path: string
+): Machine.StateNode => {
+  const node = stateNodes.byPath.get(path)
+  if (node === undefined) {
+    throw new Error(`Machine expected state path "${path}" to exist`)
+  }
+  return node
+}
+
+export const getLocalTargetScope = (
+  stateNodes: Machine.StateNodes,
+  source: string
+): string | undefined => {
+  let current: string | undefined = source
+  while (current !== undefined) {
+    const node = stateNodes.byPath.get(current)
+    if (node === undefined) {
+      return undefined
+    }
+    if (node.type === "compound") {
+      return node.path
+    }
+    current = node.parent
+  }
+  return undefined
+}
+
+const hasTargetValues = (
+  values: Readonly<Record<string, unknown>> | undefined
+): values is Readonly<Record<string, unknown>> => values !== undefined && Object.keys(values).length > 0
+
+const makeTargetWithValues = (
+  path: string,
+  value: unknown,
+  values: Readonly<Record<string, unknown>> | undefined
+): Machine.Target<any, any> =>
+  hasTargetValues(values)
+    ? Topology.makeTarget(path as any, value as any, { values: values as any })
+    : Topology.makeTarget(path as any, value as any)
+
+const getTargetBuilderDefinition = (
+  states: Machine.StateTree,
+  targetPath: string
+): Machine.TaggedSchema | Machine.StateNodeConfig => {
+  let children = states
+  let path = ""
+  let definition: Machine.TaggedSchema | Machine.StateNodeConfig | undefined
+  for (const key of targetPath.split(".")) {
+    if (!hasProperty(children, key)) {
+      throw new Error(`Machine expected state path "${targetPath}" to exist`)
+    }
+    definition = children[key]!
+    path = path === "" ? key : `${path}.${key}`
+    const node = Topology.getStateNodeDefinition(path, definition)
+    children = node.states ?? {}
+  }
+  return definition!
+}
+
+const makeParallelTarget = (
+  states: Machine.StateTree,
+  node: Machine.StateNode,
+  value: unknown,
+  selector: ((builder: unknown) => unknown) | undefined,
+  values: Readonly<Record<string, unknown>> | undefined
+): Machine.Target<any, any> => {
+  if (selector === undefined) {
+    throw new Error(`Machine expected parallel target "${node.path}" builder to provide every active region`)
+  }
+  const snapshot = makeSnapshotForNode(
+    getTargetBuilderDefinition(states, node.path),
+    node.key,
+    value,
+    selector,
+    { mode: "full", prefix: node.parent ?? "" }
+  )
+  return Topology.makeTarget(node.path as any, value as any, {
+    snapshot: snapshot as any,
+    values: values as any
+  })
+}
+
+const extendTargetValues = (
+  values: Readonly<Record<string, unknown>> | undefined,
+  path: string,
+  value: unknown
+): Readonly<Record<string, unknown>> => {
+  const next: Record<string, unknown> = {}
+  if (values !== undefined) {
+    for (const key of Object.keys(values)) {
+      next[key] = values[key]
+    }
+  }
+  next[path] = value
+  return next
+}
+
+const makeLocalTargetChildBuilder = (
+  states: Machine.StateTree,
+  stateNodes: Machine.StateNodes,
+  parentPath: string,
+  values: Readonly<Record<string, unknown>> | undefined,
+  source: string
+): unknown => {
+  const parent = getTargetBuilderNode(stateNodes, parentPath)
+  const builder: Record<string, unknown> = {}
+  for (
+    const childPath of Array.from(stateNodes.byPath.values())
+      .filter((node) => node.parent === parent.path && node.type !== "history")
+      .map((node) => node.path)
+  ) {
+    const child = getTargetBuilderNode(stateNodes, childPath)
+    if (child.type === "choice") {
+      builder[child.key] = () => Topology.makeChoiceTarget(child.path, parent.path, values)
+      continue
+    }
+    const method = withFrom(
+      (value: unknown, selector?: (builder: unknown) => unknown) => {
+        if (child.type === "atomic" || child.type === "final") {
+          return makeTargetWithValues(child.path, value, values)
+        }
+        if (child.type === "parallel") {
+          if (source !== child.path && !source.startsWith(`${child.path}.`)) {
+            return makeParallelTarget(states, child, value, selector, values)
+          }
+          if (selector === undefined) {
+            throw new Error(`Machine expected target "${child.path}" builder to provide an active child state`)
+          }
+          return selector(makeLocalTargetChildBuilder(
+            states,
+            stateNodes,
+            child.path,
+            child.schema === undefined ? values : extendTargetValues(values, child.path, value),
+            source
+          ))
+        }
+        if (selector === undefined) {
+          throw new Error(`Machine expected target "${child.path}" builder to provide an active child state`)
+        }
+        return selector(makeLocalTargetChildBuilder(
+          states,
+          stateNodes,
+          child.path,
+          child.schema === undefined ? values : extendTargetValues(values, child.path, value),
+          source
+        ))
+      },
+      child.type === "atomic" || child.type === "final" ? "leaf" : "nested",
+      child.schema !== undefined
+    )
+    builder[child.key] = child.type === "atomic" || child.type === "final"
+      ? method
+      : withInitial(method, child.path, child.schema !== undefined, values)
+  }
+  return builder
+}
+
+const makeLocalTargetBuilder = (
+  states: Machine.StateTree,
+  stateNodes: Machine.StateNodes,
+  source: string
+): unknown => {
+  const scope = getLocalTargetScope(stateNodes, source)
+  if (scope === undefined) {
+    return {}
+  }
+  const builder = makeLocalTargetChildBuilder(states, stateNodes, scope, undefined, source) as Record<string, unknown>
+  const scopeNode = getTargetBuilderNode(stateNodes, scope)
+  if (scopeNode.schema !== undefined) {
+    builder.with = withFrom(
+      (value: unknown, selector?: (builder: unknown) => unknown) => {
+        if (selector === undefined) {
+          throw new Error(`Machine expected target "${scope}" builder to provide an active child state`)
+        }
+        return selector(makeLocalTargetChildBuilder(states, stateNodes, scope, { [scope]: value }, source))
+      },
+      "nested",
+      true
+    )
+  }
+  return builder
+}
+
+const addBranchTargetChildren = (
+  builder: Record<string, unknown>,
+  states: Machine.StateTree,
+  stateNodes: Machine.StateNodes,
+  parentPath: string,
+  values: Readonly<Record<string, unknown>> | undefined,
+  source: string
+): void => {
+  const parent = getTargetBuilderNode(stateNodes, parentPath)
+  for (
+    const childPath of Array.from(stateNodes.byPath.values())
+      .filter((node) => node.parent === parent.path && node.type !== "history")
+      .map((node) => node.path)
+  ) {
+    const child = getTargetBuilderNode(stateNodes, childPath)
+    if (child.type === "choice") {
+      builder[child.key] = () => Topology.makeChoiceTarget(child.path, parent.path, values)
+      continue
+    }
+    builder[child.key] = makeBranchTargetNodeBuilder(states, stateNodes, child.path, values, source)
+  }
+}
+
+const makeBranchTargetNodeBuilder = (
+  states: Machine.StateTree,
+  stateNodes: Machine.StateNodes,
+  path: string,
+  values: Readonly<Record<string, unknown>> | undefined,
+  source: string
+): unknown => {
+  const node = getTargetBuilderNode(stateNodes, path)
+  if (node.type === "atomic" || node.type === "final") {
+    return withFrom(
+      (value: unknown) => makeTargetWithValues(node.path, value, values),
+      "leaf",
+      node.schema !== undefined
+    )
+  }
+  const builder = withFrom(
+    (value: unknown, selector?: (builder: unknown) => unknown) => {
+      if (node.type === "parallel") {
+        if (source !== node.path && !source.startsWith(`${node.path}.`)) {
+          return makeParallelTarget(states, node, value, selector, values)
+        }
+        if (selector === undefined) {
+          throw new Error(`Machine expected target "${node.path}" builder to provide an active child state`)
+        }
+        const nextBuilder: Record<string, unknown> = {}
+        addBranchTargetChildren(
+          nextBuilder,
+          states,
+          stateNodes,
+          node.path,
+          node.schema === undefined ? values : extendTargetValues(values, node.path, value),
+          source
+        )
+        return selector(nextBuilder)
+      }
+      if (selector === undefined) {
+        throw new Error(`Machine expected target "${node.path}" builder to provide an active child state`)
+      }
+      const nextBuilder: Record<string, unknown> = {}
+      addBranchTargetChildren(
+        nextBuilder,
+        states,
+        stateNodes,
+        node.path,
+        node.schema === undefined ? values : extendTargetValues(values, node.path, value),
+        source
+      )
+      return selector(nextBuilder)
+    },
+    "nested",
+    node.schema !== undefined
+  ) as unknown as Record<string, unknown>
+  withInitial(builder, node.path, node.schema !== undefined, values)
+  if (node.type !== "parallel" || source === node.path || source.startsWith(`${node.path}.`)) {
+    addBranchTargetChildren(builder, states, stateNodes, node.path, values, source)
+  }
+  return builder
+}
+
+const makeBranchTargetBuilder = (
+  states: Machine.StateTree,
+  stateNodes: Machine.StateNodes,
+  source: string
+): unknown => {
+  const rootPath = source.split(".")[0]!
+  const root = getTargetBuilderNode(stateNodes, rootPath)
+  return {
+    [root.key]: makeBranchTargetNodeBuilder(states, stateNodes, root.path, undefined, source)
+  }
+}
+
+const makeHistoryTargetBuilder = (
+  states: Machine.StateTree,
+  prefix: string
+): unknown => {
+  const builder: Record<string, unknown> = {}
+  for (const key of Object.keys(states)) {
+    const path = prefix === "" ? key : `${prefix}.${key}`
+    const definition = Topology.getStateNodeDefinition(path, states[key]!)
+    if (definition.type === "history") {
+      const parent = getParentPathRuntime(path)
+      builder[key] = () => Topology.makeHistoryTarget(path, parent)
+      continue
+    }
+    if (definition.states !== undefined) {
+      builder[key] = makeHistoryTargetBuilder(definition.states, path)
+    }
+  }
+  return builder
+}
+
+const getParentPathRuntime = (path: string): string => {
+  const separator = path.lastIndexOf(".")
+  if (separator < 0) {
+    throw new Error(`Machine expected history state "${path}" to have an active parent`)
+  }
+  return path.slice(0, separator)
+}
+
+export const makeTargetBuilder = <const States extends Machine.StateSchemas>(
+  states: States,
+  stateNodes: Machine.StateNodes
+) => {
+  const full = makeSnapshotBuilder(states, { mode: "full", prefix: "" }) as Machine.FullTargetBuilder<States>
+  const history = makeHistoryTargetBuilder(states, "") as Machine.HistoryTargetBuilder<States>
+  return <Source extends Machine.StateNodeIdentifier<States>>(source: Source): Machine.TargetBuilder<States, Source> =>
+    ({
+      none: Topology.makeNoTarget,
+      local: makeLocalTargetBuilder(states, stateNodes, source),
+      branch: makeBranchTargetBuilder(states, stateNodes, source),
+      full,
+      history
+    }) as Machine.TargetBuilder<States, Source>
+}

--- a/packages/effect-machine/src/internal/machine/transition.ts
+++ b/packages/effect-machine/src/internal/machine/transition.ts
@@ -1,0 +1,26 @@
+import type { Enqueue, Machine } from "../../Machine.js"
+
+/** Captured callbacks shared by definition construction and both planners. */
+export type TransitionHandler<States extends Machine.StateSchemas, E, R, Context> = (
+  context: Context,
+  enqueue: Enqueue<any, any>
+) => Machine.HandlerResult<States, E, R> | Machine.Declined
+
+export type TransitionEvaluator<States extends Machine.StateSchemas, E, R, Context> = (
+  context: Context,
+  enqueue: Enqueue<any, any>
+) => {
+  readonly result: Machine.HandlerResult<States, E, R> | Machine.Declined
+  readonly branchIndex: number
+  readonly branchKey: string | undefined
+}
+
+export type EventTransition<States extends Machine.StateSchemas, E, R, Context> =
+  | TransitionHandler<States, E, R, Context>
+  | {
+    readonly reenter?: boolean
+    readonly declinable?: boolean
+    readonly targets?: ReadonlyArray<string>
+    readonly transition: TransitionHandler<States, E, R, Context>
+    readonly evaluate?: TransitionEvaluator<States, E, R, Context>
+  }

--- a/packages/effect-machine/src/internal/testing/machine/format.ts
+++ b/packages/effect-machine/src/internal/testing/machine/format.ts
@@ -1,0 +1,119 @@
+import type { Machine } from "../../../Machine.js"
+import type { InitialTrace, Microstep, RunFailure, Trace, TraceStep } from "../../../testing/MachineTest.js"
+type AnyMachine = Machine.Any
+
+const canonicalize = (value: unknown, active: WeakSet<object>): unknown => {
+  if (typeof value === "number" && (!Number.isFinite(value) || Object.is(value, -0))) {
+    return { $number: Object.is(value, -0) ? "-0" : String(value) }
+  }
+  if (value === undefined) return { $undefined: true }
+  if (typeof value === "bigint") return { $bigint: String(value) }
+  if (typeof value === "symbol") return { $symbol: String(value) }
+  if (typeof value === "function") return { $function: value.name || "anonymous" }
+  if (typeof value !== "object" || value === null) return value
+  if (active.has(value)) return { $circular: true }
+  active.add(value)
+  let result: unknown
+  if (value instanceof Error) {
+    result = {
+      $error: value.name,
+      message: value.message,
+      ...Object.fromEntries(
+        Object.keys(value).sort().map((
+          key
+        ) => [key, canonicalize((value as unknown as Record<string, unknown>)[key], active)])
+      )
+    }
+  } else if (Array.isArray(value)) {
+    result = value.map((item) => canonicalize(item, active))
+  } else if (value instanceof RegExp) {
+    result = { $regexp: value.source, flags: value.flags, lastIndex: value.lastIndex }
+  } else if (value instanceof Date) {
+    result = { $date: Number.isNaN(value.getTime()) ? "Invalid Date" : value.toISOString() }
+  } else if (value instanceof Map) {
+    result = {
+      $map: Array.from(value, ([key, item]) => [canonicalize(key, active), canonicalize(item, active)]).sort((a, b) =>
+        JSON.stringify(a).localeCompare(JSON.stringify(b))
+      )
+    }
+  } else if (value instanceof Set) {
+    result = {
+      $set: Array.from(value, (item) => canonicalize(item, active)).sort((a, b) =>
+        JSON.stringify(a).localeCompare(JSON.stringify(b))
+      )
+    }
+  } else {
+    result = Object.fromEntries(
+      Object.keys(value).sort().map((key) => [key, canonicalize((value as Record<string, unknown>)[key], active)])
+    )
+  }
+  active.delete(value)
+  return result
+}
+
+export const formatValue = (value: unknown): string => JSON.stringify(canonicalize(value, new WeakSet()))
+
+const formatConfiguration = (paths: ReadonlyArray<string>): string => `[${paths.join(", ")}]`
+
+const formatMicrosteps = <M extends AnyMachine>(microsteps: ReadonlyArray<Microstep<M, any>>): Array<string> =>
+  microsteps.map((microstep, index) => {
+    const transitions = microstep.transitions.map((transition) => ({
+      source: transition.source,
+      trigger: transition.trigger,
+      reenter: transition.reenter,
+      branchIndex: transition.branchIndex,
+      target: transition.target,
+      resolvedTarget: transition.resolvedTarget
+    }))
+    return `  microstep ${index}: event=${formatValue(microstep.event)} changed=${String(microstep.changed)} ` +
+      `transitions=${formatValue(transitions)} exit=${formatConfiguration(microstep.exitPaths)} ` +
+      `entry=${formatConfiguration(microstep.entryPaths)} commands=${microstep.commands.length} ` +
+      `raised=${formatValue(microstep.raisedEvents)} emitted=${formatValue(microstep.emittedEvents)} ` +
+      `next=${formatValue(microstep.next)}`
+  })
+
+const formatInitial = <M extends AnyMachine>(initial: InitialTrace<M>): Array<string> => [
+  `initial: startingConfiguration=${formatConfiguration(initial.startingConfiguration)} ` +
+  `startingState=${formatValue(initial.startingState)} initialEntry=${
+    formatConfiguration(initial.initialEntryPaths)
+  } ` +
+  `configuration=${formatConfiguration(initial.configuration)} state=${formatValue(initial.plan.state)} ` +
+  `done=${String(initial.plan.done)} output=${formatValue(initial.plan.output)} ` +
+  `commands=${initial.plan.commands.length} emitted=${formatValue(initial.plan.emittedEvents)}`,
+  ...formatMicrosteps(initial.plan.microsteps)
+]
+
+const formatStep = <M extends AnyMachine>(step: TraceStep<M>): Array<string> => [
+  `step ${step.index}: event=${formatValue(step.event)} before=${formatConfiguration(step.beforeConfiguration)} ` +
+  `after=${formatConfiguration(step.afterConfiguration)} state=${formatValue(step.after)} ` +
+  `done=${String(step.plan.done)} output=${formatValue(step.plan.output)} ` +
+  `commands=${step.plan.commands.length} emitted=${formatValue(step.plan.emittedEvents)}`,
+  ...formatMicrosteps(step.plan.microsteps)
+]
+
+const isRunFailure = <M extends AnyMachine, Cause>(
+  trace: Trace<M> | RunFailure<Cause, M>
+): trace is RunFailure<Cause, M> => "_tag" in trace && trace._tag === "MachineTestRunFailure"
+
+export const formatTrace = <M extends AnyMachine, Cause>(trace: Trace<M> | RunFailure<Cause, M>): string => {
+  const lines = [`scenario: ${formatValue(trace.scenario)}`]
+  if (isRunFailure(trace)) {
+    if (trace.initial !== undefined) {
+      lines.push(...formatInitial(trace.initial))
+      for (const step of trace.steps) {
+        lines.push(...formatStep(step))
+      }
+    }
+    lines.push(
+      `failure: phase=${trace.phase} eventIndex=${formatValue(trace.eventIndex)} ` +
+        `event=${formatValue(trace.event)} cause=${formatValue(trace.cause)}`
+    )
+    return lines.join("\n")
+  }
+  lines.push(...formatInitial(trace.initial))
+  for (const step of trace.steps) {
+    lines.push(...formatStep(step))
+  }
+  lines.push(`final: configuration=${formatConfiguration(trace.finalConfiguration)} state=${formatValue(trace.final)}`)
+  return lines.join("\n")
+}

--- a/packages/effect-machine/src/internal/testing/machine/value.ts
+++ b/packages/effect-machine/src/internal/testing/machine/value.ts
@@ -1,0 +1,77 @@
+/**
+ * Compares decoded trace data without serializing it or invoking getters.
+ * Collection order and cycles must agree. Decoding may copy a shared value,
+ * so aliases outside the current comparison path do not require identity.
+ * Functions, symbols, and objects with opaque state retain identity semantics.
+ */
+export const sameValue = (left: unknown, right: unknown): boolean => {
+  const leftToRight = new WeakMap<object, object>()
+  const rightToLeft = new WeakMap<object, object>()
+  const compare = (a: unknown, b: unknown): boolean => {
+    if (typeof a !== "object" || a === null || typeof b !== "object" || b === null) {
+      return Object.is(a, b)
+    }
+    const knownRight = leftToRight.get(a)
+    const knownLeft = rightToLeft.get(b)
+    if (knownRight !== undefined || knownLeft !== undefined) return knownRight === b && knownLeft === a
+    leftToRight.set(a, b)
+    rightToLeft.set(b, a)
+    try {
+      if (a === b) return true
+      if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) return false
+
+      if (a instanceof Date && b instanceof Date && !Object.is(a.getTime(), b.getTime())) return false
+      if (a instanceof RegExp && b instanceof RegExp && (a.source !== b.source || a.flags !== b.flags)) return false
+      if (a instanceof ArrayBuffer && b instanceof ArrayBuffer) {
+        if (!sameBytes(new Uint8Array(a), new Uint8Array(b))) return false
+      } else if (
+        typeof SharedArrayBuffer !== "undefined" && a instanceof SharedArrayBuffer && b instanceof SharedArrayBuffer
+      ) {
+        if (!sameBytes(new Uint8Array(a), new Uint8Array(b))) return false
+      } else if (ArrayBuffer.isView(a) && ArrayBuffer.isView(b)) {
+        if (
+          !sameBytes(
+            new Uint8Array(a.buffer, a.byteOffset, a.byteLength),
+            new Uint8Array(b.buffer, b.byteOffset, b.byteLength)
+          )
+        ) return false
+      } else if (a instanceof Map && b instanceof Map) {
+        if (a.size !== b.size) return false
+        const entries = Array.from(b)
+        if (
+          !Array.from(a).every(([key, value], index) =>
+            compare(key, entries[index]![0]) && compare(value, entries[index]![1])
+          )
+        ) return false
+      } else if (a instanceof Set && b instanceof Set) {
+        if (a.size !== b.size) return false
+        const values = Array.from(b)
+        if (!Array.from(a).every((value, index) => compare(value, values[index]))) return false
+      } else if (a instanceof WeakMap || a instanceof WeakSet || a instanceof Promise) {
+        return false
+      }
+
+      const keys = Reflect.ownKeys(a)
+      if (keys.length !== Reflect.ownKeys(b).length) return false
+      if (
+        keys.length === 0 && Object.getPrototypeOf(a) !== null && Object.getPrototypeOf(a) !== Object.prototype &&
+        !(a instanceof Date || a instanceof RegExp || a instanceof Map || a instanceof Set ||
+          a instanceof ArrayBuffer || ArrayBuffer.isView(a)) &&
+        !(typeof SharedArrayBuffer !== "undefined" && a instanceof SharedArrayBuffer)
+      ) return false
+      return keys.every((key) => {
+        const x = Object.getOwnPropertyDescriptor(a, key)!
+        const y = Object.getOwnPropertyDescriptor(b, key)
+        if (y === undefined || x.enumerable !== y.enumerable || ("value" in x) !== ("value" in y)) return false
+        return "value" in x ? compare(x.value, y.value) : x.get === y.get && x.set === y.set
+      })
+    } finally {
+      leftToRight.delete(a)
+      rightToLeft.delete(b)
+    }
+  }
+  return compare(left, right)
+}
+
+const sameBytes = (left: Uint8Array, right: Uint8Array): boolean =>
+  left.byteLength === right.byteLength && left.every((byte, index) => byte === right[index])

--- a/packages/effect-machine/src/internal/testing/machine/verification.ts
+++ b/packages/effect-machine/src/internal/testing/machine/verification.ts
@@ -15,20 +15,17 @@ import type {
   Coverage,
   CoverageSummary,
   EventCoverageItem,
-  InitialTrace,
   Microstep,
   ObservedGraph,
   ObservedGraphEdge,
   ObservedGraphNode,
   PlanCompletion,
-  RunFailure,
   Scenario,
   ScenarioOptions,
   Scenarios,
   SchemaArbitraryDiagnostic,
   StateCoverageItem,
   Trace,
-  TraceStep,
   VerificationLaw,
   VerificationLawGroup,
   VerificationViolation,
@@ -38,117 +35,9 @@ import * as Protocol from "../../machine/protocol.js"
 import { toArbitraryWithReport } from "./arbitrary.js"
 import type { FiniteModel } from "./finiteModel.js"
 import * as ReferenceModel from "./referenceModel.js"
-import { rawConfigurationPaths, run } from "./trace.js"
+import { rawConfigurationPaths } from "./trace.js"
 import { makeTransitionCoverageCollector, sameTransitionTrigger } from "./transitionCoverage.js"
-
-export {
-  advanceCommand,
-  type CausalRuntimeAssertionContext,
-  type CausalRuntimeCommandActual,
-  CausalRuntimeCommandFailure,
-  type CausalRuntimeCommandRecord,
-  type CausalRuntimeCommandResult,
-  type CausalRuntimeInspectionContext,
-  type CausalRuntimeModelOptions,
-  type CausalRuntimeModelStep,
-  type CausalRuntimeTranscript,
-  type CausalVerificationAwaitContext,
-  type CausalVerificationOptions,
-  type CausalVerificationTranscript,
-  checkpointCommand,
-  type EnqueuedRuntimeAssertionContext,
-  type EnqueuedRuntimeCommandActual,
-  type EnqueuedRuntimeCommandRecord,
-  type EnqueuedRuntimeInspectionContext,
-  type EnqueuedRuntimeModelOptions,
-  type EnqueuedRuntimeModelStep,
-  type EnqueuedRuntimeTranscript,
-  formatCausalTranscript,
-  formatEnqueuedTranscript,
-  formatRuntimeTranscript,
-  runCausalCommands,
-  runEnqueuedCommands,
-  runRuntimeCommands,
-  type RuntimeAssertionContext,
-  type RuntimeAwait,
-  type RuntimeCommand,
-  type RuntimeCommandActual,
-  RuntimeCommandFailure,
-  type RuntimeCommandRecord,
-  type RuntimeCommandResult,
-  type RuntimeCommands,
-  runtimeCommands,
-  type RuntimeCommandsDiagnostics,
-  type RuntimeCommandsOptions,
-  type RuntimeInspectionContext,
-  type RuntimeModelOptions,
-  type RuntimeModelStep,
-  RuntimeObservationError,
-  RuntimeSynchronization,
-  type RuntimeTranscript,
-  sendCommand,
-  stopCommand,
-  verifyCausalCommands
-} from "./runtime.js"
-
-export type { SchemaArbitraryOpaqueFilterWarning, SchemaArbitraryReport, SchemaArbitraryWarning } from "./arbitrary.js"
-
-export {
-  compileModel,
-  type FiniteAtomicState,
-  type FiniteAutomaticTransition,
-  type FiniteCompoundState,
-  type FiniteEventTransition,
-  type FiniteFinalState,
-  type FiniteHistoryMutation,
-  type FiniteHistoryScenario,
-  type FiniteHistoryState,
-  type FiniteHistoryTransfer,
-  type FiniteModel,
-  type FiniteModelDiagnostics,
-  type FiniteModelOptions,
-  type FiniteModels,
-  finiteModels,
-  type FiniteParallelState,
-  type FiniteState,
-  type FiniteTransition,
-  type FiniteTransitionTrigger
-} from "./finiteModel.js"
-
-export {
-  ModelVerificationError,
-  type ModelVerificationField,
-  type ModelVerificationLocation,
-  type ModelVerificationMismatch,
-  type ReferenceCompletion,
-  type ReferenceHistoryRecord,
-  type ReferenceInitialStep,
-  type ReferenceMicrostep,
-  type ReferenceState,
-  type ReferenceStateValue,
-  type ReferenceStep,
-  type ReferenceTrace,
-  type ReferenceTransition
-} from "./referenceModel.js"
-
-export { assertInvariants, checkInvariants, Invariant, InvariantError, invariants } from "./invariant.js"
-
-export {
-  assertPlannerRuntimeAgreement,
-  assertRuntimeInvariants,
-  checkRuntimeInvariants,
-  PlannerRuntimeAgreementError,
-  RuntimeInvariantError,
-  runtimeInvariants
-} from "./runtimeInvariant.js"
-
-export { assertReachable, assertUnreachable, explore, findShortest, ReachabilityError } from "./exploration.js"
-
-export { probe, ProbeUnavailableError } from "./probe.js"
-
-export { run }
-
-export const interpretModel = ReferenceModel.interpretModel
+import { sameValue } from "./value.js"
 
 type AnyMachine = Machine.Machine.Any
 
@@ -255,52 +144,6 @@ export const verifyModel = <M extends AnyMachine>(
   model: FiniteModel,
   actualTrace: Trace<M>
 ): Effect.Effect<void, ReferenceModel.ModelVerificationError> => ReferenceModel.verifyModelTrace(model, actualTrace)
-
-const canonicalize = (value: unknown, active: WeakSet<object>): unknown => {
-  if (value === undefined) return { $undefined: true }
-  if (typeof value === "bigint") return { $bigint: String(value) }
-  if (typeof value === "symbol") return { $symbol: String(value) }
-  if (typeof value === "function") return { $function: value.name || "anonymous" }
-  if (typeof value !== "object" || value === null) return value
-  if (active.has(value)) return { $circular: true }
-  active.add(value)
-  let result: unknown
-  if (value instanceof Error) {
-    result = {
-      $error: value.name,
-      message: value.message,
-      ...Object.fromEntries(
-        Object.keys(value).sort().map((
-          key
-        ) => [key, canonicalize((value as unknown as Record<string, unknown>)[key], active)])
-      )
-    }
-  } else if (Array.isArray(value)) {
-    result = value.map((item) => canonicalize(item, active))
-  } else if (value instanceof Date) {
-    result = { $date: value.toISOString() }
-  } else if (value instanceof Map) {
-    result = {
-      $map: Array.from(value, ([key, item]) => [canonicalize(key, active), canonicalize(item, active)]).sort((a, b) =>
-        JSON.stringify(a).localeCompare(JSON.stringify(b))
-      )
-    }
-  } else if (value instanceof Set) {
-    result = {
-      $set: Array.from(value, (item) => canonicalize(item, active)).sort((a, b) =>
-        JSON.stringify(a).localeCompare(JSON.stringify(b))
-      )
-    }
-  } else {
-    result = Object.fromEntries(
-      Object.keys(value).sort().map((key) => [key, canonicalize((value as Record<string, unknown>)[key], active)])
-    )
-  }
-  active.delete(value)
-  return result
-}
-
-const formatValue = (value: unknown): string => JSON.stringify(canonicalize(value, new WeakSet()))
 
 const structuralFingerprint = (value: unknown): string => {
   const references = new WeakMap<object, number>()
@@ -949,8 +792,6 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const hasOwn = (value: object, key: PropertyKey): boolean => Object.prototype.hasOwnProperty.call(value, key)
 
-const sameValue = (left: unknown, right: unknown): boolean => formatValue(left) === formatValue(right)
-
 const samePaths = (left: ReadonlyArray<string>, right: ReadonlyArray<string>): boolean =>
   left.length === right.length && left.every((path, index) => path === right[index])
 
@@ -995,1103 +836,1039 @@ export const verify = <M extends AnyMachine>(
   machine: M,
   trace: Trace<M>,
   options: VerifyOptions = {}
-): Effect.Effect<void, VerificationError> => {
-  const selected = new Set<VerificationLawGroup>(
-    options.laws ?? ["configuration", "microsteps", "completion", "history", "definitions"]
-  )
-  const nodes = Machine.stateNodes(machine) as ReadonlyArray<PublicStateNode>
-  const initialDefinition = Machine.initialDefinition(machine)
-  const definitions = Machine.transitionDefinitions(machine)
-  const { ancestors, byPath, depth, isDescendantOrSelf } = makeNodeUtilities(nodes)
-  const violations: Array<VerificationViolation> = []
+): Effect.Effect<void, VerificationError> =>
+  Effect.suspend(() => {
+    const selected = new Set<VerificationLawGroup>(
+      options.laws ?? ["configuration", "microsteps", "completion", "history", "definitions"]
+    )
+    const nodes = Machine.stateNodes(machine) as ReadonlyArray<PublicStateNode>
+    const initialDefinition = Machine.initialDefinition(machine)
+    const definitions = Machine.transitionDefinitions(machine)
+    const { ancestors, byPath, depth, isDescendantOrSelf } = makeNodeUtilities(nodes)
+    const violations: Array<VerificationViolation> = []
 
-  const add = (
-    law: VerificationLaw,
-    location: VerificationLocation,
-    message: string,
-    path?: string
-  ): void => {
-    violations.push({
-      law,
-      eventIndex: location.eventIndex,
-      ...(location.microstepIndex === undefined ? {} : { microstepIndex: location.microstepIndex }),
-      ...(path === undefined ? {} : { path }),
-      message
-    })
-  }
-
-  const schemaMatches = (schema: Schema.Top | undefined, value: unknown): boolean => {
-    if (schema === undefined) return false
-    try {
-      return Schema.is(schema)(value)
-    } catch {
-      return false
+    const add = (
+      law: VerificationLaw,
+      location: VerificationLocation,
+      message: string,
+      path?: string
+    ): void => {
+      violations.push({
+        law,
+        eventIndex: location.eventIndex,
+        ...(location.microstepIndex === undefined ? {} : { microstepIndex: location.microstepIndex }),
+        ...(path === undefined ? {} : { path }),
+        message
+      })
     }
-  }
 
-  const inspectSnapshot = (
-    snapshot: unknown,
-    location: VerificationLocation,
-    label: string
-  ): SnapshotInspection => {
-    const active = new Set<string>()
-    const paths: Array<string> = []
-    const values = new Map<string, unknown>()
-    const reportConfiguration = selected.has("configuration")
-    const root = isRecord(snapshot) ? snapshot : undefined
+    const schemaMatches = (schema: Schema.Top | undefined, value: unknown): boolean => {
+      if (schema === undefined) return false
+      try {
+        return Schema.is(schema)(value)
+      } catch {
+        return false
+      }
+    }
 
-    const visit = (current: unknown, expectedParent: string | undefined, expectedPath?: string): void => {
-      if (!isRecord(current)) {
-        if (reportConfiguration) {
-          add("configuration.shape", location, `${label} must contain an object snapshot`)
-        }
-        return
-      }
-      if (typeof current.path !== "string") {
-        if (reportConfiguration) {
-          add("configuration.path", location, `${label} contains a snapshot without a string path`)
-        }
-        return
-      }
-      const path = current.path
-      if (active.has(path)) {
-        if (reportConfiguration) {
-          add("configuration.duplicate", location, `${label} activates state "${path}" more than once`, path)
-        }
-        return
-      }
-      active.add(path)
-      paths.push(path)
-      values.set(path, current.value)
+    const inspectSnapshot = (
+      snapshot: unknown,
+      location: VerificationLocation,
+      label: string
+    ): SnapshotInspection => {
+      const active = new Set<string>()
+      const paths: Array<string> = []
+      const values = new Map<string, unknown>()
+      const reportConfiguration = selected.has("configuration")
+      const root = isRecord(snapshot) ? snapshot : undefined
 
-      const node = byPath.get(path)
-      if (node === undefined) {
-        if (reportConfiguration) {
-          add("configuration.path", location, `${label} activates unknown state "${path}"`, path)
-        }
-        if (isRecord(current.state)) visit(current.state, path)
-        if (isRecord(current.states)) {
-          for (const child of Object.values(current.states)) visit(child, path)
-        }
-        return
-      }
-      if (expectedPath !== undefined && path !== expectedPath && reportConfiguration) {
-        add(
-          "configuration.hierarchy",
-          location,
-          `${label} expected region "${expectedPath}" but found "${path}"`,
-          path
-        )
-      }
-      if (node.parent !== expectedParent && reportConfiguration) {
-        add(
-          "configuration.hierarchy",
-          location,
-          expectedParent === undefined
-            ? `${label} root state "${path}" is not a machine root`
-            : `${label} state "${path}" is not a direct child of "${expectedParent}"`,
-          path
-        )
-      }
-      if (node.type === "history" || node.type === "choice") {
-        if (reportConfiguration) {
-          add("configuration.path", location, `${label} activates ${node.type} pseudo-state "${path}"`, path)
-        }
-        return
-      }
-      if (reportConfiguration && node.schema === undefined && current.value !== undefined) {
-        add("configuration.schema", location, `${label} structural state "${path}" contains a value`, path)
-      } else if (reportConfiguration && node.schema !== undefined && !schemaMatches(node.schema, current.value)) {
-        add("configuration.schema", location, `${label} value for "${path}" does not match its schema`, path)
-      }
-
-      if (node.type === "compound") {
-        if (!isRecord(current.state)) {
+      const visit = (current: unknown, expectedParent: string | undefined, expectedPath?: string): void => {
+        if (!isRecord(current)) {
           if (reportConfiguration) {
-            add(
-              "configuration.compound",
-              location,
-              `${label} compound state "${path}" must have exactly one child`,
-              path
-            )
-          }
-        } else {
-          visit(current.state, path)
-        }
-        if (hasOwn(current, "states") && reportConfiguration) {
-          add("configuration.compound", location, `${label} compound state "${path}" contains parallel regions`, path)
-        }
-        return
-      }
-
-      if (node.type === "parallel") {
-        if (!isRecord(current.states)) {
-          if (reportConfiguration) {
-            add("configuration.parallel", location, `${label} parallel state "${path}" has no region map`, path)
+            add("configuration.shape", location, `${label} must contain an object snapshot`)
           }
           return
         }
-        const expectedKeys = new Set<string>()
-        for (const childPath of node.children) {
-          const child = byPath.get(childPath)
-          if (child === undefined) continue
-          expectedKeys.add(child.key)
-          if (!hasOwn(current.states, child.key)) {
+        if (typeof current.path !== "string") {
+          if (reportConfiguration) {
+            add("configuration.path", location, `${label} contains a snapshot without a string path`)
+          }
+          return
+        }
+        const path = current.path
+        if (active.has(path)) {
+          if (reportConfiguration) {
+            add("configuration.duplicate", location, `${label} activates state "${path}" more than once`, path)
+          }
+          return
+        }
+        active.add(path)
+        paths.push(path)
+        values.set(path, current.value)
+
+        const node = byPath.get(path)
+        if (node === undefined) {
+          if (reportConfiguration) {
+            add("configuration.path", location, `${label} activates unknown state "${path}"`, path)
+          }
+          if (isRecord(current.state)) visit(current.state, path)
+          if (isRecord(current.states)) {
+            for (const child of Object.values(current.states)) visit(child, path)
+          }
+          return
+        }
+        if (expectedPath !== undefined && path !== expectedPath && reportConfiguration) {
+          add(
+            "configuration.hierarchy",
+            location,
+            `${label} expected region "${expectedPath}" but found "${path}"`,
+            path
+          )
+        }
+        if (node.parent !== expectedParent && reportConfiguration) {
+          add(
+            "configuration.hierarchy",
+            location,
+            expectedParent === undefined
+              ? `${label} root state "${path}" is not a machine root`
+              : `${label} state "${path}" is not a direct child of "${expectedParent}"`,
+            path
+          )
+        }
+        if (node.type === "history" || node.type === "choice") {
+          if (reportConfiguration) {
+            add("configuration.path", location, `${label} activates ${node.type} pseudo-state "${path}"`, path)
+          }
+          return
+        }
+        if (reportConfiguration && node.schema === undefined && current.value !== undefined) {
+          add("configuration.schema", location, `${label} structural state "${path}" contains a value`, path)
+        } else if (reportConfiguration && node.schema !== undefined && !schemaMatches(node.schema, current.value)) {
+          add("configuration.schema", location, `${label} value for "${path}" does not match its schema`, path)
+        }
+
+        if (node.type === "compound") {
+          if (!isRecord(current.state)) {
             if (reportConfiguration) {
               add(
-                "configuration.parallel",
+                "configuration.compound",
                 location,
-                `${label} parallel state "${path}" omits region "${child.key}"`,
-                childPath
+                `${label} compound state "${path}" must have exactly one child`,
+                path
               )
             }
           } else {
-            visit(current.states[child.key], path, child.path)
+            visit(current.state, path)
           }
+          if (hasOwn(current, "states") && reportConfiguration) {
+            add("configuration.compound", location, `${label} compound state "${path}" contains parallel regions`, path)
+          }
+          return
         }
-        for (const key of Object.keys(current.states)) {
-          if (!expectedKeys.has(key)) {
+
+        if (node.type === "parallel") {
+          if (!isRecord(current.states)) {
             if (reportConfiguration) {
-              add(
-                "configuration.parallel",
-                location,
-                `${label} parallel state "${path}" contains extra region "${key}"`,
-                path
-              )
+              add("configuration.parallel", location, `${label} parallel state "${path}" has no region map`, path)
             }
-            visit(current.states[key], path)
+            return
           }
+          const expectedKeys = new Set<string>()
+          for (const childPath of node.children) {
+            const child = byPath.get(childPath)
+            if (child === undefined) continue
+            expectedKeys.add(child.key)
+            if (!hasOwn(current.states, child.key)) {
+              if (reportConfiguration) {
+                add(
+                  "configuration.parallel",
+                  location,
+                  `${label} parallel state "${path}" omits region "${child.key}"`,
+                  childPath
+                )
+              }
+            } else {
+              visit(current.states[child.key], path, child.path)
+            }
+          }
+          for (const key of Object.keys(current.states)) {
+            if (!expectedKeys.has(key)) {
+              if (reportConfiguration) {
+                add(
+                  "configuration.parallel",
+                  location,
+                  `${label} parallel state "${path}" contains extra region "${key}"`,
+                  path
+                )
+              }
+              visit(current.states[key], path)
+            }
+          }
+          if (hasOwn(current, "state") && reportConfiguration) {
+            add("configuration.parallel", location, `${label} parallel state "${path}" contains a compound child`, path)
+          }
+          return
         }
-        if (hasOwn(current, "state") && reportConfiguration) {
-          add("configuration.parallel", location, `${label} parallel state "${path}" contains a compound child`, path)
+
+        if ((hasOwn(current, "state") || hasOwn(current, "states")) && reportConfiguration) {
+          add("configuration.shape", location, `${label} leaf state "${path}" contains active children`, path)
         }
+      }
+
+      visit(snapshot, undefined)
+      return { active, paths, values, root }
+    }
+
+    const validateTraceConfiguration = (
+      expected: SnapshotInspection,
+      actual: ReadonlyArray<string>,
+      location: VerificationLocation,
+      label: string
+    ): void => {
+      if (selected.has("configuration") && !samePaths(expected.paths, actual)) {
+        add(
+          "configuration.trace",
+          location,
+          `${label} configuration [${actual.join(", ")}] does not match snapshot [${expected.paths.join(", ")}]`
+        )
+      }
+    }
+
+    const validateHistory = (
+      snapshot: SnapshotInspection,
+      location: VerificationLocation,
+      label: string
+    ): void => {
+      if (!selected.has("history") || snapshot.root === undefined || !hasOwn(snapshot.root, "history")) return
+      const history = snapshot.root.history
+      if (!isRecord(history)) {
+        add("history.record", location, `${label} history metadata must be a record`)
         return
       }
-
-      if ((hasOwn(current, "state") || hasOwn(current, "states")) && reportConfiguration) {
-        add("configuration.shape", location, `${label} leaf state "${path}" contains active children`, path)
-      }
-    }
-
-    visit(snapshot, undefined)
-    return { active, paths, values, root }
-  }
-
-  const validateTraceConfiguration = (
-    expected: SnapshotInspection,
-    actual: ReadonlyArray<string>,
-    location: VerificationLocation,
-    label: string
-  ): void => {
-    if (selected.has("configuration") && !samePaths(expected.paths, actual)) {
-      add(
-        "configuration.trace",
-        location,
-        `${label} configuration [${actual.join(", ")}] does not match snapshot [${expected.paths.join(", ")}]`
-      )
-    }
-  }
-
-  const validateHistory = (
-    snapshot: SnapshotInspection,
-    location: VerificationLocation,
-    label: string
-  ): void => {
-    if (!selected.has("history") || snapshot.root === undefined || !hasOwn(snapshot.root, "history")) return
-    const history = snapshot.root.history
-    if (!isRecord(history)) {
-      add("history.record", location, `${label} history metadata must be a record`)
-      return
-    }
-    for (const [historyPath, unknownEntry] of Object.entries(history)) {
-      const historyNode = byPath.get(historyPath)
-      if (historyNode === undefined || historyNode.type !== "history" || historyNode.parent === undefined) {
-        add("history.path", location, `${label} contains unknown history record "${historyPath}"`, historyPath)
-        continue
-      }
-      if (!isRecord(unknownEntry)) {
-        add("history.record", location, `${label} history record "${historyPath}" must be an object`, historyPath)
-        continue
-      }
-      const entry = unknownEntry
-      if (entry.mode !== historyNode.history) {
-        add(
-          "history.mode",
-          location,
-          `${label} history record "${historyPath}" has mode "${
-            String(entry.mode)
-          }", expected "${historyNode.history}"`,
-          historyPath
-        )
-      }
-      if (!Array.isArray(entry.active) || !entry.active.every((path) => typeof path === "string")) {
-        add(
-          "history.record",
-          location,
-          `${label} history record "${historyPath}" must contain string paths`,
-          historyPath
-        )
-        continue
-      }
-      if (!isRecord(entry.values)) {
-        add(
-          "history.record",
-          location,
-          `${label} history record "${historyPath}" must contain a values record`,
-          historyPath
-        )
-        continue
-      }
-
-      const rememberedPaths = entry.active as ReadonlyArray<string>
-      const remembered = new Set<string>()
-      for (const path of rememberedPaths) {
-        if (remembered.has(path)) {
-          add("history.path", location, `${label} history record "${historyPath}" repeats "${path}"`, path)
+      for (const [historyPath, unknownEntry] of Object.entries(history)) {
+        const historyNode = byPath.get(historyPath)
+        if (historyNode === undefined || historyNode.type !== "history" || historyNode.parent === undefined) {
+          add("history.path", location, `${label} contains unknown history record "${historyPath}"`, historyPath)
           continue
         }
-        remembered.add(path)
-        const node = byPath.get(path)
-        if (node === undefined || node.type === "history" || node.type === "choice") {
+        if (!isRecord(unknownEntry)) {
+          add("history.record", location, `${label} history record "${historyPath}" must be an object`, historyPath)
+          continue
+        }
+        const entry = unknownEntry
+        if (entry.mode !== historyNode.history) {
           add(
-            "history.path",
+            "history.mode",
             location,
-            `${label} history record "${historyPath}" contains invalid state "${path}"`,
-            path
+            `${label} history record "${historyPath}" has mode "${
+              String(entry.mode)
+            }", expected "${historyNode.history}"`,
+            historyPath
+          )
+        }
+        if (!Array.isArray(entry.active) || !entry.active.every((path) => typeof path === "string")) {
+          add(
+            "history.record",
+            location,
+            `${label} history record "${historyPath}" must contain string paths`,
+            historyPath
           )
           continue
         }
-        const inOwnerSubtree = isDescendantOrSelf(path, historyNode.parent)
-        const inOwnerAncestry = ancestors(historyNode.parent).includes(path)
-        if (!inOwnerSubtree && !inOwnerAncestry) {
+        if (!isRecord(entry.values)) {
           add(
-            "history.path",
+            "history.record",
             location,
-            `${label} history record "${historyPath}" contains state "${path}" outside its owner`,
-            path
+            `${label} history record "${historyPath}" must contain a values record`,
+            historyPath
           )
+          continue
         }
-        const hasValue = hasOwn(entry.values, path)
-        if (node.schema === undefined && hasValue) {
-          add(
-            "history.value",
-            location,
-            `${label} history record "${historyPath}" values structural state "${path}"`,
-            path
-          )
-        } else if (node.schema !== undefined && !hasValue) {
-          add("history.value", location, `${label} history record "${historyPath}" omits value for "${path}"`, path)
-        } else if (node.schema !== undefined && !schemaMatches(node.schema, entry.values[path])) {
-          add(
-            "history.value",
-            location,
-            `${label} history value for "${path}" does not match its state schema`,
-            path
-          )
-        }
-        if (
-          entry.mode === "shallow" && isDescendantOrSelf(path, historyNode.parent) && path !== historyNode.parent &&
-          node.parent !== historyNode.parent
-        ) {
-          add(
-            "history.shallow",
-            location,
-            `${label} shallow history record "${historyPath}" contains deep descendant "${path}"`,
-            path
-          )
-        }
-      }
-      for (const path of Object.keys(entry.values)) {
-        if (!remembered.has(path)) {
-          add("history.value", location, `${label} history record "${historyPath}" has extra value "${path}"`, path)
-        }
-      }
-      if (entry.mode === "deep") {
-        for (const path of remembered) {
-          if (!isDescendantOrSelf(path, historyNode.parent) || path === historyNode.parent) continue
-          let parent: string | undefined = byPath.get(path)?.parent
-          while (parent !== undefined && isDescendantOrSelf(parent, historyNode.parent)) {
-            if (!remembered.has(parent)) {
-              add(
-                "history.deep",
-                location,
-                `${label} deep history record "${historyPath}" remembers "${path}" without ancestor "${parent}"`,
-                path
-              )
-            }
-            if (parent === historyNode.parent) break
-            parent = byPath.get(parent)?.parent
+
+        const rememberedPaths = entry.active as ReadonlyArray<string>
+        const remembered = new Set<string>()
+        for (const path of rememberedPaths) {
+          if (remembered.has(path)) {
+            add("history.path", location, `${label} history record "${historyPath}" repeats "${path}"`, path)
+            continue
           }
-        }
-      }
-      for (const ancestor of ancestors(historyNode.parent)) {
-        if (!remembered.has(ancestor)) {
-          add(
-            "history.path",
-            location,
-            `${label} history record "${historyPath}" omits owner ancestry state "${ancestor}"`,
-            ancestor
-          )
-        }
-      }
-
-      const validateRememberedControl = (path: string, recurse: boolean): void => {
-        const node = byPath.get(path)
-        if (node === undefined) return
-        const activeChildren = node.children.filter((child) => remembered.has(child))
-        if (node.type === "compound") {
-          if (activeChildren.length !== 1) {
+          remembered.add(path)
+          const node = byPath.get(path)
+          if (node === undefined || node.type === "history" || node.type === "choice") {
             add(
-              entry.mode === "deep" ? "history.deep" : "history.shallow",
+              "history.path",
               location,
-              `${label} history record "${historyPath}" must remember one child of compound state "${path}"`,
+              `${label} history record "${historyPath}" contains invalid state "${path}"`,
               path
             )
-          } else if (recurse) {
-            validateRememberedControl(activeChildren[0]!, true)
+            continue
           }
-        } else if (node.type === "parallel") {
-          for (const child of node.children) {
-            if (!remembered.has(child)) {
+          const inOwnerSubtree = isDescendantOrSelf(path, historyNode.parent)
+          const inOwnerAncestry = ancestors(historyNode.parent).includes(path)
+          if (!inOwnerSubtree && !inOwnerAncestry) {
+            add(
+              "history.path",
+              location,
+              `${label} history record "${historyPath}" contains state "${path}" outside its owner`,
+              path
+            )
+          }
+          const hasValue = hasOwn(entry.values, path)
+          if (node.schema === undefined && hasValue) {
+            add(
+              "history.value",
+              location,
+              `${label} history record "${historyPath}" values structural state "${path}"`,
+              path
+            )
+          } else if (node.schema !== undefined && !hasValue) {
+            add("history.value", location, `${label} history record "${historyPath}" omits value for "${path}"`, path)
+          } else if (node.schema !== undefined && !schemaMatches(node.schema, entry.values[path])) {
+            add(
+              "history.value",
+              location,
+              `${label} history value for "${path}" does not match its state schema`,
+              path
+            )
+          }
+          if (
+            entry.mode === "shallow" && isDescendantOrSelf(path, historyNode.parent) && path !== historyNode.parent &&
+            node.parent !== historyNode.parent
+          ) {
+            add(
+              "history.shallow",
+              location,
+              `${label} shallow history record "${historyPath}" contains deep descendant "${path}"`,
+              path
+            )
+          }
+        }
+        for (const path of Object.keys(entry.values)) {
+          if (!remembered.has(path)) {
+            add("history.value", location, `${label} history record "${historyPath}" has extra value "${path}"`, path)
+          }
+        }
+        if (entry.mode === "deep") {
+          for (const path of remembered) {
+            if (!isDescendantOrSelf(path, historyNode.parent) || path === historyNode.parent) continue
+            let parent: string | undefined = byPath.get(path)?.parent
+            while (parent !== undefined && isDescendantOrSelf(parent, historyNode.parent)) {
+              if (!remembered.has(parent)) {
+                add(
+                  "history.deep",
+                  location,
+                  `${label} deep history record "${historyPath}" remembers "${path}" without ancestor "${parent}"`,
+                  path
+                )
+              }
+              if (parent === historyNode.parent) break
+              parent = byPath.get(parent)?.parent
+            }
+          }
+        }
+        for (const ancestor of ancestors(historyNode.parent)) {
+          if (!remembered.has(ancestor)) {
+            add(
+              "history.path",
+              location,
+              `${label} history record "${historyPath}" omits owner ancestry state "${ancestor}"`,
+              ancestor
+            )
+          }
+        }
+
+        const validateRememberedControl = (path: string, recurse: boolean): void => {
+          const node = byPath.get(path)
+          if (node === undefined) return
+          const activeChildren = node.children.filter((child) => remembered.has(child))
+          if (node.type === "compound") {
+            if (activeChildren.length !== 1) {
               add(
                 entry.mode === "deep" ? "history.deep" : "history.shallow",
                 location,
-                `${label} history record "${historyPath}" omits parallel region "${child}"`,
-                child
+                `${label} history record "${historyPath}" must remember one child of compound state "${path}"`,
+                path
               )
             } else if (recurse) {
-              validateRememberedControl(child, true)
+              validateRememberedControl(activeChildren[0]!, true)
+            }
+          } else if (node.type === "parallel") {
+            for (const child of node.children) {
+              if (!remembered.has(child)) {
+                add(
+                  entry.mode === "deep" ? "history.deep" : "history.shallow",
+                  location,
+                  `${label} history record "${historyPath}" omits parallel region "${child}"`,
+                  child
+                )
+              } else if (recurse) {
+                validateRememberedControl(child, true)
+              }
+            }
+          }
+        }
+        validateRememberedControl(historyNode.parent, entry.mode === "deep")
+      }
+    }
+
+    const isCompletedControl = (path: string, active: ReadonlySet<string>): boolean => {
+      if (!active.has(path)) return false
+      const node = byPath.get(path)
+      if (node === undefined) return false
+      if (node.type === "final") return true
+      if (node.type === "compound") {
+        const child = node.children.find((candidate) => active.has(candidate))
+        return child !== undefined && byPath.get(child)?.type === "final"
+      }
+      if (node.type === "parallel") {
+        return node.children.length > 0 && node.children.every((child) => isCompletedControl(child, active))
+      }
+      return false
+    }
+
+    const completionSchema = (path: string, active: ReadonlySet<string>): Schema.Top | undefined => {
+      const node = byPath.get(path)
+      if (node === undefined) return undefined
+      if (node.type === "compound") {
+        const child = node.children.find((candidate) => active.has(candidate))
+        return child === undefined ? undefined : completionSchema(child, active)
+      }
+      return node.output ?? Schema.Void
+    }
+
+    const validateCompletions = (
+      snapshot: SnapshotInspection,
+      location: VerificationLocation,
+      label: string,
+      settled: boolean
+    ): ReadonlyMap<string, unknown> => {
+      const result = new Map<string, unknown>()
+      if (!selected.has("completion") || snapshot.root === undefined) {
+        return result
+      }
+      if (hasOwn(snapshot.root, "completed")) {
+        const completed = snapshot.root.completed
+        if (!Array.isArray(completed)) {
+          add("completion.record", location, `${label} completed metadata must be an array`)
+        } else {
+          for (const unknownEntry of completed) {
+            if (!isRecord(unknownEntry) || typeof unknownEntry.path !== "string") {
+              add("completion.record", location, `${label} contains an invalid completion record`)
+              continue
+            }
+            const path = unknownEntry.path
+            if (result.has(path)) {
+              add("completion.record", location, `${label} repeats completion "${path}"`, path)
+              continue
+            }
+            result.set(path, unknownEntry.output)
+            if (!snapshot.active.has(path) || !isCompletedControl(path, snapshot.active)) {
+              add("completion.record", location, `${label} completion "${path}" is not actively complete`, path)
+              continue
+            }
+            const schema = completionSchema(path, snapshot.active)
+            if (!schemaMatches(schema, unknownEntry.output)) {
+              add(
+                "completion.output",
+                location,
+                `${label} completion output for "${path}" does not match its schema`,
+                path
+              )
             }
           }
         }
       }
-      validateRememberedControl(historyNode.parent, entry.mode === "deep")
-    }
-  }
-
-  const isCompletedControl = (path: string, active: ReadonlySet<string>): boolean => {
-    if (!active.has(path)) return false
-    const node = byPath.get(path)
-    if (node === undefined) return false
-    if (node.type === "final") return true
-    if (node.type === "compound") {
-      const child = node.children.find((candidate) => active.has(candidate))
-      return child !== undefined && byPath.get(child)?.type === "final"
-    }
-    if (node.type === "parallel") {
-      return node.children.length > 0 && node.children.every((child) => isCompletedControl(child, active))
-    }
-    return false
-  }
-
-  const completionSchema = (path: string, active: ReadonlySet<string>): Schema.Top | undefined => {
-    const node = byPath.get(path)
-    if (node === undefined) return undefined
-    if (node.type === "compound") {
-      const child = node.children.find((candidate) => active.has(candidate))
-      return child === undefined ? undefined : completionSchema(child, active)
-    }
-    return node.output ?? Schema.Void
-  }
-
-  const validateCompletions = (
-    snapshot: SnapshotInspection,
-    location: VerificationLocation,
-    label: string,
-    settled: boolean
-  ): ReadonlyMap<string, unknown> => {
-    const result = new Map<string, unknown>()
-    if (!selected.has("completion") || snapshot.root === undefined) {
+      if (settled) {
+        for (const path of snapshot.paths) {
+          if (isCompletedControl(path, snapshot.active) && !result.has(path)) {
+            add("completion.record", location, `${label} omits settled completion "${path}"`, path)
+          }
+        }
+      }
       return result
     }
-    if (hasOwn(snapshot.root, "completed")) {
-      const completed = snapshot.root.completed
-      if (!Array.isArray(completed)) {
-        add("completion.record", location, `${label} completed metadata must be an array`)
-      } else {
-        for (const unknownEntry of completed) {
-          if (!isRecord(unknownEntry) || typeof unknownEntry.path !== "string") {
-            add("completion.record", location, `${label} contains an invalid completion record`)
-            continue
-          }
-          const path = unknownEntry.path
-          if (result.has(path)) {
-            add("completion.record", location, `${label} repeats completion "${path}"`, path)
-            continue
-          }
-          result.set(path, unknownEntry.output)
-          if (!snapshot.active.has(path) || !isCompletedControl(path, snapshot.active)) {
-            add("completion.record", location, `${label} completion "${path}" is not actively complete`, path)
-            continue
-          }
-          const schema = completionSchema(path, snapshot.active)
-          if (!schemaMatches(schema, unknownEntry.output)) {
-            add(
-              "completion.output",
-              location,
-              `${label} completion output for "${path}" does not match its schema`,
-              path
-            )
-          }
-        }
+
+    const validateSnapshotMetadata = (
+      snapshot: SnapshotInspection,
+      location: VerificationLocation,
+      label: string,
+      settled = false
+    ): ReadonlyMap<string, unknown> => {
+      validateHistory(snapshot, location, label)
+      return validateCompletions(snapshot, location, label, settled)
+    }
+
+    const sameControl = (left: SnapshotInspection, right: SnapshotInspection): boolean => {
+      if (!samePaths(left.paths, right.paths)) return false
+      for (const path of left.paths) {
+        if (!sameValue(left.values.get(path), right.values.get(path))) return false
       }
+      return sameValue(left.root?.history, right.root?.history)
     }
-    if (settled) {
-      for (const path of snapshot.paths) {
-        if (isCompletedControl(path, snapshot.active) && !result.has(path)) {
-          add("completion.record", location, `${label} omits settled completion "${path}"`, path)
-        }
+
+    const sameActivePaths = (left: SnapshotInspection, right: SnapshotInspection): boolean =>
+      left.active.size === right.active.size && Array.from(left.active).every((path) => right.active.has(path))
+
+    const sortedPaths = (paths: ReadonlyArray<string>, direction: "entry" | "exit"): ReadonlyArray<string> =>
+      [...new Set(paths)].sort((left, right) => {
+        const depthDifference = direction === "entry" ? depth(left) - depth(right) : depth(right) - depth(left)
+        if (depthDifference !== 0) return depthDifference
+        const leftOrder = byPath.get(left)?.order ?? Number.MAX_SAFE_INTEGER
+        const rightOrder = byPath.get(right)?.order ?? Number.MAX_SAFE_INTEGER
+        return direction === "entry" ? leftOrder - rightOrder : rightOrder - leftOrder
+      })
+
+    const transitionBranch = (
+      transition: Microstep<M>["transitions"][number]
+    ): Machine.Machine.TransitionBranch | undefined => {
+      const definition = definitions.find((candidate) =>
+        candidate.source === transition.source && candidate.reenter === transition.reenter &&
+        sameTransitionTrigger(candidate.trigger, transition.trigger)
+      )
+      return definition === undefined || !Number.isSafeInteger(transition.branchIndex) || transition.branchIndex < 0 ||
+          transition.branchIndex >= definition.branches.length
+        ? undefined
+        : definition.branches[transition.branchIndex]
+    }
+
+    const validateTransitionDefinition = (
+      transition: Microstep<M>["transitions"][number],
+      location: VerificationLocation
+    ): Machine.Machine.TransitionBranch | undefined => {
+      if (!selected.has("definitions")) return undefined
+      const definition = definitions.find((candidate) =>
+        candidate.source === transition.source && candidate.reenter === transition.reenter &&
+        sameTransitionTrigger(candidate.trigger, transition.trigger)
+      )
+      if (definition === undefined) {
+        add(
+          "definitions.transition",
+          location,
+          `retained transition from "${transition.source}" has no public definition`,
+          transition.source
+        )
+        return undefined
       }
-    }
-    return result
-  }
-
-  const validateSnapshotMetadata = (
-    snapshot: SnapshotInspection,
-    location: VerificationLocation,
-    label: string,
-    settled = false
-  ): ReadonlyMap<string, unknown> => {
-    validateHistory(snapshot, location, label)
-    return validateCompletions(snapshot, location, label, settled)
-  }
-
-  const sameControl = (left: SnapshotInspection, right: SnapshotInspection): boolean => {
-    if (!samePaths(left.paths, right.paths)) return false
-    for (const path of left.paths) {
-      if (!sameValue(left.values.get(path), right.values.get(path))) return false
-    }
-    return sameValue(left.root?.history, right.root?.history)
-  }
-
-  const sameActivePaths = (left: SnapshotInspection, right: SnapshotInspection): boolean =>
-    left.active.size === right.active.size && Array.from(left.active).every((path) => right.active.has(path))
-
-  const sortedPaths = (paths: ReadonlyArray<string>, direction: "entry" | "exit"): ReadonlyArray<string> =>
-    [...new Set(paths)].sort((left, right) => {
-      const depthDifference = direction === "entry" ? depth(left) - depth(right) : depth(right) - depth(left)
-      if (depthDifference !== 0) return depthDifference
-      const leftOrder = byPath.get(left)?.order ?? Number.MAX_SAFE_INTEGER
-      const rightOrder = byPath.get(right)?.order ?? Number.MAX_SAFE_INTEGER
-      return direction === "entry" ? leftOrder - rightOrder : rightOrder - leftOrder
-    })
-
-  const transitionBranch = (
-    transition: Microstep<M>["transitions"][number]
-  ): Machine.Machine.TransitionBranch | undefined => {
-    const definition = definitions.find((candidate) =>
-      candidate.source === transition.source && candidate.reenter === transition.reenter &&
-      sameTransitionTrigger(candidate.trigger, transition.trigger)
-    )
-    return definition === undefined || !Number.isSafeInteger(transition.branchIndex) || transition.branchIndex < 0 ||
+      if (
+        !Number.isSafeInteger(transition.branchIndex) || transition.branchIndex < 0 ||
         transition.branchIndex >= definition.branches.length
-      ? undefined
-      : definition.branches[transition.branchIndex]
-  }
+      ) {
+        add(
+          "definitions.branchIndex",
+          location,
+          `retained transition from "${transition.source}" selected invalid branch index ${transition.branchIndex}`,
+          transition.source
+        )
+        return undefined
+      }
+      const branch = definition.branches[transition.branchIndex]!
+      const expectedBranchKey = branch.type === "branch" ? branch.key : undefined
+      if (transition.branchKey !== expectedBranchKey) {
+        add(
+          "definitions.branchKey",
+          location,
+          `retained transition from "${transition.source}" selected branch key ` +
+            `"${String(transition.branchKey)}" instead of "${String(expectedBranchKey)}"`,
+          transition.source
+        )
+        return undefined
+      }
+      if (!targetWithinSelection(transition.target, branch, byPath)) {
+        const expected = branch.selection.kind === "none"
+          ? "an explicitly targetless result"
+          : `selection ${branch.selection.kind}:${branch.selection.scope}:${String(branch.selection.path)}`
+        add(
+          "definitions.selection",
+          location,
+          `transition branch ${transition.branchIndex} from "${transition.source}" returned ` +
+            `target "${String(transition.target)}" outside ${expected}`,
+          transition.target === undefined ? transition.source : String(transition.target)
+        )
+      }
+      if (
+        transition.updates.length !== branch.updates.length ||
+        transition.updates.some((path, index) => path !== branch.updates[index])
+      ) {
+        add(
+          "definitions.selection",
+          location,
+          `transition branch ${transition.branchIndex} from "${transition.source}" reported retained owner updates ` +
+            `${JSON.stringify(transition.updates)} instead of ${JSON.stringify(branch.updates)}`,
+          transition.source
+        )
+      }
+      return branch
+    }
 
-  const validateTransitionDefinition = (
-    transition: Microstep<M>["transitions"][number],
-    location: VerificationLocation
-  ): Machine.Machine.TransitionBranch | undefined => {
-    if (!selected.has("definitions")) return undefined
-    const definition = definitions.find((candidate) =>
-      candidate.source === transition.source && candidate.reenter === transition.reenter &&
-      sameTransitionTrigger(candidate.trigger, transition.trigger)
-    )
-    if (definition === undefined) {
-      add(
-        "definitions.transition",
-        location,
-        `retained transition from "${transition.source}" has no public definition`,
-        transition.source
-      )
-      return undefined
-    }
-    if (
-      !Number.isSafeInteger(transition.branchIndex) || transition.branchIndex < 0 ||
-      transition.branchIndex >= definition.branches.length
-    ) {
-      add(
-        "definitions.branchIndex",
-        location,
-        `retained transition from "${transition.source}" selected invalid branch index ${transition.branchIndex}`,
-        transition.source
-      )
-      return undefined
-    }
-    const branch = definition.branches[transition.branchIndex]!
-    const expectedBranchKey = branch.type === "branch" ? branch.key : undefined
-    if (transition.branchKey !== expectedBranchKey) {
-      add(
-        "definitions.branchKey",
-        location,
-        `retained transition from "${transition.source}" selected branch key ` +
-          `"${String(transition.branchKey)}" instead of "${String(expectedBranchKey)}"`,
-        transition.source
-      )
-      return undefined
-    }
-    if (!targetWithinSelection(transition.target, branch, byPath)) {
-      const expected = branch.selection.kind === "none"
-        ? "an explicitly targetless result"
-        : `selection ${branch.selection.kind}:${branch.selection.scope}:${String(branch.selection.path)}`
-      add(
-        "definitions.selection",
-        location,
-        `transition branch ${transition.branchIndex} from "${transition.source}" returned ` +
-          `target "${String(transition.target)}" outside ${expected}`,
-        transition.target === undefined ? transition.source : String(transition.target)
-      )
-    }
-    if (
-      transition.updates.length !== branch.updates.length ||
-      transition.updates.some((path, index) => path !== branch.updates[index])
-    ) {
-      add(
-        "definitions.selection",
-        location,
-        `transition branch ${transition.branchIndex} from "${transition.source}" reported retained owner updates ` +
-          `${JSON.stringify(transition.updates)} instead of ${JSON.stringify(branch.updates)}`,
-        transition.source
-      )
-    }
-    return branch
-  }
+    const validateTransitionResolutions = (
+      transitions: Microstep<M>["transitions"],
+      branches: ReadonlyArray<Machine.Machine.TransitionBranch | undefined>,
+      location: VerificationLocation
+    ): void => {
+      if (!selected.has("definitions")) return
 
-  const validateTransitionResolutions = (
-    transitions: Microstep<M>["transitions"],
-    branches: ReadonlyArray<Machine.Machine.TransitionBranch | undefined>,
-    location: VerificationLocation
-  ): void => {
-    if (!selected.has("definitions")) return
-
-    const choiceResolution = (
-      start: string,
-      afterIndex: number,
-      nested: boolean
-    ): { readonly found: boolean; readonly target: string | undefined } => {
-      const seen = new Set<string>()
-      let choice = start
-      let cursor = afterIndex + 1
-      let first = true
-      while (!seen.has(choice)) {
-        seen.add(choice)
-        let choiceIndex = -1
-        for (let index = cursor; index < transitions.length; index++) {
-          const candidate = transitions[index]!
-          if (
-            candidate.trigger.type === "choice" &&
-            (candidate.source === choice || first && nested && isDescendantOrSelf(String(candidate.source), choice))
-          ) {
-            choiceIndex = index
-            break
+      const choiceResolution = (
+        start: string,
+        afterIndex: number,
+        nested: boolean
+      ): { readonly found: boolean; readonly target: string | undefined } => {
+        const seen = new Set<string>()
+        let choice = start
+        let cursor = afterIndex + 1
+        let first = true
+        while (!seen.has(choice)) {
+          seen.add(choice)
+          let choiceIndex = -1
+          for (let index = cursor; index < transitions.length; index++) {
+            const candidate = transitions[index]!
+            if (
+              candidate.trigger.type === "choice" &&
+              (candidate.source === choice || first && nested && isDescendantOrSelf(String(candidate.source), choice))
+            ) {
+              choiceIndex = index
+              break
+            }
+          }
+          if (choiceIndex === -1) return { found: false, target: undefined }
+          const transition = transitions[choiceIndex]!
+          if (branches[choiceIndex] === undefined) return { found: false, target: undefined }
+          const target = transition.target === undefined ? undefined : String(transition.target)
+          if (target === undefined) return { found: true, target: undefined }
+          const targetNode = byPath.get(target)
+          if (targetNode?.type === "choice") {
+            choice = target
+            cursor = choiceIndex + 1
+            first = false
+            continue
+          }
+          return {
+            found: true,
+            target: targetNode?.type === "history" ? targetNode.parent : target
           }
         }
-        if (choiceIndex === -1) return { found: false, target: undefined }
-        const transition = transitions[choiceIndex]!
-        if (branches[choiceIndex] === undefined) return { found: false, target: undefined }
-        const target = transition.target === undefined ? undefined : String(transition.target)
-        if (target === undefined) return { found: true, target: undefined }
-        const targetNode = byPath.get(target)
-        if (targetNode?.type === "choice") {
-          choice = target
-          cursor = choiceIndex + 1
-          first = false
-          continue
-        }
-        return {
-          found: true,
-          target: targetNode?.type === "history" ? targetNode.parent : target
-        }
+        return { found: false, target: undefined }
       }
-      return { found: false, target: undefined }
-    }
 
-    transitions.forEach((transition, index) => {
-      if (branches[index] === undefined) return
-      const target = transition.target === undefined ? undefined : String(transition.target)
-      const resolvedTarget = transition.resolvedTarget === undefined ? undefined : String(transition.resolvedTarget)
-      const targetNode = target === undefined ? undefined : byPath.get(target)
-      let expected = target
-      let explanation = transition.updates.length > 0
-        ? target === undefined
-          ? `update owner "${transition.updates.join("\", \"")}"`
-          : `target "${target}" and update owner "${transition.updates.join("\", \"")}"`
-        : target === undefined
-        ? "an unresolved targetless transition"
-        : `target "${target}"`
+      transitions.forEach((transition, index) => {
+        if (branches[index] === undefined) return
+        const target = transition.target === undefined ? undefined : String(transition.target)
+        const resolvedTarget = transition.resolvedTarget === undefined ? undefined : String(transition.resolvedTarget)
+        const targetNode = target === undefined ? undefined : byPath.get(target)
+        let expected = target
+        let explanation = transition.updates.length > 0
+          ? target === undefined
+            ? `update owner "${transition.updates.join("\", \"")}"`
+            : `target "${target}" and update owner "${transition.updates.join("\", \"")}"`
+          : target === undefined
+          ? "an unresolved targetless transition"
+          : `target "${target}"`
 
-      if (transition.trigger.type === "choice") {
-        explanation = target === undefined ? "a targetless choice edge" : `choice edge target "${target}"`
-      } else if (targetNode?.type === "history") {
-        expected = targetNode.parent
-        explanation = `history owner "${String(targetNode.parent)}"`
-      } else if (targetNode?.type === "choice") {
-        const resolution = choiceResolution(targetNode.path, index, false)
-        if (!resolution.found) {
+        if (transition.trigger.type === "choice") {
+          explanation = target === undefined ? "a targetless choice edge" : `choice edge target "${target}"`
+        } else if (targetNode?.type === "history") {
+          expected = targetNode.parent
+          explanation = `history owner "${String(targetNode.parent)}"`
+        } else if (targetNode?.type === "choice") {
+          const resolution = choiceResolution(targetNode.path, index, false)
+          if (!resolution.found) {
+            add(
+              "definitions.resolution",
+              location,
+              `transition from "${transition.source}" targets choice "${target}" without an exact retained route`,
+              target
+            )
+            return
+          }
+          expected = resolution.target
+          explanation = expected === undefined ?
+            `targetless route from choice "${target}"` :
+            `choice route from "${target}" to "${expected}"`
+        } else if (
+          resolvedTarget !== target &&
+          (targetNode?.type === "compound" || targetNode?.type === "parallel")
+        ) {
+          const resolution = choiceResolution(targetNode.path, index, true)
+          if (resolution.found) {
+            expected = resolution.target
+            explanation = expected === undefined ?
+              `targetless nested choice route from "${target}"` :
+              `nested choice route from "${target}" to "${expected}"`
+          }
+        }
+
+        if (resolvedTarget !== expected) {
           add(
             "definitions.resolution",
             location,
-            `transition from "${transition.source}" targets choice "${target}" without an exact retained route`,
-            target
+            `transition branch ${transition.branchIndex} from "${transition.source}" resolved to ` +
+              `"${String(transition.resolvedTarget)}" instead of ${explanation}`,
+            resolvedTarget ?? target ?? String(transition.source)
           )
-          return
         }
-        expected = resolution.target
-        explanation = expected === undefined ?
-          `targetless route from choice "${target}"` :
-          `choice route from "${target}" to "${expected}"`
-      } else if (
-        resolvedTarget !== target &&
-        (targetNode?.type === "compound" || targetNode?.type === "parallel")
-      ) {
-        const resolution = choiceResolution(targetNode.path, index, true)
-        if (resolution.found) {
-          expected = resolution.target
-          explanation = expected === undefined ?
-            `targetless nested choice route from "${target}"` :
-            `nested choice route from "${target}" to "${expected}"`
-        }
-      }
-
-      if (resolvedTarget !== expected) {
-        add(
-          "definitions.resolution",
-          location,
-          `transition branch ${transition.branchIndex} from "${transition.source}" resolved to ` +
-            `"${String(transition.resolvedTarget)}" instead of ${explanation}`,
-          resolvedTarget ?? target ?? String(transition.source)
-        )
-      }
-    })
-  }
-
-  const initialChoiceRouteRoot = (): string | undefined => {
-    const routing = trace.initial.plan.microsteps[0]
-    if (
-      routing === undefined || routing.changed ||
-      routing.transitions.length === 0 ||
-      !routing.transitions.every((transition) => transition.trigger.type === "choice")
-    ) {
-      return undefined
+      })
     }
 
-    const reachableScopes: Array<string> = [initialDefinition.target]
-    let terminalRoot: string | undefined
-    for (const transition of routing.transitions) {
-      const source = String(transition.source)
-      const branch = transitionBranch(transition)
+    const initialChoiceRouteRoot = (): string | undefined => {
+      const routing = trace.initial.plan.microsteps[0]
       if (
-        branch === undefined || !targetWithinSelection(transition.target, branch, byPath) ||
-        !reachableScopes.some((scope) => isDescendantOrSelf(source, scope))
+        routing === undefined || routing.changed ||
+        routing.transitions.length === 0 ||
+        !routing.transitions.every((transition) => transition.trigger.type === "choice")
       ) {
         return undefined
       }
-      const target = transition.target === undefined ? undefined : String(transition.target)
-      if (target === undefined) return undefined
-      const targetNode = byPath.get(target)
-      const scope = targetNode?.type === "history" ? targetNode.parent : target
-      if (scope === undefined) return undefined
-      reachableScopes.push(scope)
-      terminalRoot = ancestors(scope)[0]
-    }
-    return terminalRoot
-  }
 
-  const validateMicrostep = (
-    microstep: Microstep<M, any>,
-    before: SnapshotInspection,
-    after: SnapshotInspection,
-    location: VerificationLocation
-  ): void => {
-    if (selected.has("microsteps")) {
-      const uniqueExit = new Set(microstep.exitPaths)
-      const uniqueEntry = new Set(microstep.entryPaths)
-      const reentering = microstep.transitions.filter((transition) => transition.reenter)
-      const inReentryScope = (
-        path: string,
-        transition: Microstep<M>["transitions"][number]
-      ): boolean => {
-        const target = transition.target === undefined ? undefined : byPath.get(String(transition.target))
-        if (target?.type === "history" && target.parent !== undefined && before.active.has(target.parent)) {
-          return isDescendantOrSelf(path, target.parent)
+      const reachableScopes: Array<string> = [initialDefinition.target]
+      let terminalRoot: string | undefined
+      for (const transition of routing.transitions) {
+        const source = String(transition.source)
+        const branch = transitionBranch(transition)
+        if (
+          branch === undefined || !targetWithinSelection(transition.target, branch, byPath) ||
+          !reachableScopes.some((scope) => isDescendantOrSelf(source, scope))
+        ) {
+          return undefined
         }
-        const parent = byPath.get(String(transition.source))?.parent
-        return parent === undefined || path !== parent && isDescendantOrSelf(path, parent)
+        const target = transition.target === undefined ? undefined : String(transition.target)
+        if (target === undefined) return undefined
+        const targetNode = byPath.get(target)
+        const scope = targetNode?.type === "history" ? targetNode.parent : target
+        if (scope === undefined) return undefined
+        reachableScopes.push(scope)
+        terminalRoot = ancestors(scope)[0]
       }
-      const commonLifecycleExplained = (path: string): boolean =>
-        microstep.transitions.some((transition) => {
-          if (transition.reenter) {
-            const target = transition.target === undefined ? undefined : byPath.get(String(transition.target))
-            if (target?.type === "history" && target.parent !== undefined && before.active.has(target.parent)) {
-              // Reentry into an active history owner has a dedicated boundary:
-              // only the owner subtree is exited and entered, regardless of
-              // the ordinary source/resolved-target LCA.
-              return isDescendantOrSelf(path, target.parent)
+      return terminalRoot
+    }
+
+    const validateMicrostep = (
+      microstep: Microstep<M, any>,
+      before: SnapshotInspection,
+      after: SnapshotInspection,
+      location: VerificationLocation
+    ): void => {
+      if (selected.has("microsteps")) {
+        const uniqueExit = new Set(microstep.exitPaths)
+        const uniqueEntry = new Set(microstep.entryPaths)
+        const reentering = microstep.transitions.filter((transition) => transition.reenter)
+        const inReentryScope = (
+          path: string,
+          transition: Microstep<M>["transitions"][number]
+        ): boolean => {
+          const target = transition.target === undefined ? undefined : byPath.get(String(transition.target))
+          if (target?.type === "history" && target.parent !== undefined && before.active.has(target.parent)) {
+            return isDescendantOrSelf(path, target.parent)
+          }
+          const parent = byPath.get(String(transition.source))?.parent
+          return parent === undefined || path !== parent && isDescendantOrSelf(path, parent)
+        }
+        const commonLifecycleExplained = (path: string): boolean =>
+          microstep.transitions.some((transition) => {
+            if (transition.reenter) {
+              const target = transition.target === undefined ? undefined : byPath.get(String(transition.target))
+              if (target?.type === "history" && target.parent !== undefined && before.active.has(target.parent)) {
+                // Reentry into an active history owner has a dedicated boundary:
+                // only the owner subtree is exited and entered, regardless of
+                // the ordinary source/resolved-target LCA.
+                return isDescendantOrSelf(path, target.parent)
+              }
+              if (inReentryScope(path, transition)) return true
             }
-            if (inReentryScope(path, transition)) return true
+            if (transition.resolvedTarget === undefined) return false
+            const sourceAncestors = ancestors(String(transition.source))
+            const targetAncestors = ancestors(String(transition.resolvedTarget))
+            let boundary: string | undefined
+            for (let index = 0; index < Math.min(sourceAncestors.length, targetAncestors.length); index++) {
+              if (sourceAncestors[index] !== targetAncestors[index]) break
+              boundary = sourceAncestors[index]
+            }
+            return boundary === undefined || path !== boundary && isDescendantOrSelf(path, boundary)
+          })
+        if (uniqueExit.size !== microstep.exitPaths.length) {
+          add("microsteps.unique", location, "microstep exit paths contain duplicates")
+        }
+        if (uniqueEntry.size !== microstep.entryPaths.length) {
+          add("microsteps.unique", location, "microstep entry paths contain duplicates")
+        }
+        if (!samePaths(microstep.exitPaths, sortedPaths(microstep.exitPaths, "exit"))) {
+          add("microsteps.order", location, "microstep exit paths are not deepest-first in reverse document order")
+        }
+        if (!samePaths(microstep.entryPaths, sortedPaths(microstep.entryPaths, "entry"))) {
+          add("microsteps.order", location, "microstep entry paths are not parent-first in document order")
+        }
+        for (const path of microstep.exitPaths) {
+          if (!before.active.has(path)) {
+            add("microsteps.activeBefore", location, `microstep exits inactive state "${path}"`, path)
           }
-          if (transition.resolvedTarget === undefined) return false
-          const sourceAncestors = ancestors(String(transition.source))
-          const targetAncestors = ancestors(String(transition.resolvedTarget))
-          let boundary: string | undefined
-          for (let index = 0; index < Math.min(sourceAncestors.length, targetAncestors.length); index++) {
-            if (sourceAncestors[index] !== targetAncestors[index]) break
-            boundary = sourceAncestors[index]
+        }
+        for (const path of microstep.entryPaths) {
+          if (!after.active.has(path)) {
+            add("microsteps.activeAfter", location, `microstep enters state "${path}" absent from its next state`, path)
           }
-          return boundary === undefined || path !== boundary && isDescendantOrSelf(path, boundary)
-        })
-      if (uniqueExit.size !== microstep.exitPaths.length) {
-        add("microsteps.unique", location, "microstep exit paths contain duplicates")
-      }
-      if (uniqueEntry.size !== microstep.entryPaths.length) {
-        add("microsteps.unique", location, "microstep entry paths contain duplicates")
-      }
-      if (!samePaths(microstep.exitPaths, sortedPaths(microstep.exitPaths, "exit"))) {
-        add("microsteps.order", location, "microstep exit paths are not deepest-first in reverse document order")
-      }
-      if (!samePaths(microstep.entryPaths, sortedPaths(microstep.entryPaths, "entry"))) {
-        add("microsteps.order", location, "microstep entry paths are not parent-first in document order")
-      }
-      for (const path of microstep.exitPaths) {
-        if (!before.active.has(path)) {
-          add("microsteps.activeBefore", location, `microstep exits inactive state "${path}"`, path)
         }
-      }
-      for (const path of microstep.entryPaths) {
-        if (!after.active.has(path)) {
-          add("microsteps.activeAfter", location, `microstep enters state "${path}" absent from its next state`, path)
-        }
-      }
-      for (const path of before.paths) {
-        if (!after.active.has(path) && !uniqueExit.has(path)) {
-          add("microsteps.activeBefore", location, `removed state "${path}" is missing from exit paths`, path)
-        }
-      }
-      for (const path of after.paths) {
-        if (!before.active.has(path) && !uniqueEntry.has(path)) {
-          add("microsteps.activeAfter", location, `added state "${path}" is missing from entry paths`, path)
-        }
-      }
-      for (const transition of reentering) {
         for (const path of before.paths) {
-          if (inReentryScope(path, transition) && !uniqueExit.has(path)) {
-            add(
-              "microsteps.reentry",
-              location,
-              `reentering transition from "${String(transition.source)}" omits exit lifecycle for "${path}"`,
-              path
-            )
+          if (!after.active.has(path) && !uniqueExit.has(path)) {
+            add("microsteps.activeBefore", location, `removed state "${path}" is missing from exit paths`, path)
           }
         }
         for (const path of after.paths) {
-          if (inReentryScope(path, transition) && !uniqueEntry.has(path)) {
+          if (!before.active.has(path) && !uniqueEntry.has(path)) {
+            add("microsteps.activeAfter", location, `added state "${path}" is missing from entry paths`, path)
+          }
+        }
+        for (const transition of reentering) {
+          for (const path of before.paths) {
+            if (inReentryScope(path, transition) && !uniqueExit.has(path)) {
+              add(
+                "microsteps.reentry",
+                location,
+                `reentering transition from "${String(transition.source)}" omits exit lifecycle for "${path}"`,
+                path
+              )
+            }
+          }
+          for (const path of after.paths) {
+            if (inReentryScope(path, transition) && !uniqueEntry.has(path)) {
+              add(
+                "microsteps.reentry",
+                location,
+                `reentering transition from "${String(transition.source)}" omits entry lifecycle for "${path}"`,
+                path
+              )
+            }
+          }
+        }
+        for (const path of before.paths) {
+          if (!after.active.has(path) || !uniqueExit.has(path) && !uniqueEntry.has(path)) continue
+          if (!commonLifecycleExplained(path)) {
             add(
               "microsteps.reentry",
               location,
-              `reentering transition from "${String(transition.source)}" omits entry lifecycle for "${path}"`,
+              `common state "${path}" has lifecycle without a reentering transition`,
+              path
+            )
+          } else if (!uniqueExit.has(path) || !uniqueEntry.has(path)) {
+            add(
+              "microsteps.reentry",
+              location,
+              `reentered common state "${path}" must have both exit and entry lifecycle`,
               path
             )
           }
         }
-      }
-      for (const path of before.paths) {
-        if (!after.active.has(path) || !uniqueExit.has(path) && !uniqueEntry.has(path)) continue
-        if (!commonLifecycleExplained(path)) {
-          add(
-            "microsteps.reentry",
-            location,
-            `common state "${path}" has lifecycle without a reentering transition`,
-            path
-          )
-        } else if (!uniqueExit.has(path) || !uniqueEntry.has(path)) {
-          add(
-            "microsteps.reentry",
-            location,
-            `reentered common state "${path}" must have both exit and entry lifecycle`,
-            path
-          )
+        if (!microstep.changed) {
+          if (microstep.exitPaths.length > 0 || microstep.entryPaths.length > 0) {
+            add("microsteps.changed", location, "unchanged microstep contains entry or exit paths")
+          }
+          if (!sameActivePaths(before, after)) {
+            add("microsteps.changed", location, "unchanged microstep changes its active state paths")
+          }
+        } else if (
+          microstep.exitPaths.length === 0 && microstep.entryPaths.length === 0 && sameActivePaths(before, after)
+        ) {
+          add("microsteps.changed", location, "changed microstep has no control-state change or reentry evidence")
+        }
+        for (const transition of microstep.transitions) {
+          if (
+            !before.active.has(String(transition.source)) &&
+            byPath.get(String(transition.source))?.type !== "choice"
+          ) {
+            add(
+              "microsteps.activeBefore",
+              location,
+              `transition source "${String(transition.source)}" is inactive before the microstep`,
+              String(transition.source)
+            )
+          }
+          if (
+            transition.resolvedTarget !== undefined && !after.active.has(String(transition.resolvedTarget)) &&
+            microstep.transitions.length === 1
+          ) {
+            add(
+              "microsteps.activeAfter",
+              location,
+              `resolved target "${String(transition.resolvedTarget)}" is inactive after the microstep`,
+              String(transition.resolvedTarget)
+            )
+          }
         }
       }
-      if (!microstep.changed) {
-        if (microstep.exitPaths.length > 0 || microstep.entryPaths.length > 0) {
-          add("microsteps.changed", location, "unchanged microstep contains entry or exit paths")
+      const branches = microstep.transitions.map((transition) => validateTransitionDefinition(transition, location))
+      validateTransitionResolutions(microstep.transitions, branches, location)
+    }
+
+    const validatePlanCompletion = (
+      plan: PlanCompletion<M>,
+      snapshot: SnapshotInspection,
+      completions: ReadonlyMap<string, unknown>,
+      location: VerificationLocation,
+      label: string
+    ): void => {
+      if (!selected.has("completion")) return
+      const rootPath = snapshot.paths.find((path) => byPath.get(path)?.parent === undefined)
+      const hasRootDoneTransition = rootPath !== undefined &&
+        definitions.some((definition) => definition.source === rootPath && definition.trigger.type === "done")
+      const terminal = rootPath !== undefined && isCompletedControl(rootPath, snapshot.active) && !hasRootDoneTransition
+      if (plan.done !== terminal) {
+        add(
+          "completion.done",
+          location,
+          `${label} reports done=${String(plan.done)} for terminal=${String(terminal)}`,
+          rootPath
+        )
+      }
+      if (plan.done) {
+        if (rootPath === undefined || !completions.has(rootPath)) {
+          add("completion.output", location, `${label} done plan has no root completion output`, rootPath)
+        } else if (!sameValue(plan.output, completions.get(rootPath))) {
+          add("completion.output", location, `${label} output differs from its root completion`, rootPath)
         }
-        if (!sameActivePaths(before, after)) {
-          add("microsteps.changed", location, "unchanged microstep changes its active state paths")
-        }
-      } else if (
-        microstep.exitPaths.length === 0 && microstep.entryPaths.length === 0 && sameActivePaths(before, after)
+      } else if (plan.output !== undefined) {
+        add("completion.output", location, `${label} non-done plan exposes an output`, rootPath)
+      }
+    }
+
+    const initialLocation: VerificationLocation = { eventIndex: undefined }
+    const starting = inspectSnapshot(trace.initial.startingState, initialLocation, "initial starting state")
+    if (selected.has("definitions")) {
+      const startingRoots = starting.paths.filter((path) => byPath.get(path)?.parent === undefined)
+      const routedRoot = startingRoots.length === 1 && startingRoots[0] !== initialDefinition.target
+        ? initialChoiceRouteRoot()
+        : undefined
+      if (
+        startingRoots.length !== 1 ||
+        startingRoots[0] !== initialDefinition.target && startingRoots[0] !== routedRoot
       ) {
-        add("microsteps.changed", location, "changed microstep has no control-state change or reentry evidence")
-      }
-      for (const transition of microstep.transitions) {
-        if (
-          !before.active.has(String(transition.source)) &&
-          byPath.get(String(transition.source))?.type !== "choice"
-        ) {
-          add(
-            "microsteps.activeBefore",
-            location,
-            `transition source "${String(transition.source)}" is inactive before the microstep`,
-            String(transition.source)
-          )
-        }
-        if (
-          transition.resolvedTarget !== undefined && !after.active.has(String(transition.resolvedTarget)) &&
-          microstep.transitions.length === 1
-        ) {
-          add(
-            "microsteps.activeAfter",
-            location,
-            `resolved target "${String(transition.resolvedTarget)}" is inactive after the microstep`,
-            String(transition.resolvedTarget)
-          )
-        }
+        add(
+          "definitions.initial",
+          initialLocation,
+          `initial starting state selected roots [${startingRoots.join(", ")}] without an exact route from ` +
+            `declared root "${initialDefinition.target}"`,
+          startingRoots[0] ?? initialDefinition.target
+        )
       }
     }
-    const branches = microstep.transitions.map((transition) => validateTransitionDefinition(transition, location))
-    validateTransitionResolutions(microstep.transitions, branches, location)
-  }
-
-  const validatePlanCompletion = (
-    plan: PlanCompletion<M>,
-    snapshot: SnapshotInspection,
-    completions: ReadonlyMap<string, unknown>,
-    location: VerificationLocation,
-    label: string
-  ): void => {
-    if (!selected.has("completion")) return
-    const rootPath = snapshot.paths.find((path) => byPath.get(path)?.parent === undefined)
-    const hasRootDoneTransition = rootPath !== undefined &&
-      definitions.some((definition) => definition.source === rootPath && definition.trigger.type === "done")
-    const terminal = rootPath !== undefined && isCompletedControl(rootPath, snapshot.active) && !hasRootDoneTransition
-    if (plan.done !== terminal) {
-      add(
-        "completion.done",
-        location,
-        `${label} reports done=${String(plan.done)} for terminal=${String(terminal)}`,
-        rootPath
-      )
-    }
-    if (plan.done) {
-      if (rootPath === undefined || !completions.has(rootPath)) {
-        add("completion.output", location, `${label} done plan has no root completion output`, rootPath)
-      } else if (!sameValue(plan.output, completions.get(rootPath))) {
-        add("completion.output", location, `${label} output differs from its root completion`, rootPath)
-      }
-    } else if (plan.output !== undefined) {
-      add("completion.output", location, `${label} non-done plan exposes an output`, rootPath)
-    }
-  }
-
-  const initialLocation: VerificationLocation = { eventIndex: undefined }
-  const starting = inspectSnapshot(trace.initial.startingState, initialLocation, "initial starting state")
-  if (selected.has("definitions")) {
-    const startingRoots = starting.paths.filter((path) => byPath.get(path)?.parent === undefined)
-    const routedRoot = startingRoots.length === 1 && startingRoots[0] !== initialDefinition.target
-      ? initialChoiceRouteRoot()
-      : undefined
-    if (
-      startingRoots.length !== 1 ||
-      startingRoots[0] !== initialDefinition.target && startingRoots[0] !== routedRoot
-    ) {
-      add(
-        "definitions.initial",
-        initialLocation,
-        `initial starting state selected roots [${startingRoots.join(", ")}] without an exact route from ` +
-          `declared root "${initialDefinition.target}"`,
-        startingRoots[0] ?? initialDefinition.target
-      )
-    }
-  }
-  validateSnapshotMetadata(starting, initialLocation, "initial starting state")
-  validateTraceConfiguration(
-    starting,
-    trace.initial.startingConfiguration as ReadonlyArray<string>,
-    initialLocation,
-    "initial starting"
-  )
-  if (selected.has("microsteps")) {
-    if (new Set(trace.initial.initialEntryPaths).size !== trace.initial.initialEntryPaths.length) {
-      add("microsteps.unique", initialLocation, "initial entry paths contain duplicates")
-    }
-    if (!samePaths(trace.initial.initialEntryPaths as ReadonlyArray<string>, starting.paths)) {
-      add(
-        "microsteps.order",
-        initialLocation,
-        "initial entry paths do not cover the starting configuration in definition order"
-      )
-    }
-  }
-
-  let current = starting
-  for (let index = 0; index < trace.initial.plan.microsteps.length; index++) {
-    const location: VerificationLocation = { eventIndex: undefined, microstepIndex: index }
-    const microstep = trace.initial.plan.microsteps[index]!
-    const next = inspectSnapshot(microstep.next, location, `initial microstep ${index} next state`)
-    validateSnapshotMetadata(next, location, `initial microstep ${index} next state`)
-    validateMicrostep(microstep, current, next, location)
-    current = next
-  }
-  const initialState = inspectSnapshot(trace.initial.plan.state, initialLocation, "initial plan state")
-  const initialCompletions = validateSnapshotMetadata(initialState, initialLocation, "initial plan state", true)
-  if (selected.has("microsteps") && !sameControl(current, initialState)) {
-    add("microsteps.continuity", initialLocation, "initial plan state does not continue from its final microstep")
-  }
-  validatePlanCompletion(trace.initial.plan, initialState, initialCompletions, initialLocation, "initial plan")
-  validateTraceConfiguration(
-    initialState,
-    trace.initial.configuration as ReadonlyArray<string>,
-    initialLocation,
-    "initial"
-  )
-  if (selected.has("microsteps") && !sameValue(trace.initial.startingState, trace.initial.plan.startingState)) {
-    add("microsteps.continuity", initialLocation, "initial trace starting state differs from its plan")
-  }
-  if (
-    selected.has("microsteps") &&
-    !samePaths(trace.initial.initialEntryPaths as ReadonlyArray<string>, trace.initial.plan.initialEntryPaths)
-  ) {
-    add("microsteps.continuity", initialLocation, "initial trace entry paths differ from its plan")
-  }
-
-  let previous = initialState
-  for (let eventIndex = 0; eventIndex < trace.steps.length; eventIndex++) {
-    const step = trace.steps[eventIndex]!
-    const location: VerificationLocation = { eventIndex }
-    const before = inspectSnapshot(step.before, location, `event ${eventIndex} before state`)
-    validateSnapshotMetadata(before, location, `event ${eventIndex} before state`, true)
+    validateSnapshotMetadata(starting, initialLocation, "initial starting state")
     validateTraceConfiguration(
-      before,
-      step.beforeConfiguration as ReadonlyArray<string>,
-      location,
-      `event ${eventIndex} before`
+      starting,
+      trace.initial.startingConfiguration as ReadonlyArray<string>,
+      initialLocation,
+      "initial starting"
     )
     if (selected.has("microsteps")) {
-      if (step.index !== eventIndex) {
-        add("microsteps.continuity", location, `trace step index ${step.index} does not equal ${eventIndex}`)
+      if (new Set(trace.initial.initialEntryPaths).size !== trace.initial.initialEntryPaths.length) {
+        add("microsteps.unique", initialLocation, "initial entry paths contain duplicates")
       }
-      if (!sameValue(previous.root, before.root)) {
-        add("microsteps.continuity", location, `event ${eventIndex} before state does not equal the previous state`)
-      }
-      if (!sameValue(step.event, trace.scenario.events[eventIndex])) {
-        add("microsteps.continuity", location, `event ${eventIndex} differs from its scenario event`)
+      if (!samePaths(trace.initial.initialEntryPaths as ReadonlyArray<string>, starting.paths)) {
+        add(
+          "microsteps.order",
+          initialLocation,
+          "initial entry paths do not cover the starting configuration in definition order"
+        )
       }
     }
 
-    current = before
-    for (let microstepIndex = 0; microstepIndex < step.plan.microsteps.length; microstepIndex++) {
-      const microstepLocation: VerificationLocation = { eventIndex, microstepIndex }
-      const microstep = step.plan.microsteps[microstepIndex]!
-      const next = inspectSnapshot(
-        microstep.next,
-        microstepLocation,
-        `event ${eventIndex} microstep ${microstepIndex} next state`
-      )
-      validateSnapshotMetadata(next, microstepLocation, `event ${eventIndex} microstep ${microstepIndex} next state`)
-      validateMicrostep(microstep, current, next, microstepLocation)
+    let current = starting
+    for (let index = 0; index < trace.initial.plan.microsteps.length; index++) {
+      const location: VerificationLocation = { eventIndex: undefined, microstepIndex: index }
+      const microstep = trace.initial.plan.microsteps[index]!
+      const next = inspectSnapshot(microstep.next, location, `initial microstep ${index} next state`)
+      validateSnapshotMetadata(next, location, `initial microstep ${index} next state`)
+      validateMicrostep(microstep, current, next, location)
       current = next
     }
-
-    const plannedNext = inspectSnapshot(step.plan.next, location, `event ${eventIndex} plan next state`)
-    const completions = validateSnapshotMetadata(plannedNext, location, `event ${eventIndex} plan next state`, true)
-    if (selected.has("microsteps") && !sameControl(current, plannedNext)) {
-      add(
-        "microsteps.continuity",
-        location,
-        `event ${eventIndex} plan next state does not continue its final microstep`
-      )
+    const initialState = inspectSnapshot(trace.initial.plan.state, initialLocation, "initial plan state")
+    const initialCompletions = validateSnapshotMetadata(initialState, initialLocation, "initial plan state", true)
+    if (selected.has("microsteps") && !sameControl(current, initialState)) {
+      add("microsteps.continuity", initialLocation, "initial plan state does not continue from its final microstep")
     }
-    validatePlanCompletion(step.plan, plannedNext, completions, location, `event ${eventIndex} plan`)
-
-    const after = inspectSnapshot(step.after, location, `event ${eventIndex} after state`)
-    validateSnapshotMetadata(after, location, `event ${eventIndex} after state`, true)
+    validatePlanCompletion(trace.initial.plan, initialState, initialCompletions, initialLocation, "initial plan")
     validateTraceConfiguration(
-      after,
-      step.afterConfiguration as ReadonlyArray<string>,
-      location,
-      `event ${eventIndex} after`
+      initialState,
+      trace.initial.configuration as ReadonlyArray<string>,
+      initialLocation,
+      "initial"
     )
-    if (selected.has("microsteps") && !sameValue(step.plan.next, step.after)) {
-      add("microsteps.continuity", location, `event ${eventIndex} after state differs from its plan next state`)
+    if (selected.has("microsteps") && !sameValue(trace.initial.startingState, trace.initial.plan.startingState)) {
+      add("microsteps.continuity", initialLocation, "initial trace starting state differs from its plan")
     }
-    previous = after
-  }
+    if (
+      selected.has("microsteps") &&
+      !samePaths(trace.initial.initialEntryPaths as ReadonlyArray<string>, trace.initial.plan.initialEntryPaths)
+    ) {
+      add("microsteps.continuity", initialLocation, "initial trace entry paths differ from its plan")
+    }
 
-  const finalEventIndex = trace.steps.length === 0 ? undefined : trace.steps.length - 1
-  const finalLocation: VerificationLocation = { eventIndex: finalEventIndex }
-  const final = inspectSnapshot(trace.final, finalLocation, "trace final state")
-  validateSnapshotMetadata(final, finalLocation, "trace final state", true)
-  validateTraceConfiguration(final, trace.finalConfiguration as ReadonlyArray<string>, finalLocation, "final")
-  if (selected.has("microsteps") && !sameValue(previous.root, final.root)) {
-    add("microsteps.continuity", finalLocation, "trace final state differs from its final planned state")
-  }
-
-  return violations.length === 0 ? Effect.void : Effect.fail(new VerificationError({ violations }))
-}
-
-const formatConfiguration = (paths: ReadonlyArray<string>): string => `[${paths.join(", ")}]`
-
-const formatMicrosteps = <M extends AnyMachine>(microsteps: ReadonlyArray<Microstep<M, any>>): Array<string> =>
-  microsteps.map((microstep, index) => {
-    const transitions = microstep.transitions.map((transition) => ({
-      source: transition.source,
-      trigger: transition.trigger,
-      reenter: transition.reenter,
-      branchIndex: transition.branchIndex,
-      target: transition.target,
-      resolvedTarget: transition.resolvedTarget
-    }))
-    return `  microstep ${index}: event=${formatValue(microstep.event)} changed=${String(microstep.changed)} ` +
-      `transitions=${formatValue(transitions)} exit=${formatConfiguration(microstep.exitPaths)} ` +
-      `entry=${formatConfiguration(microstep.entryPaths)} commands=${microstep.commands.length} ` +
-      `raised=${formatValue(microstep.raisedEvents)} emitted=${formatValue(microstep.emittedEvents)} ` +
-      `next=${formatValue(microstep.next)}`
-  })
-
-const formatInitial = <M extends AnyMachine>(initial: InitialTrace<M>): Array<string> => [
-  `initial: startingConfiguration=${formatConfiguration(initial.startingConfiguration)} ` +
-  `startingState=${formatValue(initial.startingState)} initialEntry=${
-    formatConfiguration(initial.initialEntryPaths)
-  } ` +
-  `configuration=${formatConfiguration(initial.configuration)} state=${formatValue(initial.plan.state)} ` +
-  `done=${String(initial.plan.done)} output=${formatValue(initial.plan.output)} ` +
-  `commands=${initial.plan.commands.length} emitted=${formatValue(initial.plan.emittedEvents)}`,
-  ...formatMicrosteps(initial.plan.microsteps)
-]
-
-const formatStep = <M extends AnyMachine>(step: TraceStep<M>): Array<string> => [
-  `step ${step.index}: event=${formatValue(step.event)} before=${formatConfiguration(step.beforeConfiguration)} ` +
-  `after=${formatConfiguration(step.afterConfiguration)} state=${formatValue(step.after)} ` +
-  `done=${String(step.plan.done)} output=${formatValue(step.plan.output)} ` +
-  `commands=${step.plan.commands.length} emitted=${formatValue(step.plan.emittedEvents)}`,
-  ...formatMicrosteps(step.plan.microsteps)
-]
-
-const isRunFailure = <M extends AnyMachine, Cause>(
-  trace: Trace<M> | RunFailure<Cause, M>
-): trace is RunFailure<Cause, M> => "_tag" in trace && trace._tag === "MachineTestRunFailure"
-
-export const formatTrace = <M extends AnyMachine, Cause>(trace: Trace<M> | RunFailure<Cause, M>): string => {
-  const lines = [`scenario: ${formatValue(trace.scenario)}`]
-  if (isRunFailure(trace)) {
-    if (trace.initial !== undefined) {
-      lines.push(...formatInitial(trace.initial))
-      for (const step of trace.steps) {
-        lines.push(...formatStep(step))
+    let previous = initialState
+    for (let eventIndex = 0; eventIndex < trace.steps.length; eventIndex++) {
+      const step = trace.steps[eventIndex]!
+      const location: VerificationLocation = { eventIndex }
+      const before = inspectSnapshot(step.before, location, `event ${eventIndex} before state`)
+      validateSnapshotMetadata(before, location, `event ${eventIndex} before state`, true)
+      validateTraceConfiguration(
+        before,
+        step.beforeConfiguration as ReadonlyArray<string>,
+        location,
+        `event ${eventIndex} before`
+      )
+      if (selected.has("microsteps")) {
+        if (step.index !== eventIndex) {
+          add("microsteps.continuity", location, `trace step index ${step.index} does not equal ${eventIndex}`)
+        }
+        if (!sameValue(previous.root, before.root)) {
+          add("microsteps.continuity", location, `event ${eventIndex} before state does not equal the previous state`)
+        }
+        if (!sameValue(step.event, trace.scenario.events[eventIndex])) {
+          add("microsteps.continuity", location, `event ${eventIndex} differs from its scenario event`)
+        }
       }
+
+      current = before
+      for (let microstepIndex = 0; microstepIndex < step.plan.microsteps.length; microstepIndex++) {
+        const microstepLocation: VerificationLocation = { eventIndex, microstepIndex }
+        const microstep = step.plan.microsteps[microstepIndex]!
+        const next = inspectSnapshot(
+          microstep.next,
+          microstepLocation,
+          `event ${eventIndex} microstep ${microstepIndex} next state`
+        )
+        validateSnapshotMetadata(next, microstepLocation, `event ${eventIndex} microstep ${microstepIndex} next state`)
+        validateMicrostep(microstep, current, next, microstepLocation)
+        current = next
+      }
+
+      const plannedNext = inspectSnapshot(step.plan.next, location, `event ${eventIndex} plan next state`)
+      const completions = validateSnapshotMetadata(plannedNext, location, `event ${eventIndex} plan next state`, true)
+      if (selected.has("microsteps") && !sameControl(current, plannedNext)) {
+        add(
+          "microsteps.continuity",
+          location,
+          `event ${eventIndex} plan next state does not continue its final microstep`
+        )
+      }
+      validatePlanCompletion(step.plan, plannedNext, completions, location, `event ${eventIndex} plan`)
+
+      const after = inspectSnapshot(step.after, location, `event ${eventIndex} after state`)
+      validateSnapshotMetadata(after, location, `event ${eventIndex} after state`, true)
+      validateTraceConfiguration(
+        after,
+        step.afterConfiguration as ReadonlyArray<string>,
+        location,
+        `event ${eventIndex} after`
+      )
+      if (selected.has("microsteps") && !sameValue(step.plan.next, step.after)) {
+        add("microsteps.continuity", location, `event ${eventIndex} after state differs from its plan next state`)
+      }
+      previous = after
     }
-    lines.push(
-      `failure: phase=${trace.phase} eventIndex=${formatValue(trace.eventIndex)} ` +
-        `event=${formatValue(trace.event)} cause=${formatValue(trace.cause)}`
-    )
-    return lines.join("\n")
-  }
-  lines.push(...formatInitial(trace.initial))
-  for (const step of trace.steps) {
-    lines.push(...formatStep(step))
-  }
-  lines.push(`final: configuration=${formatConfiguration(trace.finalConfiguration)} state=${formatValue(trace.final)}`)
-  return lines.join("\n")
-}
+
+    const finalEventIndex = trace.steps.length === 0 ? undefined : trace.steps.length - 1
+    const finalLocation: VerificationLocation = { eventIndex: finalEventIndex }
+    const final = inspectSnapshot(trace.final, finalLocation, "trace final state")
+    validateSnapshotMetadata(final, finalLocation, "trace final state", true)
+    validateTraceConfiguration(final, trace.finalConfiguration as ReadonlyArray<string>, finalLocation, "final")
+    if (selected.has("microsteps") && !sameValue(previous.root, final.root)) {
+      add("microsteps.continuity", finalLocation, "trace final state differs from its final planned state")
+    }
+
+    return violations.length === 0 ? Effect.void : Effect.fail(new VerificationError({ violations }))
+  })

--- a/packages/effect-machine/src/testing/MachineTest.ts
+++ b/packages/effect-machine/src/testing/MachineTest.ts
@@ -10,8 +10,15 @@ import type * as Schema from "effect/Schema"
 import type { FastCheck } from "effect/testing"
 import type { EnsureExecutable } from "../internal/machine/readiness.js"
 import type { SchemaArbitraryReport } from "../internal/testing/machine/arbitrary.js"
+import * as ExplorationImpl from "../internal/testing/machine/exploration.js"
 import type { FiniteModel } from "../internal/testing/machine/finiteModel.js"
-import type * as ReferenceModel from "../internal/testing/machine/referenceModel.js"
+import * as Format from "../internal/testing/machine/format.js"
+import * as InvariantTest from "../internal/testing/machine/invariant.js"
+import * as ProbeTest from "../internal/testing/machine/probe.js"
+import * as ReferenceModel from "../internal/testing/machine/referenceModel.js"
+import type * as RuntimeTest from "../internal/testing/machine/runtime.js"
+import * as RuntimeInvariantTest from "../internal/testing/machine/runtimeInvariant.js"
+import * as TraceImpl from "../internal/testing/machine/trace.js"
 import * as internal from "../internal/testing/machine/verification.js"
 import type { VerificationError } from "../internal/testing/machine/verification.js"
 import type * as Machine from "../Machine.js"
@@ -64,13 +71,13 @@ export {
   sendCommand,
   stopCommand,
   verifyCausalCommands
-} from "../internal/testing/machine/verification.js"
+} from "../internal/testing/machine/runtime.js"
 
 export type {
   SchemaArbitraryOpaqueFilterWarning,
   SchemaArbitraryReport,
   SchemaArbitraryWarning
-} from "../internal/testing/machine/verification.js"
+} from "../internal/testing/machine/arbitrary.js"
 
 export {
   compileModel,
@@ -92,7 +99,7 @@ export {
   type FiniteState,
   type FiniteTransition,
   type FiniteTransitionTrigger
-} from "../internal/testing/machine/verification.js"
+} from "../internal/testing/machine/finiteModel.js"
 
 export {
   ModelVerificationError,
@@ -108,7 +115,7 @@ export {
   type ReferenceStep,
   type ReferenceTrace,
   type ReferenceTransition
-} from "../internal/testing/machine/verification.js"
+} from "../internal/testing/machine/referenceModel.js"
 
 /**
  * Purely interprets a finite hierarchical model without compiling a
@@ -118,7 +125,7 @@ export {
  * @since 0.4.0
  */
 export const interpretModel: (model: FiniteModel, events: ReadonlyArray<string>) => ReferenceModel.ReferenceTrace =
-  internal.interpretModel
+  ReferenceModel.interpretModel
 
 type AnyMachine = Machine.Machine.Any
 
@@ -449,7 +456,7 @@ export interface Probe<M extends AnyMachine, Error = never, Output = never> {
   ) => Effect.Effect<ProbeStep<M>, Error | Machine.StoppedError>
   /** Constructors for asynchronous observation after a causal command. */
   readonly await: {
-    readonly none: internal.RuntimeAwait<
+    readonly none: RuntimeTest.RuntimeAwait<
       Machine.Machine.Snapshot<Machine.Machine.States<M>>,
       Error,
       Output
@@ -462,7 +469,7 @@ export interface Probe<M extends AnyMachine, Error = never, Output = never> {
           Output
         >
       ) => boolean
-    ) => internal.RuntimeAwait<Machine.Machine.Snapshot<Machine.Machine.States<M>>, Error, Output>
+    ) => RuntimeTest.RuntimeAwait<Machine.Machine.Snapshot<Machine.Machine.States<M>>, Error, Output>
   }
 }
 
@@ -473,7 +480,7 @@ export interface Probe<M extends AnyMachine, Error = never, Output = never> {
  * @category errors
  * @since 0.4.0
  */
-export { ProbeUnavailableError } from "../internal/testing/machine/verification.js"
+export { ProbeUnavailableError } from "../internal/testing/machine/probe.js"
 
 /**
  * Attaches testing-only causal event delivery to a running statechart.
@@ -517,7 +524,7 @@ export const probe: <M extends AnyMachine, Error, Output>(
     Error,
     Output
   >
-) => Effect.Effect<Probe<M, Error, Output>, internal.ProbeUnavailableError> = internal.probe
+) => Effect.Effect<Probe<M, Error, Output>, ProbeTest.ProbeUnavailableError> = ProbeTest.probe
 
 /**
  * The runtime error channel exposed by a managed reference for a machine.
@@ -540,8 +547,8 @@ export type RuntimeInvariantErrorChannel<M extends AnyMachine> =
  */
 export interface CausalRuntimeEvidenceRecord<M extends AnyMachine, Error, Output> {
   readonly index: number
-  readonly command: internal.RuntimeCommand<Machine.Machine.InputEvent<M>>
-  readonly actual: internal.CausalRuntimeCommandActual<M, Error, Output, unknown>
+  readonly command: RuntimeTest.RuntimeCommand<Machine.Machine.InputEvent<M>>
+  readonly actual: RuntimeTest.CausalRuntimeCommandActual<M, Error, Output, unknown>
 }
 
 /**
@@ -551,7 +558,7 @@ export interface CausalRuntimeEvidenceRecord<M extends AnyMachine, Error, Output
  * @since 0.4.0
  */
 export interface CausalRuntimeEvidence<M extends AnyMachine, Error, Output> {
-  readonly commands: ReadonlyArray<internal.RuntimeCommand<Machine.Machine.InputEvent<M>>>
+  readonly commands: ReadonlyArray<RuntimeTest.RuntimeCommand<Machine.Machine.InputEvent<M>>>
   readonly initial: Machine.RuntimeSnapshot<Machine.Machine.Snapshot<Machine.Machine.States<M>>, Error, Output>
   readonly records: ReadonlyArray<CausalRuntimeEvidenceRecord<M, Error, Output>>
   readonly final: Machine.RuntimeSnapshot<Machine.Machine.Snapshot<Machine.Machine.States<M>>, Error, Output>
@@ -581,8 +588,8 @@ export type RuntimeSnapshotObservation = "initial" | "command" | "awaited" | "fi
  */
 export interface RuntimeInvariantRecord<M extends AnyMachine> {
   readonly index: number
-  readonly command: internal.RuntimeCommand<Machine.Machine.InputEvent<M>>
-  readonly result: internal.CausalRuntimeCommandResult<M>
+  readonly command: RuntimeTest.RuntimeCommand<Machine.Machine.InputEvent<M>>
+  readonly result: RuntimeTest.CausalRuntimeCommandResult<M>
   readonly snapshot: Machine.RuntimeSnapshot<
     Machine.Machine.Snapshot<Machine.Machine.States<M>>,
     RuntimeInvariantErrorChannel<M>,
@@ -604,7 +611,7 @@ export interface RuntimeInvariantRecord<M extends AnyMachine> {
  * @since 0.4.0
  */
 export interface RuntimeInvariantTranscript<M extends AnyMachine> {
-  readonly commands: ReadonlyArray<internal.RuntimeCommand<Machine.Machine.InputEvent<M>>>
+  readonly commands: ReadonlyArray<RuntimeTest.RuntimeCommand<Machine.Machine.InputEvent<M>>>
   readonly initial: Machine.RuntimeSnapshot<
     Machine.Machine.Snapshot<Machine.Machine.States<M>>,
     RuntimeInvariantErrorChannel<M>,
@@ -632,8 +639,8 @@ export interface RuntimeSnapshotInvariantContext<M extends AnyMachine> {
   readonly phase: RuntimeSnapshotObservation
   readonly commandIndex: number | undefined
   readonly awaitedIndex: number | undefined
-  readonly command: internal.RuntimeCommand<Machine.Machine.InputEvent<M>> | undefined
-  readonly result: internal.CausalRuntimeCommandResult<M> | undefined
+  readonly command: RuntimeTest.RuntimeCommand<Machine.Machine.InputEvent<M>> | undefined
+  readonly result: RuntimeTest.CausalRuntimeCommandResult<M> | undefined
 }
 
 /**
@@ -648,8 +655,8 @@ export interface RuntimeCommandInvariantContext<M extends AnyMachine> {
   readonly record: RuntimeInvariantRecord<M>
   readonly previous: RuntimeInvariantRecord<M> | undefined
   readonly index: number
-  readonly command: internal.RuntimeCommand<Machine.Machine.InputEvent<M>>
-  readonly result: internal.CausalRuntimeCommandResult<M>
+  readonly command: RuntimeTest.RuntimeCommand<Machine.Machine.InputEvent<M>>
+  readonly result: RuntimeTest.CausalRuntimeCommandResult<M>
   readonly snapshot: RuntimeInvariantRecord<M>["snapshot"]
   readonly awaited: RuntimeInvariantRecord<M>["awaited"]
 }
@@ -762,7 +769,7 @@ export interface RuntimeInvariantBuilder<M extends AnyMachine> {
  * @since 0.4.0
  */
 export const runtimeInvariants: <M extends AnyMachine>(machine: M) => RuntimeInvariantBuilder<M> =
-  internal.runtimeInvariants
+  RuntimeInvariantTest.runtimeInvariants
 
 /**
  * Scope of a runtime invariant.
@@ -810,7 +817,7 @@ export interface RuntimeInvariantViolation<M extends AnyMachine = AnyMachine> {
   readonly commandIndex: number | undefined
   readonly awaitedIndex?: number
   readonly phase?: RuntimeSnapshotObservation
-  readonly command?: internal.RuntimeCommand<Machine.Machine.InputEvent<M>>
+  readonly command?: RuntimeTest.RuntimeCommand<Machine.Machine.InputEvent<M>>
   readonly message: string
 }
 
@@ -820,7 +827,7 @@ export interface RuntimeInvariantViolation<M extends AnyMachine = AnyMachine> {
  * @category errors
  * @since 0.4.0
  */
-export { RuntimeInvariantError } from "../internal/testing/machine/verification.js"
+export { RuntimeInvariantError } from "../internal/testing/machine/runtimeInvariant.js"
 
 /**
  * Checks runtime invariants and returns their complete non-vacuity report.
@@ -832,7 +839,8 @@ export const checkRuntimeInvariants: <M extends AnyMachine, Error, Output>(
   machine: M,
   transcript: CausalRuntimeEvidence<M, Error, Output>,
   invariants: ReadonlyArray<RuntimeInvariant<M>>
-) => Effect.Effect<RuntimeInvariantReport, internal.RuntimeInvariantError<M>> = internal.checkRuntimeInvariants
+) => Effect.Effect<RuntimeInvariantReport, RuntimeInvariantTest.RuntimeInvariantError<M>> =
+  RuntimeInvariantTest.checkRuntimeInvariants
 
 /**
  * Asserts runtime invariants against an existing causal transcript.
@@ -844,7 +852,7 @@ export const assertRuntimeInvariants: <M extends AnyMachine, Error, Output>(
   machine: M,
   transcript: CausalRuntimeEvidence<M, Error, Output>,
   invariants: ReadonlyArray<RuntimeInvariant<M>>
-) => Effect.Effect<void, internal.RuntimeInvariantError<M>> = internal.assertRuntimeInvariants
+) => Effect.Effect<void, RuntimeInvariantTest.RuntimeInvariantError<M>> = RuntimeInvariantTest.assertRuntimeInvariants
 
 /**
  * One disagreement between pure planning and a causally processed send.
@@ -854,7 +862,7 @@ export const assertRuntimeInvariants: <M extends AnyMachine, Error, Output>(
  */
 export interface PlannerRuntimeAgreementViolation<M extends AnyMachine = AnyMachine> {
   readonly commandIndex: number
-  readonly command: internal.RuntimeCommand<Machine.Machine.InputEvent<M>>
+  readonly command: RuntimeTest.RuntimeCommand<Machine.Machine.InputEvent<M>>
   readonly field:
     | "planning"
     | "handled"
@@ -874,7 +882,7 @@ export interface PlannerRuntimeAgreementViolation<M extends AnyMachine = AnyMach
  * @category errors
  * @since 0.4.0
  */
-export { PlannerRuntimeAgreementError } from "../internal/testing/machine/verification.js"
+export { PlannerRuntimeAgreementError } from "../internal/testing/machine/runtimeInvariant.js"
 
 /**
  * Checks that every processed public send agrees with a fresh pure plan.
@@ -885,8 +893,8 @@ export { PlannerRuntimeAgreementError } from "../internal/testing/machine/verifi
 export const assertPlannerRuntimeAgreement: <M extends AnyMachine, Error, Output>(
   machine: RootReadyMachine<M>,
   transcript: CausalRuntimeEvidence<M, Error, Output>
-) => Effect.Effect<void, internal.PlannerRuntimeAgreementError<M>, RunServices<M>> =
-  internal.assertPlannerRuntimeAgreement
+) => Effect.Effect<void, RuntimeInvariantTest.PlannerRuntimeAgreementError<M>, RunServices<M>> =
+  RuntimeInvariantTest.assertPlannerRuntimeAgreement
 
 /**
  * The result of evaluating one semantic invariant.
@@ -1086,7 +1094,7 @@ export const Invariant: {
     check: (context: TraceInvariantContext<M>) => InvariantOutcome,
     options?: InvariantOptions<TraceInvariantContext<M>>
   ) => TraceInvariant<M>
-} = internal.Invariant
+} = InvariantTest.Invariant
 
 /**
  * Creates invariant constructors bound to a machine's exact state and event
@@ -1122,7 +1130,7 @@ export const Invariant: {
  * @category constructors
  * @since 0.4.0
  */
-export const invariants: <M extends AnyMachine>(machine: M) => InvariantBuilder<M> = internal.invariants
+export const invariants: <M extends AnyMachine>(machine: M) => InvariantBuilder<M> = InvariantTest.invariants
 
 /**
  * The scope of a semantic invariant.
@@ -1193,7 +1201,7 @@ export interface InvariantViolation<M extends AnyMachine = AnyMachine> {
  * @category errors
  * @since 0.4.0
  */
-export { InvariantError } from "../internal/testing/machine/verification.js"
+export { InvariantError } from "../internal/testing/machine/invariant.js"
 
 /**
  * Checks user-defined semantic invariants against an existing planner trace.
@@ -1209,7 +1217,7 @@ export const checkInvariants: <M extends AnyMachine>(
   machine: M,
   trace: Trace<M>,
   invariants: ReadonlyArray<Invariant<M>>
-) => Effect.Effect<InvariantReport, internal.InvariantError<M>> = internal.checkInvariants
+) => Effect.Effect<InvariantReport, InvariantTest.InvariantError<M>> = InvariantTest.checkInvariants
 
 /**
  * Asserts user-defined semantic invariants and discards the success report.
@@ -1225,7 +1233,7 @@ export const assertInvariants: <M extends AnyMachine>(
   machine: M,
   trace: Trace<M>,
   invariants: ReadonlyArray<Invariant<M>>
-) => Effect.Effect<void, internal.InvariantError<M>> = internal.assertInvariants
+) => Effect.Effect<void, InvariantTest.InvariantError<M>> = InvariantTest.assertInvariants
 
 /**
  * User-defined identity for a logical exploration state.
@@ -1470,9 +1478,9 @@ export const explore: <M extends AnyMachine, Key extends ExplorationKey>(
   options: ExploreOptions<M, Key>
 ) => Effect.Effect<
   Exploration<M, Key>,
-  RunFailure<RunError<M>, M> | internal.InvariantError<M>,
+  RunFailure<RunError<M>, M> | InvariantTest.InvariantError<M>,
   RunServices<M>
-> = internal.explore
+> = ExplorationImpl.explore
 
 /**
  * A predicate over one explored logical state.
@@ -1498,7 +1506,7 @@ export type ReachabilityFailure = "NotFound" | "UnexpectedMatch" | "Inconclusive
  * @category errors
  * @since 0.4.0
  */
-export { ReachabilityError } from "../internal/testing/machine/verification.js"
+export { ReachabilityError } from "../internal/testing/machine/exploration.js"
 
 /**
  * Finds the first, and therefore shortest, explored state matching a
@@ -1510,7 +1518,7 @@ export { ReachabilityError } from "../internal/testing/machine/verification.js"
 export const findShortest: <M extends AnyMachine, Key extends ExplorationKey>(
   exploration: Exploration<M, Key>,
   predicate: ExplorationPredicate<M, Key>
-) => ExplorationNode<M, Key> | undefined = internal.findShortest
+) => ExplorationNode<M, Key> | undefined = ExplorationImpl.findShortest
 
 /**
  * Requires a matching state and returns its shortest witness.
@@ -1525,7 +1533,7 @@ export const assertReachable: <M extends AnyMachine, Key extends ExplorationKey>
   exploration: Exploration<M, Key>,
   name: string,
   predicate: ExplorationPredicate<M, Key>
-) => Effect.Effect<ExplorationNode<M, Key>, internal.ReachabilityError<M, Key>> = internal.assertReachable
+) => Effect.Effect<ExplorationNode<M, Key>, ExplorationImpl.ReachabilityError<M, Key>> = ExplorationImpl.assertReachable
 
 /**
  * Requires that no explored state matches a predicate.
@@ -1540,7 +1548,7 @@ export const assertUnreachable: <M extends AnyMachine, Key extends ExplorationKe
   exploration: Exploration<M, Key>,
   name: string,
   predicate: ExplorationPredicate<M, Key>
-) => Effect.Effect<void, internal.ReachabilityError<M, Key>> = internal.assertUnreachable
+) => Effect.Effect<void, ExplorationImpl.ReachabilityError<M, Key>> = ExplorationImpl.assertUnreachable
 
 /**
  * Checks a real planner trace against the independent finite statechart model
@@ -1649,7 +1657,7 @@ export type RunServices<M extends AnyMachine> = IsAny<
 export const run: <M extends AnyMachine>(
   machine: RootReadyMachine<M>,
   scenario: Scenario<M>
-) => Effect.Effect<Trace<M>, RunFailure<RunError<M>, M>, RunServices<M>> = internal.run
+) => Effect.Effect<Trace<M>, RunFailure<RunError<M>, M>, RunServices<M>> = TraceImpl.run
 
 /**
  * A deterministic hit/miss summary for a finite set declared by a machine.
@@ -2164,4 +2172,4 @@ export const verify: <M extends AnyMachine>(
  * @since 0.4.0
  */
 export const formatTrace: <M extends AnyMachine, Cause>(trace: Trace<M> | RunFailure<Cause, M>) => string =
-  internal.formatTrace
+  Format.formatTrace

--- a/packages/effect-machine/src/unstable/cluster/ClusterMachine.ts
+++ b/packages/effect-machine/src/unstable/cluster/ClusterMachine.ts
@@ -12,6 +12,7 @@ import type { Rpc } from "effect/unstable/rpc"
 import * as internal from "../../internal/machine/cluster.js"
 import { Accepted, Rejected, Storage } from "../../internal/machine/cluster.js"
 import type { EnsureExecutable } from "../../internal/machine/readiness.js"
+import type { ExcludeCompatibleRuntime } from "../../internal/machine/requirements.js"
 import type * as Machine from "../../Machine.js"
 
 type Snowflake = Snowflake.Snowflake
@@ -291,14 +292,6 @@ type EnsureJsonEncoded<
       readonly inputEvents: NonJsonInputEvent<InputEvents>
     }
   }
-
-type ExcludeCompatibleRuntime<Requirements, Events, Emits> = Requirements extends Machine.Runtime.Requirement<
-  infer RequiredEvents,
-  infer RequiredEmits
-> ? IsAny<Requirements> extends true ? Requirements
-  : [RequiredEvents] extends [Events] ? [RequiredEmits] extends [Emits] ? never : Requirements
-  : Requirements
-  : Requirements
 
 /**
  * Creates an in-memory Cluster machine checkpoint store.

--- a/packages/effect-machine/src/unstable/reactivity/AtomMachine.ts
+++ b/packages/effect-machine/src/unstable/reactivity/AtomMachine.ts
@@ -13,6 +13,10 @@ import type { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity
 import * as internal from "../../internal/machine/atom.js"
 import type { ChildNotActiveError, NotReadyError } from "../../internal/machine/atom.js"
 import type { EnsureExecutable } from "../../internal/machine/readiness.js"
+import type {
+  ExcludeCompatibleRuntime as ExcludeCompatibleMachineRuntime,
+  IsAny
+} from "../../internal/machine/requirements.js"
 import type * as Machine from "../../Machine.js"
 
 /**
@@ -40,15 +44,6 @@ const ExternalRequirementsTypeId = "~effect/reactivity/AtomMachine/ExternalRequi
 type EnsureNoExternalRequirements<Requirements> = [ExternalRequirements<Requirements>] extends [never] ? unknown : {
   readonly [ExternalRequirementsTypeId]: ExternalRequirements<Requirements>
 }
-
-type IsAny<A> = 0 extends (1 & A) ? true : false
-
-type ExcludeCompatibleMachineRuntime<Requirements, Events, Emits> = Requirements extends
-  Machine.Runtime.Requirement<infer RequiredEvents, infer RequiredEmits> ?
-  IsAny<Requirements> extends true ? Requirements
-  : [RequiredEvents] extends [Events] ? [RequiredEmits] extends [Emits] ? never : Requirements
-  : Requirements
-  : Requirements
 
 type MachineRequirements<InitialR, R, Events, Emits> = ExcludeCompatibleMachineRuntime<
   Machine.ExecutionServices<InitialR | R>,

--- a/packages/effect-machine/test/examples/can.ts
+++ b/packages/effect-machine/test/examples/can.ts
@@ -1,0 +1,15 @@
+import { Machine } from "@typeonce/effect-machine"
+import { Effect, Schema } from "effect"
+
+const internalEvents = Machine.internalEvents(Schema.TaggedStruct("Loaded", {}))
+const machine = Machine.make({
+  states: { Idle: {} },
+  events: Machine.events(),
+  internalEvents,
+  initial: (to) => to.Idle()
+}).handle({ Idle: { on: { Loaded: (to) => to.none } } })
+
+export const canLoad = Effect.gen(function*() {
+  const initial = yield* Machine.planInitial(machine)
+  return yield* Machine.can(machine, initial.state, internalEvents.Loaded())
+})

--- a/packages/effect-machine/test/internal/machine/ProtocolValidation.test.ts
+++ b/packages/effect-machine/test/internal/machine/ProtocolValidation.test.ts
@@ -1,0 +1,37 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Schema } from "effect"
+import { Machine } from "../../../src/index.js"
+import * as Configuration from "../../../src/internal/machine/configuration.js"
+import * as ExecutionPlan from "../../../src/internal/machine/executionPlan.js"
+
+describe("event validation across execution strategies", () => {
+  for (const strategy of ["generic", "auto"] as const) {
+    it.effect(`rejects mutated decoded events in the ${strategy} planner`, () =>
+      Effect.gen(function*() {
+        const Set = Schema.TaggedStruct("Set", { value: Schema.Int })
+        const events = Machine.events(Set)
+        let retained: unknown
+        const machine = Machine.make({
+          states: { Ready: Schema.TaggedStruct("Ready", {}) },
+          events,
+          initial: (to) => to.Ready().resolve(({ target }) => target.decoded({ _tag: "Ready" }))
+        }).handle({
+          Ready: {
+            on: {
+              Set: (to) =>
+                to.none.resolve(({ event }) => {
+                  retained = event
+                })
+            }
+          }
+        })
+        const initial = yield* Machine.planInitial(machine)
+        const selected = ExecutionPlan.selectExecutionPlanForTesting(machine, strategy)
+        assert.strictEqual(selected.strategy, strategy === "auto" ? "indexed-flat" : "generic")
+        const state = selected.plan.fromConfiguration(Configuration.normalizeConfigurationSync(machine, initial.state))
+        selected.plan.plan(state, events.Set({ value: 1 }), true)
+        Object.assign(retained as object, { value: "invalid" })
+        assert.throws(() => selected.plan.plan(state, retained, true), Machine.MachineSchemaDecodeError)
+      }))
+  }
+})

--- a/packages/effect-machine/test/internal/machine/support/strategyDifferential.ts
+++ b/packages/effect-machine/test/internal/machine/support/strategyDifferential.ts
@@ -5,14 +5,6 @@ import * as Configuration from "../../../../src/internal/machine/configuration.j
 import * as ExecutionPlan from "../../../../src/internal/machine/executionPlan.js"
 import * as Process from "../../../../src/internal/machine/process.js"
 
-const eventTag = (event: unknown): PropertyKey | undefined =>
-  typeof event === "object" && event !== null && "_tag" in event
-    ? (event as { readonly _tag: PropertyKey })._tag
-    : undefined
-
-const commandTags = (commands: ReadonlyArray<{ readonly _tag: string }>): ReadonlyArray<string> =>
-  commands.map((command) => command._tag)
-
 const encodeState = (
   machine: Machine.Machine.Any,
   state: unknown
@@ -25,16 +17,17 @@ const canonicalMacrostep = Effect.fn(function*(
 ) {
   return {
     next: yield* encodeState(machine, executionPlan.snapshot(planned.next)),
-    commands: commandTags(planned.commands),
+    commands: planned.commands,
     emittedEvents: planned.emittedEvents,
     microsteps: yield* Effect.forEach(
       planned.microsteps,
       (step) =>
         Effect.map(encodeState(machine, executionPlan.snapshot(step.next)), (next) => ({
           next,
-          event: eventTag(step.event),
-          commands: commandTags(step.commands),
-          raisedEvents: step.raisedEvents.map(eventTag),
+          event: step.event,
+          transitions: step.transitions,
+          commands: step.commands,
+          raisedEvents: step.raisedEvents,
           emittedEvents: step.emittedEvents,
           exitPaths: step.exitPaths,
           entryPaths: step.entryPaths,
@@ -84,8 +77,8 @@ const verifyPlannerStrategiesEffect = Effect.fn(function*(options: {
     const event = options.events[index]!
     const retainedSelectedSnapshot = selected.plan.snapshot(selectedState)
     const retainedSelectedEncoding = yield* encodeState(options.machine, retainedSelectedSnapshot)
-    const genericPlan = generic.plan.plan(genericState, event)
-    const selectedPlan = selected.plan.plan(selectedState, event)
+    const genericPlan = generic.plan.plan(genericState, event, true)
+    const selectedPlan = selected.plan.plan(selectedState, event, true)
     assert.deepStrictEqual(
       yield* canonicalMacrostep(options.machine, selected.plan, selectedPlan),
       yield* canonicalMacrostep(options.machine, generic.plan, genericPlan),

--- a/packages/effect-machine/test/machine/ProtocolOwnership.test.ts
+++ b/packages/effect-machine/test/machine/ProtocolOwnership.test.ts
@@ -1,0 +1,78 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Cause, Effect, Exit, Schema, SchemaGetter } from "effect"
+import { Machine } from "../../src/index.js"
+
+describe("protocol ownership", () => {
+  it.effect("validates a constructed event again after it escapes a resolver", () =>
+    Effect.gen(function*() {
+      const State = Schema.TaggedStruct("State", {})
+      const Set = Schema.TaggedStruct("Set", { value: Schema.Int })
+      const events = Machine.events(Set)
+      let retained: unknown
+      const machine = Machine.make({
+        states: { State },
+        events,
+        initial: (to) => to.State().resolve(({ target }) => target.decoded({ _tag: "State" }))
+      }).handle({
+        State: {
+          on: {
+            Set: (to) =>
+              to.none.resolve(({ event }) => {
+                retained = event
+              })
+          }
+        }
+      })
+      const initial = yield* Machine.planInitial(machine)
+      yield* Machine.plan(machine, initial.state, events.Set({ value: 1 }))
+      // An untyped caller can mutate decoded values retained by application code.
+      Object.assign(retained as object, { value: "invalid" })
+      const exit = yield* Effect.exit(Machine.plan(machine, initial.state, retained as Schema.Schema.Type<typeof Set>))
+      assert.isTrue(Exit.isFailure(exit))
+      if (Exit.isFailure(exit)) assert.isTrue(Cause.hasFails(exit.cause))
+    }))
+
+  it.effect("queries internal events without sending them", () =>
+    Effect.gen(function*() {
+      const State = Schema.TaggedStruct("State", {})
+      const Internal = Schema.TaggedStruct("Internal", {})
+      const internalEvents = Machine.internalEvents(Internal)
+      const machine = Machine.make({
+        states: { State },
+        events: Machine.events(),
+        internalEvents,
+        initial: (to) => to.State().resolve(({ target }) => target.decoded({ _tag: "State" }))
+      })
+        .handle({ State: { on: { Internal: (to) => to.none } } })
+      const initial = yield* Machine.planInitial(machine)
+      assert.isTrue(yield* Machine.can(machine, initial.state, { _tag: "Internal" }))
+      assert.isTrue(yield* Machine.can(machine)(initial.state, internalEvents.Internal()))
+    }))
+
+  for (const boundary of ["encode", "decode"] as const) {
+    it.effect(`preserves ${boundary} codec interruption`, () =>
+      Effect.gen(function*() {
+        const Value = boundary === "encode"
+          ? Schema.Number.pipe(
+            Schema.encode({ decode: SchemaGetter.passthrough(), encode: SchemaGetter.onSome(() => Effect.interrupt) })
+          )
+          : Schema.Number.pipe(
+            Schema.decode({ decode: SchemaGetter.onSome(() => Effect.interrupt), encode: SchemaGetter.passthrough() })
+          )
+        const State = Schema.TaggedStruct("State", { value: Value })
+        const machine = Machine.make({
+          states: { State },
+          events: Machine.events(),
+          initial: (to) => to.State().resolve(({ target }) => target.decoded({ _tag: "State", value: 1 }))
+        })
+        const initial = yield* Machine.planInitial(machine)
+        const operation: Effect.Effect<unknown, Machine.MachineSchemaDecodeError | Machine.MachineSchemaEncodeError> =
+          boundary === "encode" ?
+            Machine.encodeSnapshot(machine, initial.state)
+            : Machine.decodeSnapshot(machine, yield* Machine.encodeSnapshot(machine, initial.state))
+        const exit = yield* Effect.exit(operation)
+        assert.isTrue(Exit.isFailure(exit))
+        if (Exit.isFailure(exit)) assert.isTrue(Cause.hasInterrupts(exit.cause))
+      }))
+  }
+})

--- a/packages/effect-machine/test/machine/StateDefinition.test.ts
+++ b/packages/effect-machine/test/machine/StateDefinition.test.ts
@@ -41,6 +41,22 @@ const makeFromUnknownStates = (states: unknown): unknown =>
   })
 
 describe("exact state-definition runtime validation", () => {
+  it("captures raw definitions before compiling topology and selectors", () => {
+    const raw = { Root: { initial: "Idle" as const, states: { Idle: {}, Done: {} } } }
+    const machine = Machine.make({
+      states: raw,
+      events: Machine.events(),
+      initial: (to) => to.Root.initial.resolve(({ target }) => target.from((child) => child.Idle.from()))
+    })
+    Object.assign(raw.Root, { initial: "Done" })
+    Object.assign(raw.Root.states, { Added: {} })
+    assert.notStrictEqual(machine.states, raw)
+    assert.strictEqual(machine.states.Root.initial, "Idle")
+    assert.deepStrictEqual(Object.keys(machine.states.Root.states), ["Idle", "Done"])
+    assert.isTrue(Object.isFrozen(machine.states.Root.states))
+    assert.throws(() => machine.handle({ Root: { states: { Added: {} } } } as never), /unknown state/)
+  })
+
   it("captures reusable state definitions independently at each mount", () => {
     const TradingSlot = Machine.state({
       initial: "Idle",

--- a/packages/effect-machine/test/testing/TraceValues.test.ts
+++ b/packages/effect-machine/test/testing/TraceValues.test.ts
@@ -1,0 +1,82 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Exit, Schema } from "effect"
+import { Machine } from "../../src/index.js"
+import { MachineTest } from "../../src/testing/index.js"
+
+const State = Schema.TaggedStruct("State", { data: Schema.Unknown })
+const Ping = Schema.TaggedStruct("Ping", {})
+const make = (data: unknown) =>
+  Machine.make({
+    states: { State },
+    events: Machine.events(Ping),
+    initial: (to) => to.State().resolve(({ target }) => target.decoded({ _tag: "State", data }))
+  }).handle({ State: { on: { Ping: (to) => to.none } } })
+
+describe("trace value verification", () => {
+  const different: ReadonlyArray<readonly [string, unknown, unknown]> = [
+    ["regular expressions", /a/, /b/],
+    ["non-finite numbers", NaN, null],
+    ["infinities", Infinity, -Infinity],
+    ["signed zero", 0, -0],
+    ["symbols", Symbol("same"), Symbol("same")],
+    ["functions", function same() {}, function same() {}],
+    ["binary values", new Uint8Array([1]), new Uint8Array([2])],
+    ["map values", new Map([[1, "a"]]), new Map([[1, "b"]])],
+    ["set iteration order", new Set([1, 2]), new Set([2, 1])],
+    ["opaque state", new WeakMap(), new WeakMap()]
+  ]
+  for (const [name, before, after] of different) {
+    it.effect(`rejects changed ${name}`, () =>
+      Effect.gen(function*() {
+        const machine = make(before)
+        const trace = yield* MachineTest.run(machine, { events: [{ _tag: "Ping" }] })
+        const corrupted = { ...trace, final: { ...trace.final, value: { ...trace.final.value, data: after } } }
+        const exit = yield* Effect.exit(MachineTest.verify(machine, corrupted))
+        assert.isTrue(Exit.isFailure(exit))
+      }))
+  }
+
+  it.effect("verifies and formats invalid dates without throwing eagerly", () =>
+    Effect.gen(function*() {
+      const machine = make(new Date(NaN))
+      const trace = yield* MachineTest.run(machine, { events: [{ _tag: "Ping" }] })
+      const equivalent = { ...trace, final: { ...trace.final, value: { ...trace.final.value, data: new Date(NaN) } } }
+      yield* MachineTest.verify(machine, equivalent)
+      assert.include(MachineTest.formatTrace(equivalent), "Invalid Date")
+    }))
+
+  it.effect("defers verification until the returned Effect runs", () =>
+    Effect.gen(function*() {
+      const machine = make(1)
+      const trace = yield* MachineTest.run(machine, { events: [] })
+      let reads = 0
+      const observed = {
+        ...trace,
+        get final() {
+          reads++
+          return trace.final
+        }
+      }
+      const verify = MachineTest.verify(machine, observed)
+      assert.strictEqual(reads, 0)
+      yield* verify
+      assert.isAbove(reads, 0)
+    }))
+
+  it.effect("compares cyclic data while allowing decoded copies of shared values", () =>
+    Effect.gen(function*() {
+      const cyclic: { value: number; self?: unknown } = { value: 1 }
+      cyclic.self = cyclic
+      const copy: { value: number; self?: unknown } = { value: 1 }
+      copy.self = copy
+      const machine = make({ first: cyclic, second: cyclic })
+      const trace = yield* MachineTest.run(machine, { events: [] })
+      const equivalent = {
+        ...trace,
+        final: { ...trace.final, value: { ...trace.final.value, data: { first: cyclic, second: copy } } }
+      }
+      yield* MachineTest.verify(machine, equivalent)
+      copy.value = 2
+      assert.isTrue(Exit.isFailure(yield* Effect.exit(MachineTest.verify(machine, equivalent))))
+    }))
+})

--- a/packages/effect-machine/typetest/machine/Machine.tst.ts
+++ b/packages/effect-machine/typetest/machine/Machine.tst.ts
@@ -787,14 +787,18 @@ describe("Machine", () => {
       DownInitial.decoded(new Down({})),
       new SignInCompleted({ userId: "user-1" })
     )
-    expect(Machine.can).type.not.toBeCallableWith(
+    expect(Machine.can).type.toBeCallableWith(
       machine,
+      DownInitial.decoded(new Down({})),
+      new SignInCompleted({ userId: "user-1" })
+    )
+    expect(Machine.can(machine)).type.toBeCallableWith(
       DownInitial.decoded(new Down({})),
       new SignInCompleted({ userId: "user-1" })
     )
     expect(Machine.can(machine)).type.not.toBeCallableWith(
       DownInitial.decoded(new Down({})),
-      new SignInCompleted({ userId: "user-1" })
+      { _tag: "Undeclared" }
     )
     const publicEvents = Machine.events(SignIn)
     const overlappingInternalEvents = Machine.internalEvents(SignIn)

--- a/packages/oxlint-plugin/src/internal/ast.ts
+++ b/packages/oxlint-plugin/src/internal/ast.ts
@@ -1,5 +1,14 @@
 import type { Context, ESTree, Scope, Variable } from "@oxlint/plugins"
-import { staticMemberName } from "./imports.js"
+export const staticMemberName = (node: ESTree.Node): string | undefined => {
+  if (node.type !== "MemberExpression") return undefined
+  return node.computed
+    ? node.property.type === "Literal" && typeof node.property.value === "string"
+      ? node.property.value
+      : undefined
+    : node.property.type === "Identifier"
+    ? node.property.name
+    : undefined
+}
 
 export const unwrapExpression = (node: ESTree.Expression): ESTree.Expression => {
   let current = node

--- a/packages/oxlint-plugin/src/internal/imports.ts
+++ b/packages/oxlint-plugin/src/internal/imports.ts
@@ -1,14 +1,18 @@
-import type { ESTree } from "@oxlint/plugins"
+import type { Context, ESTree } from "@oxlint/plugins"
+
+import { resolvedVariable, staticMemberName } from "./ast.js"
 
 const effectMachineModule = "@typeonce/effect-machine"
 
 export interface MachineBindings {
-  readonly definitions: Set<string>
-  readonly machine: Set<string>
-  readonly namespaces: Set<string>
+  readonly context: Context
+  readonly definitions: Set<ESTree.Node>
+  readonly machine: Set<ESTree.Node>
+  readonly namespaces: Set<ESTree.Node>
 }
 
-export const makeMachineBindings = (): MachineBindings => ({
+export const makeMachineBindings = (context: Context): MachineBindings => ({
+  context,
   definitions: new Set(),
   machine: new Set(),
   namespaces: new Set()
@@ -24,12 +28,12 @@ export const recordMachineImport = (
 
   for (const specifier of node.specifiers) {
     if (specifier.type === "ImportNamespaceSpecifier") {
-      bindings.namespaces.add(specifier.local.name)
+      bindings.namespaces.add(specifier.local)
     } else if (
       specifier.type === "ImportSpecifier" &&
       moduleExportName(specifier.imported) === "Machine"
     ) {
-      bindings.machine.add(specifier.local.name)
+      bindings.machine.add(specifier.local)
     }
   }
 }
@@ -37,16 +41,12 @@ export const recordMachineImport = (
 export const hasMachineImport = (bindings: MachineBindings): boolean =>
   bindings.machine.size > 0 || bindings.namespaces.size > 0
 
-export const staticMemberName = (node: ESTree.Node): string | undefined => {
-  if (node.type !== "MemberExpression") return undefined
-  return node.computed
-    ? node.property.type === "Literal" && typeof node.property.value === "string"
-      ? node.property.value
-      : undefined
-    : node.property.type === "Identifier"
-    ? node.property.name
-    : undefined
-}
+const matchesBinding = (
+  node: ESTree.IdentifierReference,
+  declarations: ReadonlySet<ESTree.Node>,
+  bindings: MachineBindings
+): boolean =>
+  resolvedVariable(bindings.context, node)?.identifiers.some((identifier) => declarations.has(identifier)) === true
 
 const isNamespaceMachine = (
   node: ESTree.Node,
@@ -55,16 +55,16 @@ const isNamespaceMachine = (
   node.type === "MemberExpression" &&
   !node.computed &&
   node.object.type === "Identifier" &&
-  bindings.namespaces.has(node.object.name) &&
+  matchesBinding(node.object, bindings.namespaces, bindings) &&
   node.property.type === "Identifier" &&
   node.property.name === "Machine"
 
 const isMachineReference = (
-  node: ESTree.Node,
+  node: ESTree.Expression,
   bindings: MachineBindings
 ): boolean =>
   node.type === "Identifier"
-    ? bindings.machine.has(node.name)
+    ? matchesBinding(node, bindings.machine, bindings)
     : isNamespaceMachine(node, bindings)
 
 export const isMachineMemberCall = (
@@ -97,7 +97,7 @@ export const recordMachineDefinition = (
     node.id.type === "Identifier" &&
     node.init?.type === "CallExpression" &&
     isMachineMakeCall(node.init, bindings)
-  ) bindings.definitions.add(node.id.name)
+  ) bindings.definitions.add(node.id)
 }
 
 export const isMachineHandleCall = (
@@ -112,7 +112,7 @@ export const isMachineHandleCall = (
   const receiver = node.callee.object
   return receiver.type === "CallExpression"
     ? isMachineMakeCall(receiver, bindings)
-    : receiver.type === "Identifier" && bindings.definitions.has(receiver.name)
+    : receiver.type === "Identifier" && matchesBinding(receiver, bindings.definitions, bindings)
 }
 
 export const isMemberCall = (

--- a/packages/oxlint-plugin/src/internal/planning.ts
+++ b/packages/oxlint-plugin/src/internal/planning.ts
@@ -1,6 +1,7 @@
 import type { ESTree } from "@oxlint/plugins"
+import { resolvedVariable, staticMemberName } from "./ast.js"
 import { unwrapExpression } from "./ast.js"
-import { isMachineHandleCall, isMachineMakeCall, type MachineBindings, staticMemberName } from "./imports.js"
+import { isMachineHandleCall, isMachineMakeCall, type MachineBindings } from "./imports.js"
 
 export type PlanningFunction = ESTree.ArrowFunctionExpression | ESTree.Function
 
@@ -129,7 +130,7 @@ export const enclosingFunction = (node: ESTree.Node): PlanningFunction | undefin
   return undefined
 }
 
-const selectorRoot = (node: ESTree.Expression): string | undefined => {
+const selectorRoot = (node: ESTree.Expression): ESTree.IdentifierReference | undefined => {
   let expression = unwrapExpression(node)
   while (expression.type === "CallExpression" || expression.type === "MemberExpression") {
     expression = unwrapExpression(
@@ -138,7 +139,7 @@ const selectorRoot = (node: ESTree.Expression): string | undefined => {
         : expression.object
     )
   }
-  return expression.type === "Identifier" ? expression.name : undefined
+  return expression.type === "Identifier" ? expression : undefined
 }
 
 export const enclosingPlanningCallback = (
@@ -176,9 +177,11 @@ export const isPlanningCallback = (
     if (method !== undefined && directPlanningMethods.has(method)) {
       const owner = enclosingFunction(parent)
       const selector = owner?.params[0]
+      const root = selectorRoot(parent.callee.object)
       return owner !== undefined &&
         selector?.type === "Identifier" &&
-        selectorRoot(parent.callee.object) === selector.name &&
+        root !== undefined &&
+        resolvedVariable(bindings.context, root)?.identifiers.includes(selector) === true &&
         isPlanningCallback(owner, bindings)
     }
   }

--- a/packages/oxlint-plugin/src/internal/rules/noAsyncPlanningCallback.ts
+++ b/packages/oxlint-plugin/src/internal/rules/noAsyncPlanningCallback.ts
@@ -19,7 +19,7 @@ export const noAsyncPlanningCallback: Rule = {
     }
   },
   create(context) {
-    const bindings = makeMachineBindings()
+    const bindings = makeMachineBindings(context)
     const inspect = (node: PlanningFunction): void => {
       if (
         hasMachineImport(bindings) &&

--- a/packages/oxlint-plugin/src/internal/rules/noBrowserApiInPlanning.ts
+++ b/packages/oxlint-plugin/src/internal/rules/noBrowserApiInPlanning.ts
@@ -27,7 +27,7 @@ export const noBrowserApiInPlanning: Rule = {
     }
   },
   create(context) {
-    const bindings = makeMachineBindings()
+    const bindings = makeMachineBindings(context)
     const inspect = (node: ESTree.Expression): void => {
       if (
         !hasMachineImport(bindings) ||

--- a/packages/oxlint-plugin/src/internal/rules/noConflictingInvocationIdentity.ts
+++ b/packages/oxlint-plugin/src/internal/rules/noConflictingInvocationIdentity.ts
@@ -1,4 +1,5 @@
 import type { Context, ESTree, Rule, Variable } from "@oxlint/plugins"
+import { staticMemberName } from "../ast.js"
 import { resolvedVariable, unwrapExpression } from "../ast.js"
 import {
   hasMachineImport,
@@ -6,8 +7,7 @@ import {
   type MachineBindings,
   makeMachineBindings,
   recordMachineDefinition,
-  recordMachineImport,
-  staticMemberName
+  recordMachineImport
 } from "../imports.js"
 import { isInvokePlanningCallback, type PlanningFunction } from "../planning.js"
 
@@ -286,7 +286,7 @@ export const noConflictingInvocationIdentity: Rule = {
     }
   },
   create(context) {
-    const bindings = makeMachineBindings()
+    const bindings = makeMachineBindings(context)
     const inspect = (node: PlanningFunction): void => {
       if (!hasMachineImport(bindings) || !isInvokePlanningCallback(node, bindings)) return
       const parameter = node.params[0]

--- a/packages/oxlint-plugin/src/internal/rules/noNondeterministicPlanning.ts
+++ b/packages/oxlint-plugin/src/internal/rules/noNondeterministicPlanning.ts
@@ -17,7 +17,7 @@ export const noNondeterministicPlanning: Rule = {
     }
   },
   create(context) {
-    const bindings = makeMachineBindings()
+    const bindings = makeMachineBindings(context)
     const report = (
       node: ESTree.CallExpression | ESTree.MemberExpression | ESTree.NewExpression,
       operation: string | undefined

--- a/packages/oxlint-plugin/src/internal/rules/noRedundantResolve.ts
+++ b/packages/oxlint-plugin/src/internal/rules/noRedundantResolve.ts
@@ -1,11 +1,6 @@
 import type { ESTree, Rule } from "@oxlint/plugins"
-import {
-  hasMachineImport,
-  makeMachineBindings,
-  recordMachineDefinition,
-  recordMachineImport,
-  staticMemberName
-} from "../imports.js"
+import { staticMemberName } from "../ast.js"
+import { hasMachineImport, makeMachineBindings, recordMachineDefinition, recordMachineImport } from "../imports.js"
 import { isPlanningCallback } from "../planning.js"
 
 const returnedExpression = (
@@ -86,7 +81,7 @@ export const noRedundantResolve: Rule = {
     }
   },
   create(context) {
-    const bindings = makeMachineBindings()
+    const bindings = makeMachineBindings(context)
     return {
       ImportDeclaration: (node) => recordMachineImport(bindings, node),
       CallExpression(node) {

--- a/packages/oxlint-plugin/src/internal/rules/preferInlineHandle.ts
+++ b/packages/oxlint-plugin/src/internal/rules/preferInlineHandle.ts
@@ -48,7 +48,7 @@ export const preferInlineHandle: Rule = {
     }
   },
   create(context) {
-    const bindings = makeMachineBindings()
+    const bindings = makeMachineBindings(context)
     const candidates: Array<Candidate> = []
     return {
       ImportDeclaration: (node) => recordMachineImport(bindings, node),

--- a/packages/oxlint-plugin/test/noRedundantResolve.test.ts
+++ b/packages/oxlint-plugin/test/noRedundantResolve.test.ts
@@ -14,6 +14,16 @@ const rule = plugin.rules["no-redundant-resolve"]
 tester.run("no-redundant-resolve", rule, {
   valid: [
     `import { Machine } from "@typeonce/effect-machine"
+function unrelated(Machine: any) { Machine.make({ initial: (to) => to.Ready().resolve(({ target }) => target.from()) }) }`,
+    `import { Machine as M } from "@typeonce/effect-machine"
+function unrelated(M: any) { M.make({ initial: (to) => to.Ready().resolve(({ target }) => target.from()) }) }`,
+    `import * as EM from "@typeonce/effect-machine"
+function unrelated(EM: any) { EM.Machine.make({ initial: (to) => to.Ready().resolve(({ target }) => target.from()) }) }`,
+    `import { Machine } from "@typeonce/effect-machine"
+const definition = Machine.make({ initial: (to) => to.Ready() })
+function unrelated(definition: any) { definition.handle({ Ready: { on: { Reset: (to) => to.full.Ready().resolve(({ target }) => target.from()) } } }) }`,
+
+    `import { Machine } from "@typeonce/effect-machine"
 Machine.make({ initial: (to) => to.Ready().resolve(({ target }) => target.from({ id: "ready" })) })`,
     `import { Machine } from "@typeonce/effect-machine"
 Machine.make({ initial: (to) => to.Ready().resolve(({ target }) => target.from(), { reenter: true, actions: [] }) })`,

--- a/scripts/api-reference/examples.test.mjs
+++ b/scripts/api-reference/examples.test.mjs
@@ -1,0 +1,17 @@
+import { strict as assert } from "node:assert"
+import { readFileSync } from "node:fs"
+import { test } from "node:test"
+
+// These fixtures also compile under tsconfig.tests.json. Keep documentation
+// examples identical to the checked consumer code rather than copying by hand.
+test("Machine.can documents the compile-checked internal-event example", () => {
+  const source = readFileSync(new URL("../../packages/effect-machine/src/Machine.ts", import.meta.url), "utf8")
+  const declaration = source.indexOf("export const can:")
+  assert.ok(declaration >= 0)
+  const comment = source.slice(source.lastIndexOf("/**", declaration), declaration)
+  const example = comment.match(/```ts\n([\s\S]*?)\n \* ```/)
+  assert.ok(example)
+  const actual = example[1].split("\n").map((line) => line.replace(/^ \* ?/, "")).join("\n")
+  const expected = readFileSync(new URL("../../packages/effect-machine/test/examples/can.ts", import.meta.url), "utf8")
+  assert.equal(actual.trim(), expected.trim())
+})

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -215,10 +215,13 @@ export const checkArchitecture = ({
     "src/unstable/reactivity/index.ts"
   ])
   const implementationSeams = new Map([
-    ["src/Machine.ts", "src/internal/machine/machine.ts"],
-    ["src/testing/MachineTest.ts", "src/internal/testing/machine/verification.ts"],
-    ["src/unstable/reactivity/AtomMachine.ts", "src/internal/machine/atom.ts"],
-    ["src/unstable/cluster/ClusterMachine.ts", "src/internal/machine/cluster.ts"]
+    ["src/Machine.ts", new Set(["src/internal/machine/machine.ts"])],
+    ["src/testing/MachineTest.ts", new Set([
+      "verification", "runtime", "arbitrary", "finiteModel", "referenceModel", "invariant",
+      "runtimeInvariant", "exploration", "probe", "trace", "format"
+    ].map((name) => `src/internal/testing/machine/${name}.ts`))],
+    ["src/unstable/reactivity/AtomMachine.ts", new Set(["src/internal/machine/atom.ts"])],
+    ["src/unstable/cluster/ClusterMachine.ts", new Set(["src/internal/machine/cluster.ts"])]
   ])
   const forbiddenSemanticDependencies = new Map([
     ["src/internal/machine/topology.ts", new Set([
@@ -302,7 +305,7 @@ export const checkArchitecture = ({
       implementationSeam !== undefined &&
       !edge.typeOnly &&
       edge.target.includes("/internal/") &&
-      edge.target !== implementationSeam
+      !implementationSeam.has(edge.target)
     ) {
       diagnostics.push(diagnostic(
         "ARCH002",
@@ -412,12 +415,12 @@ export const checkArchitecture = ({
           statement.importClause === undefined ||
           statement.importClause.isTypeOnly ||
           !ts.isStringLiteral(statement.moduleSpecifier) ||
-          resolveProjectModule(
+          !implementationSeam.has(resolveProjectModule(
               statement.moduleSpecifier.text,
               sourceFile,
               program.getCompilerOptions(),
               root
-            ) !== implementationSeam
+            ))
         ) continue
         if (statement.importClause.name !== undefined) {
           implementationValues.add(statement.importClause.name.text)

--- a/scripts/check-architecture.test.mjs
+++ b/scripts/check-architecture.test.mjs
@@ -61,6 +61,24 @@ test("rejects public implementation bypasses and inferred internal signatures", 
   assert.deepEqual(rules(root), ["ARCH002", "ARCH013"])
 })
 
+test("allows testing APIs to bind directly to their owning implementation modules", () => {
+  const root = makeProject({
+    "src/testing/MachineTest.ts": 'import * as Trace from "../internal/testing/machine/trace.js"\nimport * as Format from "../internal/testing/machine/format.js"\nexport const run: () => void = Trace.run\nexport const formatTrace: () => string = Format.formatTrace',
+    "src/internal/testing/machine/trace.ts": "export const run = () => {}",
+    "src/internal/testing/machine/format.ts": 'export const formatTrace = () => "trace"'
+  })
+  assert.deepEqual(rules(root), [])
+})
+
+test("keeps testing implementation signatures explicit and rejects unrelated internals", () => {
+  const root = makeProject({
+    "src/testing/MachineTest.ts": 'import * as Format from "../internal/testing/machine/format.js"\nimport { value } from "../internal/machine/runtime.js"\nexport const formatTrace = Format.formatTrace\nexport const unrelated: number = value',
+    "src/internal/testing/machine/format.ts": 'export const formatTrace = () => "trace"',
+    "src/internal/machine/runtime.ts": "export const value = 1"
+  })
+  assert.deepEqual(new Set(rules(root)), new Set(["ARCH002", "ARCH013"]))
+})
+
 test("rejects entrypoint leaks, black-box internal imports, barrels, and legacy filenames", () => {
   const root = makeProject({
     "src/index.ts": 'export { value } from "./internal/machine/model.js"',


### PR DESCRIPTION
## Summary

- Keep `Machine.can` behavior and fix its types to accept internal events. `MachineRef.send` still accepts only public events; the JSDoc example is compiled in CI.
- Preserve interruption during snapshot serialization, revalidate reused event and emission values, and capture machine definitions so later caller mutations cannot change their behavior.
- Make `MachineTest.verify` lazy and compare decoded values without losing information through JSON. Extract target builders, child bookkeeping, invocation definitions, and shared requirement types into focused internal modules.
- Serialize devtools refreshes, stop watcher work with its server scope, and prevent lint diagnostics for shadowed machine bindings. Add regression tests and strengthen generic-versus-optimized comparisons.

## Changeset

- [x] Added or updated for a library or package-metadata change
- [ ] Not required because this PR does not change a publishable package

Compatible fixes and implementation improvements use a patch changeset.

## Validation

- [x] `pnpm check`
- [x] Automated type-performance measurement passed or was not required
- [x] Automated runtime- and memory-performance measurement passed or was not required

Local `pnpm perf:types` and `pnpm perf:runtime` passed. Hosted [CI](https://github.com/typeonce-dev/effect-machine/actions/runs/34025909697), [type performance](https://github.com/typeonce-dev/effect-machine/actions/runs/34025909692), and [runtime performance](https://github.com/typeonce-dev/effect-machine/actions/runs/34025909741) passed, and both comparison artifacts were inspected. Type scenarios added at most four instantiations. Across five independent processes per version, throughput changes ranged from -0.8% to +1.9%, heap usage remained essentially unchanged, and the regression guard passed.

<!--
The type- and runtime-performance workflows measure only relevant changes and post their base-versus-PR comparisons automatically.
Do not copy a manually measured table into this description.
-->
